### PR TITLE
fix lineage mandatory parameters

### DIFF
--- a/src/api-client/graph.js
+++ b/src/api-client/graph.js
@@ -60,12 +60,22 @@ function addGraphMethods(client) {
       return resp.data;
     });
   }
-
+  
+  /**
+   * Get the lineage nodes and edges
+   * 
+   * @param {string} projectPath   project slug (username/projectname)
+   * @param {string} commitId   full commit id in string format
+   * @param {string} filePath   full file path
+   * @example client.getFileLineage("myGitlabUser/myGitlabProject",
+   *  "3bf1c3c424833228708087686584afb77899f702",
+   *  "figs/grid_plot.png")
+   */
   client.getFileLineage = (projectPath, commitId, filePath) => {
     const query = gql`
-      query getLineage($projectPath: ProjectPath!, $commitId: CommitId, $filePath: FilePath) {
+      query getLineage($projectPath: ProjectPath!, $commitId: CommitId!, $filePath: FilePath!) {
         lineage(projectPath: $projectPath, commitId: $commitId, filePath: $filePath) {
-          nodes { id, label }
+          nodes { id, label },
           edges { source, target }
         }
       }


### PR DESCRIPTION
Makes lineage API parameters mandatory to comply with SwissDataScienceCenter/renku-graph#115

Testing this requires to use the aforementioned PR (images for `renku-knowledge-graph`: lorenzocavazzitech/knowledge-graph:0.6.0-8b454cc and `renku-graph`: lorenzocavazzitech/webhook-service:0.6.0-8b454cc).
Try to open any lineage. The current UI gets stuck at the "Loading" message. The PR solves this problem.