### PR TITLE
wrong node highlited in lineage visualization

### DIFF
--- a/src/file/Lineage.present.js
+++ b/src/file/Lineage.present.js
@@ -58,7 +58,7 @@ class FileLineageGraph extends Component {
       .setDefaultEdgeLabel(function(){ return {}; });
 
     graph.nodes.forEach(node => {
-      if (node.id.includes(this.props.path)) {
+      if (node.id.endsWith(`/${this.props.path}`)) {
         graph.centralNode = node.id;
       }
     })


### PR DESCRIPTION
The node highlighted in bold on the lineage graph is sometimes wrong when there are several files with similar names, like `data`, `data1`, `dat`.

This fixes the issue. Example:
Before: https://dev.renku.ch/projects/113/files/lineage/data2/
Later: https://lorenzotest.dev.renku.ch/projects/113/files/lineage/data2/