### PR TITLE
feat(notebooks): handle non-standard branches projects

### DIFF
--- a/src/file/File.present.js
+++ b/src/file/File.present.js
@@ -29,9 +29,10 @@ import FontAwesomeIcon from '@fortawesome/react-fontawesome'
 import faProjectDiagram from '@fortawesome/fontawesome-free-solid/faProjectDiagram'
 import faGitlab from '@fortawesome/fontawesome-free-brands/faGitlab';
 
-import { FilePreview } from './File.container';
+import { FilePreview, JupyterButton } from './index';
 import { CheckNotebookStatus, CheckNotebookIcon } from '../notebooks'
-import { API_ERRORS, ACCESS_LEVELS } from '../api-client';
+import { Loader } from '../utils/UIComponents';
+import { API_ERRORS } from '../api-client';
 
 class ShowFile extends React.Component {
   constructor(props) {
@@ -172,28 +173,22 @@ class StyledNotebook extends React.Component {
   }
 }
 
-class JupyterButton extends React.Component {
+class JupyterButtonPresent extends React.Component {
   render() {
-    if (this.props.accessLevel < ACCESS_LEVELS.MAINTAINER)
+    if (!this.props.access)
       return (<CheckNotebookIcon fetched={true} launchNotebookUrl={this.props.launchNotebookUrl} />);
 
-    const scope = {
-      namespace: this.props.projectNamespace,
-      project: this.props.projectPath,
-      branch: "master",
-      commit: "latest"
-    }
-    const { file } = this.props;
-    const filePath = file && file.file_path ? file.file_path : "";
+    if (this.props.updating)
+      return (<Loader size="16" inline="true" />);
 
     return (
       <CheckNotebookStatus
-        scope={scope}
+        scope={this.props.scope}
         client={this.props.client}
         launchNotebookUrl={this.props.launchNotebookUrl}
-        filePath={filePath} />
+        filePath={this.props.filePath} />
     );
   }
 }
 
-export { ShowFile, StyledNotebook, JupyterButton };
+export { ShowFile, StyledNotebook, JupyterButtonPresent };

--- a/src/file/File.test.js
+++ b/src/file/File.test.js
@@ -29,7 +29,8 @@ import { MemoryRouter } from 'react-router-dom';
 
 import { testClient as client } from '../api-client'
 import { generateFakeUser } from '../app-state/UserState.test';
-import { ShowFile, JupyterButton } from './File.present';
+import { JupyterButton } from './index';
+import { ShowFile } from './File.present';
 
 describe('rendering', () => {
   const users = [
@@ -38,6 +39,7 @@ describe('rendering', () => {
   ];
 
   const props = {
+    client: client,
     filePath: "/projects/1/files/blob/myFolder/myNotebook.ipynb",
     match: { url: "/projects/1", params: { id: "1" } },
     launchNotebookUrl: "/projects/1/launchNotebook",
@@ -48,9 +50,10 @@ describe('rendering', () => {
       const div = document.createElement('div');
       // * fix for tooltips https://github.com/reactstrap/reactstrap/issues/773#issuecomment-357409863
       document.body.appendChild(div);
+      const branches = { all: [], fetch: () => { } };
       ReactDOM.render(
         <MemoryRouter>
-          <JupyterButton user={user.data} client={client} {...props} />
+          <JupyterButton user={user.data} branches={branches} {...props} />
         </MemoryRouter>, div);
     });
 
@@ -59,7 +62,7 @@ describe('rendering', () => {
       document.body.appendChild(div);
       ReactDOM.render(
         <MemoryRouter>
-          <ShowFile user={user.data} client={client} {...props} />
+          <ShowFile user={user.data} {...props} />
         </MemoryRouter>, div);
     });
   }

--- a/src/file/Lineage.present.js
+++ b/src/file/Lineage.present.js
@@ -30,7 +30,7 @@ import { Card, CardHeader, CardBody, UncontrolledTooltip, Badge, Button, Alert, 
 
 import { Loader } from '../utils/UIComponents';
 import { GraphIndexingStatus } from '../project/Project';
-import { JupyterButton } from './File.present'
+import { JupyterButton } from './index';
 
 import './Lineage.css';
 

--- a/src/file/index.js
+++ b/src/file/index.js
@@ -24,7 +24,7 @@
  */
 
 
-import { FilePreview } from './File.container'
+import { FilePreview, JupyterButton } from './File.container'
 import { FileLineage } from './Lineage.container'
 
-export { FilePreview, FileLineage }
+export { FilePreview, FileLineage, JupyterButton }

--- a/src/notebooks/Notebooks.container.js
+++ b/src/notebooks/Notebooks.container.js
@@ -326,8 +326,10 @@ class CheckNotebookStatus extends Component {
   }
 
   async componentDidMount() {
-    // ! temporary -- get "latest" commit
+    // ! temporary -- ignore missing branch and get "latest" commit
     let { scope } = this.props;
+    if (!scope.branch || !scope.commit)
+      return;
     if (scope.commit === "latest") {
       let commits = await this.model.fetchCommits();
       scope.commit = commits[0];

--- a/src/notebooks/Notebooks.container.js
+++ b/src/notebooks/Notebooks.container.js
@@ -35,6 +35,7 @@ import { StatusHelper } from '../model/Model'
  * @param {Object} scope - object containing filtering parameters
  * @param {string} scope.namespace - full path of the reference namespace
  * @param {string} scope.project - path of the reference project
+ * @param {string} externalUrl - GitLabl repository url
  * @param {string} [successUrl] - redirect url to be used when a notebook is succesfully started
  * @param {Object} [history] - mandatory if successUrl is provided
  */
@@ -103,12 +104,15 @@ class StartNotebookServer extends Component {
   async selectBranch(branchName) {
     if (this._isMounted) {
       // get the useful branchName
+      let autoBranchName = false;
       if (!branchName) {
         const oldBranch = this.model.get("filters.branch");
         if (oldBranch && oldBranch.branchName)
           branchName = oldBranch.branchName;
         else
           branchName = "master";
+
+        autoBranchName = true;
       }
 
       // get the proper branch and set it
@@ -119,8 +123,14 @@ class StartNotebookServer extends Component {
         this.refreshCommits();
       }
       else {
-        this.model.setBranch({});
-        this.model.setCommit({});
+        if (autoBranchName && branches && branches.length) {
+          this.model.setBranch(branches[0]);
+          this.refreshCommits();
+        }
+        else {
+          this.model.setBranch({});
+          this.model.setCommit({});
+        }
       }
     }
   }
@@ -215,7 +225,8 @@ class StartNotebookServer extends Component {
         ...state.data,
         branches: ownProps.inherited.branches,
         autosaved: ownProps.inherited.autosaved
-      }
+      },
+      externalUrl: ownProps.inherited.externalUrl
     };
     return {
       handlers: this.handlers,

--- a/src/notebooks/Notebooks.present.js
+++ b/src/notebooks/Notebooks.present.js
@@ -397,10 +397,31 @@ class StartNotebookBranches extends Component {
   render() {
     const { branches } = this.props.data;
     let content;
-    if (StatusHelper.isUpdating(branches) || branches.length === 0) {
+    if (StatusHelper.isUpdating(branches)) {
       content = (
         <Label>Updating branches... <Loader size="14" inline="true" /></Label>
       )
+    }
+    else if (branches.length === 0) {
+      content = (
+        <React.Fragment>
+          <Label>A commit is necessary to start an interactive environment.</Label>
+          <InfoAlert timeout={0}>
+            <p>You can still do one of the following:</p>
+            <ul className="mb-0">
+              <li>
+                <ExternalLink size="sm" url={`${this.props.externalUrl}`} title="Clone the repository" /> locally
+                and add a first commit.
+              </li>
+              <li className="pt-1">
+                <Link className="btn btn-primary btn-sm" role="button" to="/project_new">
+                  Create a new project
+                </Link> from a non-empty template.
+              </li>
+            </ul>
+          </InfoAlert>
+        </React.Fragment>
+      );
     }
     else {
       if (branches.length === 1) {

--- a/src/project/Project.js
+++ b/src/project/Project.js
@@ -221,6 +221,10 @@ class View extends Component {
     // the projectStore. This is not yet necessary.
     const subUrls = this.getSubUrls();
     const subProps = {...ownProps, projectId, accessLevel, externalUrl, filesTree, projectPathWithNamespace, forkModalOpen};
+    const branches = {
+      all: this.projectState.get('system.branches'),
+      fetch: () => { this.fetchBranches() }
+    };
 
     const mapStateToProps = (state, ownProps) => {
       return {
@@ -253,6 +257,7 @@ class View extends Component {
         launchNotebookUrl={subUrls.launchNotebookUrl}
         projectNamespace={this.projectState.get('core.namespace_path')}
         projectPathOnly={this.projectState.get('core.project_path')}
+        branches={branches}
         hashElement={filesTree !== undefined ? filesTree.hash[p.match.params.filePath] : undefined} />,
 
       fileView: (p) => <ShowFile
@@ -262,6 +267,7 @@ class View extends Component {
         launchNotebookUrl={subUrls.launchNotebookUrl}
         projectNamespace={this.projectState.get('core.namespace_path')}
         projectPath={this.projectState.get('core.project_path')}
+        branches={branches}
         hashElement={filesTree !== undefined ?
           filesTree.hash[p.location.pathname.replace(this.props.match.url + '/files/blob/', '')] :
           undefined} />,

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -634,6 +634,7 @@ class ProjectStartNotebookServer extends Component {
       autosaved={this.props.system.autosaved}
       refreshBranches={this.props.fetchBranches}
       scope={{namespace: this.props.core.namespace_path, project: this.props.core.project_path}}
+      externalUrl={this.props.externalUrl}
       successUrl={this.props.notebookServersUrl}
       history={this.props.history}
     />);


### PR DESCRIPTION
The UI showed wrong feedback when trying to start a new interactive environment for projects without a `master` branch or without any branch/commit at all (note that 1 branch requires at least 1 commit, and also the other way around is also true).

This PR handles the 2 cases as follows:
* no branch named "master" --> another branch is selected
* no branch (and therefore no commit) --> the user is notified that at least 1 commit is necessary. Following the approach similar to #578, a few suggestions are provided to the user 
![Screenshot from 2019-09-05 16-29-14](https://user-images.githubusercontent.com/43481553/64351283-52d56080-cffa-11e9-9d9e-80460dd2ea2a.png)

**How to test**:
1. create a project starting from the empty template, then go to the "Notebook servers" tab and click on "Start new server"
2. clone the project locally, add a branch with a name different from "master", create a commit and push to `origin`


fix #595