### PR TITLE
change wording: from jupyter notebooks to interactive environments

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -110,8 +110,8 @@ class App extends Component {
                     renkuTemplatesUrl={this.props.params['RENKU_TEMPLATES_URL']}
                     renkuTemplatesRef={this.props.params['RENKU_TEMPLATES_REF']}
                     {...p}/> }/>
-              <Route exact path="/notebooks"
-                render={p => <Notebooks key="notebooks" standalone={true}
+              <Route exact path="/environments"
+                render={p => <Notebooks key="environments" standalone={true}
                   client={this.props.client} {...p} />} />
               <Route path="*"
                 render={p => <NotFound {...p} />} />

--- a/src/landing/NavBar.js
+++ b/src/landing/NavBar.js
@@ -119,7 +119,7 @@ class LoggedInNavBar extends Component {
 
             <ul className="navbar-nav mr-auto">
               <RenkuNavLink to="/projects" title="Projects"/>
-              <RenkuNavLink to="/notebooks" title="Notebooks"/>
+              <RenkuNavLink to="/environments" title="Interactive Environments"/>
             </ul>
             <ul className="navbar-nav">
               <li className="nav-item dropdown">

--- a/src/landing/NavBar.js
+++ b/src/landing/NavBar.js
@@ -119,7 +119,7 @@ class LoggedInNavBar extends Component {
 
             <ul className="navbar-nav mr-auto">
               <RenkuNavLink to="/projects" title="Projects"/>
-              <RenkuNavLink to="/environments" title="Interactive Environments"/>
+              <RenkuNavLink to="/environments" title="Environments"/>
             </ul>
             <ul className="navbar-nav">
               <li className="nav-item dropdown">

--- a/src/notebooks/Notebooks.present.js
+++ b/src/notebooks/Notebooks.present.js
@@ -85,7 +85,7 @@ class NotebooksPopup extends Component {
       <InfoAlert timeout={0}>
         <FontAwesomeIcon icon={faInfoCircle} /> You can start a new interactive environment by navigating
         to a project page.
-        <br />Be sure to have at least Developer privileges, then open the Interactive Environments tab.
+        <br />Be sure to have at least Developer privileges, then open the Environments tab.
       </InfoAlert>
     )
   }
@@ -789,7 +789,7 @@ class StartNotebookOptionsRunning extends Component {
         <FormGroup>
           <Label>
             An interactive environment is already running but it is currently not available.
-            You can get further details from the Interactive Environments page.
+            You can get further details from the Environments page.
           </Label>
         </FormGroup>
       );

--- a/src/notebooks/Notebooks.present.js
+++ b/src/notebooks/Notebooks.present.js
@@ -53,10 +53,10 @@ class Notebooks extends Component {
     const { standalone, loading } = this.props;
     let title, popup = null;
     if (standalone) {
-      title = (<h1>Notebooks</h1>);
+      title = (<h1>Interactive Environments</h1>);
       if (!loading) {
         const serverNumbers = Object.keys(this.props.notebooks.all).length;
-        if (serverNumbers)
+        if (!serverNumbers)
           popup = (<NotebooksPopup servers={serverNumbers} />);
       }
     }
@@ -83,8 +83,9 @@ class NotebooksPopup extends Component {
     }
     return (
       <InfoAlert timeout={0}>
-        <FontAwesomeIcon icon={faInfoCircle} /> You can start a new notebook by navigating to a project page.
-        <br />Be sure to have at least Developer privileges, then open the Notebook Servers tab.
+        <FontAwesomeIcon icon={faInfoCircle} /> You can start a new interactive environment by navigating
+        to a project page.
+        <br />Be sure to have at least Developer privileges, then open the Interactive Environments tab.
       </InfoAlert>
     )
   }
@@ -109,7 +110,7 @@ class NotebookServersList extends Component {
   render() {
     const serverNames = Object.keys(this.props.servers);
     if (serverNames.length === 0) {
-      return <p>No server is currently running. You have to start one to connect to Jupyter.</p>
+      return <p>You have to start at least one interactive environment to be able to start working.</p>
     }
     const rows = serverNames.map((k, i) =>
       <NotebookServerRow
@@ -378,7 +379,7 @@ class StartNotebookServer extends Component {
     return (
       <Row>
         <Col xs={12} sm={10} md={8} lg={6}>
-          <h3>Start new JupyterLab server</h3>
+          <h3>Start new interactive environment</h3>
           <Form>
             <StartNotebookBranches {...this.props} />
             {show.commits ? <StartNotebookCommits {...this.props} /> : null}
@@ -740,15 +741,15 @@ class StartNotebookOptions extends Component {
   render() {
     const { justStarted } = this.props;
     if (justStarted) {
-      return <Label>Starting new JupyterLab server... <Loader size="14" inline="true" /></Label>
+      return <Label>Starting new interactive environment... <Loader size="14" inline="true" /></Label>
     }
 
     const { fetched, options, all } = this.props.notebooks;
     if (!fetched) {
-      return (<Label>Verifying running servers... <Loader size="14" inline="true" /></Label>);
+      return (<Label>Verifying available environments... <Loader size="14" inline="true" /></Label>);
     }
     if (Object.keys(options).length === 0) {
-      return (<Label>Loading notebooks parameters... <Loader size="14" inline="true" /></Label>);
+      return (<Label>Loading environment parameters... <Loader size="14" inline="true" /></Label>);
     }
     if (Object.keys(all).length === 1) {
       return (<StartNotebookOptionsRunning {...this.props} />);
@@ -770,7 +771,7 @@ class StartNotebookOptionsRunning extends Component {
     if (status === "running") {
       return (
         <FormGroup>
-          <Label>A JupyterLab server is already running.</Label>
+          <Label>An interactive environment is already running.</Label>
           <br />
           <ExternalLink url={notebook.url} title="Connect" />
         </FormGroup>
@@ -779,7 +780,7 @@ class StartNotebookOptionsRunning extends Component {
     else if (status === "pending") {
       return (
         <FormGroup>
-          <Label>A JupyterLab server for this commit is starting or terminating, please wait...</Label>
+          <Label>An interactive environment for this commit is starting or terminating, please wait...</Label>
         </FormGroup>
       );
     }
@@ -787,8 +788,8 @@ class StartNotebookOptionsRunning extends Component {
       return (
         <FormGroup>
           <Label>
-            A JupyterLab server is already running but it is currently not available.
-            You can get further details from the Notebooks page.
+            An interactive environment is already running but it is currently not available.
+            You can get further details from the Interactive Environments page.
           </Label>
         </FormGroup>
       );
@@ -917,7 +918,7 @@ class ServerOptionLaunch extends Component {
   render() {
     return [
       <Button key="button" color="primary" onClick={this.checkServer}>
-        Launch Server
+        Start environment
       </Button>,
       <AutosavedDataModal key="modal"
         toggleModal={this.toggleModal.bind(this)}
@@ -954,7 +955,7 @@ class AutosavedDataModal extends Component {
           </p>
         </ModalBody>
         <ModalFooter>
-          <Button color="primary" onClick={this.props.handlers.startServer}>Launch Server</Button>
+          <Button color="primary" onClick={this.props.handlers.startServer}>Launch environment</Button>
         </ModalFooter>
       </Modal>
     </div>
@@ -972,7 +973,7 @@ class CheckNotebookIcon extends Component {
     if (notebook) {
       const status = NotebooksHelper.getStatus(notebook.status);
       if (status === "running") {
-        tooltip = "Connect to Jupyter";
+        tooltip = "Connect to JupyterLab";
         icon = (<JupyterIcon svgClass="svg-inline--fa fa-w-16 icon-link" />);
         const url = `${notebook.url}lab/tree/${this.props.filePath}`;
         link = (<a href={url} role="button" target="_blank" rel="noreferrer noopener">{icon}</a>);

--- a/src/project/Project.js
+++ b/src/project/Project.js
@@ -180,7 +180,7 @@ class View extends Component {
       mrOverviewUrl: `${baseUrl}/pending`,
       mrUrl: `${baseUrl}/pending/:mrIid`,
       launchNotebookUrl: `${baseUrl}/launchNotebook`,
-      notebookServersUrl: `${baseUrl}/notebookServers`
+      notebookServersUrl: `${baseUrl}/environments`
     }
   }
 

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -310,7 +310,7 @@ class ProjectNav extends Component {
           <RenkuNavLink exact={false} to={this.props.mrOverviewUrl} title="Pending Changes" />
         </NavItem>
         <NavItem>
-          <RenkuNavLink exact={false} to={this.props.notebookServersUrl} title="Interactive Environments" />
+          <RenkuNavLink exact={false} to={this.props.notebookServersUrl} title="Environments" />
         </NavItem>
         <NavItem>
           <RenkuNavLink exact={false} to={this.props.settingsUrl} title="Settings" />

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -310,7 +310,7 @@ class ProjectNav extends Component {
           <RenkuNavLink exact={false} to={this.props.mrOverviewUrl} title="Pending Changes" />
         </NavItem>
         <NavItem>
-          <RenkuNavLink exact={false} to={this.props.notebookServersUrl} title="Notebook Servers" />
+          <RenkuNavLink exact={false} to={this.props.notebookServersUrl} title="Interactive Environments" />
         </NavItem>
         <NavItem>
           <RenkuNavLink exact={false} to={this.props.settingsUrl} title="Settings" />
@@ -613,7 +613,7 @@ class ProjectNotebookServers extends Component {
         scope={{namespace: this.props.core.namespace_path, project: this.props.core.project_path}}
       />,
       <Link key="launch" to={ `/projects/${this.props.projectPathWithNamespace}/launchNotebook` }>
-        <Button color="primary">Start new server</Button>
+        <Button color="primary">Start new environment</Button>
       </Link>
     ];
 


### PR DESCRIPTION
I prefer to change the wording now before addressing the other routing/layout notebook related issues.
Note that the naming of `launchNotebook` route will be changed in #482 

fix #568