### PR TITLE
test: fix non blocking errors in tests

### DIFF
--- a/src/api-client/test-client.js
+++ b/src/api-client/test-client.js
@@ -100,6 +100,12 @@ const methods = {
   },
   getNotebookServerUrl: {
     response: null
+  },
+  getProjectTemplates: {
+    response: []
+  },
+  getNotebookServerOptions: {
+    response: {}
   }
 };
 


### PR DESCRIPTION
fix the following error: UnhandledPromiseRejectionWarning: TypeError: this.client.<functionName> is
not a function

how to test it: run `npm test` on all tests (parameter `a`) and verify that the aforementioned error doesn't appear anymore. It used to happen with the functions `getProjectTemplates` and `getNotebookServerOptions`