### PR TITLE
Fix ingress in default values

### DIFF
--- a/helm-chart/renku-ui/values.yaml
+++ b/helm-chart/renku-ui/values.yaml
@@ -55,6 +55,9 @@ image:
 service:
   type: ClusterIP
   port: 80
+  
+ingress:
+  enabled: false
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
Fix default values

This is likely causing `helm` issues.
```
Error: UPGRADE FAILED: render error in "renku/charts/renku-ui/templates/ingress.yaml": template: renku/charts/renku-ui/templates/ingress.yaml:1:14: executing "renku/charts/renku-ui/templates/ingress.yaml" at <.Values.ingress.enab...>: can't evaluate field enabled in type interface {}
```