### PR TITLE
Rename service in templates

### DIFF
--- a/helm-chart/renku-ui/templates/NOTES.txt
+++ b/helm-chart/renku-ui/templates/NOTES.txt
@@ -4,16 +4,16 @@
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "renku-ui.fullname" . }})
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "ui.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get svc -w {{ template "renku-ui.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "renku-ui.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+           You can watch the status of by running 'kubectl get svc -w {{ template "ui.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "ui.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "renku-ui.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "ui.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://localhost:3000 to use your application"
   kubectl port-forward $POD_NAME 3000:80
 {{- end }}

--- a/helm-chart/renku-ui/templates/_helpers.tpl
+++ b/helm-chart/renku-ui/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "renku-ui.name" -}}
+{{- define "ui.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -11,7 +11,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "renku-ui.fullname" -}}
+{{- define "ui.fullname" -}}
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
@@ -27,14 +27,14 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "renku-ui.chart" -}}
+{{- define "ui.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Define URL protocol.
 */}}
-{{- define "renku-ui.protocol" -}}
+{{- define "ui.protocol" -}}
 {{- if .Values.global.useHTTPS -}}
 https
 {{- else -}}

--- a/helm-chart/renku-ui/templates/deployment.yaml
+++ b/helm-chart/renku-ui/templates/deployment.yaml
@@ -1,22 +1,22 @@
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
-  name: {{ template "renku-ui.fullname" . }}
+  name: {{ template "ui.fullname" . }}
   labels:
-    app: {{ template "renku-ui.name" . }}
-    chart: {{ template "renku-ui.chart" . }}
+    app: {{ template "ui.name" . }}
+    chart: {{ template "ui.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app: {{ template "renku-ui.name" . }}
+      app: {{ template "ui.name" . }}
       release: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        app: {{ template "renku-ui.name" . }}
+        app: {{ template "ui.name" . }}
         release: {{ .Release.Name }}
     spec:
       containers:
@@ -29,13 +29,13 @@ spec:
               protocol: TCP
           env:
             - name: BASE_URL
-              value: {{ .Values.baseUrl | default (printf "%s://%s" (include "renku-ui.protocol" .) .Values.global.renku.domain) | quote }}
+              value: {{ .Values.baseUrl | default (printf "%s://%s" (include "ui.protocol" .) .Values.global.renku.domain) | quote }}
             - name: GITLAB_URL
-              value: {{ .Values.gitlabUrl | default (printf "%s://gitlab.%s" (include "renku-ui.protocol" .) .Values.global.renku.domain) | quote }}
+              value: {{ .Values.gitlabUrl | default (printf "%s://gitlab.%s" (include "ui.protocol" .) .Values.global.renku.domain) | quote }}
             - name: GITLAB_CLIENT_ID
               value: {{ .Values.gitlabClientId | default "renku-ui" | quote }}
             - name: JUPYTERHUB_URL
-              value: {{ .Values.jupyterhubUrl | default (printf "%s://jupyterhub.%s" (include "renku-ui.protocol" .) .Values.global.renku.domain) | quote }}
+              value: {{ .Values.jupyterhubUrl | default (printf "%s://jupyterhub.%s" (include "ui.protocol" .) .Values.global.renku.domain) | quote }}
           livenessProbe:
             httpGet:
               path: /

--- a/helm-chart/renku-ui/templates/ingress.yaml
+++ b/helm-chart/renku-ui/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "renku-ui.fullname" . -}}
+{{- $fullName := include "ui.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
 apiVersion: extensions/v1beta1
@@ -7,8 +7,8 @@ kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
-    app: {{ template "renku-ui.name" . }}
-    chart: {{ template "renku-ui.chart" . }}
+    app: {{ template "ui.name" . }}
+    chart: {{ template "ui.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 {{- with .Values.ingress.annotations }}

--- a/helm-chart/renku-ui/templates/service.yaml
+++ b/helm-chart/renku-ui/templates/service.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "renku-ui.fullname" . }}
+  name: {{ template "ui.fullname" . }}
   labels:
-    app: {{ template "renku-ui.name" . }}
-    chart: {{ template "renku-ui.chart" . }}
+    app: {{ template "ui.name" . }}
+    chart: {{ template "ui.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
@@ -15,5 +15,5 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app: {{ template "renku-ui.name" . }}
+    app: {{ template "ui.name" . }}
     release: {{ .Release.Name }}


### PR DESCRIPTION
Rename renku-ui --> ui in helm chart templates to be consistent with other services.