### PR TITLE
Verify lineage availability when browsing files

### DIFF
--- a/src/api-client/graph.js
+++ b/src/api-client/graph.js
@@ -51,8 +51,16 @@ function addGraphMethods(client) {
     });
   }
 
+  client.checkGraphStatus = (projectId) => {
+    const url = `${client.baseUrl}/projects/${projectId}/graph/status`;
+    const headers = client.getBasicHeaders();
+    return client.clientFetch(url, {method:'GET', headers}).then((resp) => {
+      return resp.data;
+    });
+  }
+
   client.getFileLineage = (projectPath, commit, filePath) => {
-    let headers = client.getBasicHeaders();
+    const headers = client.getBasicHeaders();
     return client.clientFetch(
       `${client.baseUrl}/graph/${projectPath}/lineage/${commit}/${filePath}`,
       {

--- a/src/file/Lineage.present.js
+++ b/src/file/Lineage.present.js
@@ -24,11 +24,13 @@ import * as d3 from 'd3';
 
 import { Link}  from 'react-router-dom';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
-import faFile from '@fortawesome/fontawesome-free-solid/faFile';
+import { faInfoCircle, faFile } from '@fortawesome/fontawesome-free-solid'
 import faGitlab from '@fortawesome/fontawesome-free-brands/faGitlab';
-import { Card, CardHeader, CardBody, UncontrolledTooltip, Badge } from 'reactstrap';
+import { Card, CardHeader, CardBody, UncontrolledTooltip, Badge, Button, Alert, Progress } from 'reactstrap';
 
-import {  JupyterNotebook } from './File.container';
+import { Loader } from '../utils/UIComponents';
+import { JupyterNotebook } from './File.container';
+import { GraphIndexingStatus } from '../project/Project';
 
 import './Lineage.css';
 
@@ -110,6 +112,65 @@ class FileLineageGraph extends Component {
 
 class FileLineage extends Component {
   render() {
+    const {progress, webhookJustCreated} = this.props;
+    if (progress == null) {
+      return (
+        <Loader />
+      )
+    }
+    if (progress === GraphIndexingStatus.NO_WEBHOOK) {
+      if (webhookJustCreated) {
+        return (
+          <Alert color="warning">
+            Knowledge Graph activated! Lineage computation starting soon...
+          </Alert>
+        )
+      }
+      else {
+        const action = this.props.maintainer ?
+          <Button color="warning" onClick={this.props.createWebhook}>Activate Knowledge Graph</Button> :
+          <span>You do not have sufficient rights, but a project owner can do this.</span>
+
+        return (
+          <Alert color="warning">
+            Knowledge Graph integration must be activated to view the lineage.&nbsp;
+            {action}
+          </Alert>
+        )
+      }
+    }
+    else if (progress === GraphIndexingStatus.NO_PROGRESS) {
+      let forkedInfo = null;
+      if (this.props.forked) {
+        forkedInfo = (
+          <div>
+            <br />
+            <FontAwesomeIcon icon={faInfoCircle} /> <span className="font-italic">If you recenty forked
+            this project, the graph integration will not finish until you create at least one commit.</span>
+          </div>
+        );
+      }
+      return (
+        <div>
+          <Alert color="primary">
+            Please wait, Knowledge Graph integration recently triggered.
+            {forkedInfo}
+          </Alert>
+          <Loader />
+        </div>
+      )
+    }
+    else if (progress >= GraphIndexingStatus.MIN_VALUE && progress < GraphIndexingStatus.MAX_VALUE) {
+      return (
+        <div>
+          <Alert color="primary">
+            <p>Knowledge Graph is building... {parseInt(progress)}%</p>
+            <Progress value={progress} />
+          </Alert>
+        </div>
+      )
+    }
+
     const graphObj = this.props.graph;
     const graph = (graphObj) ?
       <FileLineageGraph path={this.props.path} graph={graphObj} /> :

--- a/src/model/RenkuModels.js
+++ b/src/model/RenkuModels.js
@@ -132,7 +132,8 @@ const projectSchema = new Schema({
       status: {initial: null},
       created: {initial: null},
       possible: {initial: null},
-      stop: {initial: null}
+      stop: {initial: null},
+      progress: {initial: null}
     }
   },
   notebooks: {

--- a/src/project/Project.js
+++ b/src/project/Project.js
@@ -29,7 +29,7 @@ import { connect } from 'react-redux'
 import { StateKind } from '../model/Model';
 import Present from './Project.present'
 
-import { ProjectModel } from './Project.state'
+import { ProjectModel, GraphIndexingStatus } from './Project.state'
 import Ku from '../ku/Ku'
 import { FileLineage } from '../file'
 import { ACCESS_LEVELS } from '../api-client';
@@ -75,11 +75,12 @@ class View extends Component {
   }
   async stopNotebookServersPolling() { return this.projectState.stopNotebookServersPolling(); }
   async stopNotebookServer(serverName) { return this.projectState.stopNotebookServer(this.props.client, serverName); }
-  async createGraphWebhook() { this.projectState.createGraphWebhook(this.props.client, this.props.id); }
+  async createGraphWebhook() { return this.projectState.createGraphWebhook(this.props.client, this.props.id); }
   async stopCheckingWebhook() { this.projectState.stopCheckingWebhook(); }
-  async fetchGraphWebhook() { this.projectState.fetchGraphWebhook(this.props.client, this.props.id, this.props.user) }
+  async fetchGraphWebhook() { this.projectState.fetchGraphWebhook(this.props.client, this.props.id, this.props.user); }
   async fetchProjectFilesTree() { return this.projectState.fetchProjectFilesTree(this.props.client, this.props.id , this.cleanCurrentURL() ); }
-  async setProjectOpenFolder(client, id ,filepath) {this.projectState.setProjectOpenFolder(this.props.client, this.props.id ,filepath);}
+  async setProjectOpenFolder(filepath) { this.projectState.setProjectOpenFolder(this.props.client, this.props.id, filepath); }
+  async fetchGraphStatus() { return this.projectState.fetchGraphStatus(this.props.client, this.props.id); }
 
   async fetchAll() {
     await this.fetchProject();
@@ -98,6 +99,7 @@ class View extends Component {
       return this.props.location.pathname.replace(this.props.match.projectPath,"").replace(this.subUrls().lineagesUrl,"").replace(this.subUrls().fileContentUrl,"");
   }
 
+  // TODO: move all .set actions to Project.state.js
   checkGraphWebhook() {
     // check if data are available -- may remove this?
     if (this.projectState.get('core.available') !== true) {
@@ -193,12 +195,19 @@ class View extends Component {
     const notebookServerUrl = this.projectState.get('core.notebookServerUrl');
     const notebookServerAPI = this.projectState.get('core.notebookServerAPI');
     const filesTree = this.projectState.get('filesTree');
+    const graphProgress = this.projectState.get('webhook.progress');
+    const mergeRequests = this.projectState.get('system.merge_requests');
+    const maintainer = this.projectState.get('visibility.accessLevel') >= ACCESS_LEVELS.MAINTAINER ?
+      true :
+      false;
+    const forkedData = this.projectState.get('system.forked_from_project');
+    const forked = (forkedData != null && Object.keys(forkedData).length > 0) ?
+      true :
+      false;
 
     // Access to the project state could be given to the subComponents by connecting them here to
     // the projectStore. This is not yet necessary.
     const subProps = {...ownProps, projectId, accessLevel, externalUrl, notebookServerUrl, notebookServerAPI, filesTree};
-
-    const mergeRequests = this.projectState.get('system.merge_requests');
 
     const mapStateToProps = (state, ownProps) => {
       return {
@@ -226,6 +235,9 @@ class View extends Component {
         path={p.match.params.filePath}
         notebook={"Notebook"}
         accessLevel={accessLevel}
+        progress={graphProgress}
+        maintainer={maintainer}
+        forked={forked}
         hashElement={filesTree !== undefined ? filesTree.hash[p.match.params.filePath] : undefined} />,
 
       fileView: (p) => <ShowFile
@@ -299,7 +311,7 @@ class View extends Component {
       //this.fetchModifiedFiles();
     },
     setOpenFolder: (filePath) => { 
-      this.setProjectOpenFolder(this.props.client, this.props.id, filePath);
+      this.setProjectOpenFolder(filePath);
     },
     fetchCIJobs: () => { this.fetchCIJobs() },
     startNotebookServersPolling: () => {
@@ -313,10 +325,13 @@ class View extends Component {
     },
     createGraphWebhook: (e) => { 
       e.preventDefault();
-      this.createGraphWebhook();
+      return this.createGraphWebhook();
     },
     onCloseGraphWebhook: () => {
       this.stopCheckingWebhook();
+    },
+    fetchGraphStatus: () => {
+      return this.fetchGraphStatus();
     }
   };
 
@@ -353,3 +368,4 @@ class View extends Component {
 }
 
 export default { New, View, List };
+export { GraphIndexingStatus };


### PR DESCRIPTION
Closes #451 

While browsing a project's `File` tab, the graph is now displayed only if the lineage is available. Otherwise, the user gets a notification depending on the current status:
* Project needs to be indexed
* Project indexing has just been re-triggered
* Indexing is currently ongoing

This can be tested here https://lorenzotest.dev.renku.ch

There is an annoying issue at the moment: when a project is forked on Gitlab and the webhook is created, no Push Event is returned by Gitlab, therefore the knowledge graph is never built correctly. (TODO: Add reference to SwissDataScienceCenter/renku-graph issue)

