### PR TITLE
feat: button to fork a project

### DIFF
--- a/src/model/RenkuModels.js
+++ b/src/model/RenkuModels.js
@@ -53,6 +53,25 @@ const newProjectSchema = new Schema({
   display: {schema: displaySchema, mandatory: true}
 });
 
+const forkDisplaySchema = new Schema({
+  title: {initial:'', mandatory: true},
+  description: {initial: '', mandatory: true},
+  displayId: {initial: '', mandatory: false},
+  slug: {initial: '', mandatory: true},
+  loading: {initial: false, mandatory: false},
+  errors: {initial: [], mandatory: false},
+
+  statuses: {initial: []},
+  namespaces: {initial: []},
+  namespaceGroup: {initial: null},
+  namespacesFetched: {initial: false}
+})
+
+const forkProjectSchema = new Schema({
+  meta: {schema: metaSchema, mandatory: true},
+  display: {schema: forkDisplaySchema, mandatory: true}
+});
+
 const projectSchema = new Schema({
   core: {
     schema: {
@@ -139,4 +158,4 @@ const projectSchema = new Schema({
   }
 });
 
-export { userSchema, metaSchema, displaySchema, newProjectSchema, projectSchema };
+export { userSchema, metaSchema, displaySchema, newProjectSchema, projectSchema, forkProjectSchema };

--- a/src/project/Project.js
+++ b/src/project/Project.js
@@ -39,6 +39,7 @@ import { MergeRequest, MergeRequestList } from '../merge-request';
 import List from './list';
 import New from './new';
 import { ShowFile } from '../file/File.present';
+import Fork from './fork';
 
 // TODO: This component has grown too much and needs restructuring. One option would be to insert
 // TODO: another container component between this top-level project component and the presentational
@@ -204,10 +205,10 @@ class View extends Component {
     const forked = (forkedData != null && Object.keys(forkedData).length > 0) ?
       true :
       false;
-
+    const forkModalOpen = this.projectState.get('forkModalOpen');
     // Access to the project state could be given to the subComponents by connecting them here to
     // the projectStore. This is not yet necessary.
-    const subProps = {...ownProps, projectId, accessLevel, externalUrl, notebookServerUrl, notebookServerAPI, filesTree};
+    const subProps = {...ownProps, projectId, accessLevel, externalUrl, notebookServerUrl, notebookServerAPI, filesTree, forkModalOpen};
 
     const mapStateToProps = (state, ownProps) => {
       return {
@@ -253,7 +254,17 @@ class View extends Component {
       mrView: (p) => <MergeRequest
         key="mr" {...subProps}
         iid={p.match.params.mrIid}
-        updateProjectState={this.fetchAll.bind(this)}/>
+        updateProjectState={this.fetchAll.bind(this)}/>,
+
+      fork: () => <Fork 
+        projectId={this.projectState.get('core.id')}
+        title={this.projectState.get('core.title')}
+        forkModalOpen={forkModalOpen} 
+        toogleForkModal={this.eventHandlers.toogleForkModal} 
+        history={this.props.history}
+        client={this.props.client} 
+        user={this.props.user} />
+
     }
   }
 
@@ -276,6 +287,10 @@ class View extends Component {
       const projectId = this.projectState.get('core.id') || parseInt(this.props.match.params.id, 10);
       const starred = this.getStarred(this.props.user, projectId);
       this.projectState.star(this.props.client, projectId, this.props.userStateDispatch, starred)
+    },
+    toogleForkModal: (e) => {
+      e.preventDefault();
+      this.projectState.toogleForkModal();
     },
     onCreateMergeRequest: (branch) => {
       const core = this.projectState.get('core');
@@ -332,6 +347,7 @@ class View extends Component {
     const externalUrl = this.projectState.get('core.external_url');
     const canCreateMR = state.visibility.accessLevel >= ACCESS_LEVELS.DEVELOPER;
     const imageBuild = this.getImageBuildStatus();
+    const forkModalOpen = this.projectState.get('forkModalOpen');
 
     return {
       ...this.projectState.get(),
@@ -339,6 +355,7 @@ class View extends Component {
       ...this.subUrls(),
       ...this.subComponents.bind(this)(internalId, ownProps),
       starred,
+      forkModalOpen,
       settingsReadOnly,
       suggestedMRBranches,
       externalUrl,

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -40,7 +40,7 @@ import { Card, CardBody, CardHeader } from 'reactstrap';
 
 import FontAwesomeIcon from '@fortawesome/react-fontawesome'
 import faStarRegular from '@fortawesome/fontawesome-free-regular/faStar'
-import { faStar as faStarSolid, faInfoCircle, faExternalLinkAlt } from '@fortawesome/fontawesome-free-solid'
+import { faStar as faStarSolid, faInfoCircle, faExternalLinkAlt, faCodeBranch } from '@fortawesome/fontawesome-free-solid'
 import { faExclamationTriangle, faLock , faUserFriends, faGlobe, faSearch } from '@fortawesome/fontawesome-free-solid'
 
 import { ExternalLink, Loader, RenkuNavLink, TimeCaption} from '../utils/UIComponents'
@@ -244,16 +244,18 @@ class ProjectViewHeaderOverview extends Component {
     const system = this.props.system;
     const starButtonText = this.props.starred ? 'unstar' : 'star';
     const starIcon = this.props.starred ? faStarSolid : faStarRegular;
+    const forkButtonText = 'fork';
+    const forkIcon = faCodeBranch
     return (
       <Container fluid>
         <Row>
-          <Col xs={12} md={9}>
+          <Col xs={12} md={6}>
             <h3>{core.title} <ProjectVisibilityLabel visibilityLevel={this.props.visibility.level}/></h3>
             <p>
               <span>{this.props.core.path_with_namespace}{forkedFrom}</span> <br />
             </p>
           </Col>
-          <Col xs={12} md={3}>
+          <Col xs={12} md={6}>
             <div className="d-flex flex-md-row-reverse">
               <div className={`fixed-width-${this.props.starred ? '120' : '100'}`}>
                 <form className="input-group input-group-sm">
@@ -264,6 +266,17 @@ class ProjectViewHeaderOverview extends Component {
                   </div>
                   <input className="form-control border-primary text-right"
                     placeholder={system.star_count} aria-label="starCount" readOnly={true} />
+                </form>
+              </div>
+              <div className={`fixed-width-100 pr-1`}>
+                <form className="input-group input-group-sm">
+                  <div className="input-group-prepend">
+                    <button className="btn btn-outline-primary" onClick={this.props.toogleForkModal}>
+                      <FontAwesomeIcon icon={forkIcon} /> {forkButtonText}
+                    </button>
+                  </div>
+                  <input className="form-control border-primary text-right"
+                    placeholder={system.forks_count} aria-label="starCount" readOnly={true} />
                 </form>
               </div>
             </div>
@@ -282,6 +295,7 @@ class ProjectViewHeaderOverview extends Component {
           </Col>
         </Row>
         <KnowledgeGraphIntegrationWarningBanner {...this.props} />
+        {this.props.fork(this.props)}
       </Container>
     )
   }

--- a/src/project/Project.state.js
+++ b/src/project/Project.state.js
@@ -271,6 +271,11 @@ class ProjectModel extends StateModel {
     })
   }
 
+  toogleForkModal() {
+    let forkModalOpen = this.get('forkModalOpen');
+    this.set("forkModalOpen" , forkModalOpen === undefined || forkModalOpen === false ? true : false);
+  }
+
   star(client, id, userStateDispatch, starred) {
     client.starProject(id, starred).then(() => {
       // TODO: Bad naming here - will be resolved once the user state is re-implemented.

--- a/src/project/fork/ProjectFork.container.js
+++ b/src/project/fork/ProjectFork.container.js
@@ -1,0 +1,176 @@
+/*!
+ * Copyright 2017 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  incubator-renku-ui
+ *
+ *  Project.js
+ *  Container components for fork project.
+ */
+
+import React, { Component } from 'react';
+import { connect } from 'react-redux'
+import { slugFromTitle } from '../../utils/HelperFunctions';
+import { StateKind, StateModel } from '../../model/Model';
+import { forkProjectSchema } from '../../model/RenkuModels';
+import ForkProjectModal from './ProjectFork.present'
+
+
+class Fork extends Component {
+  constructor(props) {
+    super(props);
+    this.forkProject = new StateModel(forkProjectSchema, StateKind.REDUX);
+
+    this.handlers = {
+      onSubmit: this.onSubmit.bind(this),
+      onProjectNamespaceChange: this.onProjectNamespaceChange.bind(this),
+      onProjectNamespaceAccept: this.onProjectNamespaceAccept.bind(this),
+      fetchMatchingNamespaces: this.fetchMatchingNamespaces.bind(this),
+      fetchAllNamespaces: this.fetchAllNamespaces.bind(this),
+      toogleForkModal: this.toogleForkModal.bind(this)
+    };
+    this.mapStateToProps = this.doMapStateToProps.bind(this);
+  }
+
+  async fetchAllNamespaces() {
+    if(!this.forkProject.get('display.namespacesFetched')){
+      this.forkProject.set('display.namespacesFetched', true)
+      const namespaces = await this.fetchNamespaces();
+      if (namespaces == null) {
+        // This seems to break in a test on Travis, but this code is not necessary locally. Need to investigate.
+        this.forkProject.set('display.namespaces',[])
+        return;
+      }
+      const username = this.props.user.username;
+      const namespace = namespaces.data.filter(n => n.name === username)
+      if (namespace.length > 0) this.forkProject.set('meta.projectNamespace', namespace[0]);
+      this.forkProject.set('display.namespaces', namespaces)
+    }
+  }
+
+  onSubmit() {
+    this.forkProject.set('meta.id', this.props.projectId)
+    if (this.forkProject.get('display.errors')) {
+      this.forkProject.set('display.errors', []);
+    }
+
+    this.forkProject.set('display.loading', true);
+    this.props.client.forkProject(this.forkProject.get().meta)
+      .then((project) => {
+        this.forkProject.set('display.loading', false);
+        this.props.history.push(`/projects/${project.id}`);
+      })
+      .catch(error => {
+        let display_messages = [];
+        if (error.errorData && error.errorData.message) {
+          const all_messages = error.errorData.message;
+          const messages = Object.keys(all_messages)
+            .filter(mex => all_messages[mex].length)
+            .reduce((obj, mex) => { obj[mex] = all_messages[mex]; return obj; }, {});
+          
+          // the most common error is the duplicate name, we can rewrite it for readability
+          if (Object.keys(messages).includes("name") && /already.+taken/.test(messages["name"].join("; "))) {
+            display_messages = [`title: ${messages["name"].join("; ")}`];
+          }
+          else {
+            console.log(messages)
+            display_messages = Object.keys(messages)
+              .map(mex => `${mex}: ${messages[mex].join("; ")}`);
+          }
+        }
+        else {
+          display_messages = ["unknown"];
+        }
+        this.forkProject.set('display.errors', display_messages);
+        this.forkProject.set('display.loading', false);
+      });
+
+  }
+
+  onProjectNamespaceChange(value) {
+    if (this.forkProject.get('display.errors')) {
+      this.forkProject.set('display.errors', []);
+    }
+    this.forkProject.set('meta.projectNamespace', value);
+  }
+
+  onProjectNamespaceAccept() {
+    const namespace = this.forkProject.get('meta.projectNamespace');
+    if (namespace.kind !== 'group') {
+      this.forkProject.set('display.namespaceGroup',null)
+      return;
+    }
+
+    this.props.client.getGroupByPath(namespace.full_path).then(r => {
+      const group = r.data;
+      this.forkProject.set('display.namespaceGroup',group)
+    })
+  }
+
+  doMapStateToProps(state, ownProps) {
+    const model = this.forkProject.mapStateToProps(state, ownProps);
+    return {model}
+  }
+
+  fetchNamespaces(search=null) {
+    const queryParams = {};
+    if (search != null) queryParams['search'] = search;
+    return this.props.client.getNamespaces(queryParams);
+  }
+
+  // https://developer.mozilla.org/en/docs/Web/JavaScript/Guide/Regular_Expressions#Using_Special_Characters
+  escapeRegexCharacters(str) {
+    return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+
+  async fetchMatchingNamespaces(search) {
+    if(this.forkProject.get('display.namespaces')){
+      const namespaces = this.forkProject.get('display.namespaces');
+      if ( namespaces.pagination.totalPages > 1) return this.fetchNamespaces(search).then(r => r.data);
+  
+      // We have all the data, just filter in the browser
+      let escapedValue = this.escapeRegexCharacters(search.trim());
+      if (escapedValue === '') escapedValue = '.*';
+      const regex = new RegExp(escapedValue, 'i');
+      return Promise.resolve(namespaces.data.filter(namespace => regex.test(namespace.name)))
+    }
+  }
+
+  toogleForkModal(e){
+    if (this.forkProject.get('display.errors')) {
+      this.forkProject.set('display.errors', []);
+    }
+    this.props.toogleForkModal(e);
+  }
+ 
+  render() {
+    const ConnectedForkProject = connect(this.mapStateToProps)(ForkProjectModal);
+    return <ConnectedForkProject
+      forkModalOpen={this.props.forkModalOpen}
+      namespaces={this.forkProject.get('display.namespaces.data')}
+      visibilities={this.forkProject.get('display.visibilities')}
+      templates={this.forkProject.get('display.templates')}
+      handlers={this.handlers}
+      store={this.forkProject.reduxStore}
+      slug={slugFromTitle(this.props.title)}
+      user={this.props.user} />;
+  }
+}
+
+
+export default Fork;

--- a/src/project/fork/ProjectFork.present.js
+++ b/src/project/fork/ProjectFork.present.js
@@ -1,0 +1,255 @@
+/*!
+ * Copyright 2018 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  ProjectNew.present.js
+ *  Presentational components.
+ */
+
+
+
+import React, { Component } from 'react';
+
+import Autosuggest from 'react-autosuggest';
+
+import { Row, Col, Button, FormGroup, FormText, Label } from 'reactstrap';
+import {  InputGroup, InputGroupAddon, InputGroupText } from 'reactstrap';
+import { Alert } from 'reactstrap';
+
+import collection from 'lodash/collection';
+import { Loader } from '../../utils/UIComponents'
+import '../new/Project.style.css'
+import {Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
+
+
+class ProjectPath extends Component {
+  constructor(props) {
+    super(props);
+
+    this.onChange = this.doChange.bind(this);
+    this.onBlur = this.doBlur.bind(this);
+    this.onSuggestionsFetchRequested = this.doSuggestionsFetchRequested.bind(this);
+    this.onSuggestionsClearRequested = this.doSuggestionsClearRequested.bind(this);
+
+    this.state = {
+      suggestions: [],
+      input: this.props.namespace.name
+    };
+  }
+
+  componentDidMount(){
+    this.props.fetchAllNamespaces();
+  }
+
+  componentDidUpdate(prevProps, prevState, snapshot) {
+    if (this.props.namespace.name !== prevProps.namespace.name) {
+      this.setState({input: this.props.namespace.name});
+    }
+  }
+
+  getSuggestionValue(suggestion) {
+    return suggestion;
+  }
+
+  renderSuggestion(suggestion) {
+    return <span>{suggestion.name}</span>;
+  }
+
+  renderSectionTitle(section) {
+    return (
+      <strong>{section.kind}</strong>
+    );
+  }
+
+  getSectionSuggestions(section) {
+    return section.namespaces;
+  }
+
+  doBlur(event, {highlightedSuggestion}) {
+    // Take the highlighted suggestion or return to the selected namespace
+    if (null != highlightedSuggestion) {
+      this.props.onChange(highlightedSuggestion);
+      this.props.onAccept();
+    }
+    this.setState({input: this.props.namespace.name})
+  }
+
+  doChange(event, { newValue, method }) {
+    // If the user typed, store it as local input, otherwise set the selection
+    if (method === 'type') {
+      this.setState({input: newValue});
+    } else {
+      this.props.onChange(newValue)
+    }
+    if (method === 'enter' || method === 'click') {
+      this.props.onAccept();
+    }
+  }
+
+  async doSuggestionsFetchRequested({ value, reason }) {
+    let searchValue = value;
+    // Do a broad search on input-focused to show many options
+    if (reason === 'input-focused') searchValue = '';
+    const matches = await this.props.fetchMatchingNamespaces(searchValue);
+    const namespaces = collection.groupBy(matches, 'kind');
+    const suggestions = ['user', 'group']
+      .map(section => {
+        const sectionNs = namespaces[section];
+        return {
+          kind: section,
+          namespaces: (sectionNs == null) ? [] : sectionNs
+        };
+      })
+      .filter(section => section.namespaces.length > 0);
+
+    // Show current as first on input-focused, otherwise do not show
+    if (reason === 'input-focused') {
+      const current = {kind: 'current', namespaces: [this.props.namespace]};
+      suggestions.splice(0, 0, current);
+    }
+    this.setState({ suggestions });
+  }
+
+  doSuggestionsClearRequested() {
+    this.setState({
+      suggestions: [],
+    });
+  }
+
+  render() {
+    const { suggestions } = this.state;
+    const inputProps = {
+      placeholder: "{user}",
+      value: this.state.input || '',
+      onChange: this.onChange,
+      onBlur: this.onBlur
+    };
+    // See https://github.com/moroshko/react-autosuggest#themeProp
+    const defaultTheme = {
+      container:                'react-autosuggest__container',
+      containerOpen:            'react-autosuggest__container--open',
+      input:                    'react-autosuggest__input',
+      inputOpen:                'react-autosuggest__input--open',
+      inputFocused:             'react-autosuggest__input--focused',
+      suggestionsContainer:     'react-autosuggest__suggestions-container',
+      suggestionsContainerOpen: 'react-autosuggest__suggestions-container--open',
+      suggestionsList:          'react-autosuggest__suggestions-list',
+      suggestion:               'react-autosuggest__suggestion',
+      suggestionFirst:          'react-autosuggest__suggestion--first',
+      suggestionHighlighted:    'react-autosuggest__suggestion--highlighted',
+      sectionContainer:         'react-autosuggest__section-container',
+      sectionContainerFirst:    'react-autosuggest__section-container--first',
+      sectionTitle:             'react-autosuggest__section-title'
+    };
+    // Override the input theme to match our visual style
+    const theme = {...defaultTheme, ...{input: 'form-control'}};
+    return <FormGroup>
+      <Label>Project Home</Label>
+      <InputGroup>
+        <Autosuggest
+          multiSection={true}
+          highlightFirstSuggestion={true}
+          suggestions={suggestions}
+          inputProps={inputProps}
+          theme={theme}
+          shouldRenderSuggestions={(v) => true}
+          onSuggestionsFetchRequested={this.onSuggestionsFetchRequested}
+          onSuggestionsClearRequested={this.onSuggestionsClearRequested}
+          getSuggestionValue={this.getSuggestionValue}
+          renderSuggestion={this.renderSuggestion}
+          renderSectionTitle={this.renderSectionTitle}
+          getSectionSuggestions={this.getSectionSuggestions} />
+        <InputGroupAddon addonType="append">
+          <InputGroupText>/</InputGroupText>
+          <InputGroupText>{this.props.slug}</InputGroupText>
+        </InputGroupAddon>
+      </InputGroup>
+      <FormText color="muted">{"By default, a project is owned by the user that forked it, but \
+        it can optionally be forked within a group."}</FormText>
+    </FormGroup>
+  }
+}
+
+class ForkProjectModal extends Component {
+
+  render() {
+    return <div>
+      <Modal 
+        isOpen={this.props.forkModalOpen !== undefined && this.props.forkModalOpen !== false} 
+        toggle={this.props.handlers.toogleForkModal} 
+        className={this.props.className}>
+        <ModalHeader toggle={this.props.handlers.toogleForkModal}>Fork Project</ModalHeader>
+        <ModalBody>
+          <ProjectPath 
+            namespace={this.props.model.meta.projectNamespace} 
+            slug={this.props.slug}
+            namespaces={this.props.namespaces}
+            onChange={this.props.handlers.onProjectNamespaceChange}
+            onAccept={this.props.handlers.onProjectNamespaceAccept}
+            fetchMatchingNamespaces={this.props.handlers.fetchMatchingNamespaces} 
+            fetchAllNamespaces={this.props.handlers.fetchAllNamespaces}/>
+          <SubmitErrors errors={this.props.model.display.errors} />
+          <SubmitLoader loading={this.props.model.display.loading} />
+        </ModalBody>
+        <ModalFooter>
+          <Button color="primary" onClick={this.props.handlers.onSubmit}>Fork</Button>{' '}
+          <Button color="secondary" onClick={this.props.handlers.toogleForkModal}>Cancel</Button>
+        </ModalFooter>
+      </Modal>
+    </div>
+      
+  }
+}
+
+class SubmitLoader extends Component {
+  render() {
+    if (!this.props.loading) return null;
+    return(<Loader size="16" inline="true" margin="2" />)
+  }
+}
+
+class SubmitErrors extends Component {
+  render() {
+    if (!this.props.errors || !this.props.errors.length) return null;
+    return(
+      <div>
+        <Alert color="danger">
+          <Col>
+            <Row>
+              {
+                this.props.errors.length > 1
+                  ? <h5>Some errors occurred</h5>
+                  : <h5>An error occurred</h5>
+              }
+            </Row>
+            {this.props.errors.map(error => (
+              <Row key={error}>
+                {error}
+              </Row>
+            ))}
+          </Col>
+        </Alert>
+      </div>
+    )
+  }
+
+}
+
+export default ForkProjectModal;

--- a/src/project/fork/index.js
+++ b/src/project/fork/index.js
@@ -1,0 +1,28 @@
+/*!
+ * Copyright 2018 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  project/fork
+ *  Components for the fork project page
+ */
+
+import Fork from './ProjectFork.container';
+
+export default Fork;


### PR DESCRIPTION
New button added to fork a project in the project page.

![image](https://user-images.githubusercontent.com/42647877/59093444-3dc23600-8914-11e9-970a-10c00b3c5288.png)

When the button is clicked a modal opens and gives the user the option to choose a namespace (like in the project creation) --> we could also give the user the option to set a new name for the forked project.

![image](https://user-images.githubusercontent.com/42647877/59093500-61857c00-8914-11e9-9a1d-4e8501e72b5b.png)

The submit action is still not finished, it throws some errors (i think the project is not forked properly or maybe we need to do a first commit and set some other things like in the project creation) 

==> I did this before going on holidays and a bit in a rush, I reused lot's of the code of the create project and it could happen that there are redundant things or things that are not right.


