### PR TITLE
fix(notebook): restore link between notebook files and Jupyter server

### DIFF
--- a/src/api-client/project.js
+++ b/src/api-client/project.js
@@ -306,11 +306,9 @@ function addProjectMethods(client) {
     return client.putProjectField(projectId, name, 'tag_list', tags);
   }
 
-
   client.setDescription = (projectId, name, description) => {
     return client.putProjectField(projectId, name, 'description', description);
   }
-
 
   client.starProject = (projectId, starred) => {
     const headers = client.getBasicHeaders();
@@ -323,7 +321,6 @@ function addProjectMethods(client) {
     })
 
   }
-
 
   client.putProjectField = (projectId, name, field_name, field_value) => {
     const putData = { id: projectId, name, [field_name]: field_value };
@@ -338,26 +335,17 @@ function addProjectMethods(client) {
 
   }
 
-
-  // TODO: This method should not return the notebook server API.
+  // ! TODO: remove this and use client.getNotebookServers instead
   client.getNotebookServerUrl = async (projectId, projectPath, commitSha = 'latest', ref = 'master') => {
     if (commitSha === 'latest') {
       commitSha = await (client.getCommits(projectId).then(resp => resp.data[0].id));
     }
     const headers = client.getBasicHeaders();
-    return client.clientFetch(`${client.baseUrl}/notebooks/${projectPath}/${commitSha}`, {
-      method: 'GET',
-      headers: headers
-    })
+    const url = `${client.baseUrl}/notebooks/${projectPath}/${commitSha}`;
+    return client.clientFetch(url, { method: 'GET', headers})
       .then(resp => resp.data)
-      .then(server => {
-        return {
-          notebookServerUrl: server.url ? server.url : null,
-          notebookServerAPI: `${client.baseUrl}/notebooks/${projectPath}/${commitSha}`
-        }
-      })
+      .then(server => server.url ? server.url : null)
   }
-
 
   client.getArtifactsUrl = (projectId, job, branch = 'master') => {
     const headers = client.getBasicHeaders();
@@ -379,7 +367,6 @@ function addProjectMethods(client) {
       })
   }
 
-
   client.getArtifact = (projectId, job, artifact, branch = 'master') => {
     const options = { method: 'GET', headers: client.getBasicHeaders() };
     return client.getArtifactsUrl(projectId, job, branch)
@@ -390,7 +377,6 @@ function addProjectMethods(client) {
         return Promise.all([resourceUrl, client.clientFetch(resourceUrl, options, client.returnTypes.full)])
       })
   }
-
 
   client.getJobs = (projectId) => {
     let headers = client.getBasicHeaders();

--- a/src/api-client/test-client.js
+++ b/src/api-client/test-client.js
@@ -80,9 +80,6 @@ const methods = {
       data: []
     }
   },
