### PR TITLE
feat: project visibility label added to project page

### DIFF
--- a/src/project/Project.css
+++ b/src/project/Project.css
@@ -3,3 +3,11 @@ Button.alert-link {
   border: 0;
   vertical-align: bottom;
 }
+
+.visibilityLabel {
+  display: inline;
+  color: rgba(0, 0, 0, 0.5);
+  /* color: black; */
+  margin-left: 0.1em;
+  font-size: 0.55em;
+}

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -41,7 +41,7 @@ import { Card, CardBody, CardHeader } from 'reactstrap';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome'
 import faStarRegular from '@fortawesome/fontawesome-free-regular/faStar'
 import { faStar as faStarSolid, faInfoCircle, faExternalLinkAlt } from '@fortawesome/fontawesome-free-solid'
-import { faExclamationTriangle } from '@fortawesome/fontawesome-free-solid'
+import { faExclamationTriangle, faLock , faUserFriends, faGlobe } from '@fortawesome/fontawesome-free-solid'
 
 import { ExternalLink, Loader, RenkuNavLink, TimeCaption} from '../utils/UIComponents'
 import { InfoAlert, SuccessAlert, WarnAlert, ErrorAlert } from '../utils/UIComponents'
@@ -93,6 +93,21 @@ class ImageBuildInfoBadge extends Component {
     return <Link className={`badge badge-${imageBuildAlertColor[imageBuild.status]}`}
       title={imageBuildStatusText[imageBuild.status] || imageBuildStatusText['failed']}
       to={this.props.notebooksUrl}>Notebooks</Link>
+  }
+}
+
+class ProjectVisibilityLabel extends Component {
+  render(){
+    switch(this.props.visibilityLevel) {
+    case "private":
+      return  <span className="visibilityLabel"><FontAwesomeIcon icon={faLock}/> Private</span>
+    case "internal":
+      return  <span className="visibilityLabel"><FontAwesomeIcon icon={faUserFriends}/> Internal</span>
+    case "public":
+      return  <span className="visibilityLabel"><FontAwesomeIcon icon={faGlobe}/> Public</span>
+    default:
+      return null;
+    }
   }
 }
 
@@ -233,7 +248,7 @@ class ProjectViewHeaderOverview extends Component {
       <Container fluid>
         <Row>
           <Col xs={12} md={9}>
-            <h3>{core.title}</h3>
+            <h3>{core.title} <ProjectVisibilityLabel visibilityLevel={this.props.visibility.level}/></h3>
             <p>
               <span>{this.props.core.path_with_namespace}{forkedFrom}</span> <br />
             </p>


### PR DESCRIPTION
A label was aded to show the project visibility. 

It looks as follows:

![image](https://user-images.githubusercontent.com/42647877/60102547-d3075c00-9755-11e9-867b-9efd6deae518.png)


![image](https://user-images.githubusercontent.com/42647877/60102181-190ff000-9755-11e9-9696-56e49ada2207.png)

![image](https://user-images.githubusercontent.com/42647877/60102215-262cdf00-9755-11e9-9f6a-400dce12065f.png)
