### PR TITLE
refactor(notebook): invoke notebook apis according to new url structure

### DIFF
--- a/src/api-client/notebook-servers.js
+++ b/src/api-client/notebook-servers.js
@@ -80,9 +80,9 @@ function addNotebookServersMethods(client) {
       });
   }
 
-  client.getNotebookServerOptions = (projectUrl, commitId) => {
+  client.getNotebookServerOptions = () => {
     const headers = client.getBasicHeaders();
-    const url = `${client.baseUrl}/notebooks/${projectUrl}/${commitId}/server_options`;
+    const url = `${client.baseUrl}/notebooks/server_options`;
 
     return client.clientFetch(url, {
       method: 'GET',
@@ -96,16 +96,22 @@ function addNotebookServersMethods(client) {
     });
   }
 
-  client.startNotebook = (projectUrl, branchName, commitId, options) => {
+  client.startNotebook = (namespacePath, projectPath, branchName, commitId, options) => {
     const headers = client.getBasicHeaders();
     headers.append('Content-Type', 'application/json');
-    const url = `${client.baseUrl}/notebooks/${projectUrl}/${commitId}`;
+    const url = `${client.baseUrl}/notebooks/servers`;
+    const parameters = {
+      namespace: namespacePath,
+      project: projectPath,
+      commit_sha: commitId,
+      branch: branchName,
+      ...options
+    };
 
     return client.clientFetch(url, {
       method: 'POST',
       headers,
-      queryParams: { branch: branchName },
-      body: JSON.stringify(options)
+      body: JSON.stringify(parameters)
     }).then((resp) => {
       return resp.data;
     });

--- a/src/api-client/project.js
+++ b/src/api-client/project.js
@@ -420,6 +420,8 @@ function carveProject(projectJson) {
   result['metadata']['core']['external_url'] = projectJson['web_url'];
   result['metadata']['core']['path_with_namespace'] = projectJson['path_with_namespace'];
   result['metadata']['core']['owner'] = projectJson['owner'];
+  result['metadata']['core']['namespace_path'] = projectJson['namespace']['full_path'];
+  result['metadata']['core']['project_path'] = projectJson['path'];
 
   result['metadata']['system']['tag_list'] = projectJson['tag_list'];
   result['metadata']['system']['star_count'] = projectJson['star_count'];

--- a/src/notebooks/Notebooks.container.js
+++ b/src/notebooks/Notebooks.container.js
@@ -33,7 +33,9 @@ import { StatusHelper } from '../model/Model'
  * @param {Object[]} autosaved   Autosaved branches
  * @param {function} refreshBranches   Function to invoke to refresh the list of branches
  * @param {number} projectId   id of the reference project
- * @param {number} projectPath   path of the reference project
+ * @param {string} projectSlug   slug of the reference project (namespace + project path)
+ * @param {string} namespacePath   full path of the reference namespace
+ * @param {string} projectPath   path of the reference project
  * @param {Object} client   api-client used to query the gateway
  * @param {string} successUrl  Optional: url to redirect when then notebook is succesfully started
  * @param {Object} history  Optional: used with successUrl to properly set the new url without reloading the page
@@ -167,7 +169,7 @@ class StartNotebookServer extends Component {
       return;
     }
     this.model.setCommit(commit);
-    this.model.verifyIfRunning(this.props.projectId, this.props.projectPath);
+    this.model.verifyIfRunning(this.props.projectId, this.props.projectSlug);
   }
 
   setCommitFromId(eventOrId) {
@@ -201,7 +203,7 @@ class StartNotebookServer extends Component {
     for (let commitCurrent of filteredCommits) {
       if (commit.id === commitCurrent.id) {
         // necessary for istant refresh in the UI
-        this.model.verifyIfRunning(this.props.projectId, this.props.projectPath);
+        this.model.verifyIfRunning(this.props.projectId, this.props.projectSlug);
         return true;
       }
     }
@@ -237,13 +239,13 @@ class StartNotebookServer extends Component {
     // Data from notebooks/servers endpoint needs some time to update propery.
     // To avoid flickering UI, just set a temporary state and display a loading wheel.
     // TODO: change this when the notebook service will be updated.
-    const { successUrl } = this.props;
+    const { successUrl, namespacePath, projectPath } = this.props;
     if (!successUrl) {
-      this.model.startServer(this.props.projectPath);
+      this.model.startServer(namespacePath, projectPath);
     }
     else {
       this.setState({ "starting": true });
-      this.model.startServer(this.props.projectPath).then((data) => {
+      this.model.startServer(namespacePath, projectPath).then((data) => {
         this.props.history.push(successUrl);
       });
     }
@@ -261,7 +263,7 @@ class StartNotebookServer extends Component {
   }
 
   startNotebookPolling() {
-    this.model.startNotebookPolling(this.props.projectId, this.props.projectPath, true);
+    this.model.startNotebookPolling(this.props.projectId, this.props.projectSlug, true);
   }
 
   stopNotebookPolling() {
@@ -289,7 +291,7 @@ class StartNotebookServer extends Component {
       store={this.model.reduxStore}
       inherited={this.props} // need to espose them for mapStateToProps, but don't whan to pollute props
       projectId={this.props.projectId}
-      projectPath={this.props.projectPath}
+      projectSlug={this.props.projectSlug}
       justStarted={this.state.starting}
     />;
   }

--- a/src/notebooks/Notebooks.present.js
+++ b/src/notebooks/Notebooks.present.js
@@ -578,7 +578,7 @@ class StartNotebookOptions extends Component {
     }
     else if (status === false) {
       const { notebookOptions } = this.props.data;
-      if (!notebookOptions.commitId || notebookOptions.commitId !== commit.id) {
+      if (Object.keys(notebookOptions).length === 0) {
         content = (
           <Label>Loading notebook parameters... <Loader size="14" inline="true" /></Label>
         );

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -624,7 +624,9 @@ class ProjectStartNotebookServer extends Component {
       autosaved={this.props.system.autosaved}
       refreshBranches={this.props.fetchBranches}
       projectId={this.props.core.id}
-      projectPath={this.props.core.displayId}
+      projectSlug={this.props.core.displayId}
+      namespacePath={this.props.core.namespace_path}
+      projectPath={this.props.core.project_path}
       client={this.props.client}
       successUrl={this.props.notebookServersUrl}
       history={this.props.history}


### PR DESCRIPTION
This PR adapts the UI to the new notebook APIs as defined in SwissDataScienceCenter/renku-notebooks#188

It addresses the first point of #518. The main benefit of this URL change is a possible simplification of the UI logic, but that will be addressed in a subsequent PR.

How to test: create a chartpress image from the renku-notebooks PR and update the renku deployment -- or simply update the k8s services images with `lorenzocavazzitech/renku-notebooks:0.5.0-521877a` for `<namespace>-renku-notebooks` and  `lorenzocavazzitech/jupyterhub-k8s:0.5.0-521877a` for `hub`. It won't be possible to start new notebooks without this PR applied.

Preview available at https://lorenzotest.dev.renku.ch