### PR TITLE
refactor: project url uses namespace and name instead of id

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -77,13 +77,20 @@ class App extends Component {
 
               {/*TODO: This route should be handled by <Route path="/projects/:id(\d+)" too. Until this is the
                  TODO: case, the ku_new route must be listed BEFORE the project one.   */}
-              <Route exact path="/projects/:projectId(\d+)/ku_new"
-                render={(p) => <Ku.New key="ku_new" client={this.props.client} {...p}/>}/>
+              <Route exact path="/projects/:projectNamespace/:projectName/ku_new"
+                render={(p) => <Ku.New key="ku_new" projectPathWithNamespace={`${p.match.params.projectNamespace}/${p.match.params.projectName}`} client={this.props.client} {...p}/>}/>
               {/* pull out the underlying parts of the url and pass them to the project view */}
-              <Route path="/projects/:id(\d+)"
-                render={p => <Project.View key="project" id={p.match.params.id} {...p}
+              <Route path="/projects/:projectNamespace/:projectName"
+                render={p => <Project.View key={`${p.match.params.projectNamespace}/${p.match.params.projectName}`} projectPathWithNamespace={`${p.match.params.projectNamespace}/${p.match.params.projectName}`} {...p}
                   user={this.props.userState.getState().user} userStateDispatch={this.props.userState.dispatch}
-                  client={this.props.client} params={this.props.params}/>}/>
+                  client={this.props.client} params={this.props.params}/>}
+              />
+              <Route path="/projects/:id(\d+)"
+                render={p =>  <Project.View key={`${p.match.params.id}`} projectId={`${p.match.params.id}`} {...p}
+                  user={this.props.userState.getState().user} userStateDispatch={this.props.userState.dispatch}
+                  client={this.props.client} params={this.props.params}/>
+                }
+              />
               <Route path="/projects" render={
                 p => <Project.List
                   key="projects"
@@ -94,11 +101,11 @@ class App extends Component {
               }/>
               <Route exact path="/project_new"
                 render={(p) =>
-                  <Project.New key="project_new" 
+                  <Project.New key="project_new"
                     client={this.props.client}
-                    user={this.props.userState.getState().user} 
-                    renkuTemplatesUrl={this.props.params['RENKU_TEMPLATES_URL']} 
-                    renkuTemplatesRef={this.props.params['RENKU_TEMPLATES_REF']} 
+                    user={this.props.userState.getState().user}
+                    renkuTemplatesUrl={this.props.params['RENKU_TEMPLATES_URL']}
+                    renkuTemplatesRef={this.props.params['RENKU_TEMPLATES_REF']}
                     {...p}/> }/>
               <Route exact path="/notebooks"
                 render={p => <Notebooks key="notebooks" standalone={true}

--- a/src/api-client/ku.js
+++ b/src/api-client/ku.js
@@ -29,11 +29,11 @@ function addKuMethods(client) {
   }
 
 
-  client.postProjectKu = (projectId, ku) => {
+  client.postProjectKu = (projectPathWithNamespace, ku) => {
     let headers = client.getBasicHeaders();
     headers.append('Content-Type', 'application/json');
 
-    return client.clientFetch(`${client.baseUrl}/projects/${projectId}/issues`, {
+    return client.clientFetch(`${client.baseUrl}/projects/${encodeURIComponent(projectPathWithNamespace)}/issues`, {
       method: 'POST',
       headers: headers,
       body: JSON.stringify(ku)

--- a/src/ku/Ku.js
+++ b/src/ku/Ku.js
@@ -38,7 +38,6 @@ import ReactMarkdown from 'react-markdown';
 import {createStore} from '../utils/EnhancedState'
 import State from './Ku.state'
 import {Avatar, ExternalLink, FieldGroup, TimeCaption } from '../utils/UIComponents'
-import { getActiveProjectId } from '../utils/HelperFunctions'
 import { Contribution, NewContribution } from '../contribution'
 
 
@@ -92,7 +91,7 @@ class New extends Component {
     this.state = {statuses: []}
     this.store = createStore(State.New.reducer);
     this.onSubmit = client => this.handleSubmit.bind(this, client);
-    this.projectId = getActiveProjectId(this.props.location.pathname);
+    this.projectPathWithNamespace = this.props.projectPathWithNamespace;
   }
 
   submitData() {
@@ -101,7 +100,7 @@ class New extends Component {
     body.confidential = state.visibility.level === 'Restricted';
     body.title = state.core.title;
     body.description = state.core.description;
-    return [this.projectId, body]
+    return [this.projectPathWithNamespace, body]
   }
 
   handleSubmit(client) {
@@ -110,7 +109,7 @@ class New extends Component {
       client.postProjectKu(...this.submitData())
         .then(newKu => {
           this.store.dispatch(State.List.append([newKu]));
-          this.props.history.push({pathname: `/projects/${this.projectId}/kus/`});
+          this.props.history.push({pathname: `/projects/${this.projectPathWithNamespace}/kus/`});
         });
     }
   }

--- a/src/landing/NavBar.js
+++ b/src/landing/NavBar.js
@@ -32,7 +32,7 @@ import faPlus from '@fortawesome/fontawesome-free-solid/faPlus'
 
 import logo from './logo.svg';
 import { RenkuNavLink, Loader } from '../utils/UIComponents'
-import { getActiveProjectId } from '../utils/HelperFunctions'
+import { getActiveProjectPathWithNamespace } from '../utils/HelperFunctions'
 import QuickNav from '../utils/quicknav'
 
 import './NavBar.css';
@@ -97,8 +97,10 @@ class LoggedInNavBar extends Component {
   }
   render() {
     // Display the Ku/Notebook server related header options only if a project is active.
-    const activeProjectId = getActiveProjectId(this.props.location.pathname);
-    const kuDropdown = activeProjectId ? <RenkuNavLink to={`/projects/${activeProjectId}/ku_new`} title="Ku" /> : null;
+    const activeProjectPathWithNamespace = getActiveProjectPathWithNamespace(this.props.location.pathname);
+    const kuDropdown = activeProjectPathWithNamespace ?
+      <RenkuNavLink to={`/projects/${activeProjectPathWithNamespace}/ku_new`} title="Ku" />
+      : null;
     // TODO If there is is an active project, show it in the navbar
 
     return (
@@ -163,7 +165,7 @@ class AnonymousNavBar extends Component {
 
           <div className="collapse navbar-collapse" id="navbarSupportedContent">
             <QuickNav user={this.props.userState.getState().user} client={this.props.client}/>
-            
+
             <ul className="navbar-nav mr-auto">
               <RenkuNavLink to="/projects" title="Projects"/>
             </ul>

--- a/src/merge-request/MergeRequest.container.js
+++ b/src/merge-request/MergeRequest.container.js
@@ -43,7 +43,7 @@ class MergeRequestContainer extends Component {
     this.props.client.mergeMergeRequest(this.props.projectId, this.props.iid)
       .then(() => {
         this.props.updateProjectState();
-        this.props.history.push(`/projects/${this.props.projectId}/pending`)
+        this.props.history.push(`/projects/${this.props.projectPathWithNamespace}/pending`)
       });
   }
 

--- a/src/notebooks/Notebooks.container.js
+++ b/src/notebooks/Notebooks.container.js
@@ -26,7 +26,7 @@ import { StatusHelper } from '../model/Model'
 
 /**
  * Displays a start page for new Jupiterlab servers.
- * 
+ *
  * @param {Object} client - api-client used to query the gateway
  * @param {Object[]} branches - Branches as returned by gitlab "/branches" API - no autosaved branches
  * @param {Object[]} autosaved - Autosaved branches
@@ -178,9 +178,9 @@ class StartNotebookServer extends Component {
   }
 
   async retriggerPipeline() {
-    const projectSlug = `${this.props.scope.namespace}%2F${this.props.scope.project}`;
+    const projectPathWithNamespace = `${this.props.scope.namespace}%2F${this.props.scope.project}`;
     const pipelineId = this.model.get('pipelines.main.id');
-    await this.props.client.retryPipeline(projectSlug, pipelineId);
+    await this.props.client.retryPipeline(projectPathWithNamespace, pipelineId);
     return this.refreshPipelines();
   }
 
@@ -243,7 +243,7 @@ class StartNotebookServer extends Component {
 
 /**
  * Display the list of Notebook servers
- * 
+ *
  * @param {Object} client - api-client used to query the gateway
  * @param {boolean} standalone - Indicates whether it's displayed as standalone
  * @param {Object} [scope] - object containing filtering parameters

--- a/src/notebooks/Notebooks.present.js
+++ b/src/notebooks/Notebooks.present.js
@@ -209,7 +209,7 @@ class NotebookServerRowFull extends Component {
     else {
       const projectLink = <NotebookServerRowProject
         display={`${annotations["namespace"]}/${annotations["projectName"]}`}
-        id={annotations["projectId"]}
+        link={`${annotations["namespace"]}/${annotations["projectName"]}`}
       />
       columns = [projectLink, `${annotations["branch"]}/${annotations["commit-sha"].substring(0, 8)}`];
     }
@@ -246,7 +246,7 @@ class NotebookServerRowCompact extends Component {
       rowsHeader = Columns.large.default;
       const projectLink = <NotebookServerRowProject
         display={`${annotations["namespace"]}/${annotations["projectName"]}`}
-        id={annotations["projectId"]}
+        link={`${annotations["namespace"]}/${annotations["projectName"]}`}
       />
       rows = [projectLink, `${annotations["branch"]}/${annotations["commit-sha"].substring(0, 8)}`];
     }
@@ -278,7 +278,7 @@ class NotebookServerRowCompact extends Component {
 class NotebookServerRowProject extends Component {
   render() {
     return (
-      <Link to={`/projects/${this.props.id}`}>
+      <Link to={`/projects/${this.props.link}`}>
         {this.props.display}
       </Link>
     )

--- a/src/notebooks/Notebooks.state.js
+++ b/src/notebooks/Notebooks.state.js
@@ -88,7 +88,7 @@ const ExpectedAnnotations = {
 const NotebooksHelper = {
   /**
    * compute the status of a notebook
-   * 
+   *
    * @param {Object} either the notebook or the notebook.status object as returned by the GET /servers API
    */
   getStatus: (data) => {
@@ -104,9 +104,9 @@ const NotebooksHelper = {
   },
   /**
    * add missing annotations from the notebook servers
-   * 
-   * @param {object} annotations 
-   * @param {string} domain 
+   *
+   * @param {object} annotations
+   * @param {string} domain
    */
   cleanAnnotations(annotations, domain = "renku.io") {
     let cleaned = {};
@@ -131,7 +131,7 @@ class NotebooksModel extends StateModel {
   // * Filters * //
   /**
    * Set filtering parameters
-   * 
+   *
    * @param {Object} data - the filters to be set
    * @param {string} data.namespace - full namespace path
    * @param {string} data.project - full project path
@@ -409,8 +409,8 @@ class NotebooksModel extends StateModel {
   async fetchCommits() {
     this.set('data.fetching', true);
     const filters = this.get('filters');
-    const projectSlug = `${filters.namespace}%2F${filters.project}`;
-    return this.client.getCommits(projectSlug, filters.branch.name)
+    const projectPathWithNamespace = `${filters.namespace}%2F${filters.project}`;
+    return this.client.getCommits(projectPathWithNamespace, filters.branch.name)
       .then(resp => {
         this.setObject({
           data: {

--- a/src/project/list/ProjectList.present.js
+++ b/src/project/list/ProjectList.present.js
@@ -18,7 +18,7 @@
 
 import React, { Component } from 'react';
 import { Link, Route, Switch }  from 'react-router-dom';
-import { Row, Col } from 'reactstrap';
+import { Row, Col, Alert } from 'reactstrap';
 import { Button, Form, InputGroup, FormText, Input, Label } from 'reactstrap';
 import { Nav, NavItem, InputGroupButtonDropdown, DropdownToggle, DropdownMenu, DropdownItem} from 'reactstrap';
 
@@ -33,7 +33,7 @@ class ProjectListRow extends Component {
   render() {
     const projectsUrl = this.props.projectsUrl;
     const title =
-      <Link to={`${projectsUrl}/${this.props.id}`}>
+      <Link to={`${projectsUrl}/${this.props.path_with_namespace}`}>
         {this.props.path_with_namespace || 'no title'}
       </Link>
     const description = this.props.description !== '' ? this.props.description : 'No description available';
@@ -199,6 +199,23 @@ class ProjectsSearch extends Component {
   }
 }
 
+class NotFoundInsideProject extends Component {
+  render(){
+    return <Col key="nofound">
+      <Row>
+        <Col xs={12} md={12}>
+          <Alert color="primary">
+            <h4>404 - Page not found</h4>
+          The URL
+            <strong> { this.props.location.pathname.replace(this.props.match.url,'') } </strong>
+           is not a subpath of <strong>/projects</strong>. You can navigate through renku projects using the tabs on top.
+          </Alert>
+        </Col>
+      </Row>
+    </Col>
+  }
+}
+
 class ProjectList extends Component {
   render() {
     const hasUser = this.props.user.id ? true : false;
@@ -249,6 +266,7 @@ class ProjectList extends Component {
                     displayProjects={memberProjects}
                     loading={loading}
                     emptyListText="You are logged in, but you have not yet created any projects. " />} />
+                <Route component={NotFoundInsideProject} />
               </Switch>
               :
               <Switch>
@@ -262,6 +280,7 @@ class ProjectList extends Component {
                   render= { props => <ProjectsSearch loggedOutMessage="You need to be logged in to be able to see a list with your own projects, therefore we will display all projects for you to explore." {...this.props} />} />
                 <Route exact path={urlMap.projectsUrl}
                   render= { props => <ProjectsSearch {...this.props} />} />
+                <Route component={NotFoundInsideProject} />
               </Switch>
           }
         </Col>

--- a/src/utils/HelperFunctions.js
+++ b/src/utils/HelperFunctions.js
@@ -23,9 +23,11 @@ const AUTOSAVED_PREFIX = "renku/autosave/";
 
 const slugFromTitle = (title) => title.replace(/\s/g, '-').toLowerCase();
 
-function getActiveProjectId(currentPath) {
+function getActiveProjectPathWithNamespace(currentPath) {
   try {
-    return currentPath.match(/\/projects\/(\d+)/)[0].replace('/projects/', '')
+    if(currentPath.includes('/projects/') && currentPath.split('/').length > 3 ){
+      return currentPath.split('/')[1]+'/'+currentPath.split('/')[2]
+    } return null;
   } catch(TypeError) {
     return null
   }
@@ -44,4 +46,4 @@ function splitAutosavedBranches(branches) {
   return { standard, autosaved };
 }
 
-export { slugFromTitle, getActiveProjectId, splitAutosavedBranches }
+export { slugFromTitle, getActiveProjectPathWithNamespace, splitAutosavedBranches }


### PR DESCRIPTION
This addresses #167 

Old URLs that where using the project id will be rerouted to the corresponding namespace/project-name url is possible.

There could be some edge cases that overlap with the new routing, priority will be given to the new schema, i think this edge cases don't exist in reality in renku.

Test Deployment:
https://virginiatest.dev.renku.ch/

Since this traverses all of the projects routing I would appreciate you testing it, if you find some error let me know :)

