### PR TITLE
feat(notebooks): notebook servers for anonymous users

### DIFF
--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -294,13 +294,7 @@ class ProjectViewHeader extends Component {
 }
 
 class ProjectNav extends Component {
-
   render() {
-    const notebookServers = this.props.user.id ?
-      <NavItem>
-        <RenkuNavLink exact={false} to={this.props.notebookServersUrl} title="Notebook Servers" />
-      </NavItem>:
-      null
     return (
       <Nav pills className={'nav-pills-underline'}>
         <NavItem>
@@ -315,11 +309,14 @@ class ProjectNav extends Component {
         <NavItem>
           <RenkuNavLink exact={false} to={this.props.mrOverviewUrl} title="Pending Changes" />
         </NavItem>
-        {notebookServers}
+        <NavItem>
+          <RenkuNavLink exact={false} to={this.props.notebookServersUrl} title="Notebook Servers" />
+        </NavItem>
         <NavItem>
           <RenkuNavLink exact={false} to={this.props.settingsUrl} title="Settings" />
         </NavItem>
-      </Nav>)
+      </Nav>
+    );
   }
 }
 
@@ -565,13 +562,43 @@ class ProjectViewFiles extends Component {
   }
 }
 
-function notebookLauncher(visibility, notebookLauncher) {
-  let content = null;
-  if (visibility.accessLevel >= ACCESS_LEVELS.DEVELOPER) {
-    content = notebookLauncher;
-  } else {
-    content = (<p>You are missing the permissions to launch Jupyter from this project.</p>);
+function notebookLauncher(userId, accessLevel, notebookLauncher, fork) {
+  if (accessLevel >= ACCESS_LEVELS.DEVELOPER)
+    return (<Col xs={12}>{notebookLauncher}</Col>);
+
+  let content = [<p key="no-permission">You are missing the permissions to launch an interactive environment
+    from this project.</p>];
+  if (userId == null) {
+    content = content.concat(
+      <InfoAlert timeout={0} key="login-info">
+        <p className="mb-0">
+          <FontAwesomeIcon icon={faInfoCircle} /> You need to be logged in to use our interactive environments.
+        </p>
+      </InfoAlert>
+    );
   }
+  else {
+    content = content.concat(
+      <InfoAlert timeout={0} key="login-info">
+        <p>Since this is not a private project, you can still do one of the following:</p>
+        <ul className="mb-0">
+          <li>
+            <Button className="p-0 border-0" color="link" onClick={(event) => fork(event)}>
+              Fork the project
+            </Button> and start an interactive environment from there.
+          </li>
+          <li>
+            If you received the link to this project from a maintainer, ask them
+            to <a href="https://renku.readthedocs.io/en/latest/user/collaboration.html#added-to-project"
+              target="_blank" rel="noreferrer noopener">
+              grant you the necessary permissions
+            </a>.
+          </li>
+        </ul>
+      </InfoAlert>
+    );
+  }
+
   return (<Col xs={12}>{content}</Col>);
 }
 
@@ -588,7 +615,10 @@ class ProjectNotebookServers extends Component {
       </Link>
     ];
 
-    return (notebookLauncher(this.props.visibility, content));
+    return (notebookLauncher(this.props.user.id,
+      this.props.visibility.accessLevel,
+      content,
+      this.props.toogleForkModal));
   }
 }
 
@@ -604,7 +634,10 @@ class ProjectStartNotebookServer extends Component {
       history={this.props.history}
     />);
 
-    return (notebookLauncher(this.props.visibility, content));
+    return (notebookLauncher(this.props.user.id,
+      this.props.visibility.accessLevel,
+      content,
+      this.props.toggleModalFork));
   }
 }
 

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -573,7 +573,8 @@ function notebookLauncher(userId, accessLevel, notebookLauncher, fork, postLogin
     content = content.concat(
       <InfoAlert timeout={0} key="login-info">
         <p className="mb-0">
-          <FontAwesomeIcon icon={faInfoCircle} /> <Link className="btn btn-primary btn-sm" to={to} previous={postLoginUrl}>Log in</Link> to use interactive environments.
+          <Link className="btn btn-primary btn-sm" to={to} previous={postLoginUrl}>Log in</Link> to use
+          interactive environments.
         </p>
       </InfoAlert>
     );

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -562,17 +562,18 @@ class ProjectViewFiles extends Component {
   }
 }
 
