### PR TITLE
feat(datasets): tab for datasets inside project overview

### DIFF
--- a/src/project/Project.css
+++ b/src/project/Project.css
@@ -20,3 +20,9 @@ Button.alert-link {
 .selected-dataset .fs-element{
   background-color: #e9ecef;
 }
+
+.datasetDescriptionText{
+  font-size: 14px;
+  margin-block-start: 0.5em;
+  margin-block-end: 0.5em;
+}

--- a/src/project/Project.js
+++ b/src/project/Project.js
@@ -141,6 +141,7 @@ class View extends Component {
       baseUrl: baseUrl,
       overviewUrl: `${baseUrl}/overview`,
       statsUrl: `${baseUrl}/overview/stats`,
+      overviewDatasetsUrl: `${baseUrl}/overview/datasets`,
       kusUrl: `${baseUrl}/kus`,
       kuNewUrl: `${baseUrl}/ku_new`,
       kuUrl: `${baseUrl}/kus/:kuIid(\\d+)`,

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -476,6 +476,9 @@ class ProjectViewOverviewNav extends Component {
         <NavItem>
           <RenkuNavLink to={`${this.props.statsUrl}`} title="Stats" />
         </NavItem>
+        <NavItem>
+          <RenkuNavLink to={`${this.props.overviewDatasetsUrl}`} title="Datasets" />
+        </NavItem>
       </Nav>)
   }
 }
@@ -517,8 +520,11 @@ class ProjectViewOverview extends Component {
             <Route exact path={this.props.baseUrl} render={props => {
               return <ProjectViewReadme readme={this.props.data.readme} {...this.props} />
             }} />
-            <Route path={this.props.statusUrl} render={props =>
+            <Route exact path={this.props.statsUrl} render={props =>
               <ProjectViewStats {...this.props} />}
+            />
+            <Route exact path={this.props.overviewDatasetsUrl} render={props =>
+              <ProjectViewDatasetsOverview {...this.props} />}
             />
           </Switch>
         </Col>
@@ -629,6 +635,66 @@ class ProjectViewFiles extends Component {
         </Switch>
       </Col>
     ]
+  }
+}
+
+class ProjectViewDatasetRow extends Component{
+
+  HTMLtoText = (textContent) =>{
+    var temp = document.createElement("div");
+    temp.innerHTML = textContent;
+    return temp.textContent || temp.innerText || "";
+  }
+
+  render(){
+    return <Card style={{ marginBottom: '1rem'}} key={this.props.dataset.identifier}>
+      <CardBody>
+        <Link to={this.props.fullDatasetUrl}><strong style={{ display: 'block'}}>{this.props.dataset.name+"\n"}</strong></Link>
+        {
+          this.props.dataset.creator !== undefined &&  this.props.dataset.creator !== null?  
+            <small style={{ display: 'block'}} className="font-weight-light">
+              {this.props.dataset.creator.map((creator) => creator.name).join("; ")}
+            </small>
+            : null  
+        } 
+        {
+          this.props.dataset.description !== undefined && this.props.dataset.description !== null? 
+            <p className="datasetDescriptionText font-weight-normal">
+              {this.props.dataset.description.length > 500 ? 
+                this.HTMLtoText(this.props.dataset.description).substr(0,500)+"...":
+                this.HTMLtoText(this.props.dataset.description)
+              }
+            </p>
+            : null
+        }
+        {
+          this.props.dataset.date_published !== undefined && this.props.dataset.date_published !== null ?
+            <small className="font-italic">{"Date published: "+this.props.dataset.date_published["@value"]}</small>
+            : null
+        }
+      </CardBody>
+    </Card>
+  }
+}
+
+class ProjectViewDatasetsOverview extends Component {
+
+  componentDidMount() {
+    this.props.fetchDatasets();
+  }
+  
+  render() {
+    if(this.props.datasets === undefined) 
+      return <p>Loading datasets...</p>;
+
+    if(this.props.datasets.length === 0) 
+      return <p>No datasets to display...</p>
+
+    let datasets = this.props.datasets.map((dataset) => 
+      <ProjectViewDatasetRow key={dataset.identifier} dataset={dataset} fullDatasetUrl={`${this.props.datasetsUrl}/${dataset.identifier}`}/>
+    );
+
+    return <Col key="project-datasets" > {datasets} </Col>
   }
 }
 


### PR DESCRIPTION
There is a tab for datasets inside project overview tab, there still needs to be a button that redirects the user to the detailed overview of the dataset. It still needs to be decided what information exactly we want to display.

![image](https://user-images.githubusercontent.com/42647877/62215511-64966900-b3a7-11e9-9ef8-1ff7cf6e89d9.png)

Addresses #525 