-  getNotebookServerUrl: {
-    response: ''
-  },
   getNamespaces: {
     response: {
       data: samples.namespaces
@@ -97,6 +94,12 @@ const methods = {
     response: {
       data: []
     }
+  },
+  getRepositoryFile: {
+    response: null
+  },
+  getNotebookServerUrl: {
+    response: null
   }
 };
 

--- a/src/file/File.test.js
+++ b/src/file/File.test.js
@@ -1,0 +1,67 @@
+/*!
+ * Copyright 2019 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  Files.test.js
+ *  Tests for file.
+ */
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { MemoryRouter } from 'react-router-dom';
+
+import { testClient as client } from '../api-client'
+import { generateFakeUser } from '../app-state/UserState.test';
+import { ShowFile } from './File.present';
+import { LaunchJupyter } from './File.container';
+
+describe('rendering', () => {
+  const users = [
+    { type: "anonymous", data: generateFakeUser(true) },
+    { type: "logged", data: generateFakeUser() }
+  ];
+
+  const props = {
+    filePath: "/projects/1/files/blob/myFolder/myNotebook.ipynb",
+    match: { url: "/projects/1", params: {id: "1"} },
+    launchNotebookUrl: "/projects/1/launchNotebook",
+  };
+
+  for (let user of users) {
+    it(`renders LaunchJupyter for ${user.type} user`, () => {
+      const div = document.createElement('div');
+      // * fix for tooltips https://github.com/reactstrap/reactstrap/issues/773#issuecomment-357409863
+      document.body.appendChild(div);
+      ReactDOM.render(
+        <MemoryRouter>
+          <LaunchJupyter user={user.data} client={client} {...props} />
+        </MemoryRouter>, div);
+    });
+
+    it(`renders ShowFile for ${user.type} user`, () => {
+      const div = document.createElement('div');
+      document.body.appendChild(div);
+      ReactDOM.render(
+        <MemoryRouter>
+          <ShowFile user={user.data} client={client} {...props} />
+        </MemoryRouter>, div);
+    });
+  }
+});

--- a/src/file/Lineage.present.js
+++ b/src/file/Lineage.present.js
@@ -22,14 +22,14 @@ import graphlib from 'graphlib';
 import dagreD3 from 'dagre-d3';
 import * as d3 from 'd3';
 
-import { Link}  from 'react-router-dom';
+import { Link }  from 'react-router-dom';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import { faInfoCircle, faFile } from '@fortawesome/fontawesome-free-solid'
 import faGitlab from '@fortawesome/fontawesome-free-brands/faGitlab';
 import { Card, CardHeader, CardBody, UncontrolledTooltip, Badge, Button, Alert, Progress } from 'reactstrap';
 
 import { Loader } from '../utils/UIComponents';
-import { JupyterNotebook } from './File.container';
+import { LaunchJupyter } from './File.container';
 import { GraphIndexingStatus } from '../project/Project';
 
 import './Lineage.css';
@@ -300,15 +300,8 @@ class FileLineage extends Component {
     </span>
 
     let buttonJupyter = this.props.filePath.endsWith(".ipynb") ?
-      <JupyterNotebook
-        key="notebook-button"
-        justButton={true}
-        filePath={this.props.filePath}
-        notebook={this.props.notebook}
-        accessLevel={this.props.accessLevel}
-        {...this.props}
-      /> : null;
-
+      <LaunchJupyter {...this.props} /> :
+      null;
 
     return <Card>
       <CardHeader className="align-items-baseline">
@@ -316,7 +309,7 @@ class FileLineage extends Component {
         {this.props.path}
         <span className="caption align-baseline">&nbsp;Lineage and usage</span>
         <div className="float-right" >
-          <span>{buttonJupyter}</span>
+          {buttonJupyter}
           <span>{buttonGit}</span>
           <span>{buttonFile}</span>
         </div>

--- a/src/project/Project.state.js
+++ b/src/project/Project.state.js
@@ -206,15 +206,6 @@ class ProjectModel extends StateModel {
     }
     filesTree.hash[folderPath].childrenOpen = !filesTree.hash[folderPath].childrenOpen;
     this.set('filesTree',filesTree);
-  } 
-
-  fetchNotebookServerUrl(client, id) {
-    const pathWithNamespace = this.get('core.path_with_namespace');
-    client.getNotebookServerUrl(id, pathWithNamespace)
-      .then(urls => {
-        this.set('core.notebookServerUrl', urls.notebookServerUrl);
-        this.set('core.notebookServerAPI', urls.notebookServerAPI);
-      });
   }
 
   fetchModifiedFiles(client, id) {

--- a/src/project/filestreeview/treeviewstyle.css
+++ b/src/project/filestreeview/treeviewstyle.css
@@ -117,13 +117,7 @@
 }
 
 .jupyter-icon:hover{
-    -moz-transform: rotate(360deg) ;
-	/* WebKit */
-	-webkit-transform:  rotate(360deg);
-	/* Opera */
-	-o-transform: rotate(360deg) ;
-	/* Standard */
-	transform: rotate(360deg) ;
+
     cursor: pointer;
 }
 


### PR DESCRIPTION
The component `<LaunchNotebookButton>` was partially broken and a lot of obsolete code has not been removed.
This PR restores the Jupyter button functionality during the preview of a notebook in a project's File tab. Please mind that the status of the running notebook is still not updated realtime (will be addressed later).

Preview: https://lorenzotest.dev.renku.ch
How to test: open any notebook in the project's File View. If you are not logged in or you don't have enough permissions, you shouldn't see the Jupyter icon on the top right (https://lorenzotest.dev.renku.ch/projects/95/files/blob/notebooks/zhbikes-notebook.ipynb), otherwise you will see it with a popups message on mouse hover. By clicking, you will open the notebook in Jupyter or go to the "start server" page if no server is running on master/last commit. 

*****

More specifically these are the parts included:
* cleanup of `clientFetch` function in `APIclient` (to be removed in the near future)
* cleanup and fix of many components in `Files` (overlapping between `File` and `Lineage` components is still there for a few components)
* removed `fetchNotebookServerUrl` from `Project`
* added `File.test` with a few unit tests and fixed previous uncaught error while running `npm test`

Sadly, it was not possible to split this in multiple PRs without temporary breaking some functionalities.

partially addresses #462 and #428