### PR TITLE
feat(notebooks): check docker image related pipeline before starting a new server

### DIFF
--- a/src/api-client/index.js
+++ b/src/api-client/index.js
@@ -29,6 +29,7 @@ import addKuMethods  from './ku';
 import addInstanceMethods from './instance';
 import addNotebookServersMethods from './notebook-servers';
 import addGraphMethods from './graph';
+import addPipelineMethods from './pipeline';
 
 import testClient from './test-client'
 
@@ -64,6 +65,7 @@ class APIClient {
     addInstanceMethods(this);
     addNotebookServersMethods(this);
     addGraphMethods(this);
+    addPipelineMethods(this);
   }
 
   // A fetch method which is attached to a API client instance so that it can

--- a/src/api-client/pipeline.js
+++ b/src/api-client/pipeline.js
@@ -1,0 +1,86 @@
+/*!
+ * Copyright 2019 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function addPipelineMethods(client) {
+  client.runPipeline = (projectId) => {
+    const headers = client.getBasicHeaders();
+    headers.append('Content-Type', 'application/json');
+    return client.clientFetch(`${client.baseUrl}/projects/${projectId}/pipeline`, {
+      method: 'POST',
+      headers: headers,
+      body: JSON.stringify({
+        ref: "master"
+      })
+    })
+  }
+
+  /**
+   * Get the array of pipeline from GitLab
+   * 
+   * @param {number|string} projectId - project id or slug
+   * @param {string} commit - commit id of the pipelines
+   */
+  client.getPipelines = (projectId, commitId) => {
+    const headers = client.getBasicHeaders();
+    headers.append('Content-Type', 'application/json');
+    const url = `${client.baseUrl}/projects/${projectId}/pipelines`;
+    const parameters = { sha: commitId };
+
+    return client.clientFetch(url, {
+      method: 'GET',
+      headers,
+      queryParams: parameters
+    }).then(response => response.data);
+  }
+
+  /**
+   * Get all jobs for a specific pipeline
+   * 
+   * @param {number|string} projectId - project id or slug
+   * @param {number} pipelineId - pipeline id
+   */
+  client.getPipelineJobs = (projectId, pipelineId) => {
+    const headers = client.getBasicHeaders();
+    headers.append('Content-Type', 'application/json');
+    const url = `${client.baseUrl}/projects/${projectId}/pipelines/${pipelineId}/jobs`;
+
+    return client.clientFetch(url, {
+      method: 'GET',
+      headers,
+    }).then(response => response.data);
+  }
+
+  /**
+   * Run again all jobs for a specific pipeline
+   * 
+   * @param {number|string} projectId - project id or slug
+   * @param {number} pipelineId - pipeline id
+   */
+  client.retryPipeline = (projectId, pipelineId) => {
+    const headers = client.getBasicHeaders();
+    headers.append('Content-Type', 'application/json');
+    const url = `${client.baseUrl}/projects/${projectId}/pipelines/${pipelineId}/retry`;
+
+    return client.clientFetch(url, {
+      method: 'POST',
+      headers,
+    }).then(response => response.data);
+  }
+}
+
+export default addPipelineMethods;

--- a/src/api-client/project.js
+++ b/src/api-client/project.js
@@ -200,7 +200,7 @@ function addProjectMethods(client) {
     }
   }
 
