### PR TITLE
fix jupyterhub API

### DIFF
--- a/src/api-client/index.js
+++ b/src/api-client/index.js
@@ -78,11 +78,6 @@ class APIClient {
 
         // For permission errors we send the user to login
         if (reLogin && error.case === API_ERRORS.unauthorizedError){
-          //TODO: when jupyterhub has refresh tokens we should remove the following if and return promise.
-          if( error.response && error.response.url && error.response.url.includes("/api/notebooks"))
-            return Promise.reject(error);
-            // TODO: instead of rejecting, redirect to a new page with short explanation and logout after a countdown
-            // return this.doLogout();
           return this.doLogin();
         }
 
@@ -96,7 +91,6 @@ class APIClient {
         else {
           return Promise.reject(error);
         }
-
       })
 
       .then(response => {


### PR DESCRIPTION
Closes #424 

Preview available at https://lorenzotest.dev.renku.ch

Please try it to be sure the problem solved by #404 doesn't come back.
If you wan't to play with rancher to try to generate 401 responses, the `lorenzotest` namespace is in the `UI-team` folder.