### PR TITLE
fix: add elements to anonymous user navbar

### DIFF
--- a/src/landing/NavBar.js
+++ b/src/landing/NavBar.js
@@ -162,7 +162,12 @@ class AnonymousNavBar extends Component {
           </button>
 
           <div className="collapse navbar-collapse" id="navbarSupportedContent">
-            <ul className="navbar-nav ml-auto">
+            <QuickNav user={this.props.userState.getState().user} client={this.props.client}/>
+            
+            <ul className="navbar-nav mr-auto">
+              <RenkuNavLink to="/projects" title="Projects"/>
+            </ul>
+            <ul className="navbar-nav">
               <RenkuToolbarItemUser {...this.props } user={this.props.userState.getState().user} />
             </ul>
           </div>


### PR DESCRIPTION
Navbar for anonymous users shows a link to the project list and the search box, as it already happens for logged in users.

![Screenshot from 2019-07-17 16-45-22](https://user-images.githubusercontent.com/43481553/61385243-4d894e80-a8b2-11e9-9559-3c3528666d87.png)

fix #426