-  client.getProjectStatus = (projectId) =>{
+  client.getProjectStatus = (projectId) => {
     const headers = client.getBasicHeaders();
     headers.append('Content-Type', 'application/json');
     return client.clientFetch(`${client.baseUrl}/projects/${projectId}/import`, {
@@ -211,34 +211,22 @@ function addProjectMethods(client) {
     }).catch((error) => "error");
   } 
 
-  function runPipeline(projectId){
-    const headers = client.getBasicHeaders();
-    headers.append('Content-Type', 'application/json');
-    return  client.clientFetch(`${client.baseUrl}/projects/${projectId}/pipeline`, {
-      method: 'POST',
-      headers: headers,
-      body: JSON.stringify({
-        ref: "master"
-      })
-    })
-  }
-
-  client.startPipeline =  (projectId) => {
+  client.startPipeline = (projectId) => {
     const headers = client.getBasicHeaders();
     headers.append('Content-Type', 'application/json');
     let pipelineStarted = false;
-    let counter= 0;
+    let counter = 0;
     const projectStatusTimeout = setTimeout(() => {
-      if(pipelineStarted === true || counter === 10) 
+      if (pipelineStarted === true || counter === 10)
         clearTimeout(projectStatusTimeout);
       else {
         client.getProjectStatus(projectId).then((forkProjectStatus) => {
-          if(forkProjectStatus === 'finished'){
-            runPipeline(projectId).then(resp => {
+          if (forkProjectStatus === 'finished') {
+            client.runPipeline(projectId).then(resp => {
               pipelineStarted = true;
               clearTimeout(projectStatusTimeout);
-            });    
-          } else if(forkProjectStatus === 'failed' || forkProjectStatus === 'error'){
+            });
+          } else if (forkProjectStatus === 'failed' || forkProjectStatus === 'error') {
             clearTimeout(projectStatusTimeout);
           } else {
             counter++;
@@ -248,21 +236,21 @@ function addProjectMethods(client) {
     }, 3000);
   }
 
-  function redirectWhenForkFinished(projectId, history){
+  function redirectWhenForkFinished(projectId, history) {
     const headers = client.getBasicHeaders();
     headers.append('Content-Type', 'application/json');
     let redirected = false;
-    let counter= 0;
+    let counter = 0;
     const projectStatusTimeout = setTimeout(() => {
-      if(redirected === true || counter === 200) 
+      if (redirected === true || counter === 200)
         clearTimeout(projectStatusTimeout);
       else {
         client.getProjectStatus(projectId).then((forkProjectStatus) => {
-          if(forkProjectStatus === 'finished'){
+          if (forkProjectStatus === 'finished') {
             redirected = true;
             clearTimeout(projectStatusTimeout);
             history.push(`/projects/${projectId}`);
-          } else if(forkProjectStatus === 'failed' || forkProjectStatus === 'error'){
+          } else if (forkProjectStatus === 'failed' || forkProjectStatus === 'error') {
             clearTimeout(projectStatusTimeout);
           } else {
             counter++;
@@ -298,7 +286,7 @@ function addProjectMethods(client) {
     let promises = [newProjectPromise];
     if (createGraphWebhookPromise) {
       promises = promises.concat(createGraphWebhookPromise);
-    }    
+    }
 
     promises = promises.concat(startPipelinePromise);
 

--- a/src/api-client/project.js
+++ b/src/api-client/project.js
@@ -374,15 +374,6 @@ function addProjectMethods(client) {
       })
   }
 
-  client.getJobs = (projectId) => {
-    let headers = client.getBasicHeaders();
-    return client.clientFetch(`${client.baseUrl}/projects/${projectId}/jobs`, {
-      method: 'GET',
-      headers,
-      queryParams: { per_page: 100 }
-    }, 'json', false)
-  }
-
   client.getProjectTemplates = (renkuTemplatesUrl, renkuTemplatesRef) => {
     const formatedApiURL = getApiURLfromRepoURL(renkuTemplatesUrl);
     return fetchJson(`${formatedApiURL}/git/trees/${renkuTemplatesRef}`)

--- a/src/api-client/test-client.js
+++ b/src/api-client/test-client.js
@@ -75,11 +75,6 @@ const methods = {
       data: []
     }
   },
-  getJobs: {
-    response: {
-      data: []
-    }
-  },
   getNamespaces: {
     response: {
       data: samples.namespaces

--- a/src/model/RenkuModels.js
+++ b/src/model/RenkuModels.js
@@ -124,7 +124,6 @@ const projectSchema = new Schema({
       merge_requests: {schema: [], initial:[]},
       branches: {schema: [], initial:[]},
       autosaved: {schema: [], initial:[]},
-      ci_jobs: {schema: [], initial:[]}
     }
   },
   files: {

--- a/src/project/Project.js
+++ b/src/project/Project.js
@@ -69,7 +69,6 @@ class View extends Component {
   async fetchMergeRequests() { return this.projectState.fetchMergeRequests(this.props.client, this.props.id); }
   async fetchModifiedFiles() { return this.projectState.fetchModifiedFiles(this.props.client, this.props.id); }
   async fetchBranches() { return this.projectState.fetchBranches(this.props.client, this.props.id); }
-  async fetchCIJobs() { return this.projectState.fetchCIJobs(this.props.client, this.props.id); }
   async createGraphWebhook() { return this.projectState.createGraphWebhook(this.props.client, this.props.id); }
   async stopCheckingWebhook() { this.projectState.stopCheckingWebhook(); }
   async fetchGraphWebhook() { this.projectState.fetchGraphWebhook(this.props.client, this.props.id, this.props.user); }
@@ -83,12 +82,8 @@ class View extends Component {
 
   async fetchAll() {
     await this.fetchProject();
-
-    // these are fetched only if user is logged in
-    if (this.props.user.id) {
-      this.fetchCIJobs();
+    if (this.props.user.id)
       this.checkGraphWebhook();
-    }
   }
 
   cleanCurrentURL(){
@@ -144,7 +139,6 @@ class View extends Component {
       fileContentUrl: `${fileContentUrl}`,
       lineagesUrl: `${filesUrl}/lineage`,
       lineageUrl: `${filesUrl}/lineage/:filePath+`,
-      notebooksUrl: `${filesUrl}/notebooks`,
       notebookUrl: `${fileContentUrl}/:filePath([^.]+.ipynb)`,
       dataUrl: `${filesUrl}/data`,
       workflowsUrl: `${filesUrl}/workflows`,
@@ -171,24 +165,6 @@ class View extends Component {
       .filter(branch => branch.name !== 'master')
       .filter(branch => !branch.merged)
       .filter(branch => mergeRequestBranches.indexOf(branch.name) < 0);
-  }
-
-  getImageBuildStatus() {
-    const ciJobs = this.projectState.get('system.ci_jobs');
-
-    // We don't want to flash an alert while the state is updating.
-    if (ciJobs === this.projectState._updatingPropVal) return;
-
-    const buildJobs = (ciJobs || [])
-      .filter((job) => job.name === 'image_build')
-      .sort((job1, job2) => job1.created_at > job2.created_at ? -1 : 1);
-
-    if (buildJobs.length === 0) {
-      return;
-    }
-    else {
-      return buildJobs[0]
-    }
   }
 
   subComponents(projectId, ownProps) {
@@ -323,7 +299,6 @@ class View extends Component {
     setOpenFolder: (filePath) => { 
       this.setProjectOpenFolder(filePath);
     },
-    fetchCIJobs: () => { this.fetchCIJobs() },
     createGraphWebhook: (e) => { 
       e.preventDefault();
       return this.createGraphWebhook();
@@ -346,7 +321,6 @@ class View extends Component {
     const suggestedMRBranches = this.getMrSuggestions();
     const externalUrl = this.projectState.get('core.external_url');
     const canCreateMR = state.visibility.accessLevel >= ACCESS_LEVELS.DEVELOPER;
-    const imageBuild = this.getImageBuildStatus();
     const forkModalOpen = this.projectState.get('forkModalOpen');
 
     return {
@@ -360,7 +334,6 @@ class View extends Component {
       suggestedMRBranches,
       externalUrl,
       canCreateMR,
-      imageBuild
     }
   }
 

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -53,20 +53,6 @@ import { ACCESS_LEVELS } from '../api-client';
 
 import './Project.css';
 
-const imageBuildStatusText = {
-  failed: 'No notebook image has been built. You can still open a notebook server with the default image.',
-  canceled: 'The notebook image build has been cancelled.  You can still open a notebook server with the default image',
-  running: 'The notebook image build is still ongoing. Wait a bit before launching a notebook...',
-  pending: 'The notebook image build is still pending. Wait a bit before launching a notebook...'
-};
-
-const imageBuildAlertColor = {
-  failed: 'danger',
-  canceled: 'danger',
-  running: 'warning',
-  pending: 'warning'
-};
-
 function filterPaths(paths, blacklist) {
   // Return paths to do not match the blacklist of regexps.
   const result = paths.filter(p => blacklist.every(b => p.match(b) === null))
@@ -84,16 +70,6 @@ function webhookError(props) {
     return false;
   }
   return true;
-}
-
-class ImageBuildInfoBadge extends Component {
-  render() {
-    const imageBuild = this.props.imageBuild || { status: 'success' };
-    if (imageBuild.status === 'success') return null;
-    return <Link className={`badge badge-${imageBuildAlertColor[imageBuild.status]}`}
-      title={imageBuildStatusText[imageBuild.status] || imageBuildStatusText['failed']}
-      to={this.props.notebooksUrl}>Notebooks</Link>
-  }
 }
 
 class ProjectVisibilityLabel extends Component {
@@ -289,9 +265,6 @@ class ProjectViewHeaderOverview extends Component {
                 }
               </div>
             </div>
-            <p className="text-md-right">
-              <ImageBuildInfoBadge notebooksUrl={this.props.notebooksUrl} imageBuild={this.props.imageBuild} />
-            </p>
           </Col>
         </Row>
         <KnowledgeGraphIntegrationWarningBanner {...this.props} />

--- a/src/project/Project.state.js
+++ b/src/project/Project.state.js
@@ -285,16 +285,6 @@ class ProjectModel extends StateModel {
 
     })
   }
-
-  fetchCIJobs(client, id) {
-    this.setUpdating({system: {ci_jobs: true}});
-    client.getJobs(id)
-      .then(resp => resp.data)
-      .then((d) => {
-        this.set('system.ci_jobs', d)
-      })
-      .catch((error) => this.set('system.ci_jobs', []));
-  }
 }
 
 export { ProjectModel, GraphIndexingStatus };

--- a/src/utils/UIComponents.js
+++ b/src/utils/UIComponents.js
@@ -202,6 +202,9 @@ class ExternalLink extends Component {
     if (this.props.disabled) {
       className += " disabled";
     }
+    if (this.props.className) {
+      className += ` ${this.props.className}`;
+    }
     return <a href={this.props.url}
       className={className} role="button" target="_blank"
       rel="noreferrer noopener">{this.props.title}</a>


### PR DESCRIPTION
When starting a new interactive environment, the UI now checks for the Docker image availability.
Behind the scenes, only the GitLab pipelines are effectively checked -- technically it is still possible that the pipeline containing the image build process has correctly terminated but the image is not available anymore in the Docker repository.

Preview available here: https://lorenzotest.dev.renku.ch/

How to test: open a project, create a new commit and open the "start new server" page just after. Verify that the "Docker Image" badge says something is ongoing and is updated later.
It's possible to play a bit with the relevant pipeline by opening it in GitLab and start/stop/re-run it. The information should be updated almost immediately.

fix #495

![Screenshot from 2019-08-22 09-29-48](https://user-images.githubusercontent.com/43481553/63495083-73ac9a80-c4bf-11e9-8ec2-84d3ffd5302f.png)
