### PR TITLE
feat(fork): the user can change the name of the forked project

### DIFF
--- a/src/api-client/project.js
+++ b/src/api-client/project.js
@@ -292,9 +292,12 @@ function addProjectMethods(client) {
     }, 3000);
   }
 
-  client.forkProject = (projectMeta, history) => {
+  client.forkProject = (projectSchema, history) => {
+    const projectMeta = projectSchema.meta
     const gitlabProject = {
-      id: projectMeta.id
+      id: projectMeta.id,
+      name: projectSchema.display.title,
+      path: projectSchema.display.slug
     };
     if (projectMeta.projectNamespace != null) gitlabProject.namespace = projectMeta.projectNamespace.id;
     const headers = client.getBasicHeaders();

--- a/src/project/fork/ProjectFork.container.js
+++ b/src/project/fork/ProjectFork.container.js
@@ -35,14 +35,15 @@ class Fork extends Component {
   constructor(props) {
     super(props);
     this.forkProject = new StateModel(forkProjectSchema, StateKind.REDUX);
-
     this.handlers = {
       onSubmit: this.onSubmit.bind(this),
       onProjectNamespaceChange: this.onProjectNamespaceChange.bind(this),
       onProjectNamespaceAccept: this.onProjectNamespaceAccept.bind(this),
       fetchMatchingNamespaces: this.fetchMatchingNamespaces.bind(this),
       fetchAllNamespaces: this.fetchAllNamespaces.bind(this),
-      toogleForkModal: this.toogleForkModal.bind(this)
+      toogleForkModal: this.toogleForkModal.bind(this),
+      onTitleChange: this.onTitleChange.bind(this),
+      setProjectTitle: this.setProjectTitle.bind(this)
     };
     this.mapStateToProps = this.doMapStateToProps.bind(this);
   }
@@ -63,6 +64,15 @@ class Fork extends Component {
     }
   }
 
+  setProjectTitle(title){
+    this.forkProject.set('display.title',title);
+    this.forkProject.set('display.slug', slugFromTitle(title));
+  }
+
+  onTitleChange(e) {
+    this.setProjectTitle(e.target.value);
+  }
+
   onSubmit() {
     this.forkProject.set('meta.id', this.props.projectId)
     if (this.forkProject.get('display.errors')) {
@@ -70,7 +80,7 @@ class Fork extends Component {
     }
 
     this.forkProject.set('display.loading', true);
-    this.props.client.forkProject(this.forkProject.get().meta , this.props.history)
+    this.props.client.forkProject(this.forkProject.get() , this.props.history)
       .catch(error => {
         let display_messages = [];
         if (error.errorData && error.errorData.message) {
@@ -163,7 +173,7 @@ class Fork extends Component {
       templates={this.forkProject.get('display.templates')}
       handlers={this.handlers}
       store={this.forkProject.reduxStore}
-      slug={slugFromTitle(this.props.title)}
+      title={this.props.title}
       user={this.props.user} />;
   }
 }

--- a/src/project/fork/ProjectFork.present.js
+++ b/src/project/fork/ProjectFork.present.js
@@ -34,7 +34,7 @@ import {  InputGroup, InputGroupAddon, InputGroupText } from 'reactstrap';
 import { Alert } from 'reactstrap';
 
 import collection from 'lodash/collection';
-import { Loader } from '../../utils/UIComponents'
+import { FieldGroup, Loader } from '../../utils/UIComponents'
 import '../new/Project.style.css'
 import {Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
 
@@ -189,7 +189,12 @@ class ProjectPath extends Component {
 
 class ForkProjectModal extends Component {
 
+  componentDidMount(){
+    this.props.handlers.setProjectTitle(this.props.title);
+  }
+
   render() {
+    const titleHelp = this.props.model.display.slug.length > 0 ? `Id: ${this.props.model.display.slug}` : null;
     return <div>
       <Modal 
         isOpen={this.props.forkModalOpen !== undefined && this.props.forkModalOpen !== false} 
@@ -197,9 +202,13 @@ class ForkProjectModal extends Component {
         className={this.props.className}>
         <ModalHeader toggle={this.props.handlers.toogleForkModal}>Fork Project</ModalHeader>
         <ModalBody>
+          <FieldGroup id="title" type="text" label="Title" placeholder="A brief name to identify the project"
+            help={titleHelp} value={this.props.model.display.title}
+            feedback={this.props.model.display.title} 
+            onChange={this.props.handlers.onTitleChange} />
           <ProjectPath 
-            namespace={this.props.model.meta.projectNamespace} 
-            slug={this.props.slug}
+            slug={this.props.model.display.slug}
+            namespace={this.props.model.meta.projectNamespace}
             namespaces={this.props.namespaces}
             onChange={this.props.handlers.onProjectNamespaceChange}
             onAccept={this.props.handlers.onProjectNamespaceAccept}


### PR DESCRIPTION
There is a new field inside the project fork modal where the user can change the name of the forked project.

![image](https://user-images.githubusercontent.com/42647877/65187932-69a19b80-da6d-11e9-8050-09c098ba62d7.png)
