### PR TITLE
Added help page, moved and adjusted footer.

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -39,8 +39,6 @@ body {
   position: absolute;
   bottom: 0;
   width: 100%;
-  height: 60px; /* Set the fixed height of the footer here */
-  line-height: 60px; /* Vertically center the text there */
   background-color: #f5f5f5;
 }
 

--- a/src/App.js
+++ b/src/App.js
@@ -30,9 +30,10 @@ import { BrowserRouter as Router, Route, Switch, Redirect }  from 'react-router-
 
 import Project from './project/Project'
 import Ku from './ku/Ku'
-import { Landing, LoggedInNavBar, AnonymousNavBar } from './landing'
+import { Landing, LoggedInNavBar, AnonymousNavBar, FooterNavbar } from './landing'
 import Notebooks from './notebooks';
 import { Login } from './login'
+import Help from './help'
 import { UserAvatar } from './utils/UIComponents'
 
 class RenkuNavBar extends Component {
@@ -45,13 +46,7 @@ class RenkuNavBar extends Component {
 
 class RenkuFooter extends Component {
   render() {
-    return <footer className="footer">
-      <div className="container">
-        <span className="text-muted">
-          <a href="https://datascience.ch">&copy; SDSC {(new Date()).getFullYear()}</a>
-        </span>
-      </div>
-    </footer>
+    return <FooterNavbar {...this.props} />
   }
 }
 
@@ -76,6 +71,8 @@ class App extends Component {
                   key="landing" welcomePage={this.props.params['WELCOME_PAGE']}
                   user={this.props.userState.getState().user}
                   {...p} />} />
+              <Route path="/help"
+                render ={p => <Help key="help" {...p} {...this.props} /> } />
 
               {/*TODO: This route should be handled by <Route path="/projects/:id(\d+)" too. Until this is the
                  TODO: case, the ku_new route must be listed BEFORE the project one.   */}

--- a/src/help/Help.container.js
+++ b/src/help/Help.container.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2018 - Swiss Data Science Center (SDSC)
+ * Copyright 2019 - Swiss Data Science Center (SDSC)
  * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
  * Eidgenössische Technische Hochschule Zürich (ETHZ).
  *
@@ -19,11 +19,32 @@
 /**
  *  renku-ui
  *
- *  landing
- *  Components for the landing page
+ *  Help.container.js
+ *  Container components for help
  */
 
-import Landing from './Landing';
-import { LoggedInNavBar, AnonymousNavBar, FooterNavbar } from './NavBar';
+ 
+import React, { Component } from 'react';
 
-export { Landing, LoggedInNavBar, AnonymousNavBar, FooterNavbar };
+import { Help as HelpPresent } from './Help.present';
+
+class Help extends Component { 
+  urlMap() {
+    const baseUrl = this.props.match.url;
+    return {
+      base: baseUrl,
+      getting: `${baseUrl}/getting`,
+      tutorials: `${baseUrl}/tutorials`,
+      features: `${baseUrl}/features`,
+      setup: `${baseUrl}/setup`,
+    }
+  }
+
+  render() {
+    return (
+      <HelpPresent url={ this.urlMap() } />
+    )
+  }
+}
+
+export { Help };

--- a/src/help/Help.present.js
+++ b/src/help/Help.present.js
@@ -1,0 +1,174 @@
+/*!
+ * Copyright 2019 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  Help.present.js
+ *  Presentational components for help.
+ */
+
+
+import React, { Component } from 'react';
+import { Route }  from 'react-router-dom';
+import { RenkuNavLink } from '../utils/UIComponents';
+
+import { Row, Col } from 'reactstrap';
+import { Nav, NavItem } from 'reactstrap';
+
+
+class HelpNav extends Component {
+  render() {
+    return (
+      <Nav pills className={'nav-pills-underline'}>
+        <NavItem>
+          <RenkuNavLink to={this.props.url.base} alternate={this.props.url.getting} title="Getting Help" />
+        </NavItem>
+        <NavItem>
+          <RenkuNavLink to={this.props.url.tutorials} title="Tutorials" />
+        </NavItem>
+        <NavItem>
+          <RenkuNavLink to={this.props.url.features} title="Features" />
+        </NavItem>
+        <NavItem>
+          <RenkuNavLink to={this.props.url.setup} title="Set Up / Admin" />
+        </NavItem>
+      </Nav> 
+    )
+  }
+}
+
+class HelpGetting extends Component {
+  render() {
+    return (
+      <div>
+        <h2>Gitter</h2>
+        <p>
+          Want to reach out to the development team? Contact us
+          on <a href="https://gitter.im/SwissDataScienceCenter/renku" target="_blank" rel="noreferrer noopener">
+            Gitter</a>,
+          we would be happy to chat with you.
+        </p>
+        <h2>GitHub</h2>
+        <p>
+          Renku is open source and being developed
+          on <a href="https://github.com/SwissDataScienceCenter/renku" target="_blank" rel="noreferrer noopener">
+            GitHub</a>.
+          We encourage you to contact us with questions, comments, issues, or any kind of feedback.
+        </p>
+      </div>
+    )
+  }
+}
+
+class HelpTutorials extends Component {
+  render() {
+    return (
+      <div>
+        <h2>First steps</h2>
+        <p>
+          If you are here for the first time or you are not sure how to use Renku, we reccomend you to go through
+          our <a href="https://renku.readthedocs.io/en/latest/user/firststeps.html"
+            target="_blank" rel="noreferrer noopener">tutorial</a>.
+        </p>
+      </div>
+    )
+  }
+}
+
+class HelpFeatures extends Component {
+  render() {
+    return (
+      <div>
+        <h2>Features</h2>
+        <p>
+          Renku consists of a collection of services, including a web-based user interface
+          and a command-line client, exploiting in a coherent setup the joint features of:
+        </p>
+        <ul>
+          <li><a href="https://gitlab.com" target="_blank" rel="noreferrer noopener">
+            GitLab</a> -  repository management</li>
+          <li><a href="http://jupyter.org/hub" target="_blank" rel="noreferrer noopener">
+            JupyterHub</a> - interactive notebooks</li>
+          <li><a href="https://kubernetes.io" target="_blank" rel="noreferrer noopener">
+            Kubernetes</a> - container orchestration</li>
+          <li><a href="https://www.keycloak.org" target="_blank" rel="noreferrer noopener">
+            Keycloak</a> - identity and access management</li>
+          <li>
+            <a href="https://www.commonwl.org" target="_blank" rel="noreferrer noopener">
+              Common Workflow Language</a> - analysis workflows &amp; tools description
+          </li>
+        </ul>
+        <p>
+          More information is available in
+          our <a href="https://renku.readthedocs.io/en/latest/introduction/index.html#features"
+            target="_blank" rel="noreferrer noopener">documentation</a>.
+        </p>
+      </div>
+    )
+  }
+}
+
+class HelpSetup extends Component {
+  render() {
+    return (
+      <div>
+        <h2>Running the platform</h2>
+        <p>
+          It is easy to deploy the Renku platform
+          on <a href="https://github.com/kubernetes/minikube" target="_blank" rel="noreferrer noopener">
+              minikube</a>.
+          You can find the instructions on
+          our <a href="https://renku.readthedocs.io/en/latest/developer/setup.html"
+            target="_blank" rel="noreferrer noopener">documentation</a>.
+        </p>
+      </div>
+    )
+  }
+}
+
+class HelpContent extends Component {
+  render() {
+    return [
+      <Route exact path={this.props.url.base} key="base" 
+        render={props => <HelpGetting key="getting" {...this.props} />} />,
+      <Route path={this.props.url.getting} key="getting" 
+        render={props => <HelpGetting key="getting" {...this.props} />} />,
+      <Route path={this.props.url.tutorials} key="tutorials" 
+        render={props => <HelpTutorials key="tutorials" {...this.props} />} />,
+      <Route path={this.props.url.features} key="features" 
+        render={props => <HelpFeatures key="features" {...this.props} />} />,
+      <Route path={this.props.url.setup} key="setup" 
+        render={props => <HelpSetup key="setup" {...this.props} />} />,
+    ]        
+  }
+}
+
+class Help extends Component {
+  render() {
+    return [
+      <Row key="header"><Col md={8}><h1>Using Renku</h1></Col></Row>,
+      <Row key="spacePre"><Col xs={12}>&nbsp;</Col></Row>,
+      <Row key="nav"><Col xs={12}><HelpNav {...this.props} /></Col></Row>,
+      <Row key="spacePost"><Col xs={12}>&nbsp;</Col></Row>,
+      <Row key="content"><Col md={8}><HelpContent {...this.props} /></Col></Row>,
+    ];
+  }
+}
+
+export { Help }

--- a/src/help/index.js
+++ b/src/help/index.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2018 - Swiss Data Science Center (SDSC)
+ * Copyright 2019 - Swiss Data Science Center (SDSC)
  * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
  * Eidgenössische Technische Hochschule Zürich (ETHZ).
  *
@@ -19,11 +19,10 @@
 /**
  *  renku-ui
  *
- *  landing
- *  Components for the landing page
+ *  help
+ *  Components for the help page
  */
 
-import Landing from './Landing';
-import { LoggedInNavBar, AnonymousNavBar, FooterNavbar } from './NavBar';
+import { Help } from './Help.container';
 
-export { Landing, LoggedInNavBar, AnonymousNavBar, FooterNavbar };
+export default Help;

--- a/src/landing/NavBar.css
+++ b/src/landing/NavBar.css
@@ -1,0 +1,4 @@
+.footer .navbar .nav-link {
+    padding: 0.5rem;
+    white-space: nowrap;
+}

--- a/src/landing/NavBar.js
+++ b/src/landing/NavBar.js
@@ -25,6 +25,7 @@
 
 import React, { Component } from 'react';
 import { Link }  from 'react-router-dom'
+import { Navbar, NavLink, Nav } from 'reactstrap';
 
 import FontAwesomeIcon from '@fortawesome/react-fontawesome'
 import faPlus from '@fortawesome/fontawesome-free-solid/faPlus'
@@ -34,6 +35,7 @@ import { RenkuNavLink } from '../utils/UIComponents'
 import { getActiveProjectId } from '../utils/HelperFunctions'
 import QuickNav from '../utils/quicknav'
 
+import './NavBar.css';
 
 class RenkuToolbarItemUser extends Component {
   render() {
@@ -51,6 +53,7 @@ class RenkuToolbarItemUser extends Component {
         </a>
         <div key="menu" className="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
           <a className="dropdown-item" href="/auth/realms/Renku/account?referrer=renku-ui">Profile</a>
+          <Link className="dropdown-item" to="/help">Help</Link>
           <a
             className="dropdown-item"
             href={`${gatewayURL}/auth/logout?redirect_url=${redirect_url}`}
@@ -169,4 +172,26 @@ class AnonymousNavBar extends Component {
   }
 }
 
-export { LoggedInNavBar, AnonymousNavBar }
+class FooterNavbar extends Component {
+  render() {
+    return (
+      <footer className="footer">
+        <Navbar className="flex-nowrap">
+          <span>&copy; SDSC {(new Date()).getFullYear()}</span>
+          <Nav className="ml-auto">
+            <Link className="nav-link" to="/">
+              <img src={logo} alt="Renku" height="21" />
+            </Link>
+          </Nav>
+          <Nav className="ml-auto">
+            <RenkuNavLink to="/help" title="Help"/>
+            <NavLink target="_blank" href="https://gitter.im/SwissDataScienceCenter/renku">Gitter</NavLink>
+            <NavLink target="_blank" href="https://datascience.ch/who-we-are/">About</NavLink>
+          </Nav>
+        </Navbar>
+      </footer>
+    )
+  }
+}
+
+export { LoggedInNavBar, AnonymousNavBar, FooterNavbar }


### PR DESCRIPTION
Added a new help page with 4 tabs, with routing path `/help*`.
Re-implemented the footer as a `NavBar` and moved to `/landing` folder along with the top navbar.
Added links to help page in the footer and in the user menu.

closes #382 