### PR TITLE
Manually start dev server inside telepresence shell

### DIFF
--- a/run-telepresence.sh
+++ b/run-telepresence.sh
@@ -37,4 +37,10 @@ tee > ./public/config.json << EOF
   "WELCOME_PAGE": "${WELCOME_PAGE}"
 }
 EOF
-BROWSER=none telepresence --swap-deployment renku-ui --namespace renku --method inject-tcp --expose 3000:80 --run npm start
+
+echo "================================================================================================================="
+echo "Once telepresence has started, type the following command to start the development server:"
+echo "BROWSER=none npm start"
+echo "================================================================================================================="
+
+BROWSER=none telepresence --swap-deployment renku-ui --namespace renku --method inject-tcp --expose 3000:80 --run-shell


### PR DESCRIPTION
Killing telepresence can leave the swapped k8s deployment broken. We therefore run a shell and manually start the dev server which can be killed followed by gracefully exiting telepresence.