### PR TITLE
fix tooltip positioning

### DIFF
--- a/src/file/File.container.js
+++ b/src/file/File.container.js
@@ -39,6 +39,7 @@ class JupyterNotebookContainer extends Component {
       notebookServerUrl={this.props.notebookServerUrl}
       notebookServerAPI={this.props.notebookServerAPI}
       client={this.props.client}
+      user={this.props.user}
     />
   }
 }

--- a/src/file/File.present.js
+++ b/src/file/File.present.js
@@ -98,14 +98,17 @@ class LaunchNotebookButton extends React.Component {
     const className = props.className;
 
     // Create a tooltip that will explain the deactivated button
+    const message = this.props.user && this.props.user.id ?
+      "You have to launch Jupyter in Notebook Servers":
+      "Please login to open notebooks"
     const tooltip = this.state.serverRunning ? null :
       <Tooltip
         id="JupyterButtonTooltip"
-        target="createPlus"
-        placement="bottom"
+        target="tooltipButton"
+        placement="top"
         isOpen={this.state.showTooltip}
       >
-        You have to launch Jupyter first!
+        {message}
       </Tooltip>
 
     const externalUrl = this.props.deploymentUrl || this.props.notebookServerUrl;
@@ -148,6 +151,7 @@ const JupyterNotebookPresent = props => {
           notebookServerAPI={props.notebookServerAPI}
           client={props.client}
           label="Open Notebook"
+          user={props.user}
         />
       </Col>
     </Row>,


### PR DESCRIPTION
The `Tooltip` displayed by `LaunchNotebookButton` is crashing the UI when an anonymous user tries to preview a notebook file, as pointed out by @cchoirat . This PR fixes this problem by attaching the `Tooltip` to `LaunchNotebookButton` button instead of the plus icon on top NavBar which is not available when not logged id.

It also fixes the message
* Anonymous users can't start a Jupiter server, should be prompted to log in
* Logged users can now start Jupiter server from the `Notebook Servers` tab, not from the plus icon