### PR TITLE
fix(notebook): fix launch server function

### DIFF
--- a/src/api-client/notebook-servers.js
+++ b/src/api-client/notebook-servers.js
@@ -98,6 +98,7 @@ function addNotebookServersMethods(client) {
 
   client.startNotebook = (projectUrl, branchName, commitId, options) => {
     const headers = client.getBasicHeaders();
+    headers.append('Content-Type', 'application/json');
     const url = `${client.baseUrl}/notebooks/${projectUrl}/${commitId}`;
 
     return client.clientFetch(url, {


### PR DESCRIPTION
fix #540

The API is now invoked with the proper `Content-Type` header.
How to test it: start a new notebook changing the "CPU request" parameter from `0.1` to `0.5`. Connect and type in a command window `printenv | grep CPU` to check if the value is correct.

Preview available at https://lorenzotest.dev.renku.ch