### PR TITLE
perf(notebooks): move servers filtering to backend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14300,9 +14300,9 @@
       }
     },
     "reactstrap": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-8.0.0.tgz",
-      "integrity": "sha512-Rd7MyaFnZZXe1lbeBlgkxzyv+u7Z/ots0yYoO6ijT7/0uGsNwB1ch2h2t7Tf6u05jpbTFlLD+lyBEER0eibcQw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-8.0.1.tgz",
+      "integrity": "sha512-GvUWEL+a2+3npK1OxTXcNBMHXX4x6uc1KQRzK7yAOl+8sAHTRWqjunvMUfny3oDh8yKVzgqpqQlWWvs1B2HR9A==",
       "requires": {
         "@babel/runtime": "^7.2.0",
         "classnames": "^2.2.3",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "react-motion": "^0.5.2",
     "react-redux": "^5.0.6",
     "react-router-dom": "^4.2.2",
-    "reactstrap": "^8.0.0",
+    "reactstrap": "^8.0.1",
     "redux": "^3.7.2",
     "redux-thunk": "^2.2.0",
     "styled-jsx": "^2.2.6",

--- a/src/App.js
+++ b/src/App.js
@@ -98,7 +98,6 @@ class App extends Component {
                     user={this.props.userState.getState().user} {...p}/> }/>
               <Route exact path="/notebooks"
                 render={p => <Notebooks key="notebooks" standalone={true}
-                  user={this.props.userState.getState().user}
                   client={this.props.client} {...p} />} />
               <Route path="*"
                 render={p => <NotFound {...p} />} />

--- a/src/notebooks/Notebooks.container.js
+++ b/src/notebooks/Notebooks.container.js
@@ -19,260 +19,190 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux'
 
-import { NotebookServers } from './Notebooks.present';
+import { NotebooksModel } from './Notebooks.state';
 import { StartNotebookServer as StartNotebookServerPresent } from './Notebooks.present';
-
-import NotebooksModel from './Notebooks.state';
 import { Notebooks as NotebooksPresent } from './Notebooks.present';
 import { StatusHelper } from '../model/Model'
 
 /**
  * Displays a start page for new Jupiterlab servers.
  * 
+ * @param {Object} client   api-client used to query the gateway
  * @param {Object[]} branches   Branches as returned by gitlab "/branches" API - no autosaved branches
  * @param {Object[]} autosaved   Autosaved branches
  * @param {function} refreshBranches   Function to invoke to refresh the list of branches
- * @param {number} projectId   id of the reference project
- * @param {string} projectSlug   slug of the reference project (namespace + project path)
- * @param {string} namespacePath   full path of the reference namespace
- * @param {string} projectPath   path of the reference project
- * @param {Object} client   api-client used to query the gateway
- * @param {string} successUrl  Optional: url to redirect when then notebook is succesfully started
- * @param {Object} history  Optional: used with successUrl to properly set the new url without reloading the page
+ * @param {Object} scope    object containing filtering parameters
+ * @param {string} scope.namespace    full path of the reference namespace
+ * @param {string} scope.project    path of the reference project
+ * @param {string} [successUrl] - redirect url to be used when a notebook is succesfully started
+ * @param {Object} [history] - mandatory if successUrl is provided
  */
 class StartNotebookServer extends Component {
   constructor(props) {
     super(props);
     this.model = new NotebooksModel(props.client);
 
+    if (props.scope) {
+      this.model.setNotebookFilters(props.scope);
+    }
+
     this.handlers = {
       refreshBranches: this.refreshBranches.bind(this),
       refreshCommits: this.refreshCommits.bind(this),
-      setBranch: this.setBranchFromName.bind(this),
-      setCommit: this.setCommitFromId.bind(this),
+      setBranch: this.selectBranch.bind(this),
+      setCommit: this.selectCommit.bind(this),
       toggleMergedBranches: this.toggleMergedBranches.bind(this),
       setDisplayedCommits: this.setDisplayedCommits.bind(this),
       setServerOption: this.setServerOptionFromEvent.bind(this),
       startServer: this.startServer.bind(this)
     }
 
-    this.state = { 
+    this.state = {
       first: true,
-      startring: false
+      starting: false
     };
   }
 
   componentDidMount() {
     this._isMounted = true;
-    this.startNotebookPolling();
+    this.model.startNotebookPolling(true);
     this.refreshBranches();
   }
 
   componentWillUnmount() {
-    this.stopNotebookPolling();
+    this.model.stopNotebookPolling();
     this._isMounted = false;
   }
 
   componentDidUpdate(previousProps) {
-    // TODO: this is a temporary fix, remove it once the component won't be
-    // rerendered multiple times at the first url load
+    // TODO: temporary fix to prevent issue with component rerendered multiple times at the first url load
     if (this.state.first &&
         StatusHelper.isUpdating(previousProps.branches) &&
         !StatusHelper.isUpdating(this.props.branches)) {
-      this.autoselectBranch(this.props.branches);
       this.setState({ first: false });
-    }
-  }
-
-  refreshBranches() {
-    const { branches } = this.props;
-    if (StatusHelper.isUpdating(branches)) return;
-    this.props.refreshBranches().then((branches) => {
-      this.autoselectBranch(branches);
-    });
-  }
-
-  setBranch(branch) {
-    const oldBranch = this.model.get("filters.branch");
-    if (!branch.name || branch.name === oldBranch.name)
-      return;
-    this.model.setBranch(branch);
-    this.refreshCommits(branch);
-  } 
-  
-  setBranchFromName(eventOrName) {
-    const { branches } = this.props;
-    const branchName = eventOrName.target ?
-      eventOrName.target.value :
-      eventOrName;
-    for (let branchCurrent of branches) {
-      if (branchName === branchCurrent.name) {
-        this.setBranch(branchCurrent);
+      if (this._isMounted) {
+        this.selectBranch();
       }
     }
   }
 
-  validateBranch(updatedBranches, updatedBranch) {
-    const branch = updatedBranch ?
-      updatedBranch :
-      this.model.get("filters.branch");
-    if (branch.name === undefined)
-      return true;
-    
-    const branches = updatedBranches ?
-      updatedBranches :
-      this.props.branches;
-    const filterBranches = !this.model.get("filters.includeMergedBranches");
-    const filteredBranches = filterBranches ?
-      branches.filter(branch => !branch.merged ? branch : null ) :
-      branches;
-    for (let branchCurrent of filteredBranches) {
-      if (branch.name === branchCurrent.name) {
-        return true;
-      }
-    }
-
-    this.setBranch({});
-    this.setCommit({});
-    return false;
-  }
-
-  autoselectBranch(branches, defaultBranch = "master") {
+  async refreshBranches() {
     if (this._isMounted) {
-      const branch = this.model.get("filters.branch");
-      if (!branch.name) {
-        const autoSelect = branches.filter(branch => branch.name === defaultBranch);
-        if (autoSelect.length !== 1) return; // improve this logic if necessary when defaultBranch will be dynamic
-        this.setBranch(autoSelect[0]);
+      if (StatusHelper.isUpdating(this.props.branches))
+        return;
+      await this.props.refreshBranches();
+      if (this._isMounted && this.state.first) {
+        this.selectBranch();
+      }
+    }
+  }
+
+  async selectBranch(branchName) {
+    if (this._isMounted) {
+      // get the useful branchName
+      if (!branchName) {
+        const oldBranch = this.model.get("filters.branch");
+        if (oldBranch && oldBranch.branchName)
+          branchName = oldBranch.branchName;
+        else
+          branchName = "master";
+      }
+
+      // get the proper branch and set it
+      const { branches } = this.props;
+      const branch = branches.filter(branch => branch.name === branchName);
+      if (branch.length === 1) {
+        this.model.setBranch(branch[0]);
+        this.refreshCommits();
       }
       else {
-        this.validateBranch(branches);
+        this.model.setBranch({});
+        this.model.setCommit({});
       }
     }
   }
 
-  refreshCommits(updatedBranch) {
-    const commits = this.model.get("data.commits");
-    if (StatusHelper.isUpdating(commits)) return;
-    const { projectId } = this.props;
-    const branch = updatedBranch && typeof updatedBranch === "string" ?
-      updatedBranch :
-      this.model.get("filters.branch");
-    this.model.fetchCommits(projectId, branch.name).then((commits) => {
-      this.autoselectCommit(commits);
-    });
-  }
-
-  setCommit(commit) {
-    const oldCommit = this.model.get("filters.commit");
-    if (commit.id === oldCommit.id) {
-      return;
-    }
-    this.model.setCommit(commit);
-    this.model.verifyIfRunning(this.props.projectId, this.props.projectSlug);
-  }
-
-  setCommitFromId(eventOrId) {
-    const commits = this.model.get("data.commits");
-    const commitId = eventOrId.target ?
-      eventOrId.target.value :
-      eventOrId;
-    for (let commitCurrent of commits) {
-      if (commitId === commitCurrent.id) {
-        this.setCommit(commitCurrent);
-      }
-    }
-  }
-
-  validateCommit(updatedCommits, updatedCommit) {
-    const commit = updatedCommit ?
-      updatedCommit :
-      this.model.get("filters.commit");
-    if (commit.id === undefined) {
-      return true;
-    }
-
-    const commits = updatedCommits ?
-      updatedCommits :
-      this.model.get("data.commits");
-
-    const maxCommits = this.model.get("filters.displayedCommits");
-    const filteredCommits = maxCommits && maxCommits > 0 ?
-      commits.slice(0, maxCommits) :
-      commits;
-    for (let commitCurrent of filteredCommits) {
-      if (commit.id === commitCurrent.id) {
-        // necessary for istant refresh in the UI
-        this.model.verifyIfRunning(this.props.projectId, this.props.projectSlug);
-        return true;
-      }
-    }
-
-    this.setCommit({});
-    return false;
-  }
-
-  autoselectCommit(commits, defaultCommit = 0) {
+  async refreshCommits() {
     if (this._isMounted) {
+      if (this.model.get("data.fetching"))
+        return;
+
+      await this.model.fetchCommits();
       if (this._isMounted) {
-        const commit = this.model.get("filters.commit");
-        if (!commit.id) {
-          const autoSelect = commits[defaultCommit];
-          if (!autoSelect) return; // improve this logic if "latest" won't be the default anymore
-          this.setCommit(autoSelect);
-        }
-        else {
-          this.validateCommit(commits);
-        }
+        this.selectCommit();
       }
+    }
+  }
+
+  async selectCommit(commitId) {
+    if (this._isMounted) {
+      // get the useful commitId
+      if (!commitId) {
+        const oldCommit = this.model.get("filters.commit");
+        if (oldCommit && oldCommit.id)
+          commitId = oldCommit.id;
+        else
+          commitId = "latest";
+      }
+
+      // get the proper commit and set it
+      const maximum = this.model.get("filters.displayedCommits");
+      const commits = maximum && parseInt(maximum) > 0 ?
+        this.model.get("data.commits").slice(0, maximum) :
+        this.model.get("data.commits");
+
+      let commit;
+      if (commitId === "latest")
+        commit = commits[0];
+      else {
+        commit = commits.filter(commit => commit.id === commitId);
+        if (commit.length !== 1) {
+          this.model.setCommit({});
+          return;
+        }
+        commit = commit[0];
+      }
+
+      this.model.setCommit(commit);
+      this.model.fetchNotebookOptions();
     }
   }
 
   setServerOptionFromEvent(option, event) {
     const value = event.target.checked !== undefined ?
-      event.target.checked:
+      event.target.checked :
       event.target.value;
     this.model.setNotebookOptions(option, value);
   }
 
   startServer() {
-    // Data from notebooks/servers endpoint needs some time to update propery.
-    // To avoid flickering UI, just set a temporary state and display a loading wheel.
-    // TODO: change this when the notebook service will be updated.
-    const { successUrl, namespacePath, projectPath } = this.props;
-    if (!successUrl) {
-      this.model.startServer(namespacePath, projectPath);
-    }
-    else {
-      this.setState({ "starting": true });
-      this.model.startServer(namespacePath, projectPath).then((data) => {
-        this.props.history.push(successUrl);
-      });
-    }
+    //* Data from notebooks/servers endpoint needs some time to update properly.
+    //* To avoid flickering UI, just set a temporary state and display a loading wheel.
+    const { successUrl, history } = this.props;
+    this.setState({ "starting": true });
+    this.model.startServer().then(() => {
+      this.setState({ "starting": false });
+      if (successUrl && history)
+        history.push(successUrl);
+    });
   }
 
-  toggleMergedBranches(event) {
+  toggleMergedBranches() {
     const currentSetting = this.model.get("filters.includeMergedBranches");
     this.model.setMergedBranches(!currentSetting);
-    this.validateBranch();
+    this.selectBranch();
   }
 
-  setDisplayedCommits(event) {
-    this.model.setDisplayedCommits(event.target.value);
-    this.validateCommit();
+  setDisplayedCommits(number) {
+    this.model.setDisplayedCommits(number);
+    this.selectCommit();
   }
 
-  startNotebookPolling() {
-    this.model.startNotebookPolling(this.props.projectId, this.props.projectSlug, true);
-  }
-
-  stopNotebookPolling() {
-    this.model.stopNotebookPolling();
-  }
-  
   mapStateToProps(state, ownProps) {
-    const augmentedState = { ...state,
-      data: {...state.data,
+    const augmentedState = {
+      ...state,
+      data: {
+        ...state.data,
         branches: ownProps.inherited.branches,
         autosaved: ownProps.inherited.autosaved
       }
@@ -289,44 +219,46 @@ class StartNotebookServer extends Component {
 
     return <ConnectedStartNotebookServer
       store={this.model.reduxStore}
-      inherited={this.props} // need to espose them for mapStateToProps, but don't whan to pollute props
-      projectId={this.props.projectId}
-      projectSlug={this.props.projectSlug}
+      inherited={this.props}
       justStarted={this.state.starting}
     />;
   }
 }
 
 /**
+ * Display the list of Notebook servers
+ * 
  * @param {Object} client   api-client used to query the gateway
  * @param {boolean} standalone   Indicates whether it's displayed as standalone
- * @param {number} projectId   Optional, used to focus on a single project
+ * @param {Object} [scope]    object containing filtering parameters
+ * @param {string} [scope.namespace]    full path of the reference namespace
+ * @param {string} [scope.project]    path of the reference project
+ * @param {string} [scope.branch]   branch name
+ * @param {string} [scope.commit]   commit full id
  */
 class Notebooks extends Component {
   constructor(props) {
     super(props);
     this.model = new NotebooksModel(props.client);
 
+    if (props.scope) {
+      this.model.setNotebookFilters(props.scope);
+    }
+
     this.handlers = {
-      onStopNotebook: this.onStopNotebook.bind(this)
+      stopNotebook: this.stopNotebook.bind(this)
     }
   }
 
   componentDidMount() {
-    this.startNotebookPolling();
+    this.model.startNotebookPolling();
   }
 
   componentWillUnmount() {
-    this.stopNotebookPolling();
-  }
-
-  startNotebookPolling() {
-    this.model.startNotebookPolling(this.props.projectId);
-  }
-  stopNotebookPolling() {
     this.model.stopNotebookPolling();
   }
-  onStopNotebook(serverName){
+
+  stopNotebook(serverName) {
     this.model.stopNotebook(serverName);
   }
 
@@ -344,10 +276,9 @@ class Notebooks extends Component {
       store={this.model.reduxStore}
       user={this.props.user}
       standalone={this.props.standalone ? this.props.standalone : false}
-      projectId={this.props.projectId}
+      scope={this.props.scope}
     />
   }
 }
 
-
-export { NotebookServers, Notebooks, StartNotebookServer };
+export { Notebooks, StartNotebookServer };

--- a/src/notebooks/index.js
+++ b/src/notebooks/index.js
@@ -23,6 +23,7 @@
  *
  */
 
-import { Notebooks, NotebookServers, StartNotebookServer } from './Notebooks.container';
+import { Notebooks, StartNotebookServer } from './Notebooks.container';
+import { NotebooksHelper } from './Notebooks.state'
 
-export { NotebookServers, Notebooks, StartNotebookServer }
+export { Notebooks, StartNotebookServer, NotebooksHelper }

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -605,8 +605,10 @@ function notebookLauncher(visibility, notebookLauncher) {
 class ProjectNotebookServers extends Component {
   render() {
     const content = [
-      <Notebooks key="notebooks" standalone={false}
-        projectId={this.props.id} client={this.props.client}
+      <Notebooks key="notebooks"
+        standalone={false}
+        client={this.props.client}
+        scope={{namespace: this.props.core.namespace_path, project: this.props.core.project_path}}
       />,
       <Link key="launch" to={ `/projects/${this.props.id}/launchNotebook` }>
         <Button color="primary">Start new server</Button>
@@ -620,14 +622,11 @@ class ProjectNotebookServers extends Component {
 class ProjectStartNotebookServer extends Component {
   render() {
     let content = (<StartNotebookServer
+      client={this.props.client}
       branches={this.props.system.branches}
       autosaved={this.props.system.autosaved}
       refreshBranches={this.props.fetchBranches}
-      projectId={this.props.core.id}
-      projectSlug={this.props.core.displayId}
-      namespacePath={this.props.core.namespace_path}
-      projectPath={this.props.core.project_path}
-      client={this.props.client}
+      scope={{namespace: this.props.core.namespace_path, project: this.props.core.project_path}}
       successUrl={this.props.notebookServersUrl}
       history={this.props.history}
     />);


### PR DESCRIPTION
Improves performances by transferring all the filtering logic to the backend. Refactors components
in Notebooks pages to simplify re-using parts of the code.

How to test it: ideally there aren't big differences at the user's level. The best way to test is by playing with notebooks, especially
- go in any own project in the `Notebook servers` tab and try to start, connect to and stop a notebook
- go in the global `Notebook` page and check if the information is accurate

Preview at: https://lorenzotest.dev.renku.ch

fix #518