### PR TITLE
Knowledge graph warning for new projects fixed

### DIFF
--- a/src/project/new/ProjectNew.present.js
+++ b/src/project/new/ProjectNew.present.js
@@ -34,6 +34,9 @@ import { Button, FormGroup, FormText, Label } from 'reactstrap';
 import { Input, InputGroup, InputGroupAddon, InputGroupText } from 'reactstrap';
 import { Alert } from 'reactstrap';
 
+import FontAwesomeIcon from '@fortawesome/react-fontawesome'
+import { faInfoCircle, faExternalLinkAlt } from '@fortawesome/fontawesome-free-solid'
+
 import collection from 'lodash/collection';
 import { FieldGroup, Loader } from '../../utils/UIComponents'
 import './Project.style.css';
@@ -193,9 +196,15 @@ class DataVisibility extends Component {
       <option key={v.value} value={v.value}>{v.name}</option>
     )
     let warningPrivate = null;
-    if (this.props.value === "private") {
-      warningPrivate = <FormText color="danger">
-        The Knowledge Graph may make some metadata public; the contents will remain private.
+    if (this.props.value !== "public") {
+      warningPrivate = <FormText color="primary">
+        <FontAwesomeIcon icon={faInfoCircle} /> The Knowledge Graph may make some metadata public;
+        the contents will remain private.
+        <br />
+        <a href="https://renku.readthedocs.io/en/latest/introduction/lineage.html"
+          target="_blank" rel="noopener noreferrer">
+          <FontAwesomeIcon icon={faExternalLinkAlt} /> Read more about Lineage.
+        </a>
       </FormText>;
     }
     return <FormGroup>


### PR DESCRIPTION
closes #417 

The warning now appears also for internal projects and it should be more clear that it's not an error.
A link to the lineage page in the docs is provided.

This is the "new project" page

![Screenshot from 2019-04-03 13-10-36](https://user-images.githubusercontent.com/43481553/55474658-05e7fb00-5612-11e9-94f4-766816c362b6.png)

Temporarily test link: https://lorenzotest.dev.renku.ch/
It's a bit fancy compared to the previous solution, let me know if you like it or not.