### PR TITLE
feat(templates): the  user can configure a url and ref to fetch templates from

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -21,6 +21,8 @@ echo " Configuration:"
 echo " GATEWAY_URL=${GATEWAY_URL:-http://gateway.renku.build}"
 echo " BASE_URL=${BASE_URL:-http://renku.build}"
 echo " RENKU_VERSION=${RENKU_VERSION}"
+echo " RENKU_TEMPLATES_URL=${RENKU_TEMPLATES_URL}"
+echo " RENKU_TEMPLATES_REF=${RENKU_TEMPLATES_REF}"
 echo "==================================================="
 
 tee > /usr/share/nginx/html/config.json << EOF
@@ -28,7 +30,9 @@ tee > /usr/share/nginx/html/config.json << EOF
   "BASE_URL": "${BASE_URL:-http://renku.build}",
   "GATEWAY_URL": "${GATEWAY_URL:-http://gateway.renku.build}",
   "WELCOME_PAGE": "${WELCOME_PAGE}",
-  "RENKU_VERSION": "${RENKU_VERSION}"
+  "RENKU_VERSION": "${RENKU_VERSION}",
+  "RENKU_TEMPLATES_URL": "${RENKU_TEMPLATES_URL}",
+  "RENKU_TEMPLATES_REF": "${RENKU_TEMPLATES_REF}"
 }
 EOF
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -20,7 +20,6 @@ echo "==================================================="
 echo " Configuration:"
 echo " GATEWAY_URL=${GATEWAY_URL:-http://gateway.renku.build}"
 echo " BASE_URL=${BASE_URL:-http://renku.build}"
-echo " RENKU_VERSION=${RENKU_VERSION}"
 echo " RENKU_TEMPLATES_URL=${RENKU_TEMPLATES_URL}"
 echo " RENKU_TEMPLATES_REF=${RENKU_TEMPLATES_REF}"
 echo "==================================================="
@@ -30,7 +29,6 @@ tee > /usr/share/nginx/html/config.json << EOF
   "BASE_URL": "${BASE_URL:-http://renku.build}",
   "GATEWAY_URL": "${GATEWAY_URL:-http://gateway.renku.build}",
   "WELCOME_PAGE": "${WELCOME_PAGE}",
-  "RENKU_VERSION": "${RENKU_VERSION}",
   "RENKU_TEMPLATES_URL": "${RENKU_TEMPLATES_URL}",
   "RENKU_TEMPLATES_REF": "${RENKU_TEMPLATES_REF}"
 }

--- a/helm-chart/renku-ui/templates/deployment.yaml
+++ b/helm-chart/renku-ui/templates/deployment.yaml
@@ -36,6 +36,10 @@ spec:
               value: {{ .Values.gatewayUrl | default (printf "%s://gateway.%s" (include "ui.protocol" .) .Values.global.renku.domain) | quote }}
             - name: WELCOME_PAGE
               value: {{ .Values.welcomePage.text | b64enc | quote }}
+            - name: RENKU_TEMPLATES_URL
+              value: {{ required "templateRepository.url must be specified, e.g., https://github.com/repos/SwissDataScienceCenter/renku-project-template" .Values.templatesRepository.url | quote }}
+            - name: RENKU_TEMPLATES_REF
+              value: {{ required "templateRepository.ref must be specified, e.g., master" .Values.templatesRepository.ref | quote }}
           livenessProbe:
             httpGet:
               path: /

--- a/helm-chart/renku-ui/templates/deployment.yaml
+++ b/helm-chart/renku-ui/templates/deployment.yaml
@@ -28,8 +28,6 @@ spec:
               containerPort: {{ .Values.service.port }}
               protocol: TCP
           env:
-            - name: RENKU_VERSION
-              value: {{ .Values.global.renku.version | default ( .Chart.Version ) | quote }}
             - name: BASE_URL
               value: {{ .Values.baseUrl | default (printf "%s://%s" (include "ui.protocol" .) .Values.global.renku.domain) | quote }}
             - name: GATEWAY_URL

--- a/helm-chart/renku-ui/values.yaml
+++ b/helm-chart/renku-ui/values.yaml
@@ -57,3 +57,7 @@ welcomePage:
     ## Welcome to Renku!
     Renku is software for collaborative data science. With Renku you can share code and data,
     discuss problems and solutions, and coordinate data-science projects.
+
+templatesRepository:
+  url: https://github.com/SwissDataScienceCenter/renku-project-template
+  ref: 0.1.1

--- a/run-telepresence.sh
+++ b/run-telepresence.sh
@@ -62,7 +62,6 @@ tee > ./public/config.json << EOF
   "BASE_URL": "${BASE_URL}",
   "GATEWAY_URL": "${BASE_URL}/api",
   "WELCOME_PAGE": "${WELCOME_PAGE}",
