### PR TITLE
feat(projects): search by username and group

### DIFF
--- a/src/api-client/project.js
+++ b/src/api-client/project.js
@@ -120,6 +120,24 @@ function addProjectMethods(client) {
     });
   }
 
+  client.getProjectsBy = (searchIn, userOrGroupId, queryParams) => {
+    let headers = client.getBasicHeaders();
+    return client.clientFetch(`${client.baseUrl}/${searchIn}/${userOrGroupId}/projects`, {
+      method: 'GET',
+      headers,
+      queryParams
+    });
+  }
+
+  client.searchUsersOrGroups = (queryParams, searchIn) => {
+    let headers = client.getBasicHeaders();
+    return client.clientFetch(`${client.baseUrl}/${searchIn}`, {
+      method: 'GET',
+      headers,
+      queryParams
+    }).then(result => result.data);
+  }
+
   client.getProjectFiles = (projectId) => {
     return client.getRepositoryTree(projectId, { path: '', recursive: true }).then((tree) => {
       const files = tree

--- a/src/project/list/ProjectList.test.js
+++ b/src/project/list/ProjectList.test.js
@@ -62,7 +62,7 @@ describe('new project actions', () => {
     expect(model.get('currentPage')).toEqual(undefined);
   });
   it('does search with a query', () => {
-    return model.setQueryPageNumberAndPath("", 1,fakeHistory.pathName, 'last_activity_at').then(() => {
+    return model.setQueryPageNumberAndPath("", 1,fakeHistory.pathName, 'last_activity_at', false, 'projects').then(() => {
       expect(model.get('currentPage')).toEqual(1);
       expect(model.get('totalItems')).toEqual(1);
       expect(model.get('pathName')).toEqual(fakeHistory.pathName);


### PR DESCRIPTION
The user can search by user name and group name. 

Before reviewing the pr is important to understand that gitlab has big limitations on the search api, at some point this will have to be addressed differently.

It looks as follows:

![image](https://user-images.githubusercontent.com/42647877/64193166-80949b00-ce7c-11e9-82e9-17522cafaeac.png)

![image](https://user-images.githubusercontent.com/42647877/64193144-75416f80-ce7c-11e9-9695-482c28b30f6a.png)

Test deployment: https://virginiatest.dev.renku.ch/

Closes: #560 
