### PR TITLE
WIP feat(datasets): with datasets explorer

### DIFF
--- a/src/api-client/project.js
+++ b/src/api-client/project.js
@@ -102,8 +102,8 @@ function addProjectMethods(client) {
     });
   }
 
-  client.getProjectFiles = (projectId) => {
-    return client.getRepositoryTree(projectId, { path: '', recursive: true }).then((tree) => {
+  client.getProjectFiles = (projectId, path='') => {
+    return client.getRepositoryTree(projectId, { path: path, recursive: true }).then((tree) => {
       const files = tree
         .filter((treeObj) => treeObj.type === 'blob')
         .map((treeObj) => treeObj.path);
@@ -393,6 +393,24 @@ function addProjectMethods(client) {
       .then(manifestSha => fetchJson(`${TemplatesReposUrl.BLOBS}${manifestSha}`))
       .then(data => {return yaml.load(atob(data.content))})
       .then(data => {data.push(client.getEmptyProjectObject()); return data;});
+  }
+
+  client.getDatasetJson = (projectId, datasetId) => {
+    return client.getRepositoryFile(projectId, `.renku/datasets/${datasetId}/metadata.yml`, 'master', 'raw')
+      .then(result => yaml.load(result));
+  }
+
+  client.getProjectDatasets = (projectId) => {
+    const datasetsPromise = client.getRepositoryTree(projectId, { path: '.renku/datasets', recursive: true })
+      .then(data => 
+        data.filter(treeObj => treeObj.type === 'blob' && treeObj.name === 'metadata.yml')
+          .map(dataset => 
+            client.getRepositoryFile(projectId, dataset.path, 'master', 'raw').then(result => yaml.load(result))
+          )
+      )
+
+    return Promise.resolve(datasetsPromise)
+      .then(datasetsContent => Promise.all(datasetsContent))
   }
 }
 

--- a/src/dataset/Dataset.container.js
+++ b/src/dataset/Dataset.container.js
@@ -1,0 +1,25 @@
+/*!
+ * Copyright 2018 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import DatasetView from './Dataset.present';
+
+export default function ShowDataset(props) {
+
+  return <DatasetView dataset={props.dataset}/>
+}

--- a/src/dataset/Dataset.present.js
+++ b/src/dataset/Dataset.present.js
@@ -1,0 +1,125 @@
+/*!
+ * Copyright 2018 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { Col, Card, CardHeader, CardBody, Table } from 'reactstrap';
+import { Loader } from '../utils/UIComponents';
+import faDownload from '@fortawesome/fontawesome-free-solid/faDownload'
+import FontAwesomeIcon from '@fortawesome/react-fontawesome'
+
+function DatasetTableRow({dataset, label, prop, propFunc=null, type=null}) {
+  if (dataset[prop] == null) return null;
+  let propVal = (propFunc) ? propFunc(dataset[prop]).toString() : dataset[prop].toString();
+  propVal = type==="link" ? 
+    <a rel="noopener noreferrer" target="_blank" href={propVal}>{propVal}</a> 
+    : propVal;
+  return (
+    <tr>
+      <td><strong>{label}:</strong></td>
+      <td>{propVal}</td>
+    </tr>
+  )
+}
+
+function DisplayDetails(props){
+  return <Card key="datasetFiles">
+    <CardHeader className="align-items-baseline">
+      <span className="caption align-baseline">Dataset Info</span>
+    </CardHeader>
+    <CardBody>
+      <Table size="sm" borderless>
+        <tbody>
+          <DatasetTableRow dataset={props.dataset} label="Created" prop="created" />
+          <DatasetTableRow dataset={props.dataset} label="Added" prop="added" />
+          <DatasetTableRow dataset={props.dataset} label="Published" prop="date_published" propFunc={(val)=>val["@value"]} />
+          <DatasetTableRow dataset={props.dataset} label="Keywords" prop="keywords" propFunc={(val)=>val.join(", ")} />
+          <DatasetTableRow dataset={props.dataset} label="Language" prop="in_language" propFunc={(val)=>val.name}/>
+          <DatasetTableRow dataset={props.dataset} label="URL" prop="url" type="link"/>
+          <DatasetTableRow dataset={props.dataset} label="Label" prop="_label" />
+        </tbody>
+      </Table>
+    </CardBody>
+  </Card>
+}
+
+function DisplayFiles(props){
+  if (props.files === undefined) return null;
+
+  return <Card key="datasetDetails">
+    <CardHeader className="align-items-baseline">
+      <span className="caption align-baseline">Dataset Files</span>
+    </CardHeader>
+    <CardBody>
+      <Table size="sm" borderless>
+        <thead>
+          <tr>
+            <th>Path</th>
+            <th className="text-center" >Download</th>
+          </tr>
+        </thead>
+        <tbody>
+          { props.files.map((file)=>
+            <tr key={file._id}>
+              <td>{file.path}</td>
+              <td className="text-center">
+                <a href={file.url}>
+                  <FontAwesomeIcon className="icon-grey" icon={faDownload}>
+                  </FontAwesomeIcon>
+                </a>
+              </td>
+            </tr>  
+          )}
+        </tbody>
+      </Table>
+    </CardBody>
+  </Card>
+}
+
+
+export default function DatasetView(props){
+  
+  if(props.dataset === undefined)
+    return <Loader />;
+  
+  if(props.dataset === null)
+    return "The dataset that was selected could not be found."
+
+  const dataset = props.dataset;
+
+  return  <Col>
+    <div style={{paddingLeft:"4px"}}>
+      <h4 key="datasetTitle">
+        {dataset.name}
+      </h4>
+      {
+        dataset.creator !== undefined ?  
+          <small style={{ display: 'block'}} className="font-weight-light">
+            {dataset.creator.map((creator) => creator.name).join("; ")}
+          </small>
+          : null  
+      }
+      <br />
+      <p dangerouslySetInnerHTML={{__html: dataset.description}}>
+      </p>
+    </div>
+    <DisplayDetails dataset={dataset} />
+    <br />
+    <DisplayFiles files={dataset.files} />
+  </Col>
+
+}

--- a/src/dataset/index.js
+++ b/src/dataset/index.js
@@ -1,0 +1,29 @@
+/*!
+ * Copyright 2017 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  incubator-renku-ui
+ *
+ *  file/index.js
+ *  Module for file rendering in Renku.
+ */
+
+
+import ShowDataset from './Dataset.container'
+
+export default ShowDataset;

--- a/src/project/Project.css
+++ b/src/project/Project.css
@@ -11,3 +11,12 @@ Button.alert-link {
   margin-left: 0.1em;
   font-size: 0.55em;
 }
+
+.selected-dataset{
+  font-weight: normal;
+  background-color: #e9ecef;
+}
+
+.selected-dataset .fs-element{
+  background-color: #e9ecef;
+}

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -49,6 +49,7 @@ import { SpecialPropVal } from '../model/Model'
 import { ProjectTags, ProjectTagList } from './shared'
 import { Notebooks, StartNotebookServer } from '../notebooks'
 import FilesTreeView from './filestreeview/FilesTreeView';
+import DatasetsListView from './datasets/DatasetsListView';
 import { ACCESS_LEVELS } from '../api-client';
 
 import './Project.css';
@@ -340,6 +341,9 @@ class ProjectNav extends Component {
           <RenkuNavLink exact={false} to={this.props.filesUrl} title="Files" />
         </NavItem>
         <NavItem>
+          <RenkuNavLink exact={false} to={this.props.datasetsUrl} title="Datasets" />
+        </NavItem>
+        <NavItem>
           <RenkuNavLink exact={false} to={this.props.mrOverviewUrl} title="Pending Changes" />
         </NavItem>
         {notebookServers}
@@ -520,6 +524,42 @@ class ProjectViewOverview extends Component {
         </Col>
       </Row>
     </Col>
+  }
+}
+
+class ProjectDatasetsNav extends Component {
+
+  componentDidMount() {
+    this.props.fetchDatasets();
+  }
+
+  render() {
+    const loading = isRequestPending(this.props, 'datasets');
+    const allDatasets = this.props.core.datasets || []
+    if (loading && (allDatasets.length < 1 || this.props.core.datasets===undefined)) {
+      return <Loader />
+    }
+    return <DatasetsListView
+      datasets={this.props.core.datasets}
+      datasetsUrl={this.props.datasetsUrl}
+    />;
+  }
+}
+
+
+class ProjectViewDatasets extends Component {
+
+  render() {
+    return [
+      <Col key="datasetsnav" sm={12} md={4} lg={2}>
+        <ProjectDatasetsNav {...this.props} />
+      </Col>
+      ,
+      <Col key="datasetcontent" sm={12} md={8} lg={10}>
+        <Route path={this.props.datasetUrl}
+          render={p => this.props.datasetView(p)} />
+      </Col>
+    ]
   }
 }
 
@@ -788,6 +828,8 @@ class ProjectView extends Component {
               render={props => <ProjectViewKus key="kus" {...this.props} />} />
             <Route path={this.props.filesUrl}
               render={props => <ProjectViewFiles key="files" {...this.props} />} />
+            <Route path={this.props.datasetsUrl}
+              render={props => <ProjectViewDatasets key="datasets" {...this.props} />} />
             <Route path={this.props.settingsUrl}
               render={props => <ProjectSettings key="settings" {...this.props} />} />
             <Route path={this.props.mrOverviewUrl}

--- a/src/project/Project.state.js
+++ b/src/project/Project.state.js
@@ -205,7 +205,25 @@ class ProjectModel extends StateModel {
       this.fetchProjectFilesTree(client,id,"",folderPath);
     }
     filesTree.hash[folderPath].childrenOpen = !filesTree.hash[folderPath].childrenOpen;
-    this.set('filesTree',filesTree);
+    this.set('filesTree',filesTree);  
+  }
+
+  fetchProjectDatasets(client, id){
+    if(this.get('core.datasets')) return this.get('core.datasets');
+    if(this.get('transient.requests.datasets') === SpecialPropVal.UPDATING) return;
+    this.setUpdating({transient:{requests:{datasets: true}}});
+   
+    return client.getProjectDatasets(id)
+      .then(datasets => {
+        datasets = datasets.map(dataset => {
+          dataset.identifier = dataset.identifier.split('-').join("");
+          return dataset;
+        } )
+        const updatedState = { datasets: datasets, transient:{requests:{datasets: false}} };
+        this.set('core.datasets', datasets);
+        this.setObject(updatedState);
+        return datasets;
+      });
   }
 
   fetchModifiedFiles(client, id) {

--- a/src/project/datasets/DatasetsListView.js
+++ b/src/project/datasets/DatasetsListView.js
@@ -1,0 +1,51 @@
+import React, { useState } from 'react';
+import { NavLink } from 'react-router-dom';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome'
+import faTable from '@fortawesome/fontawesome-free-solid/faTable'
+import '../filestreeview/treeviewstyle.css';
+import { Loader } from '../../utils/UIComponents';
+
+function DatasetListRow(props){
+  const dataset = props.dataset
+  return <NavLink 
+    activeClassName="selected-dataset" 
+    key={dataset.identifier} 
+    to={`${props.datasetsUrl}/${dataset.identifier}/`} 
+  >
+    <div className={"fs-element"}>
+      <FontAwesomeIcon className="icon-grey" icon={faTable} /> {dataset.name}
+    </div>
+  </NavLink>
+}
+
+export default function DatasetsListView(props){
+  const [datasets, setDatasets] = useState(undefined);
+
+  useState(()=>{
+    if(datasets === undefined && props.datasets !== undefined) 
+      setDatasets(props.datasets);
+  })
+
+  return(
+    <div className="tree-container">
+      <div className="tree-title">
+        <span className="tree-header-title text-truncate">
+          Datasets List
+        </span>
+      </div> 
+      <nav>
+        {
+          datasets !== undefined ? 
+            datasets.map((dataset)=> 
+              <DatasetListRow
+                key={"dataset-"+dataset.identifier}
+                dataset={dataset}
+                datasetsUrl={props.datasetsUrl} />
+            ) 
+            : <Loader />
+        }
+      </nav>
+    </div>
+  )
+    
+}


### PR DESCRIPTION
This addresses #525 .

There is now a dataset explorer that is similar to the file explorer but for datasets. 

This is "WIP" for two reasons:
1) We are getting the datasets info from the yml file in .renku instead of the KG.
2) This only works for datasets imported with the latest renku version. The older versions have the files in the dataset in a different way than the new ones so this makes everything break. Also, the older version for data import don't include so much data.

Test Deployment:
https://virginiatest.dev.renku.ch/projects/412/datasets/cc0c4e5f87d7411485c77577b0addca2/

Preview:
![image](https://user-images.githubusercontent.com/42647877/62868578-44a36580-bd16-11e9-9075-aae61f2728e0.png)



