### PR TITLE
Deactivate SW

### DIFF
--- a/src/utils/ServiceWorker.js
+++ b/src/utils/ServiceWorker.js
@@ -19,6 +19,9 @@ const isLocalhost = Boolean(
 );
 
 export default function register() {
+  // Do not enable service workers for now
+  return;
+  
   if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
     // The URL constructor is available in all browsers that support SW.
     const publicUrl = new URL(process.env.PUBLIC_URL, window.location);


### PR DESCRIPTION
The service worker gobles up too many paths.

As long as it does this, I would suggest to deactivate it like it is done here, or to configure it to only serve static assets.