### PR TITLE
fix(fileviewer): files with type commit have a preview now

### DIFF
--- a/src/file/File.container.js
+++ b/src/file/File.container.js
@@ -29,7 +29,6 @@ import { API_ERRORS } from '../api-client';
 
 const IMAGE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'tiff', 'pdf', 'gif'];
 const CODE_EXTENSIONS = ['py', 'js', 'json', 'sh', 'r', 'txt', 'yml', 'csv', 'parquet', 'cwl', 'job', 'prn', 'rout', 'dcf', 'rproj', 'rst', 'bat'];
-const NO_EXTENSION_FILE = ['Dockerfile', 'errlog', 'log', 'gitignore', 'gitattributes', 'dockerignore', 'lock']
 
 // FIXME: Unify the file viewing for kus (embedded) and independent file viewing.
 // FIXME: Javascript highlighting is broken for large files.
@@ -42,14 +41,14 @@ class FilePreview extends React.Component {
       return null
     } else {
       if(this.props.file.file_name.match(/\.(.*)/)===null)
-        return this.props.file.file_name;
+        return null;
       else return this.props.file.file_name.split('.').pop().toLowerCase();
     }
   };
 
   fileIsCode = () => CODE_EXTENSIONS.indexOf(this.getFileExtension()) >= 0;
   fileIsImage = () => IMAGE_EXTENSIONS.indexOf(this.getFileExtension()) >= 0;
-  fileHasNoExtension = () => NO_EXTENSION_FILE.indexOf(this.getFileExtension())>=0;
+  fileHasNoExtension = () => this.getFileExtension()===null;
 
   highlightBlock = () => {
     // FIXME: Usage of findDOMNode is discouraged.

--- a/src/project/filestreeview/FilesTreeView.js
+++ b/src/project/filestreeview/FilesTreeView.js
@@ -65,7 +65,7 @@ class TreeNode extends Component {
     let selected = this.props.nodeInsideIsSelected ? " selected-file " : "";
     
 
-    if(this.props.node.type === "blob"){
+    if(this.props.node.type === "blob" || this.props.node.type === "commit"){
       elementToRender = 
         <div className={order+" "+hidden+" "+selected}>
           <div className={"fs-element"} >


### PR DESCRIPTION
Context: there could be files of type "commit" inside the file tree of gitlab, we only have one example of this in the vom_natt project. 
![image](https://user-images.githubusercontent.com/42647877/64968858-27c4f980-d8a3-11e9-9a99-9f5a504d4e3b.png)


Before when the user was clicking the file nothing was happening (because there was no link) and now the fileviewer tries to display the file: 
![image](https://user-images.githubusercontent.com/42647877/64968786-03691d00-d8a3-11e9-81e3-cc0820339c4a.png)
