### PR TITLE
refactor: add local timezone aware date format

### DIFF
--- a/src/notebooks/Notebooks.present.js
+++ b/src/notebooks/Notebooks.present.js
@@ -652,7 +652,7 @@ class StartNotebookCommits extends Component {
       commits;
     const commitOptions = filteredCommits.map((commit) => {
       return <option key={commit.id} value={commit.id}>
-        {commit.short_id} - {commit.author_name} - {Time.toISOString(commit.committed_date)}
+        {commit.short_id} - {commit.author_name} - {Time.toIsoTimezoneString(commit.committed_date)}
       </option>
     });
     return (

--- a/src/utils/Time.js
+++ b/src/utils/Time.js
@@ -41,7 +41,7 @@ class Time {
     throw(new Error("Invalid date"));
   }
 
-  static toISOString(inputDate, type="datetime") {
+  static toIsoString(inputDate, type="datetime") {
     const date = this.parseDate(inputDate);
     const readableDate = date.toISOString().substring(0, 19).replace("T", " ");
     if (type === "datetime") {
@@ -56,6 +56,13 @@ class Time {
     else {
       throw(new Error(`Uknown type "${type}"`));
     }
+  }
+
+  static toIsoTimezoneString(inputDate, type="datetime") {
+    // add the timezone manually and then convert to ISO string
+    const date = this.parseDate(inputDate);
+    const isoDate = new Date(date.getTime() - (date.getTimezoneOffset() * 60000)).toISOString();
+    return this.toIsoString(isoDate, type);
   }
 }
 


### PR DESCRIPTION
The commit datetime showed to the user while launching a new notebook is now local timezone aware.

fix #571