### PR TITLE
fix travis deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,16 +52,6 @@ script:
 deploy:
   - provider: script
     skip_cleanup: true
-    script: >-
-      openssl aes-256-cbc -K $encrypted_5c6845b5ee69_key -iv $encrypted_5c6845b5ee69_iv -in github_deploy_key.enc -out github_deploy_key -d;
-      chmod 600 github_deploy_key;
-      eval $(ssh-agent -s);
-      ssh-add github_deploy_key;
-      make login;
-      cd helm-chart;
-      chartpress --commit-range "${TRAVIS_COMMIT_RANGE}" --push --publish-chart;
-      docker push renku/renku-ui:latest;
-      git diff;
-      cd ..
+    script: bash travis-deploy.sh
     on:
-      branch: master
+      branch: fix-travis-deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_install:
 
 install:
   - travis_retry pip install -U pip
-  - travis_retry pip install -e git+https://github.com/jirikuncar/chartpress#egg=chartpress
+  - travis_retry pip install chartpress
   # Installing Helm
   - wget -q ${HELM_URL}/${HELM_TGZ}
   - tar xzfv ${HELM_TGZ}
@@ -54,4 +54,4 @@ deploy:
     skip_cleanup: true
     script: bash travis-deploy.sh
     on:
-      branch: fix-travis-deploy
+      branch: master

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ endif
 
 IMAGES=renku-ui
 
-GIT_MASTER_HEAD_SHA:=$(shell git rev-parse --short=12 --verify HEAD)
+GIT_MASTER_HEAD_SHA:=$(shell git rev-parse --short=7 --verify HEAD)
 
 PLATFORM_DOMAIN?=renku.build
 GITLAB_URL?=http://gitlab.$(PLATFORM_DOMAIN)

--- a/helm-chart/chartpress.yaml
+++ b/helm-chart/chartpress.yaml
@@ -13,4 +13,3 @@ charts:
         # Dockerfile path relative to chartpress.yaml
         dockerfilePath: ../Dockerfile
         valuesPath: image
-        paths:

--- a/travis-deploy.sh
+++ b/travis-deploy.sh
@@ -1,0 +1,31 @@
+#!/bin/env bash
+#
+# Copyright 2018 - Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# generate ssh key to use for docker hub login
+openssl aes-256-cbc -K "${encrypted_5c6845b5ee69_key}" -iv "${encrypted_5c6845b5ee69_iv}" -in github_deploy_key.enc -out github_deploy_key -d
+chmod 600 github_deploy_key
+eval $(ssh-agent -s)
+ssh-add github_deploy_key
+make login
+
+# build charts/images and push
+cd helm-chart
+chartpress --commit-range "${TRAVIS_COMMIT_RANGE}" --push --publish-chart
+docker push renku/renku-ui:latest
+git diff
+cd ..

--- a/travis-deploy.sh
+++ b/travis-deploy.sh
@@ -16,6 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -e
+
 # generate ssh key to use for docker hub login
 openssl aes-256-cbc -K "${encrypted_5c6845b5ee69_key}" -iv "${encrypted_5c6845b5ee69_iv}" -in github_deploy_key.enc -out github_deploy_key -d
 chmod 600 github_deploy_key
@@ -25,7 +27,7 @@ make login
 
 # build charts/images and push
 cd helm-chart
-chartpress --commit-range "${TRAVIS_COMMIT_RANGE}" --push --publish-chart
-docker push renku/renku-ui:latest
+chartpress --push --publish-chart
+chartpress --tag latest --push
 git diff
 cd ..


### PR DESCRIPTION
The crappy solution to this problem:

```
fatal: ambiguous argument '18b8ab0dc619...b8acc3c48c0c': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.6.3/bin/chartpress", line 11, in <module>
    sys.exit(main())
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/chartpress.py", line 207, in main
    push=args.push,
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/chartpress.py", line 78, in build_images
    if commit_range and not path_touched(*paths, commit_range=commit_range):
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/chartpress.py", line 43, in path_touched
    'git', 'diff', '--name-only', commit_range, *paths
  File "/opt/python/3.6.3/lib/python3.6/subprocess.py", line 336, in check_output
    **kwargs).stdout
  File "/opt/python/3.6.3/lib/python3.6/subprocess.py", line 418, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['git', 'diff', '--name-only', '18b8ab0dc619...b8acc3c48c0c', '..']' returned non-zero exit 
```

Basically don't use a commit range otherwise rebase/squash commits will apparently not work correctly on travis (see https://github.com/travis-ci/travis-ci/issues/2668). We are building on any change in the repo anyway so this shouldn't really matter too much. 
