### PR TITLE
Logout and redirect to login when jupyterhub token expires

### DIFF
--- a/src/api-client/index.js
+++ b/src/api-client/index.js
@@ -26,7 +26,6 @@ import addUserMethods  from './user';
 import addKuMethods  from './ku';
 import addInstanceMethods from './instance';
 import addNotebookServersMethods from './notebook-servers';
-
 import testClient from './test-client'
 
 const ACCESS_LEVELS = {
@@ -74,9 +73,11 @@ class APIClient {
       .catch((error) => {
 
         // For permission errors we send the user to login
-        // TODO: forbidden should not be included here, but test further
-        if (error.case === API_ERRORS.unauthorizedError) {
-          return this.doLogin()
+        if (error.case === API_ERRORS.unauthorizedError){
+          //TODO: when jupyterhub has refresh tokens we should remove the following if and return promise.
+          if( error.response && error.response.url && error.response.url.includes("/api/notebooks"))
+            return Promise.reject(error);
+          return this.doLogin();
         }
 
         // Alert only if corresponding option is set to true
@@ -117,6 +118,10 @@ class APIClient {
 
   doLogin() {
     window.location = `${this.baseUrl}/auth/login?redirect_url=${encodeURIComponent(window.location.href)}`;
+  }
+
+  doLogout(){
+    window.location=`${this.baseUrl}/auth/logout?redirect_url=${encodeURIComponent(window.location.href)}`
   }
 
   getBasicHeaders() {

--- a/src/file/File.present.js
+++ b/src/file/File.present.js
@@ -83,6 +83,9 @@ class LaunchNotebookButton extends React.Component {
       .then(response => {
         const serverStatus = !(!response.data.pending && !response.data.ready);
         this.setState({serverRunning: serverStatus})
+      })
+      .catch(e => {
+        console.log("Unexpected error in LaunchNotebook button", e)
       });
     this.previousNotebookServerAPI = this.props.notebookServerAPI;
   }

--- a/src/notebooks/Notebooks.present.js
+++ b/src/notebooks/Notebooks.present.js
@@ -24,6 +24,44 @@ import { ACCESS_LEVELS } from '../api-client';
 
 import { Loader, ExternalLink } from '../utils/UIComponents'
 
+class LogOutUser extends Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      timer: null,
+      logedout: false
+    }
+  }
+
+  componentWillUnmount() {
+    this.state.timer.clear()
+  }
+
+  componentDidMount() {
+    this.setState({
+      timer: setTimeout(() => {
+        this.setState({ logedout: true });
+        this.props.client.doLogout();
+      }, 6000)
+    });
+  }
+
+  render() {
+    return (
+      this.state.logedout ?
+        <Col md={8}>We logged you out.</Col>
+        :
+        <Col md={{ size: 6, offset: 3 }}>
+          <p align="center">You will be logged out because your JupyterLab token expired.
+            <br /> Please log in again to continue working with Renku.
+          </p>
+          <Loader />
+        </Col>
+    )
+  }
+}
+
 class RenderedServerOptions extends Component {
   render() {
     if (this.props.loader) {
@@ -196,8 +234,8 @@ class NotebookServers extends Component {
     return <div>
       <NotebookServersList {...this.props} />
       <NotebookServersLaunch {...this.props} />
-    </div> 
+    </div>
   }
 }
 
-export { NotebookServerOptions, NotebookServers }
+export { NotebookServerOptions, NotebookServers, LogOutUser }


### PR DESCRIPTION
This addresses the bug #370 (It solves the problem following the instructions that @ableuler describes in the bug) This is a way of "fake-replicating" the bug so we can't be 100% sure that it will work, but it should.