### PR TITLE
Display commit and timestamp information about the file in the file view

### DIFF
--- a/src/api-client/repository.js
+++ b/src/api-client/repository.js
@@ -94,6 +94,21 @@ function addRepositoryMethods(client) {
     )
   }
 
+  client.getRepositoryCommit = (projectId, commitSHA) => {
+    let headers = client.getBasicHeaders();
+    return client.clientFetch(
+      `${client.baseUrl}/projects/${projectId}/repository/commits/${commitSHA}`, {
+        method: 'GET',
+        headers: headers
+      },
+      client.returnTypes.full,
+      false
+    ).then(response => {
+      return response.json();
+    })
+  }
+
+
   // TODO: Merge to following methods into one
   client.getRepositoryFile = (projectId, path, ref='master', encoding='base64') => {
     let headers = client.getBasicHeaders();

--- a/src/file/File.present.js
+++ b/src/file/File.present.js
@@ -34,6 +34,36 @@ import { CheckNotebookStatus, CheckNotebookIcon } from '../notebooks'
 import { Loader } from '../utils/UIComponents';
 import { API_ERRORS } from '../api-client';
 
+
+/**
+ * Display the Card with file information. Has the following parameters:
+ *
+ * @param {string} filePath - Path of the file
+ * @param {string} commitHash - Commit hash for the file
+ * @param {Component} buttonGraph - Button to switch to graph view
+ * @param {Component} buttonGit - Button to switch to GitLab.
+ * @param {Component} buttonJupyter - Button to switch to Jupyter.
+ * @param {Object} body - Content to show as the body of the card
+ * @param {Component} lfsBadge - Badge to show for LFS (or null)
+ */
+class FileCard extends React.Component {
+  render() {
+    return <Card>
+      <CardHeader className="align-items-baseline">
+        {this.props.lfsBadge}
+        {this.props.filePath}
+        <span className="caption align-baseline">&nbsp;File view</span>
+        <div className="float-right" >
+          {this.props.buttonJupyter}
+          {this.props.buttonGit}
+          {this.props.buttonGraph}
+        </div>
+      </CardHeader>
+      <CardBody>{this.props.body}</CardBody>
+    </Card>
+  }
+}
+
 class ShowFile extends React.Component {
   constructor(props) {
     super(props);
@@ -89,18 +119,14 @@ class ShowFile extends React.Component {
       </a>
     </span>
 
-    if (this.state.error !== null){
-      return <Card>
-        <CardHeader className="align-items-baseline">
-          {this.props.filePath.split('\\').pop().split('/').pop()}
-          <span className="caption align-baseline">&nbsp;File view</span>
-          <div className="float-right" >
-            {buttonGit}
-            {buttonGraph}
-          </div>
-        </CardHeader>
-        <CardBody>{this.state.error}</CardBody>
-      </Card>;
+    if (this.state.error !== null) {
+      return <FileCard filePath={this.props.filePath.split('\\').pop().split('/').pop()}
+        commitHash={this.state.file.commit_id}
+        buttonGraph={buttonGraph}
+        buttonGit={buttonGit}
+        buttonJupyter={null}
+        body={this.state.error}
+        lfsBadge={null} />
     }
 
     if (this.state.file == null) return <Card>
@@ -112,31 +138,22 @@ class ShowFile extends React.Component {
     const isLFSBadge = isLFS ?
       <Badge className="lfs-badge" color="light">LFS</Badge> :
       null;
-    
+
     let buttonJupyter = null;
     if (this.props.filePath.endsWith(".ipynb"))
       buttonJupyter = (<JupyterButton {...this.props} file={this.state.file} />);
 
-    return (
-      <Card>
-        <CardHeader className="align-items-baseline">
-          {isLFSBadge}
-          {this.props.filePath.replace(this.props.match.url + '/files/blob/', '')}
-          <span className="caption align-baseline">&nbsp;File view</span>
-          <div className="float-right" >
-            {buttonJupyter}
-            {buttonGit}
-            {buttonGraph}
-          </div>
-        </CardHeader>
-        <CardBody>
-          <FilePreview
-            file={this.state.file}
-            {...this.props}
-          />
-        </CardBody>
-      </Card>
-    )
+    const body = <FilePreview
+      file={this.state.file}
+      {...this.props}
+    />
+    return <FileCard filePath={this.props.filePath.replace(this.props.match.url + '/files/blob/', '')}
+      commitHash={this.state.file.commit_id}
+      buttonGraph={buttonGraph}
+      buttonGit={buttonGit}
+      buttonJupyter={buttonJupyter}
+      body={body}
+      lfsBadge={isLFSBadge} />
   }
 }
 

--- a/src/file/File.test.js
+++ b/src/file/File.test.js
@@ -29,8 +29,7 @@ import { MemoryRouter } from 'react-router-dom';
 
 import { testClient as client } from '../api-client'
 import { generateFakeUser } from '../app-state/UserState.test';
-import { JupyterButton } from './index';
-import { ShowFile } from './File.present';
+import { ShowFile, JupyterButton } from './index';
 
 describe('rendering', () => {
   const users = [

--- a/src/file/index.js
+++ b/src/file/index.js
@@ -24,7 +24,7 @@
  */
 
 
-import { FilePreview, JupyterButton } from './File.container'
+import { FilePreview, JupyterButton, ShowFile } from './File.container'
 import { FileLineage } from './Lineage.container'
 
-export { FilePreview, FileLineage, JupyterButton }
+export { FilePreview, FileLineage, JupyterButton, ShowFile }

--- a/src/project/Project.js
+++ b/src/project/Project.js
@@ -38,7 +38,7 @@ import { MergeRequest, MergeRequestList } from '../merge-request';
 
 import List from './list';
 import New from './new';
-import { ShowFile } from '../file/File.present';
+import { ShowFile } from '../file';
 import Fork from './fork';
 
 // TODO: This component has grown too much and needs restructuring. One option would be to insert


### PR DESCRIPTION
Commit hash, with link to commit in github, commit message, commit author, and commit date/time has been added to the display.

It looks like 

![image](https://user-images.githubusercontent.com/1196411/64796626-43b55c00-d580-11e9-808a-7a7518ac0061.png)

Running on https://sekhartest.dev.renku.ch/ for testing.

Fix #487.