### PR TITLE
feat: dropdown in project search to order projects

### DIFF
--- a/src/app-state/UserState.js
+++ b/src/app-state/UserState.js
@@ -52,13 +52,13 @@ const UserState = {
       .then(response => {
         dispatch(UserState.set({...response.data, available: true}));
         // TODO: Replace this after re-implementation of user state.
-        client.getProjects({starred: true})
+        client.getProjects({starred: true, order_by: 'last_activity_at'})
           .then((projectResponse) => {
             const reducedProjects = projectResponse.data.map((project) => starredProjectMetadata(project));
             dispatch(UserState.setStarred(reducedProjects));
           })
           .catch(() => dispatch(UserState.setStarred([])));
-        client.getProjects({membership: true})
+        client.getProjects({membership: true, order_by: 'last_activity_at'})
           .then((projectResponse) => {
             const reducedProjects = projectResponse.data.map((project) => starredProjectMetadata(project));
             dispatch(UserState.setMember(reducedProjects));

--- a/src/project/list/ProjectList.present.js
+++ b/src/project/list/ProjectList.present.js
@@ -19,11 +19,15 @@
 import React, { Component } from 'react';
 import { Link, Route, Switch }  from 'react-router-dom';
 import { Row, Col } from 'reactstrap';
-import { Button, Form, FormGroup, FormText, Input, Label } from 'reactstrap';
-import { Nav, NavItem } from 'reactstrap';
+import { Button, Form, InputGroup, FormText, Input, Label } from 'reactstrap';
+import { Nav, NavItem, InputGroupButtonDropdown, DropdownToggle, DropdownMenu, DropdownItem} from 'reactstrap';
 
 import { Avatar, Loader, Pagination,  TimeCaption , RenkuNavLink } from '../../utils/UIComponents';
 import { ProjectTagList } from '../shared';
+import faCheck from '@fortawesome/fontawesome-free-solid/faCheck';
+import faSortAmountUp from '@fortawesome/fontawesome-free-solid/faSortAmountUp';
+import faSortAmountDown from '@fortawesome/fontawesome-free-solid/faSortAmountDown';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome'
 
 class ProjectListRow extends Component {
   render() {
@@ -49,11 +53,30 @@ class ProjectSearchForm extends Component {
 
   render() {
     return [<Form key="form" onSubmit={this.props.handlers.onSearchSubmit} inline>
-      <FormGroup>
-        <Label for="searchQuery" hidden>Query</Label>
+      <InputGroup>
         <Input name="searchQuery" id="searchQuery" placeholder="Search Text" style={{minWidth: "300px"}}
-          value={this.props.searchQuery} onChange={this.props.handlers.onSearchQueryChange} />
-      </FormGroup>
+          value={this.props.searchQuery} onChange={this.props.handlers.onSearchQueryChange} className="border-primary" />
+        <Label for="searchQuery" hidden>Query</Label>
+        <InputGroupButtonDropdown addonType="append" toggle={this.props.handlers.onOrderByDropdownToogle} isOpen={this.props.orderByDropdownOpen} >
+          <Button outline color="primary" onClick={this.props.handlers.toogleSearchSorting}>
+            { this.props.orderSearchAsc ? <FontAwesomeIcon icon={faSortAmountUp}/> : <FontAwesomeIcon icon={faSortAmountDown}/> }
+          </Button>
+          <DropdownToggle outline caret color="primary" >
+            Order By
+          </DropdownToggle>
+          <DropdownMenu>
+            <DropdownItem value={this.props.orderByValuesMap.NAME} onClick={this.props.handlers.changeSearchDropdownOrder}>
+              {this.props.orderBy === this.props.orderByValuesMap.NAME ? <FontAwesomeIcon icon={faCheck} /> :null} Name
+            </DropdownItem>
+            <DropdownItem value={this.props.orderByValuesMap.CREATIONDATE} onClick={this.props.handlers.changeSearchDropdownOrder}>
+              {this.props.orderBy === this.props.orderByValuesMap.CREATIONDATE ? <FontAwesomeIcon icon={faCheck} /> :null} Creation Date
+            </DropdownItem>
+            <DropdownItem value={this.props.orderByValuesMap.UPDATEDDATE} onClick={this.props.handlers.changeSearchDropdownOrder}>
+              {this.props.orderBy === this.props.orderByValuesMap.UPDATEDDATE ? <FontAwesomeIcon icon={faCheck} /> :null} Updated Date
+            </DropdownItem>
+          </DropdownMenu>
+        </InputGroupButtonDropdown>
+      </InputGroup>
       &nbsp;
       <Button color="primary" onClick={this.props.handlers.onSearchSubmit}>
         Search
@@ -159,8 +182,14 @@ class ProjectsSearch extends Component {
           :
           <span></span>
       }
-      <Col md={8}>
-        <ProjectSearchForm searchQuery={this.props.searchQuery} handlers={this.props.handlers} />
+      <Col md={12}>
+        <ProjectSearchForm 
+          orderByValuesMap={this.props.orderByValuesMap} 
+          orderBy={this.props.orderBy} 
+          orderByDropdownOpen={this.props.orderByDropdownOpen} 
+          orderSearchAsc={this.props.orderSearchAsc}
+          searchQuery={this.props.searchQuery} 
+          handlers={this.props.handlers} />
       </Col>
     </Row>,
     <Row key="spacer2"><Col md={8}>&nbsp;</Col></Row>,
@@ -191,7 +220,6 @@ class ProjectList extends Component {
         </Col>
       </Row>,
       <ProjectNavTabs loggedIn={hasUser} key="navbar" urlMap={urlMap}/>,
-      <Row key="spacer"><Col md={12}>&nbsp;</Col></Row>,
       <Row key="content">
         <Col key="" md={12}>
           {

--- a/src/project/list/ProjectList.state.js
+++ b/src/project/list/ProjectList.state.js
@@ -43,9 +43,9 @@ const projectListSchema = new Schema({
   totalItems: {mandatory: true},
   currentPage: {mandatory: true},
   perPage: {mandatory: true},
+  orderBy: {initial:'last_activity_at', mandatory:true},
   pages: {initial: [], schema: [{projectsPageSchema}]}
 });
-
 
 class ProjectListModel extends StateModel {
   constructor(client) {
@@ -70,9 +70,23 @@ class ProjectListModel extends StateModel {
     this.set('selected',selected);
   }
 
-  setQueryPageNumberAndPath(query, pageNumber, pathName) {
+  setOrderDropdownOpen(value){
+    this.set('orderByDropdownOpen', value);
+  }
+
+  setOrderBy(orderBy){
+    this.set('orderBy', orderBy);
+  }
+
+  setOrderSearchAsc(orderSearchAsc){
+    this.set('orderSearchAsc', orderSearchAsc);
+  }
+
+  setQueryPageNumberAndPath(query, pageNumber, pathName, orderBy, orderSearchAsc) {
     this.setQuery(query)
     this.setPathName(pathName)
+    this.setOrderBy(orderBy)
+    this.setOrderSearchAsc(orderSearchAsc);
     return this.setPage(pageNumber)
   }
 
@@ -81,7 +95,9 @@ class ProjectListModel extends StateModel {
     const pageNumber = this.get('currentPage');
     const perPage = this.get('perPage');
     const query = this.get('query');
-    return this.client.getProjects({search: query, page: pageNumber, per_page: perPage})
+    const orderBy = this.get('orderBy');
+    const sort = this.get('orderSearchAsc') === true ? 'asc' : 'desc';
+    return this.client.getProjects({search: query, page: pageNumber, per_page: perPage, order_by: orderBy, sort:sort})
       .then(response => {
         const pagination = response.pagination;
         this.set('currentPage', pagination.currentPage);

--- a/src/project/list/ProjectList.test.js
+++ b/src/project/list/ProjectList.test.js
@@ -62,7 +62,7 @@ describe('new project actions', () => {
     expect(model.get('currentPage')).toEqual(undefined);
   });
   it('does search with a query', () => {
-    return model.setQueryPageNumberAndPath("", 1,fakeHistory.pathName).then(() => {
+    return model.setQueryPageNumberAndPath("", 1,fakeHistory.pathName, 'last_activity_at').then(() => {
       expect(model.get('currentPage')).toEqual(1);
       expect(model.get('totalItems')).toEqual(1);
       expect(model.get('pathName')).toEqual(fakeHistory.pathName);


### PR DESCRIPTION
With dropdown in project search to order projects by name, created date, and updated date. 

With sorting included (Ascending - Descending) --> I'm not sure this button icons are the best, if you have better ones i can change them.

![image](https://user-images.githubusercontent.com/42647877/60525748-40cffc80-9cef-11e9-837c-4f6cc2de13fd.png)
