### PR TITLE
fix: fork to project works for groups

### DIFF
--- a/src/api-client/project.js
+++ b/src/api-client/project.js
@@ -168,7 +168,7 @@ function addProjectMethods(client) {
     const gitlabProject = {
       id: projectMeta.id
     };
-    if (projectMeta.projectNamespace != null) gitlabProject.namespace_id = projectMeta.projectNamespace.id;
+    if (projectMeta.projectNamespace != null) gitlabProject.namespace = projectMeta.projectNamespace.id;
     const headers = client.getBasicHeaders();
     headers.append('Content-Type', 'application/json');
 


### PR DESCRIPTION
There was an error on the JSON body sent on the POST request, it was set to "namespace_id" but it should have been "namespace".
