### PR TITLE
opt-out from knowledge graph for new private projects

### DIFF
--- a/src/api-client/project.js
+++ b/src/api-client/project.js
@@ -128,8 +128,10 @@ function addProjectMethods(client) {
       body: JSON.stringify(gitlabProject)
     })
       .then(resp => {
-        createGraphWebhookPromise = client.createGraphWebhook(resp.data.id);
-        return resp.data
+        if (!renkuProject.meta.optoutKg) {
+          createGraphWebhookPromise = client.createGraphWebhook(resp.data.id);
+        }
+        return resp.data;
       });
 
     // When the provided version does not exist, we log an error and uses latest.
@@ -142,7 +144,11 @@ function addProjectMethods(client) {
         return getPayload(gitlabProject.name, 'latest')
       });
 
-    return Promise.all([newProjectPromise, payloadPromise, createGraphWebhookPromise])
+    let promises = [newProjectPromise, payloadPromise];
+    if (createGraphWebhookPromise) {
+      promises = promises.concat(createGraphWebhookPromise);
+    }    
+    return Promise.all(promises)
       .then(([data, payload]) => {
         if (data.errorData)
           return Promise.reject(data);

--- a/src/model/RenkuModels.js
+++ b/src/model/RenkuModels.js
@@ -36,6 +36,7 @@ const metaSchema = new Schema({
   // author: {schema: userSchema, mandatory: false},
   projectNamespace: {initial: {}, mandatory: false},
   visibility: {initial: 'public', mandatory: true},
+  optoutKg: {initial: false, mandatory: false},
 });
 
 const displaySchema = new Schema({

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -40,7 +40,8 @@ import { Card, CardBody, CardHeader } from 'reactstrap';
 
 import FontAwesomeIcon from '@fortawesome/react-fontawesome'
 import faStarRegular from '@fortawesome/fontawesome-free-regular/faStar'
-import { faStar as faStarSolid, faInfoCircle } from '@fortawesome/fontawesome-free-solid'
+import { faStar as faStarSolid, faInfoCircle, faExternalLinkAlt } from '@fortawesome/fontawesome-free-solid'
+import { faExclamationTriangle } from '@fortawesome/fontawesome-free-solid'
 
 import { ExternalLink, Loader, RenkuNavLink, TimeCaption} from '../utils/UIComponents'
 import { InfoAlert, SuccessAlert, WarnAlert, ErrorAlert } from '../utils/UIComponents'
@@ -192,9 +193,14 @@ class KnowledgeGraphPrivateWarning extends Component {
     if (!this.props.isPrivate) return null;
     return (
       <p className="font-italic">
-        <span className="font-weight-bold">WARNING! </span>
-        This is a private project. Though contents remain private, the Knowledge Graph may make some metadata public;
-        only activate if that is acceptable.
+        {/* <span className="font-weight-bold">WARNING! </span> */}
+        <FontAwesomeIcon icon={faExclamationTriangle} /> This is a private project. Though contents remain private,
+        the Knowledge Graph may make some metadata public; only activate if that is acceptable.
+        <br />
+        <a href="https://renku.readthedocs.io/en/latest/user/knowledge-graph.html"
+          target="_blank" rel="noopener noreferrer">
+          <FontAwesomeIcon icon={faExternalLinkAlt} /> Read more about the Knowledge Graph integration.
+        </a>
       </p>
     )
   }

--- a/src/project/new/ProjectNew.container.js
+++ b/src/project/new/ProjectNew.container.js
@@ -64,6 +64,7 @@ class New extends Component {
       onTitleChange: this.onTitleChange.bind(this),
       onDescriptionChange: this.onDescriptionChange.bind(this),
       onVisibilityChange: this.onVisibilityChange.bind(this),
+      onOptoutKgChange: this.onOptoutKgChange.bind(this),
       onProjectNamespaceChange: this.onProjectNamespaceChange.bind(this),
       onProjectNamespaceAccept: this.onProjectNamespaceAccept.bind(this),
       fetchMatchingNamespaces: this.fetchMatchingNamespaces.bind(this)
@@ -136,10 +137,22 @@ class New extends Component {
   }
 
   onDescriptionChange(e) { this.newProject.set('display.description', e.target.value); }
-  onVisibilityChange(e) { this.newProject.set('meta.visibility', e.target.value); }
+  
+  onVisibilityChange(e) {
+    this.newProject.set('meta.visibility', e.target.value);
+    if (e.target.value !== "private") {
+      this.newProject.set('meta.optoutKg', false);
+    }
+  }
+
+  onOptoutKgChange(e) {
+    this.newProject.set('meta.optoutKg', e.target.checked);
+  }
+
   onProjectNamespaceChange(value) {
     this.newProject.set('meta.projectNamespace', value);
   }
+
   onProjectNamespaceAccept() {
     const namespace = this.newProject.get('meta.projectNamespace');
     if (namespace.kind !== 'group') {

--- a/src/project/new/ProjectNew.present.js
+++ b/src/project/new/ProjectNew.present.js
@@ -195,26 +195,41 @@ class DataVisibility extends Component {
     const options = visibilities.map(v =>
       <option key={v.value} value={v.value}>{v.name}</option>
     )
-    let warningPrivate = null;
-    if (this.props.value !== "public") {
-      warningPrivate = <FormText color="primary">
-        <FontAwesomeIcon icon={faInfoCircle} /> The Knowledge Graph may make some metadata public;
-        the contents will remain private.
-        <br />
-        <a href="https://renku.readthedocs.io/en/latest/introduction/lineage.html"
-          target="_blank" rel="noopener noreferrer">
-          <FontAwesomeIcon icon={faExternalLinkAlt} /> Read more about Lineage.
-        </a>
-      </FormText>;
+    let content = [
+      <FormGroup key="visibility">
+        <Label>Visibility</Label>
+        <Input type="select" placeholder="visibility"
+          value={this.props.visibilityValue}
+          onChange={this.props.onVisibilityChange} >
+          {options}
+        </Input>
+        <FormText color="muted">{vizExplanation}</FormText>
+      </FormGroup>
+    ]
+    if (this.props.visibilityValue === "private") {
+      const optout = (
+        <FormGroup key="optout">
+          <Label check style={{marginLeft:"1.25rem"}}>
+            <Input type="checkbox" id="myCheckbox"
+              value={this.props.optoutKgValue}
+              onChange={this.props.onOptoutKgChange} />
+            Opt-out from Knowledge Graph
+          </Label>
+          <FormText color="primary">
+            <FontAwesomeIcon icon={faInfoCircle} /> The Knowledge Graph may make some metadata public,
+            opt-out if this is not acceptable.
+            <br />
+            <a href="https://renku.readthedocs.io/en/latest/user/knowledge-graph.html"
+              target="_blank" rel="noopener noreferrer">
+              <FontAwesomeIcon icon={faExternalLinkAlt} /> Read more about the Knowledge Graph integration.
+            </a>
+          </FormText>
+        </FormGroup>
+      )
+      content = content.concat(optout);
     }
-    return <FormGroup>
-      <Label>Visibility</Label>
-      <Input type="select" placeholder="visibility" value={this.props.value} onChange={this.props.onChange}>
-        {options}
-      </Input>
-      {warningPrivate}
-      <FormText color="muted">{vizExplanation}</FormText>
-    </FormGroup>
+
+    return content;
   }
 }
 
@@ -243,9 +258,11 @@ class ProjectNew extends Component {
             onAccept={this.props.handlers.onProjectNamespaceAccept}
             fetchMatchingNamespaces={this.props.handlers.fetchMatchingNamespaces} />
           <DataVisibility
-            value={this.props.model.meta.visibility}
             visibilities={this.props.visibilities}
-            onChange={this.props.handlers.onVisibilityChange} />
+            visibilityValue={this.props.model.meta.visibility}
+            optoutKgValue={this.props.model.meta.optoutKg}
+            onVisibilityChange={this.props.handlers.onVisibilityChange}
+            onOptoutKgChange={this.props.handlers.onOptoutKgChange} />
           <br/>
           <SubmitErrors errors={this.props.model.display.errors} />
           <Button color="primary" onClick={this.props.handlers.onSubmit} disabled={this.props.model.display.loading}>


### PR DESCRIPTION
Adds the possibility to opt-out from Knowledge Graph when creating a new project with `private` visibility.

Test available at https://lorenzotest.dev.renku.ch