### PR TITLE
feat: add basic 404 page not found

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -34,6 +34,7 @@ import { Landing, LoggedInNavBar, AnonymousNavBar, FooterNavbar } from './landin
 import { Notebooks } from './notebooks';
 import { Login } from './authentication'
 import Help from './help'
+import NotFound from './not-found'
 import { UserAvatar } from './utils/UIComponents'
 
 class RenkuNavBar extends Component {
@@ -99,6 +100,8 @@ class App extends Component {
                 render={p => <Notebooks key="notebooks" standalone={true}
                   user={this.props.userState.getState().user}
                   client={this.props.client} {...p} />} />
+              <Route path="*"
+                render={p => <NotFound {...p} />} />
             </Switch>
           </main>
           <Route component={RenkuFooter} />

--- a/src/not-found/NotFound.container.js
+++ b/src/not-found/NotFound.container.js
@@ -1,0 +1,38 @@
+/*!
+ * Copyright 2019 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  NotFound.container.js
+ *  Container components for not-found
+ */
+
+import React, { Component } from 'react';
+
+import { NotFound as NotFoundPresent } from './NotFound.present';
+
+class NotFound extends Component {
+  render() {
+    return (
+      <NotFoundPresent {...this.props} />
+    );
+  }
+}
+
+export { NotFound }

--- a/src/not-found/NotFound.present.js
+++ b/src/not-found/NotFound.present.js
@@ -1,0 +1,57 @@
+/*!
+ * Copyright 2019 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  NotFound.present.js
+ *  Presentational components for not-found
+ */
+
+import React, { Component } from 'react';
+import { Link } from 'react-router-dom';
+import { Row, Col, Button } from 'reactstrap';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import { faSearch } from '@fortawesome/fontawesome-free-solid';
+
+class NotFound extends Component {
+  render() {
+    return (
+      <Row>
+        <Col>
+          <h1>Error 404</h1>
+          <h3>
+            Page not found <FontAwesomeIcon icon={faSearch} flip="horizontal" />
+          </h3>
+          <div>&nbsp;</div>
+          <p>
+            We could not find the page &quot;<i>{ this.props.match.url }</i>&quot; in our website.
+          </p>
+          <Link to="/">
+            <Button color="primary">
+              Back to home
+            </Button>
+          </Link>
+          
+        </Col>
+      </Row>
+    );
+  }
+}
+
+export { NotFound }

--- a/src/not-found/index.js
+++ b/src/not-found/index.js
@@ -1,0 +1,28 @@
+/*!
+ * Copyright 2019 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  not-found
+ *  Components for the not-found page
+ */
+
+import { NotFound } from './NotFound.container';
+
+export default NotFound;

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -41,7 +41,7 @@ import { Card, CardBody, CardHeader } from 'reactstrap';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome'
 import faStarRegular from '@fortawesome/fontawesome-free-regular/faStar'
 import { faStar as faStarSolid, faInfoCircle, faExternalLinkAlt } from '@fortawesome/fontawesome-free-solid'
-import { faExclamationTriangle, faLock , faUserFriends, faGlobe } from '@fortawesome/fontawesome-free-solid'
+import { faExclamationTriangle, faLock , faUserFriends, faGlobe, faSearch } from '@fortawesome/fontawesome-free-solid'
 
 import { ExternalLink, Loader, RenkuNavLink, TimeCaption} from '../utils/UIComponents'
 import { InfoAlert, SuccessAlert, WarnAlert, ErrorAlert } from '../utils/UIComponents'
@@ -717,8 +717,9 @@ class ProjectViewNotFound extends Component {
 
     return <Row>
       <Col>
-        <h1>404</h1>
-        <h2>Project not found</h2>
+        <h1>Error 404</h1>
+        <h3>Project not found <FontAwesomeIcon icon={faSearch} flip="horizontal" /></h3>
+        <div>&nbsp;</div>
         <p>We could not find project #{this.props.id}.</p>
         <p>
           It is possible that the project has been deleted by its owner or you don&apos;t have permission to access it.


### PR DESCRIPTION
Basic "404 page not found" added to the UI.
The style of the previous "Project not found" has been aligned too.

![Screenshot from 2019-07-04 14-20-44](https://user-images.githubusercontent.com/43481553/60666712-fc1ba100-9e67-11e9-9bcd-ae5b1e4e8943.png)

closes #488 