### PR TITLE
ci: fix failing travis deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_install:
 
 install:
   - travis_retry pip install -U pip
-  - travis_retry pip install "chartpress>=0.2.1"
+  - travis_retry pip install "chartpress>=0.2.1" "ruamel.yaml==0.15.54"
   # Installing Helm
   - wget -q ${HELM_URL}/${HELM_TGZ}
   - tar xzfv ${HELM_TGZ}


### PR DESCRIPTION
travis deploy failing due to incompatibility between chartpress and new version of ruamel.yaml