### PR TITLE
feat: pipeline starts without creating a trigger

### DIFF
--- a/src/project/fork/ProjectFork.container.js
+++ b/src/project/fork/ProjectFork.container.js
@@ -70,11 +70,7 @@ class Fork extends Component {
     }
 
     this.forkProject.set('display.loading', true);
-    this.props.client.forkProject(this.forkProject.get().meta)
-      .then((project) => {
-        this.forkProject.set('display.loading', false);
-        this.props.history.push(`/projects/${project.id}`);
-      })
+    this.props.client.forkProject(this.forkProject.get().meta , this.props.history)
       .catch(error => {
         let display_messages = [];
         if (error.errorData && error.errorData.message) {

--- a/src/project/fork/ProjectFork.present.js
+++ b/src/project/fork/ProjectFork.present.js
@@ -209,8 +209,18 @@ class ForkProjectModal extends Component {
           <SubmitLoader loading={this.props.model.display.loading} />
         </ModalBody>
         <ModalFooter>
-          <Button color="primary" onClick={this.props.handlers.onSubmit}>Fork</Button>{' '}
-          <Button color="secondary" onClick={this.props.handlers.toogleForkModal}>Cancel</Button>
+          <Button 
+            color="primary" 
+            disabled={ this.props.model.display.loading } 
+            onClick={this.props.handlers.onSubmit}>
+            Fork
+          </Button>{' '}
+          <Button 
+            color="secondary" 
+            disabled={ this.props.model.display.loading } 
+            onClick={this.props.handlers.toogleForkModal}>
+            Cancel
+          </Button>
         </ModalFooter>
       </Modal>
     </div>
@@ -221,7 +231,11 @@ class ForkProjectModal extends Component {
 class SubmitLoader extends Component {
   render() {
     if (!this.props.loading) return null;
-    return(<Loader size="16" inline="true" margin="2" />)
+    return(
+      <FormText color="primary">
+        <Loader size="16" inline="true" margin="2"/>
+        The project is being forked...
+      </FormText> )
   }
 }
 


### PR DESCRIPTION
The pipeline starts now without creating a trigger.

To test fork a project and go to CI/CD => pipelines in gitlab and you will see that after forking a project there is a pipeline running. 

For some reason it fails for old projects. I think in the future we can after redirect offer the option to restart failed pipelines (Like for Knowledge Graph).

Closes #511 