### PR TITLE
fix(notebook): avoid to create notebook url for anonymous users

### DIFF
--- a/src/api-client/project.js
+++ b/src/api-client/project.js
@@ -214,7 +214,7 @@ function addProjectMethods(client) {
       .then(resp => resp.data)
       .then(server => {
         return {
-          notebookServerUrl: server.url,
+          notebookServerUrl: server.url ? server.url : null,
           notebookServerAPI: `${client.baseUrl}/notebooks/${projectPath}/${commitSha}`
         }
       })

--- a/src/project/Project.js
+++ b/src/project/Project.js
@@ -78,9 +78,14 @@ class View extends Component {
   async createGraphWebhook() { return this.projectState.createGraphWebhook(this.props.client, this.props.id); }
   async stopCheckingWebhook() { this.projectState.stopCheckingWebhook(); }
   async fetchGraphWebhook() { this.projectState.fetchGraphWebhook(this.props.client, this.props.id, this.props.user); }
-  async fetchProjectFilesTree() { return this.projectState.fetchProjectFilesTree(this.props.client, this.props.id , this.cleanCurrentURL() ); }
-  async setProjectOpenFolder(filepath) { this.projectState.setProjectOpenFolder(this.props.client, this.props.id, filepath); }
+  async fetchProjectFilesTree() {
+    return this.projectState.fetchProjectFilesTree(this.props.client, this.props.id, this.cleanCurrentURL());
+  }
+  async setProjectOpenFolder(filepath) {
+    this.projectState.setProjectOpenFolder(this.props.client, this.props.id, filepath);
+  }
   async fetchGraphStatus() { return this.projectState.fetchGraphStatus(this.props.client, this.props.id); }
+  async fetchNotebookServerUrl() { return this.projectState.fetchNotebookServerUrl(this.props.client, this.props.id); }
 
   async fetchAll() {
     await this.fetchProject();
@@ -89,6 +94,7 @@ class View extends Component {
     if (this.props.user.id) {
       this.fetchCIJobs();
       this.checkGraphWebhook();
+      this.fetchNotebookServerUrl();
     }
   }
 
@@ -332,6 +338,9 @@ class View extends Component {
     },
     fetchGraphStatus: () => {
       return this.fetchGraphStatus();
+    },
+    fetchNotebookServerUrl: () => {
+      return this.fetchNotebookServerUrl();
     }
   };
 

--- a/src/project/Project.state.js
+++ b/src/project/Project.state.js
@@ -114,7 +114,7 @@ class ProjectModel extends StateModel {
   // TODO: Do we really want to re-fetch the entire project on every change?
   fetchProject(client, id) {
     this.setUpdating({core: {available: true}});
-    return client.getProject(id, {statistics:true})
+    return client.getProject(id, {statistics: true})
       .then(resp => resp.data)
       .then(d => {
         const updatedState = {
@@ -124,7 +124,6 @@ class ProjectModel extends StateModel {
           statistics: d.metadata.statistics
         };
         this.setObject(updatedState);
-        this.fetchNotebookServerUrl(client, id, updatedState);
         return d;
       })
       .catch(err => {
@@ -291,8 +290,9 @@ class ProjectModel extends StateModel {
     return client.stopNotebookServer(serverName);
   }
 
-  fetchNotebookServerUrl(client, id, projectState) {
-    client.getNotebookServerUrl(id, projectState.core.path_with_namespace)
+  fetchNotebookServerUrl(client, id) {
+    const pathWithNamespace = this.get('core.path_with_namespace');
+    client.getNotebookServerUrl(id, pathWithNamespace)
       .then(urls => {
         this.set('core.notebookServerUrl', urls.notebookServerUrl);
         this.set('core.notebookServerAPI', urls.notebookServerAPI);


### PR DESCRIPTION
The project's notebook URL computation generates an API call (before #460, it was computed locally) that results in a `401` response for anonymous users, which triggers the authentication. There is no need to compute that URL for users who can't possibly have a running notebook server.

To reproduce: open any public project on dev as anonymous user (e.g. https://dev.renku.ch/projects/72). This will trigger authentication due to a call to `https://dev.renku.ch/api/notebooks/.../f6404d191d8067eda7a7083efdf57e4b7f56922b`