-function notebookLauncher(userId, accessLevel, notebookLauncher, fork) {
+function notebookLauncher(userId, accessLevel, notebookLauncher, fork, postLoginUrl, externalUrl) {
   if (accessLevel >= ACCESS_LEVELS.DEVELOPER)
     return (<Col xs={12}>{notebookLauncher}</Col>);
 
-  let content = [<p key="no-permission">You are missing the permissions to launch an interactive environment
-    from this project.</p>];
+  let content = [<p key="no-permission">You do not have sufficient permissions to launch an interactive environment
+    for this project.</p>];
   if (userId == null) {
+    const to = { "pathname": "/login", "state": { previous: postLoginUrl } };
     content = content.concat(
       <InfoAlert timeout={0} key="login-info">
         <p className="mb-0">
-          <FontAwesomeIcon icon={faInfoCircle} /> You need to be logged in to use our interactive environments.
+          <FontAwesomeIcon icon={faInfoCircle} /> <Link className="btn btn-primary btn-sm" to={to} previous={postLoginUrl}>Log in</Link> to use interactive environments.
         </p>
       </InfoAlert>
     );
@@ -580,15 +581,15 @@ function notebookLauncher(userId, accessLevel, notebookLauncher, fork) {
   else {
     content = content.concat(
       <InfoAlert timeout={0} key="login-info">
-        <p>Since this is not a private project, you can still do one of the following:</p>
+        <p>You can still do one of the following:</p>
         <ul className="mb-0">
           <li>
-            <Button className="p-0 border-0 align-baseline" color="link" onClick={(event) => fork(event)}>
+            <Button size="sm" color="primary" onClick={(event) => fork(event)}>
               Fork the project
-            </Button> and start an interactive environment from there.
+            </Button> and start an interactive environment from your fork.
           </li>
-          <li>
-            If you received the link to this project from a maintainer, ask them
+          <li className="pt-1">
+            <ExternalLink size="sm" url={`${externalUrl}/project_members`} title="Contact a maintainer" /> and ask them
             to <a href="https://renku.readthedocs.io/en/latest/user/collaboration.html#added-to-project"
               target="_blank" rel="noreferrer noopener">
               grant you the necessary permissions
@@ -618,7 +619,9 @@ class ProjectNotebookServers extends Component {
     return (notebookLauncher(this.props.user.id,
       this.props.visibility.accessLevel,
       content,
-      this.props.toogleForkModal));
+      this.props.toogleForkModal,
+      this.props.location.pathname,
+      this.props.externalUrl));
   }
 }
 
@@ -637,7 +640,9 @@ class ProjectStartNotebookServer extends Component {
     return (notebookLauncher(this.props.user.id,
       this.props.visibility.accessLevel,
       content,
-      this.props.toggleModalFork));
+      this.props.toggleModalFork,
+      this.props.location.pathname,
+      this.props.externalUrl));
   }
 }
 

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -583,7 +583,7 @@ function notebookLauncher(userId, accessLevel, notebookLauncher, fork) {
         <p>Since this is not a private project, you can still do one of the following:</p>
         <ul className="mb-0">
           <li>
-            <Button className="p-0 border-0" color="link" onClick={(event) => fork(event)}>
+            <Button className="p-0 border-0 align-baseline" color="link" onClick={(event) => fork(event)}>
               Fork the project
             </Button> and start an interactive environment from there.
           </li>


### PR DESCRIPTION
Notebook servers tab is now displayed also to users without sufficient permissions for the project.
The page contains an alert with meaningful information about what the user can do.

![Screenshot from 2019-08-22 14-44-39](https://user-images.githubusercontent.com/43481553/63516050-82f60d00-c4ec-11e9-9967-54fbd7a5d5a6.png)

fix #565