-  "RENKU_VERSION": "latest",
   "RENKU_TEMPLATES_URL": "https://github.com/SwissDataScienceCenter/renku-project-template",
   "RENKU_TEMPLATES_REF": "master"
 }

--- a/run-telepresence.sh
+++ b/run-telepresence.sh
@@ -62,7 +62,9 @@ tee > ./public/config.json << EOF
   "BASE_URL": "${BASE_URL}",
   "GATEWAY_URL": "${BASE_URL}/api",
   "WELCOME_PAGE": "${WELCOME_PAGE}",
-  "RENKU_VERSION": "latest"
+  "RENKU_VERSION": "latest",
+  "RENKU_TEMPLATES_URL": "https://github.com/SwissDataScienceCenter/renku-project-template",
+  "RENKU_TEMPLATES_REF": "master"
 }
 EOF
 

--- a/src/App.js
+++ b/src/App.js
@@ -94,8 +94,12 @@ class App extends Component {
               }/>
               <Route exact path="/project_new"
                 render={(p) =>
-                  <Project.New key="project_new" client={this.props.client}
-                    user={this.props.userState.getState().user} {...p}/> }/>
+                  <Project.New key="project_new" 
+                    client={this.props.client}
+                    user={this.props.userState.getState().user} 
+                    renkuTemplatesUrl={this.props.params['RENKU_TEMPLATES_URL']} 
+                    renkuTemplatesRef={this.props.params['RENKU_TEMPLATES_REF']} 
+                    {...p}/> }/>
               <Route exact path="/notebooks"
                 render={p => <Notebooks key="notebooks" standalone={true}
                   client={this.props.client} {...p} />} />

--- a/src/api-client/index.js
+++ b/src/api-client/index.js
@@ -50,9 +50,8 @@ class APIClient {
   // ku    -->  issue
 
 
-  constructor(baseUrl, renkuVersion) {
+  constructor(baseUrl) {
     this.baseUrl = baseUrl;
-    this.renkuVersion = renkuVersion;
     this.returnTypes = RETURN_TYPES
     this.graphqlClient = new ApolloClient({
       uri: `${baseUrl}/graphql`

--- a/src/index.js
+++ b/src/index.js
@@ -19,10 +19,7 @@ configPromise.then((res) => {
     // We use a redux store to hold some global application state.
     const store = createStore(reducer);
 
-    const client = new APIClient(
-      params.GATEWAY_URL,
-      params.RENKU_VERSION
-    );
+    const client = new APIClient(params.GATEWAY_URL);
 
     function mapStateToProps(state, ownProps){
       return {...state, ...ownProps}

--- a/src/project/new/ProjectNew.container.js
+++ b/src/project/new/ProjectNew.container.js
@@ -75,7 +75,7 @@ class New extends Component {
   }
 
   async fetchProjectTemplates(){
-    return this.props.client.getProjectTemplates();
+    return this.props.client.getProjectTemplates(this.props.renkuTemplatesUrl, this.props.renkuTemplatesRef);
   }
 
   async componentDidMount() {
@@ -107,7 +107,7 @@ class New extends Component {
     const validation = this.validate();
     if (validation.result) {
       this.newProject.set('display.loading', true);
-      this.props.client.postProject(this.newProject.get())
+      this.props.client.postProject(this.newProject.get(), this.props.renkuTemplatesUrl, this.props.renkuTemplatesRef)
         .then((project) => {
           this.newProject.set('display.loading', false);
           this.props.history.push(`/projects/${project.id}`);


### PR DESCRIPTION
Addresses #561 

I created the branch 'test-branch-manifests' inside our templates project for testing reasons.

In case there is no branch and url configured it fails. Specifications say that default should be master but if there is no URL it will fail anyway unless we want to set the url from our templates project as default along with master.

I had to modify also my public/config.json to make it work, i'm not sure something is missing in the configuration I made. My config file looks like this now (i put it here because is an untracked file):

{
  "BASE_URL": "https://virginia.dev.renku.ch",
  "GATEWAY_URL": "https://virginia.dev.renku.ch/api",
  "WELCOME_PAGE": "IyMgV2VsY29tZSB0byBSZW5rdSB0aHJvdWdoIHRlbGVwcmVzZW5jZQpTb21lIGRlcGxveW1lbnQtc3BlY2lmaWMgaW5mb3JtYXRpb24gd2lsbCBiZSByZWFkIGZyb20gdGhlIHlvdXIgdmFsdWVzLnlhbWwgZmlsZSBhbmQgYmUgZGlzcGxheWVkIGFzIG1hcmtkb3duIGZpbGUuCg==",
  "RENKU_VERSION": "latest",
  "RENKU_TEMPLATES_URL": "https://github.com/repos/SwissDataScienceCenter/renku-project-template",
  "RENKU_TEMPLATES_REF": "test-branch-manifests"
}
