### PR TITLE
Adding new project now provides an alert when some errors occurs

### DIFF
--- a/src/api-client/errors.js
+++ b/src/api-client/errors.js
@@ -63,7 +63,7 @@ function throwAPIErrors(response) {
 
 function alertAPIErrors(error) {
   switch (error.case) {
-  case API_ERRORS.permissionError:
+  case API_ERRORS.forbiddenError:
     alert('You don\'t have the necessary permission to view this information or perform this action.');
     break;
   case API_ERRORS.notFoundError:

--- a/src/api-client/index.js
+++ b/src/api-client/index.js
@@ -74,7 +74,8 @@ class APIClient {
       .catch((error) => {
 
         // For permission errors we send the user to login
-        if (error.case === API_ERRORS.permissionError) {
+        // TODO: forbidden should not be included here, but test further
+        if (error.case === API_ERRORS.unauthorizedError) {
           return this.doLogin()
         }
 

--- a/src/api-client/project.js
+++ b/src/api-client/project.js
@@ -100,6 +100,8 @@ function addProjectMethods(client) {
 
     return Promise.all([newProjectPromise, payloadPromise])
       .then(([data, payload]) => {
+        if (data.errorData)
+          return Promise.reject(data);
         return client.postCommit(data.id, payload).then(() => data);
       });
   }

--- a/src/model/RenkuModels.js
+++ b/src/model/RenkuModels.js
@@ -42,7 +42,9 @@ const displaySchema = new Schema({
   title: {initial:'', mandatory: true},
   description: {initial: '', mandatory: true},
   displayId: {initial: '', mandatory: false},
-  slug: {initial: '', mandatory: true}
+  slug: {initial: '', mandatory: true},
+  loading: {initial: false, mandatory: false},
+  errors: {initial: [], mandatory: false},
 });
 
 const newProjectSchema = new Schema({

--- a/src/project/new/ProjectNew.present.js
+++ b/src/project/new/ProjectNew.present.js
@@ -32,9 +32,10 @@ import Autosuggest from 'react-autosuggest';
 import { Row, Col } from 'reactstrap';
 import { Button, FormGroup, FormText, Label } from 'reactstrap';
 import { Input, InputGroup, InputGroupAddon, InputGroupText } from 'reactstrap';
+import { Alert } from 'reactstrap';
 
 import collection from 'lodash/collection';
-import { FieldGroup } from '../../utils/UIComponents'
+import { FieldGroup, Loader } from '../../utils/UIComponents'
 import './Project.style.css';
 
 
@@ -230,13 +231,49 @@ class ProjectNew extends Component {
             visibilities={this.props.visibilities}
             onChange={this.props.handlers.onVisibilityChange} />
           <br/>
-          <Button color="primary" onClick={this.props.handlers.onSubmit}>
+          <SubmitErrors errors={this.props.model.display.errors} />
+          <Button color="primary" onClick={this.props.handlers.onSubmit} disabled={this.props.model.display.loading}>
             Create
           </Button>
+          <SubmitLoader loading={this.props.model.display.loading} />
         </form>
       </Col></Row>
     ]
   }
+}
+
+class SubmitLoader extends Component {
+  render() {
+    if (!this.props.loading) return null;
+    return(<Loader size="16" inline="true" margin="2" />)
+  }
+}
+
+class SubmitErrors extends Component {
+  render() {
+    if (!this.props.errors || !this.props.errors.length) return null;
+    return(
+      <div>
+        <Alert color="danger">
+          <Col>
+            <Row>
+              {
+                this.props.errors.length > 1
+                  ? <h5>Some errors occurred</h5>
+                  : <h5>An error occurred</h5>
+              }
+            </Row>
+            {this.props.errors.map(error => (
+              <Row key={error}>
+                {error}
+              </Row>
+            ))}
+          </Col>
+        </Alert>
+      </div>
+    )
+  }
+
 }
 
 export default ProjectNew;


### PR DESCRIPTION
The user now gets an alert when some errors occur while creating a new project. This addresses #387 as well as other generic errors.
The "Create" button is also disabled after the first click until a response comes from the API, and a Loader is displayed in the meanwhile.