### PR TITLE
fix(notebook): fix errors introduced by #498

### DIFF
--- a/src/api-client/notebook-servers.js
+++ b/src/api-client/notebook-servers.js
@@ -59,6 +59,7 @@ function addNotebookServersMethods(client) {
             if (parseInt(annotations.projectId) === parseInt(id)) {
               return server;
             }
+            return null;
           })
           .reduce((obj, key) => {obj[key] = servers[key]; return obj}, {});
       }

--- a/src/notebooks/Notebooks.state.js
+++ b/src/notebooks/Notebooks.state.js
@@ -25,6 +25,7 @@
 
 import { Schema, StateKind, StateModel } from '../model/Model';
 import { cleanAnnotations } from '../api-client/notebook-servers';
+import { StatusHelper } from '../model/Model'
 
 const notebooksSchema = new Schema({
   notebooks: {
@@ -118,6 +119,7 @@ class NotebooksModel extends StateModel {
     const notebooks = servers ?
       servers :
       this.get('notebooks.all');
+    if (StatusHelper.isUpdating(notebooks)) return;
     const branch = this.get('filters.branch');
     const commit = this.get('filters.commit');
     for (let notebookName of Object.keys(notebooks)) { 
@@ -148,6 +150,7 @@ class NotebooksModel extends StateModel {
 
   notebookPollingIteration(projectId, projectPath, first, checkRunning) {
     const fetchPromise = this.fetchNotebooks(first, projectId);
+    if (!fetchPromise) return;
     if (checkRunning) {
       return fetchPromise.then((servers) => {
         return this.verifyIfRunning(projectId, projectPath, servers);
@@ -249,3 +252,4 @@ class NotebooksModel extends StateModel {
 }
 
 export default NotebooksModel;
+


### PR DESCRIPTION
#498 introduced a bug in "Notebook.state" since the polling actions are never interrupted when needed
-- e.g. when the query to the servers endpoint is skipped or the list of servers is still updating.

To test it, open the debug console while trying to launch a new notebook from any project (i.e. in the `launchNotebook` page). Without this PR, every now and then, the console will log an error (it may take long). When applying this PR, the chain of functions called in "Notebooks.state" to test for running notebooks is interrupted when needed