### PR TITLE
fix: the interval of the notebook server is lowered when servers are ready

### DIFF
--- a/src/project/Project.js
+++ b/src/project/Project.js
@@ -29,7 +29,7 @@ import { connect } from 'react-redux'
 import { StateKind } from '../model/Model';
 import Present from './Project.present'
 
-import { ProjectModel, GraphIndexingStatus } from './Project.state'
+import { ProjectModel, GraphIndexingStatus, PollingInterval } from './Project.state'
 import Ku from '../ku/Ku'
 import { FileLineage } from '../file'
 import { ACCESS_LEVELS } from '../api-client';
@@ -71,7 +71,7 @@ class View extends Component {
   async fetchBranches() { return this.projectState.fetchBranches(this.props.client, this.props.id); }
   async fetchCIJobs() { return this.projectState.fetchCIJobs(this.props.client, this.props.id); }
   async startNotebookServersPolling() {
-    return this.projectState.startNotebookServersPolling(this.props.client, this.props.id);
+    return this.projectState.startNotebookServersPolling(this.props.client, this.props.id,PollingInterval.START);
   }
   async stopNotebookServersPolling() { return this.projectState.stopNotebookServersPolling(); }
   async stopNotebookServer(serverName) { return this.projectState.stopNotebookServer(this.props.client, serverName); }


### PR DESCRIPTION
The intervals of the notebook server start at 3000,
when the servers are all ready the polling is set to 6000
if they are unready again for reason they are seat to 3000 again.

On top of that, if there are no servers all the polling stops.