### PR TITLE
Update Notebooks components

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -96,7 +96,7 @@ class App extends Component {
                   <Project.New key="project_new" client={this.props.client}
                     user={this.props.userState.getState().user} {...p}/> }/>
               <Route exact path="/notebooks"
-                render={p => <Notebooks key="notebooks"
+                render={p => <Notebooks key="notebooks" standalone={true}
                   user={this.props.userState.getState().user}
                   client={this.props.client} {...p} />} />
             </Switch>

--- a/src/api-client/notebook-servers.js
+++ b/src/api-client/notebook-servers.js
@@ -44,7 +44,6 @@ function cleanAnnotations(annotations, domain) {
 
 function addNotebookServersMethods(client) {
   client.getNotebookServers = (id, branch, commit) => {
-    // TODO: add filtering logic here, remove from Notebook
     const headers = client.getBasicHeaders();
     const url = `${client.baseUrl}/notebooks/servers`;
     return client.clientFetch(url, {
@@ -55,7 +54,12 @@ function addNotebookServersMethods(client) {
       if (id) {
         // TODO: remove this filter when this API will support projectId filtering
         servers = Object.keys(servers)
-          .filter(server => servers[server].annotations["renku.io/projectId"] === id)
+          .filter(server => {
+            const annotations = cleanAnnotations(servers[server]["annotations"], "renku.io");
+            if (parseInt(annotations.projectId) === parseInt(id)) {
+              return server;
+            }
+          })
           .reduce((obj, key) => {obj[key] = servers[key]; return obj}, {});
       }
       return { "data": servers };

--- a/src/model/RenkuModels.js
+++ b/src/model/RenkuModels.js
@@ -136,12 +136,6 @@ const projectSchema = new Schema({
       stop: {initial: null},
       progress: {initial: null}
     }
-  },
-  notebooks: {
-    schema: {
-      polling: {initial: null},
-      all: {initial: {}}
-    }
   }
 });
 

--- a/src/notebooks/Notebooks.container.js
+++ b/src/notebooks/Notebooks.container.js
@@ -33,7 +33,7 @@ import { StatusHelper } from '../model/Model'
  * @param {function} refreshBranches   Function to invoke to refresh the list of branches
  * @param {number} projectId   id of the reference project
  * @param {number} projectPath   path of the reference project
- * @param {Object[]} client   api-client used to query the gateway
+ * @param {Object} client   api-client used to query the gateway
  * @param {string} successUrl  Optional: url to redirect when then notebook is succesfully started
  * @param {Object} history  Optional: used with successUrl to properly set the new url without reloading the page
  */
@@ -260,7 +260,7 @@ class StartNotebookServer extends Component {
   }
 
   startNotebookPolling() {
-    this.model.startNotebookPolling(this.props.projectId, this.props.projectPath);
+    this.model.startNotebookPolling(this.props.projectId, this.props.projectPath, true);
   }
 
   stopNotebookPolling() {
@@ -293,6 +293,11 @@ class StartNotebookServer extends Component {
   }
 }
 
+/**
+ * @param {Object} client   api-client used to query the gateway
+ * @param {boolean} standalone   Indicates whether it's displayed as standalone
+ * @param {number} projectId   Optional, used to focus on a single project
+ */
 class Notebooks extends Component {
   constructor(props) {
     super(props);
@@ -312,7 +317,7 @@ class Notebooks extends Component {
   }
 
   startNotebookPolling() {
-    this.model.startNotebookPolling();
+    this.model.startNotebookPolling(this.props.projectId);
   }
   stopNotebookPolling() {
     this.model.stopNotebookPolling();
@@ -334,6 +339,8 @@ class Notebooks extends Component {
     return <VisibleNotebooks
       store={this.model.reduxStore}
       user={this.props.user}
+      standalone={this.props.standalone ? this.props.standalone : false}
+      projectId={this.props.projectId}
     />
   }
 }

--- a/src/project/Project.js
+++ b/src/project/Project.js
@@ -29,7 +29,7 @@ import { connect } from 'react-redux'
 import { StateKind } from '../model/Model';
 import Present from './Project.present'
 
-import { ProjectModel, GraphIndexingStatus, PollingInterval } from './Project.state'
+import { ProjectModel, GraphIndexingStatus } from './Project.state'
 import Ku from '../ku/Ku'
 import { FileLineage } from '../file'
 import { ACCESS_LEVELS } from '../api-client';
@@ -69,11 +69,6 @@ class View extends Component {
   async fetchModifiedFiles() { return this.projectState.fetchModifiedFiles(this.props.client, this.props.id); }
   async fetchBranches() { return this.projectState.fetchBranches(this.props.client, this.props.id); }
   async fetchCIJobs() { return this.projectState.fetchCIJobs(this.props.client, this.props.id); }
-  async startNotebookServersPolling() {
-    return this.projectState.startNotebookServersPolling(this.props.client, this.props.id,PollingInterval.START);
-  }
-  async stopNotebookServersPolling() { return this.projectState.stopNotebookServersPolling(); }
-  async stopNotebookServer(serverName) { return this.projectState.stopNotebookServer(this.props.client, serverName, this.props.id); }
   async createGraphWebhook() { return this.projectState.createGraphWebhook(this.props.client, this.props.id); }
   async stopCheckingWebhook() { this.projectState.stopCheckingWebhook(); }
   async fetchGraphWebhook() { this.projectState.fetchGraphWebhook(this.props.client, this.props.id, this.props.user); }
@@ -311,15 +306,6 @@ class View extends Component {
       this.setProjectOpenFolder(filePath);
     },
     fetchCIJobs: () => { this.fetchCIJobs() },
-    startNotebookServersPolling: () => {
-      this.startNotebookServersPolling();
-    },
-    stopNotebookServersPolling: () => {
-      this.stopNotebookServersPolling();
-    },
-    stopNotebookServer: (serverName) => {
-      this.stopNotebookServer(serverName);
-    },
     createGraphWebhook: (e) => { 
       e.preventDefault();
       return this.createGraphWebhook();

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -47,7 +47,7 @@ import { ExternalLink, Loader, RenkuNavLink, TimeCaption} from '../utils/UICompo
 import { InfoAlert, SuccessAlert, WarnAlert, ErrorAlert } from '../utils/UIComponents'
 import { SpecialPropVal } from '../model/Model'
 import { ProjectTags, ProjectTagList } from './shared'
-import { NotebookServers, StartNotebookServer } from '../notebooks'
+import { Notebooks, StartNotebookServer } from '../notebooks'
 import FilesTreeView from './filestreeview/FilesTreeView';
 import { ACCESS_LEVELS } from '../api-client';
 
@@ -579,14 +579,6 @@ class ProjectViewFiles extends Component {
 }
 
 class ProjectNotebookServers extends Component {
-  componentDidMount() {
-    this.props.startNotebookServersPolling();
-  }
-
-  componentWillUnmount() {
-    this.props.stopNotebookServersPolling();
-  }
-
   render() {
     let launch = null;
     if (this.props.visibility.accessLevel >= ACCESS_LEVELS.DEVELOPER) {
@@ -600,11 +592,7 @@ class ProjectNotebookServers extends Component {
 
     return (
       <Col xs={12}>
-        <NotebookServers
-          servers={ this.props.notebooks.all }
-          stop= { this.props.stopNotebookServer }
-          projectId={this.props.id}
-        />
+        <Notebooks projectId={this.props.id} client={this.props.client} standalone={false} />
         {launch}
       </Col>
     )

--- a/src/project/Project.state.js
+++ b/src/project/Project.state.js
@@ -38,11 +38,6 @@ const GraphIndexingStatus = {
   MAX_VALUE: 100
 };
 
-export const PollingInterval = {
-  START: 3000,
-  READY: 60000
-}
-
 class ProjectModel extends StateModel {
   constructor(stateBinding, stateHolder, initialState) {
     super(projectSchema, stateBinding, stateHolder, initialState)
@@ -211,89 +206,6 @@ class ProjectModel extends StateModel {
     filesTree.hash[folderPath].childrenOpen = !filesTree.hash[folderPath].childrenOpen;
     this.set('filesTree',filesTree);
   } 
-
-  makeNotebookServerPollingStart(client,id,interval){
-    this.set('notebooks.pollingInterval', interval);
-    const newPoller = setInterval(() => {
-      return this.fetchNotebookServers(client, id);
-    }, interval);
-    this.set('notebooks.polling', newPoller);
-
-    // invoke immediatly the first time
-    return this.fetchNotebookServers(client, id, true);
-  }
-
-  startNotebookServersPolling(client, id, interval) {
-    const oldPoller = this.get('notebooks.polling');
-    const oldInterval = this.get('notebooks.pollingInterval');
-    if (oldPoller == null) {
-      this.set('notebooks.pollingInterval', interval);
-      return this.makeNotebookServerPollingStart(client,id,interval);
-    } else {
-      if(oldInterval !== undefined && oldInterval !== interval){
-        return this.changeNotebookServerPollingInterval(client,id,interval);
-      }
-    }
-  }
-
-  changeNotebookServerPollingInterval(client, id, newInterval){
-    this.stopNotebookServersPolling();
-    this.set('notebooks.pollingInterval', newInterval);
-    return this.makeNotebookServerPollingStart(client,id,newInterval);
-  }
-
-  stopNotebookServersPolling() {
-    const poller = this.get('notebooks.polling');
-    if (poller) {
-      this.set('notebooks.polling', null);
-      this.set('notebooks.pollingInterval', null);
-      clearTimeout(poller);
-    }
-  }
-
-  fetchNotebookServers(client, id, first) {
-    if(this.get('notebooks.all')=== SpecialPropVal.UPDATING) return;
-    if (first)  this.setUpdating({notebooks: {all: true}});
-    return client.getNotebookServers(id)
-      .then(resp => {
-        const serverNames = Object.keys(resp.data).sort();
-        if(serverNames && serverNames.length > 0){
-          const allServersReady = serverNames.map((k, i) =>
-            resp.data[k].ready
-          ).filter(ready => ready === false).length === 0;
-          if(allServersReady && this.get('notebooks.pollingInterval')!== PollingInterval.READY){
-            this.changeNotebookServerPollingInterval(client, id, PollingInterval.READY);
-          } else if(!allServersReady && this.get('notebooks.pollingInterval') !== PollingInterval.START){
-            this.changeNotebookServerPollingInterval(client, id, PollingInterval.START);
-          }
-        } else {
-          this.stopNotebookServersPolling();
-        }
-        // TODO: filter for current project
-        this.set('notebooks.all', resp.data);
-      });
-  }
-
-  stopNotebookServer(client, serverName, id) {
-    // manually set the state instead of waiting for the promise to resolve
-    const updatedState = {
-      notebooks: {
-        all: {
-          [serverName]: {
-            ready: false,
-            pending: "stop"
-          }
-        }
-      }
-    }
-
-    const oldInterval = this.get('notebooks.pollingInterval');
-    if (oldInterval !== PollingInterval.START) {
-      this.changeNotebookServerPollingInterval(client, id, PollingInterval.START);
-    }
-    this.setObject(updatedState);
-    return client.stopNotebookServer(serverName);
-  }
 
   fetchNotebookServerUrl(client, id) {
     const pathWithNamespace = this.get('core.path_with_namespace');


### PR DESCRIPTION
This is the UI adaptation to handle the API responses from SwissDataScienceCenter/renku-notebooks#177 (requires also SwissDataScienceCenter/renku-notebooks#187)

A preview is available here: https://lorenzotest.dev.renku.ch

At the moment we have lost the distinction between "starting" and "stopping" servers, we only mark them as "pending". This may be acceptable, but the UI shows that after the stop API is invoked, the server will still be considered "ready" for a while.
An idea to improve this could be using an extra annotation to save in the pod the information that the stop command has been invoked by the user, then returning it in the `/servers` endpoint in the status.