### PR TITLE
fix(navbar): the key cloack user profile opens in a new tab

### DIFF
--- a/src/landing/NavBar.js
+++ b/src/landing/NavBar.js
@@ -55,7 +55,7 @@ class RenkuToolbarItemUser extends Component {
           {this.props.userAvatar}
         </a>
         <div key="menu" className="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
-          <a className="dropdown-item" href="/auth/realms/Renku/account?referrer=renku-ui">Profile</a>
+          <a className="dropdown-item" target="_blank" rel="noreferrer noopener" href="/auth/realms/Renku/account?referrer=renku-ui">Profile</a>
           <Link className="dropdown-item" to="/help">Help</Link>
           <a
             className="dropdown-item"


### PR DESCRIPTION
Closes #401 

I think the cleanest option for this is as @ciyer mentioned, opening a new tab.

The user might have to refresh after changing things but i don't see this as a major issue. Otherwise we might have to send key cloack a redirect link... i'm not sure that is possible. 