### PR TITLE
fixed navigation for anonymous users

### DIFF
--- a/src/api-client/index.js
+++ b/src/api-client/index.js
@@ -66,14 +66,15 @@ class APIClient {
     url,
     options={headers: new Headers()},
     returnType=RETURN_TYPES.json,
-    alertOnErr=false
+    alertOnErr=false,
+    reLogin=true
   ) {
 
     return renkuFetch(url, options)
       .catch((error) => {
 
         // For permission errors we send the user to login
-        if (error.case === API_ERRORS.unauthorizedError){
+        if (reLogin && error.case === API_ERRORS.unauthorizedError){
           //TODO: when jupyterhub has refresh tokens we should remove the following if and return promise.
           if( error.response && error.response.url && error.response.url.includes("/api/notebooks"))
             return Promise.reject(error);

--- a/src/api-client/user.js
+++ b/src/api-client/user.js
@@ -16,15 +16,17 @@
  * limitations under the License.
  */
 
- 
+import { RETURN_TYPES } from './utils';
+
+
 function addUserMethods(client) {
   client.getUser = () => {
     let headers = client.getBasicHeaders();
     return client.clientFetch(`${client.baseUrl}/user`, {
       method: 'GET',
       headers: headers
-    })
-
+    },
+    RETURN_TYPES.json, false, false)
   }
 }
 

--- a/src/project/Project.js
+++ b/src/project/Project.js
@@ -52,8 +52,13 @@ class View extends Component {
 
   componentDidMount() {
     this.fetchAll();
-    // TODO Simplify this method to just fetch basic project information.
-    // this.fetchProject();
+  }
+
+  componentDidUpdate(prevProps, prevState, snapshot) {
+    // re-fetch when user login data are available
+    if (!prevProps.user && this.props.user) {
+      this.fetchAll();
+    }
   }
 
   async fetchProject() { return this.projectState.fetchProject(this.props.client, this.props.id); }
@@ -69,7 +74,9 @@ class View extends Component {
 
   async fetchAll() {
     await this.fetchProject();
-    this.fetchCIJobs();
+    if (this.props.user) {
+      this.fetchCIJobs();
+    }
   }
 
   getStarred(user, projectId) {

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -204,6 +204,11 @@ class ProjectViewHeader extends Component {
 class ProjectNav extends Component {
 
   render() {
+    const notebookServers = this.props.user ?
+      <NavItem>
+        <RenkuNavLink exact={false} to={this.props.notebookServersUrl} title="Notebook Servers" />
+      </NavItem>:
+      null
     return (
       <Nav pills className={'nav-pills-underline'}>
         <NavItem>
@@ -218,9 +223,7 @@ class ProjectNav extends Component {
         <NavItem>
           <RenkuNavLink exact={false} to={this.props.mrOverviewUrl} title="Pending Changes" />
         </NavItem>
-        <NavItem>
-          <RenkuNavLink exact={false} to={this.props.notebookServersUrl} title="Notebook Servers" />
-        </NavItem>
+        {notebookServers}
         <NavItem>
           <RenkuNavLink exact={false} to={this.props.settingsUrl} title="Settings" />
         </NavItem>


### PR DESCRIPTION
Users who were not logged in were mistakenly redirected to login page even when they shouldn't (e.g. navigate thorough a public project).

Preview available at https://lorenzotest.dev.renku.ch
Example of public repo: https://lorenzotest.dev.renku.ch/projects/72/
If login is triggered, be sure to clean browser cache/cookies