### PR TITLE
feat(notebook): improve user feedback when stopping a notebook

### DIFF
--- a/src/notebooks/Notebooks.container.js
+++ b/src/notebooks/Notebooks.container.js
@@ -325,7 +325,7 @@ class Notebooks extends Component {
     this.model.stopNotebookPolling();
   }
   onStopNotebook(serverName){
-    this.model.stopNotebook(serverName);
+    return this.model.stopNotebook(serverName);
   }
 
   mapStateToProps(state, ownProps) {

--- a/src/notebooks/Notebooks.present.js
+++ b/src/notebooks/Notebooks.present.js
@@ -116,7 +116,47 @@ class NotebookServerRowProject extends Component {
   }
 }
 
+class StopNotebookModal extends Component {
+  render() {
+    return <div>
+      <Modal isOpen={this.props.show}>
+        <ModalHeader>Stopping server</ModalHeader>
+        <ModalBody>
+          <p>The following notebook server is going to stop soon</p>
+          <ul>
+            <li>Namespace: {this.props.namespace}</li>
+            <li>Project: {this.props.project}</li>
+            <li>Branch: {this.props.branch}</li>
+            <li>Commit: {this.props.commit}</li>
+          </ul>
+          <span>Please wait... <Loader size="14" inline="true" margin="1" /></span>
+        </ModalBody>
+      </Modal>
+    </div>
+  }
+}
+
 class NotebookServerRowFull extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      showModal: false,
+      currentServer: {}
+    };
+    this.stopServer = this.stopServer.bind(this);
+  }
+
+  showModal(option) {
+    this.setState({showModal: option });
+  }
+
+  stopServer(serverId) {
+    this.showModal(true);
+    this.props.onStopServer(serverId)
+      .then(data => { this.showModal(false); })
+      .catch(error => { this.showModal(false); });
+  }
+
   render() {
     const {annotations, status, url} = this.props;
     let columns;
@@ -134,6 +174,12 @@ class NotebookServerRowFull extends Component {
       <tr>
         <td className="align-middle">
           {columns[0]}
+          <StopNotebookModal key="modal" show={this.state.showModal}
+            namespace = {annotations["namespace"]}
+            project = {annotations["projectName"]}
+            branch = {annotations["branch"]}
+            commit = {annotations["commit-sha"].substring(0,8)}
+          />
         </td>
         <td className="align-middle">
           {columns[1]}
@@ -142,7 +188,7 @@ class NotebookServerRowFull extends Component {
           <NotebookServerRowAction
             status={status}
             name={this.props.name}
-            onStopServer={this.props.onStopServer}
+            onStopServer={this.stopServer}
             url={url}
           />
         </td>

--- a/src/notebooks/Notebooks.state.js
+++ b/src/notebooks/Notebooks.state.js
@@ -244,10 +244,11 @@ class NotebooksModel extends StateModel {
   }
 
   stopNotebook(serverName) {
-    // manually set the state instead of waiting for the promise to resolve
-    const updatedState = { notebooks: { all: { [serverName]: { status: { ready: false } } } } };
-    this.setObject(updatedState);
-    return this.client.stopNotebookServer(serverName);
+    return this.client.stopNotebookServer(serverName).then((resp => {
+      const updatedState = { notebooks: { all: { [serverName]: { status: { ready: false } } } } };
+      this.setObject(updatedState);
+      return resp;
+    }));
   }
 }
 


### PR DESCRIPTION
This PR changes the user experience when stopping a notebook server.

After the user clicks on "Stop server", a modal will appear informing that the server is stopping. It disappears only when the response comes from the "delete server" API -- usually a few seconds.
The server status will be displayed correctly once the modal is gone. 

![Screenshot from 2019-07-15 15-27-45](https://user-images.githubusercontent.com/43481553/61219841-5abd0680-a715-11e9-9262-0f3175b6d230.png)

fix #513 -- but wait to merge this until a decision on how to address the original issue is taken.