### PR TITLE
feat(notebook): add support for autosaved branches

### DIFF
--- a/src/model/RenkuModels.js
+++ b/src/model/RenkuModels.js
@@ -123,6 +123,7 @@ const projectSchema = new Schema({
       http_url: {initial: '',},
       merge_requests: {schema: [], initial:[]},
       branches: {schema: [], initial:[]},
+      autosaved: {schema: [], initial:[]},
       ci_jobs: {schema: [], initial:[]}
     }
   },

--- a/src/notebooks/Notebooks.container.js
+++ b/src/notebooks/Notebooks.container.js
@@ -29,7 +29,8 @@ import { StatusHelper } from '../model/Model'
 /**
  * Displays a start page for new Jupiterlab servers.
  * 
- * @param {Object[]} branches   Branches as redurnet by gitlab "/branches" API
+ * @param {Object[]} branches   Branches as returned by gitlab "/branches" API - no autosaved branches
+ * @param {Object[]} autosaved   Autosaved branches
  * @param {function} refreshBranches   Function to invoke to refresh the list of branches
  * @param {number} projectId   id of the reference project
  * @param {number} projectPath   path of the reference project
@@ -270,8 +271,9 @@ class StartNotebookServer extends Component {
   mapStateToProps(state, ownProps) {
     const augmentedState = { ...state,
       data: {...state.data,
-        branches: ownProps.inherited.branches
-      } // add "branches" to data
+        branches: ownProps.inherited.branches,
+        autosaved: ownProps.inherited.autosaved
+      }
     };
     return {
       handlers: this.handlers,

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -619,6 +619,7 @@ class ProjectStartNotebookServer extends Component {
       <Col xs={12}>
         <StartNotebookServer
           branches={this.props.system.branches}
+          autosaved={this.props.system.autosaved}
           refreshBranches={this.props.fetchBranches}
           projectId={this.props.core.id}
           projectPath={this.props.core.displayId}

--- a/src/utils/HelperFunctions.js
+++ b/src/utils/HelperFunctions.js
@@ -18,6 +18,9 @@
 
 // title.Author: Alex K. - https://stackoverflow.com/users/246342/alex-k
 // Source: https://stackoverflow.com/questions/6507056/replace-all-whitespace-characters/6507078#6507078
+
+const AUTOSAVED_PREFIX = "renku/autosave/";
+
 const slugFromTitle = (title) => title.replace(/\s/g, '-').toLowerCase();
 
 function getActiveProjectId(currentPath) {
@@ -28,4 +31,17 @@ function getActiveProjectId(currentPath) {
   }
 }
 
-export { slugFromTitle, getActiveProjectId }
+function splitAutosavedBranches(branches) {
+  const autosaved = branches
+    .filter(branch => branch.name.startsWith(AUTOSAVED_PREFIX))
+    .map(branch => {
+      let autosave = {}
+      const autosaveData = branch.name.replace(AUTOSAVED_PREFIX, "").split("/");
+      [ autosave.namespace, autosave.branch, autosave.commit, autosave.finalCommit ] = autosaveData;
+      return {...branch, autosave};
+    });
+  const standard = branches.filter(branch => !branch.name.startsWith(AUTOSAVED_PREFIX));
+  return { standard, autosaved };
+}
+
+export { slugFromTitle, getActiveProjectId, splitAutosavedBranches }

--- a/src/utils/Utils.test.js
+++ b/src/utils/Utils.test.js
@@ -23,7 +23,8 @@
  *  test fo utilities
  */
 
- import Time from './Time';
+import Time from './Time';
+import { splitAutosavedBranches } from './HelperFunctions';
 
 describe('Time class helper', () => {
   const Dates = {
@@ -53,5 +54,23 @@ describe('Time class helper', () => {
     expect(Time.toISOString(Dates.UTCZ_STRING, "time")).toEqual(Dates.ISO_READABLE_TIME);
     const fakeType = "not existing"
     expect(() => { Time.toISOString(Dates.UTCZ_STRING, fakeType) }).toThrow(`Uknown type "${fakeType}"`);
+  });
+});
+
+describe('Helper functions', () => {
+  const branches = [
+    { name: "master" },
+    { name: "renku/autosave/myuser/master/1234567/890acbd" }
+  ];
+
+  it('function splitAutosavedBranches', () => {
+    const splittedBranches = splitAutosavedBranches(branches);
+    expect(splittedBranches.standard.length).toEqual(1);
+    expect(splittedBranches.autosaved.length).toEqual(1);
+    const [ namespace, branch, commit, finalCommit ] = branches[1].name.replace("renku/autosave/", "").split("/");
+    expect(splittedBranches.autosaved[0].autosave.namespace).toEqual(namespace);
+    expect(splittedBranches.autosaved[0].autosave.branch).toEqual(branch);
+    expect(splittedBranches.autosaved[0].autosave.commit).toEqual(commit);
+    expect(splittedBranches.autosaved[0].autosave.finalCommit).toEqual(finalCommit);
   });
 });


### PR DESCRIPTION
Add support for the autosaved branches features introduced by SwissDataScienceCenter/renku-notebooks#189 by separating the renku/autosave branches from the
user-created branches and showing a warning to the user when starting a new JupyterLab server from a
branch/commit combination with available autosaved content.

How to test it:
A preview is available at https://lorenzotest.dev.renku.ch
* Start a new JupiterLab server for any of your projects
* Connect to the server and do some work -- creating a new empty file or modifying an existing one is enough
* Stop the server from the Notebooks table.

If you now try to start again another server from the same branch/commit combination, a popup will warn you about existing autosaved data.
![Screenshot from 2019-07-12 15-52-39](https://user-images.githubusercontent.com/43481553/61133149-1fc09600-a4bd-11e9-8187-75869bd014da.png)

If you try to replicate the same steps in https://dev.renku-ch, you will see an extra branch in the branches list and no warning popup will appear when you click on the "Launch Server" button.

![Screenshot from 2019-07-12 16-04-04](https://user-images.githubusercontent.com/43481553/61133992-e0934480-a4be-11e9-9f73-1a2e340278b8.png)



fix #507
closes #429 