### PR TITLE
feat(environments): create environment route with sub-routes

### DIFF
--- a/src/notebooks/Notebooks.container.js
+++ b/src/notebooks/Notebooks.container.js
@@ -262,6 +262,7 @@ class StartNotebookServer extends Component {
  *
  * @param {Object} client - api-client used to query the gateway
  * @param {boolean} standalone - Indicates whether it's displayed as standalone
+ * @param {string} [urlNewEnvironment] - url to "new environment" page
  * @param {Object} [scope] - object containing filtering parameters
  * @param {string} [scope.namespace] - full path of the reference namespace
  * @param {string} [scope.project] - path of the reference project
@@ -309,6 +310,7 @@ class Notebooks extends Component {
       user={this.props.user}
       standalone={this.props.standalone ? this.props.standalone : false}
       scope={this.props.scope}
+      urlNewEnvironment={this.props.urlNewEnvironment}
     />
   }
 }

--- a/src/notebooks/Notebooks.container.js
+++ b/src/notebooks/Notebooks.container.js
@@ -188,10 +188,21 @@ class StartNotebookServer extends Component {
     return this.refreshPipelines();
   }
 
-  setServerOptionFromEvent(option, event) {
-    const value = event.target.type.toLowerCase() === "checkbox"?
-      event.target.checked :
-      event.target.value;
+  setServerOptionFromEvent(option, event, providedValue = null) {
+    const target = event.target.type.toLowerCase();
+    let value = providedValue;
+    if (!providedValue) {
+      if (target === "button") {
+        value = event.target.textContent;
+      }
+      else if (target === "checkbox") {
+        value = event.target.checked;
+      }
+      else {
+        value = event.target.value;
+      }
+    }
+
     this.model.setNotebookOptions(option, value);
   }
 

--- a/src/notebooks/Notebooks.present.js
+++ b/src/notebooks/Notebooks.present.js
@@ -67,6 +67,7 @@ class Notebooks extends Component {
           servers={serverNumbers}
           standalone={this.props.standalone}
           loading={loading}
+          urlNewEnvironment={this.props.urlNewEnvironment}
         />
       </Col>
     </Row>
@@ -86,13 +87,21 @@ class NotebooksPopup extends Component {
     if (this.props.servers || this.props.loading)
       return null;
 
-    const suggestion = this.props.standalone ?
-      "You can start a new interactive environment by navigating to a project page" :
-      "You can start a new interactive environment by clicking on New in the side bar";
+    let suggestion = "You can start a new interactive environment by navigating to a project page.";
+    if (!this.props.standalone) {
+      let newOutput = "New";
+      if (this.props.urlNewEnvironment)
+        newOutput = (<Link className="btn btn-primary btn-sm" role="button" to={this.props.urlNewEnvironment}>
+          New</Link>);
+
+      suggestion = (<span>
+        You can start a new interactive environment by clicking on {newOutput} in the side bar.
+      </span>);
+    }
 
     return (
       <InfoAlert timeout={0}>
-        <FontAwesomeIcon icon={faInfoCircle} /> {suggestion}.
+        <FontAwesomeIcon icon={faInfoCircle} /> {suggestion}
       </InfoAlert>
     );
   }

--- a/src/notebooks/Notebooks.present.js
+++ b/src/notebooks/Notebooks.present.js
@@ -50,44 +50,51 @@ const Columns = {
 // * Notebooks code * //
 class Notebooks extends Component {
   render() {
-    const { standalone, loading } = this.props;
-    let title, popup = null;
-    if (standalone) {
-      title = (<h1>Interactive Environments</h1>);
-      if (!loading) {
-        const serverNumbers = Object.keys(this.props.notebooks.all).length;
-        if (!serverNumbers)
-          popup = (<NotebooksPopup servers={serverNumbers} />);
-      }
-    }
+    const serverNumbers = Object.keys(this.props.notebooks.all).length;
+    const loading = this.props.notebooks.fetched ?
+      false :
+      true;
 
     return <Row>
       <Col>
-        {title}
+        <NotebooksTitle standalone={this.props.standalone} />
         <NotebookServers
           servers={this.props.notebooks.all}
-          loading={this.props.notebooks.fetched ? false : true}
+          loading={loading}
           stopNotebook={this.props.handlers.stopNotebook}
-          scope={this.props.scope}
+          scope={this.props.scope} />
+        <NotebooksPopup
+          servers={serverNumbers}
+          standalone={this.props.standalone}
+          loading={loading}
         />
-        {popup}
       </Col>
     </Row>
   }
 }
 
+class NotebooksTitle extends Component {
+  render() {
+    if (this.props.standalone)
+      return (<h1>Interactive Environments</h1>);
+    return (<h3>Interactive Environments</h3>);
+  }
+}
+
 class NotebooksPopup extends Component {
   render() {
-    if (this.props.servers) {
+    if (this.props.servers || this.props.loading)
       return null;
-    }
+
+    const suggestion = this.props.standalone ?
+      "You can start a new interactive environment by navigating to a project page" :
+      "You can start a new interactive environment by clicking on New in the side bar";
+
     return (
       <InfoAlert timeout={0}>
-        <FontAwesomeIcon icon={faInfoCircle} /> You can start a new interactive environment by navigating
-        to a project page.
-        <br />Be sure to have at least Developer privileges, then open the Environments tab.
+        <FontAwesomeIcon icon={faInfoCircle} /> {suggestion}.
       </InfoAlert>
-    )
+    );
   }
 }
 

--- a/src/notebooks/Notebooks.present.js
+++ b/src/notebooks/Notebooks.present.js
@@ -87,7 +87,9 @@ class NotebooksPopup extends Component {
     if (this.props.servers || this.props.loading)
       return null;
 
-    let suggestion = "You can start a new interactive environment by navigating to a project page.";
+    let suggestion = (<span>
+      You can start a new interactive environment from the <i>Environments</i> tab of a project.
+    </span>);
     if (!this.props.standalone) {
       let newOutput = "New";
       if (this.props.urlNewEnvironment)
@@ -126,7 +128,7 @@ class NotebookServersList extends Component {
   render() {
     const serverNames = Object.keys(this.props.servers);
     if (serverNames.length === 0) {
-      return <p>You have to start at least one interactive environment to be able to start working.</p>
+      return <p>No currently running environments.</p>
     }
     const rows = serverNames.map((k, i) =>
       <NotebookServerRow

--- a/src/notebooks/Notebooks.present.js
+++ b/src/notebooks/Notebooks.present.js
@@ -808,7 +808,9 @@ class StartNotebookServerOptions extends Component {
   render() {
     const { options } = this.props.notebooks;
     const selectedOptions = this.props.filters.options;
-    const renderedServerOptions = Object.keys(options)
+    const sortedOptionKeys = Object.keys(options)
+      .sort((a, b) => parseInt(options[a].order) - parseInt(options[b].order));
+    const renderedServerOptions = sortedOptionKeys
       .filter(key => key !== "commitId")
       .map(key => {
         const serverOption = { ...options[key], selected: selectedOptions[key] };

--- a/src/notebooks/Notebooks.present.js
+++ b/src/notebooks/Notebooks.present.js
@@ -20,7 +20,7 @@ import React, { Component } from 'react';
 import Media from 'react-media';
 import { Link } from 'react-router-dom';
 
-import { Form, FormGroup, FormText, Label, Input, Button, Row, Col, Table } from 'reactstrap';
+import { Form, FormGroup, FormText, Label, Input, Button, ButtonGroup, Row, Col, Table } from 'reactstrap';
 import { UncontrolledButtonDropdown, DropdownToggle, DropdownMenu, DropdownItem } from 'reactstrap';
 import { UncontrolledTooltip, UncontrolledPopover, PopoverHeader, PopoverBody } from 'reactstrap';
 import { Badge } from 'reactstrap';
@@ -812,8 +812,8 @@ class StartNotebookServerOptions extends Component {
       .filter(key => key !== "commitId")
       .map(key => {
         const serverOption = { ...options[key], selected: selectedOptions[key] };
-        const onChange = (event) => {
-          this.props.handlers.setServerOption(key, event);
+        const onChange = (event, value) => {
+          this.props.handlers.setServerOption(key, event, value);
         };
 
         switch (serverOption.type) {
@@ -853,12 +853,21 @@ class StartNotebookServerOptions extends Component {
 
 class ServerOptionEnum extends Component {
   render() {
+    const { selected } = this.props;
     return (
-      <Input type="select" id={this.props.id} onChange={this.props.onChange}>
-        {this.props.options.map((optionName, i) => {
-          return <option key={i} value={optionName}>{optionName}</option>
-        })}
-      </Input>
+      <div>
+        <ButtonGroup>
+          {this.props.options.map((optionName, i) => {
+            const color = optionName === selected ? "primary" : "outline-primary";
+            return (
+              <Button
+                color={color}
+                key={optionName}
+                onClick={event => this.props.onChange(event, optionName)}>{optionName}</Button>
+            );
+          })}
+        </ButtonGroup>
+      </div>
     );
   }
 }

--- a/src/notebooks/Notebooks.present.js
+++ b/src/notebooks/Notebooks.present.js
@@ -818,7 +818,7 @@ class StartNotebookServerOptions extends Component {
 
         switch (serverOption.type) {
         case 'enum':
-          return <FormGroup key={key}>
+          return <FormGroup key={key} className={serverOption.options.length === 1 ? 'mb-0' : ''}>
             <Label>{serverOption.displayName}</Label>
             <ServerOptionEnum {...serverOption} onChange={onChange} />
           </FormGroup>;
@@ -854,6 +854,10 @@ class StartNotebookServerOptions extends Component {
 class ServerOptionEnum extends Component {
   render() {
     const { selected } = this.props;
+
+    if (this.props.options.length === 1)
+      return (<label>: {this.props.selected}</label>);
+
     return (
       <div>
         <ButtonGroup>

--- a/src/project/Project.js
+++ b/src/project/Project.js
@@ -179,7 +179,7 @@ class View extends Component {
       settingsUrl: `${baseUrl}/settings`,
       mrOverviewUrl: `${baseUrl}/pending`,
       mrUrl: `${baseUrl}/pending/:mrIid`,
-      launchNotebookUrl: `${baseUrl}/launchNotebook`,
+      launchNotebookUrl: `${baseUrl}/environments/new`,
       notebookServersUrl: `${baseUrl}/environments`
     }
   }

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -607,8 +607,8 @@ function notebookLauncher(userId, accessLevel, notebookLauncher, fork, postLogin
 class ProjectEnvironments extends Component {
   render() {
     return [
-      <Col key="nav" xs={12} md={2} lg={2}>
-        <Nav pills className={'flex-column'}>
+      <Col key="nav" xs={12} md={2}>
+        <Nav pills className="flex-column mb-3">
           <NavItem>
             <RenkuNavLink to={this.props.notebookServersUrl} title="Running" />
           </NavItem>
@@ -618,7 +618,7 @@ class ProjectEnvironments extends Component {
         </Nav>
         {/* <ProjectViewOverviewNav {...this.props} /> */}
       </Col>,
-      <Col key="content" xs={12} md={10} lg={10}>
+      <Col key="content" xs={12} md={10}>
         <Switch>
           <Route exact path={this.props.notebookServersUrl}
             render={props => <ProjectNotebookServers {...this.props} />} />

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -616,7 +616,6 @@ class ProjectEnvironments extends Component {
             <RenkuNavLink to={this.props.launchNotebookUrl} title="New" />
           </NavItem>
         </Nav>
-        {/* <ProjectViewOverviewNav {...this.props} /> */}
       </Col>,
       <Col key="content" xs={12} md={10}>
         <Switch>

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -636,6 +636,7 @@ class ProjectNotebookServers extends Component {
       <Notebooks key="notebooks"
         standalone={false}
         client={this.props.client}
+        urlNewEnvironment={this.props.launchNotebookUrl}
         scope={{ namespace: this.props.core.namespace_path, project: this.props.core.project_path }} />
     );
 

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -564,7 +564,7 @@ class ProjectViewFiles extends Component {
 
 function notebookLauncher(userId, accessLevel, notebookLauncher, fork, postLoginUrl, externalUrl) {
   if (accessLevel >= ACCESS_LEVELS.DEVELOPER)
-    return (<Col xs={12}>{notebookLauncher}</Col>);
+    return (<div>{notebookLauncher}</div>);
 
   let content = [<p key="no-permission">You do not have sufficient permissions to launch an interactive environment
     for this project.</p>];
@@ -601,21 +601,43 @@ function notebookLauncher(userId, accessLevel, notebookLauncher, fork, postLogin
     );
   }
 
-  return (<Col xs={12}>{content}</Col>);
+  return (<div>{content}</div>);
+}
+
+class ProjectEnvironments extends Component {
+  render() {
+    return [
+      <Col key="nav" xs={12} md={2} lg={2}>
+        <Nav pills className={'flex-column'}>
+          <NavItem>
+            <RenkuNavLink to={this.props.notebookServersUrl} title="Running" />
+          </NavItem>
+          <NavItem>
+            <RenkuNavLink to={this.props.launchNotebookUrl} title="New" />
+          </NavItem>
+        </Nav>
+        {/* <ProjectViewOverviewNav {...this.props} /> */}
+      </Col>,
+      <Col key="content" xs={12} md={10} lg={10}>
+        <Switch>
+          <Route exact path={this.props.notebookServersUrl}
+            render={props => <ProjectNotebookServers {...this.props} />} />
+          <Route path={this.props.launchNotebookUrl}
+            render={props => <ProjectStartNotebookServer {...this.props} />} />
+        </Switch>
+      </Col>
+    ];
+  }
 }
 
 class ProjectNotebookServers extends Component {
   render() {
-    const content = [
+    const content = (
       <Notebooks key="notebooks"
         standalone={false}
         client={this.props.client}
-        scope={{namespace: this.props.core.namespace_path, project: this.props.core.project_path}}
-      />,
-      <Link key="launch" to={ `/projects/${this.props.projectPathWithNamespace}/launchNotebook` }>
-        <Button color="primary">Start new environment</Button>
-      </Link>
-    ];
+        scope={{ namespace: this.props.core.namespace_path, project: this.props.core.project_path }} />
+    );
 
     return (notebookLauncher(this.props.user.id,
       this.props.visibility.accessLevel,
@@ -826,9 +848,7 @@ class ProjectView extends Component {
               <Route path={this.props.mrOverviewUrl}
                 render={props => <ProjectMergeRequestList key="files-changes" {...this.props} />} />
               <Route path={this.props.notebookServersUrl}
-                render={props => <ProjectNotebookServers key="notebook-servers" {...this.props} />} />
-              <Route path={this.props.launchNotebookUrl}
-                render={props => <ProjectStartNotebookServer key="start-server" {...this.props} />}/>
+                render={props => <ProjectEnvironments key="environments" {...this.props} />} />
               <Route component={NotFoundInsideProject} />
             </Switch>
           </Row>


### PR DESCRIPTION
This PR integrates the "launch notebook" page into the new "Environments" tab, applying also minor changes to the layout according to #482. Please note that it doesn't filter/change the environment options (refer to the issue).

Preview: https://lorenzotest.dev.renku.ch/

![Screenshot from 2019-09-17 08-54-59](https://user-images.githubusercontent.com/43481553/65018215-dcedc500-d928-11e9-8ae2-00f48e6d088b.png)
