### PR TITLE
Fix bug that leads to integration test failure

### DIFF
--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -373,8 +373,8 @@ class FileFolderList extends Component {
       mrIids = this.props.mrIids;
     }
     else {
-      alerts = this.props.paths.map(() => '');
-      mrIids = this.props.paths.map(() => []);
+      alerts = paths.map(() => '');
+      mrIids = paths.map(() => []);
     }
 
     const linkUrl = this.props.linkUrl;


### PR DESCRIPTION
Fix an error that was occurring when navigating directly to the files tab without previously having loaded all the data (for example when hitting the reload button or during integration tests).