### PR TITLE
Fixed template for http scheme

### DIFF
--- a/helm-chart/renku-ui/templates/_helpers.tpl
+++ b/helm-chart/renku-ui/templates/_helpers.tpl
@@ -35,7 +35,7 @@ Create chart name and version as used by the chart label.
 Define URL protocol.
 */}}
 {{- define "renku-ui.protocol" -}}
-{{- if .Values.global.renku.https -}}
+{{- if .Values.global.useHTTPS -}}
 https
 {{- else -}}
 http


### PR DESCRIPTION
Quickfix, as the value from `renku` is `global.useHTTPS`.