### PR TITLE
Introduce form validation

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -1,0 +1,5 @@
+{
+  "BASE_URL": "http://192.168.99.100",
+  "JUPYTERHUB_URL": "http://192.168.99.100/jupyterhub",
+  "GATEWAY_URL": "http://192.168.99.100/api"
+}

--- a/src/project/Project.js
+++ b/src/project/Project.js
@@ -83,15 +83,17 @@ class New extends Component {
 
   doMapStateToProps(state, ownProps) {
     const model = this.newProject.mapStateToProps(state, ownProps);
-    const statuses = {}
-    this.state.statuses.forEach((d) => { Object.keys(d).forEach(k => statuses[k] = d[k])});
-    const handlers = this.handlers;
-    return {model, handlers, statuses}
+    return {model}
   }
 
   render() {
     const ConnectedNewProject = connect(this.mapStateToProps)(Present.ProjectNew);
-    return <ConnectedNewProject store={this.newProject.reduxStore}/>;
+    const statuses = {}
+    this.state.statuses.forEach((d) => { Object.keys(d).forEach(k => statuses[k] = d[k])});
+    return <ConnectedNewProject
+      statuses={statuses}
+      handlers={this.handlers}
+      store={this.newProject.reduxStore}/>;
   }
 }
 

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -215,18 +215,16 @@ class ProjectViewHeader extends Component {
                 </form>
               </div>
             </div>
-            <p className="pt-3">
-              <div className="d-flex flex-md-row-reverse">
-                <div>
-                  <a key="link" target="_blank" href={this.props.externalUrl}
-                    className="btn btn-primary" role="button">View Project in GitLab</a>
-                </div>
-                <div>&nbsp;</div>
-                <div>
-                  {this.props.launchNotebookServerButton}
-                </div>
+            <div className="d-flex flex-md-row-reverse pt-3">
+              <div>
+                <a key="link" target="_blank" href={this.props.externalUrl}
+                  className="btn btn-primary" role="button">View Project in GitLab</a>
               </div>
-            </p>
+              <div>&nbsp;</div>
+              <div>
+                {this.props.launchNotebookServerButton}
+              </div>
+            </div>
             <p className="text-md-right pt-3">
               <ImageBuildInfoBadge notebooksUrl={this.props.notebooksUrl} imageBuild={this.props.imageBuild} />
             </p>

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -73,7 +73,8 @@ class DataVisibility extends Component {
 class ProjectNew extends Component {
 
   render() {
-    const titleHelp = this.props.display.slug.length > 0 ? `Id: ${this.props.display.slug}` : null;
+    const statuses = this.props.statuses;
+    const titleHelp = this.props.model.display.slug.length > 0 ? `Id: ${this.props.model.display.slug}` : null;
     return [
       <Row key="header"><Col md={8}>
         <h1>New Project</h1>
@@ -81,11 +82,14 @@ class ProjectNew extends Component {
       <Row key="body"><Col md={8}>
         <form action="" method="post" encType="multipart/form-data" id="js-upload-form">
           <FieldGroup id="title" type="text" label="Title" placeholder="A brief name to identify the project"
-            help={titleHelp} value={this.props.display.title} onChange={this.props.handlers.onTitleChange} />
+            help={titleHelp} value={this.props.model.display.title}
+            feedback={statuses.title} invalid={statuses.title != null}
+            onChange={this.props.handlers.onTitleChange} />
           <FieldGroup id="description" type="textarea" label="Description" placeholder="A description of the project"
             help="A description of the project helps users understand it and is highly recommended."
-            value={this.props.display.description} onChange={this.props.handlers.onDescriptionChange} />
-          <DataVisibility value={this.props.meta.visibility} onChange={this.props.handlers.onVisibilityChange} />
+            feedback={statuses.description} invalid={statuses.description != null}
+            value={this.props.model.display.description} onChange={this.props.handlers.onDescriptionChange} />
+          <DataVisibility value={this.props.model.meta.visibility} onChange={this.props.handlers.onVisibilityChange} />
           <br/>
           <Button color="primary" onClick={this.props.handlers.onSubmit}>
             Create

--- a/src/utils/UIComponents.js
+++ b/src/utils/UIComponents.js
@@ -25,7 +25,7 @@
  */
 
 import React, { Component } from 'react';
-import { FormGroup, FormText, Input, Label } from 'reactstrap';
+import { FormFeedback, FormGroup, FormText, Input, Label } from 'reactstrap';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome'
 import faUser from '@fortawesome/fontawesome-free-solid/faUser'
 import human from 'human-time';
@@ -66,14 +66,36 @@ class Avatar extends Component {
   }
 }
 
+// Old FieldGroup implementation
+//
+// class FieldGroup extends Component {
+//   render() {
+//     const label = this.props.label,
+//       help = this.props.help,
+//       props = this.props;
+//     return <FormGroup>
+//       <Label>{label}</Label>
+//       <Input {...props} />
+//       {help && <FormText color="muted">{help}</FormText>}
+//     </FormGroup>
+//   }
+// }
+
 class FieldGroup extends Component {
   render() {
     const label = this.props.label,
       help = this.props.help,
+      feedback = this.props.feedback,
       props = this.props;
+    const subprops = {}
+    if (props.valid === true)
+      subprops.valid = "true";
+    if (props.invalid === true)
+      subprops.invalid = "true";
     return <FormGroup>
       <Label>{label}</Label>
       <Input {...props} />
+      {feedback && <FormFeedback {...subprops}>{feedback}</FormFeedback>}
       {help && <FormText color="muted">{help}</FormText>}
     </FormGroup>
   }


### PR DESCRIPTION
Fix #217.

There are two forms that needed validation: "New Project" and "New Ku". Project uses the Model infrastructure, Ku uses Redux directly. I implemented lightweight solutions in each case: the project defers validation to the model, the ku does validation in the UI directly. I did not want to implement anything very generic yet, since we have only two examples to draw from. Once we have a few more, we can implement more generic validation handling.