### PR TITLE
fix(notebooks): pick correct value in notebook options range inputs

### DIFF
--- a/src/notebooks/Notebooks.container.js
+++ b/src/notebooks/Notebooks.container.js
@@ -169,7 +169,7 @@ class StartNotebookServer extends Component {
   }
 
   setServerOptionFromEvent(option, event) {
-    const value = event.target.checked !== undefined ?
+    const value = event.target.type.toLowerCase() === "checkbox"?
       event.target.checked :
       event.target.value;
     this.model.setNotebookOptions(option, value);


### PR DESCRIPTION
Components including `<input type="range">` html elements in the notebook options selection were not working correctly anymore because the target value was not properly selected.
This PR fixes it restoring the possibility to choose the number of GPU for a notebook -- only for renku deployments where this is allowed like `limited`.

fix #574