### PR TITLE
fix(notebook): check user privileges before rendering notebook components

### DIFF
--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -592,43 +592,45 @@ class ProjectViewFiles extends Component {
   }
 }
 
+function notebookLauncher(visibility, notebookLauncher) {
+  let content = null;
+  if (visibility.accessLevel >= ACCESS_LEVELS.DEVELOPER) {
+    content = notebookLauncher;
+  } else {
+    content = (<p>You are missing the permissions to launch Jupyter from this project.</p>);
+  }
+  return (<Col xs={12}>{content}</Col>);
+}
+
 class ProjectNotebookServers extends Component {
   render() {
-    let launch = null;
-    if (this.props.visibility.accessLevel >= ACCESS_LEVELS.DEVELOPER) {
-      launch = <Link to={ `/projects/${this.props.id}/launchNotebook` }>
+    const content = [
+      <Notebooks key="notebooks" standalone={false}
+        projectId={this.props.id} client={this.props.client}
+      />,
+      <Link key="launch" to={ `/projects/${this.props.id}/launchNotebook` }>
         <Button color="primary">Start new server</Button>
       </Link>
-    }
-    else {
-      launch = <p>You are missing the permissions to launch Jupyter from this project.</p>
-    }
+    ];
 
-    return (
-      <Col xs={12}>
-        <Notebooks projectId={this.props.id} client={this.props.client} standalone={false} />
-        {launch}
-      </Col>
-    )
+    return (notebookLauncher(this.props.visibility, content));
   }
 }
 
 class ProjectStartNotebookServer extends Component {
   render() {
-    return (
-      <Col xs={12}>
-        <StartNotebookServer
-          branches={this.props.system.branches}
-          autosaved={this.props.system.autosaved}
-          refreshBranches={this.props.fetchBranches}
-          projectId={this.props.core.id}
-          projectPath={this.props.core.displayId}
-          client={this.props.client}
-          successUrl={this.props.notebookServersUrl}
-          history={this.props.history}
-        />
-      </Col>
-    )
+    let content = (<StartNotebookServer
+      branches={this.props.system.branches}
+      autosaved={this.props.system.autosaved}
+      refreshBranches={this.props.fetchBranches}
+      projectId={this.props.core.id}
+      projectPath={this.props.core.displayId}
+      client={this.props.client}
+      successUrl={this.props.notebookServersUrl}
+      history={this.props.history}
+    />);
+
+    return (notebookLauncher(this.props.visibility, content));
   }
 }
 


### PR DESCRIPTION
The UI now checks the user privileges before rendering any notebook-related components.

This fixes #510 and improves also the output for the "Notebook Servers" tab by avoiding any useless call to `/servers` API.

A preview is available at https://lorenzotest.dev.renku.ch/
To test it, try accessing https://lorenzotest.dev.renku.ch/projects/8/launchNotebook

![Screenshot from 2019-07-17 15-56-26](https://user-images.githubusercontent.com/43481553/61381539-7823d900-a8ab-11e9-8f80-796e69a4b2da.png)

