### PR TITLE
fix(lineage): "no lineage information" message wasn't readable

### DIFF
--- a/src/file/Lineage.css
+++ b/src/file/Lineage.css
@@ -32,3 +32,11 @@ g.workflow polygon {
 .graphContainer{
   text-align: center;
 }
+
+g.nolineage text{
+  font-size: 16px;
+}
+
+g.nolineage rect{  
+  fill: #fff;
+}

--- a/src/file/Lineage.present.js
+++ b/src/file/Lineage.present.js
@@ -105,14 +105,13 @@ class FileLineageGraph extends Component {
     })
 
     if (graph.centralNode == null) {
-      subGraph.setNode("0", {id: "0", label: "No lineage information." });
+      subGraph.setNode("0", {id: "0", class:"nolineage", label: "No lineage information." });
     } else {
       graph.nodes.forEach(n => {
         const label = getNodeLabel(n, NODE_COUNT);
         subGraph.setNode(n.id, {
           id: n.id,
           label,
-          // class: nodeIdToClass(n.id, graph.centralNode, n.type, getNodeLabel(n, NODE_COUNT)),
           class: nodeToClass(n, graph.centralNode, label),
           shape: n.type === "commit" ? "diamond" : "rect"
         });


### PR DESCRIPTION
The no lineage message was displayed like this: 

![image](https://user-images.githubusercontent.com/42647877/61636536-1e018a00-ac96-11e9-8d2c-b72e7348cfdd.png)


And now is readable: 

![image](https://user-images.githubusercontent.com/42647877/61636283-91ef6280-ac95-11e9-8342-f8005744d376.png)
