### PR TITLE
move environments logic to a single global model

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -83,15 +83,25 @@ class App extends Component {
                 render={(p) => <Ku.New key="ku_new" projectPathWithNamespace={`${p.match.params.projectNamespace}/${p.match.params.projectName}`} client={this.props.client} {...p}/>}/>
               {/* pull out the underlying parts of the url and pass them to the project view */}
               <Route path="/projects/:projectNamespace/:projectName"
-                render={p => <Project.View key={`${p.match.params.projectNamespace}/${p.match.params.projectName}`} projectPathWithNamespace={`${p.match.params.projectNamespace}/${p.match.params.projectName}`} {...p}
-                  user={this.props.userState.getState().user} userStateDispatch={this.props.userState.dispatch}
-                  client={this.props.client} params={this.props.params}/>}
+                render={p => <Project.View key={`${p.match.params.projectNamespace}/${p.match.params.projectName}`}
+                  projectPathWithNamespace={`${p.match.params.projectNamespace}/${p.match.params.projectName}`}
+                  client={this.props.client}
+                  params={this.props.params}
+                  model={this.props.model}
+                  user={this.props.userState.getState().user}
+                  userStateDispatch={this.props.userState.dispatch}
+                  {...p}
+                />}
               />
               <Route path="/projects/:id(\d+)"
-                render={p =>  <Project.View key={`${p.match.params.id}`} projectId={`${p.match.params.id}`} {...p}
-                  user={this.props.userState.getState().user} userStateDispatch={this.props.userState.dispatch}
-                  client={this.props.client} params={this.props.params}/>
-                }
+                render={p => <Project.View key={`${p.match.params.id}`}
+                  projectId={`${p.match.params.id}`} {...p}
+                  client={this.props.client}
+                  params={this.props.params}
+                  model={this.props.model}
+                  user={this.props.userState.getState().user}
+                  userStateDispatch={this.props.userState.dispatch}
+                />}
               />
               <Route path="/projects" render={
                 p => <Project.List
@@ -111,8 +121,13 @@ class App extends Component {
                     renkuTemplatesRef={this.props.params['RENKU_TEMPLATES_REF']}
                     {...p}/> }/>
               <Route exact path="/environments"
-                render={p => <Notebooks key="environments" standalone={true}
-                  client={this.props.client} {...p} />} />
+                render={p => <Notebooks key="environments"
+                  standalone={true}
+                  client={this.props.client}
+                  model={this.props.model}
+                  {...p}
+                />}
+              />
               <Route path="*"
                 render={p => <NotFound {...p} />} />
             </Switch>

--- a/src/file/File.container.js
+++ b/src/file/File.container.js
@@ -182,15 +182,23 @@ class JupyterButton extends React.Component {
     let updating = false;
     if (branches.all && StatusHelper.isUpdating(branches.all))
       updating = true;
-    const filePath = file && file.file_path ? file.file_path : "";
+
+    let filePath = "";
+    if (file) {
+      if (file.file_path)
+        filePath = file.file_path;
+      else
+        filePath = file;
+    }
 
     return (
       <JupyterButtonPresent
+        client={this.props.client}
+        model={this.props.model}
         access={true}
         scope={this.getScope()}
         filePath={filePath}
         updating={updating}
-        client={this.props.client}
         launchNotebookUrl={this.props.launchNotebookUrl} />
     );
   }
@@ -255,7 +263,7 @@ class ShowFile extends React.Component {
 
     let buttonJupyter = null;
     if (this.props.filePath.endsWith(".ipynb"))
-      buttonJupyter = (<JupyterButton {...this.props} file={this.props.file} />);
+      buttonJupyter = (<JupyterButton {...this.props} file={filePath} />);
 
     return <ShowFilePresent externalUrl={this.props.externalUrl}
       filePath={filePath}

--- a/src/file/File.present.js
+++ b/src/file/File.present.js
@@ -210,8 +210,9 @@ class JupyterButtonPresent extends React.Component {
 
     return (
       <CheckNotebookStatus
-        scope={this.props.scope}
         client={this.props.client}
+        model={this.props.model}
+        scope={this.props.scope}
         launchNotebookUrl={this.props.launchNotebookUrl}
         filePath={this.props.filePath} />
     );

--- a/src/file/File.test.js
+++ b/src/file/File.test.js
@@ -20,7 +20,7 @@
  *  renku-ui
  *
  *  Files.test.js
- *  Tests for file.
+ *  Tests for file components.
  */
 
 import React from 'react';
@@ -30,6 +30,10 @@ import { MemoryRouter } from 'react-router-dom';
 import { testClient as client } from '../api-client'
 import { generateFakeUser } from '../app-state/UserState.test';
 import { ShowFile, JupyterButton } from './index';
+import { StateModel, globalSchema } from '../model'
+
+
+const model = new StateModel(globalSchema);
 
 describe('rendering', () => {
   const users = [
@@ -38,7 +42,8 @@ describe('rendering', () => {
   ];
 
   const props = {
-    client: client,
+    client,
+    model,
     filePath: "/projects/1/files/blob/myFolder/myNotebook.ipynb",
     match: { url: "/projects/1", params: { id: "1" } },
     launchNotebookUrl: "/projects/1/launchNotebook",

--- a/src/index.js
+++ b/src/index.js
@@ -10,13 +10,16 @@ import App from './App';
 // import registerServiceWorker from './utils/ServiceWorker';
 import APIClient from './api-client'
 import { UserState, reducer} from './app-state';
+import { StateModel, globalSchema } from './model'
 
 const configPromise = fetch('/config.json');
 
 configPromise.then((res) => {
   res.json().then((params) => {
+    // Create the global model containing the formal schema definition and the redux store
+    const model = new StateModel(globalSchema);
 
-    // We use a redux store to hold some global application state.
+    // TODO: move user store under the StateModel representation and fetch data in App
     const store = createStore(reducer);
 
     const client = new APIClient(params.GATEWAY_URL);
@@ -28,9 +31,9 @@ configPromise.then((res) => {
     // Load the user profile and dispatch the result to the store.
     UserState.fetchAppUser(client, store.dispatch);
 
-    const VisibleApp = connect(mapStateToProps, null, null, {storeKey: 'userState'})(App);
+    const VisibleApp = connect(mapStateToProps, null, null, { storeKey: 'userState' })(App);
     ReactDOM.render(
-      <VisibleApp client={client} params={params} userState={store}/>,
+      <VisibleApp client={client} params={params} userState={store} model={model} />,
       document.getElementById('root')
     );
 

--- a/src/model/GlobalSchema.js
+++ b/src/model/GlobalSchema.js
@@ -1,0 +1,33 @@
+/*!
+ * Copyright 2019 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  model/GlobalSchema.js
+ *  Schema for all Components.
+ */
+
+import { Schema } from './index';
+import { notebooksSchema } from './RenkuModels';
+
+const globalSchema = new Schema({
+  notebooks: { schema: notebooksSchema }
+})
+
+export { globalSchema };

--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -166,7 +166,7 @@ class ReactStateModel {
 }
 
 class StateModel {
-  constructor(schema, stateBinding, stateHolder, initialState) {
+  constructor(schema, stateBinding = StateKind.REDUX, stateHolder = null, initialState = null) {
     this.stateBinding = stateBinding;
     this.schema = schema;
 

--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -263,7 +263,7 @@ class SubModel {
       leafObj = leafObj[prop];
     });
     Object.keys(obj).forEach((prop) => leafObj[prop] = obj[prop]);
-    this.baseModel.set(fullObj);
+    this.baseModel.setObject(fullObj);
   }
 
   setUpdating(options) {

--- a/src/model/RenkuModels.js
+++ b/src/model/RenkuModels.js
@@ -158,4 +158,49 @@ const projectSchema = new Schema({
   }
 });
 
+const notebooksSchema = new Schema({
+  notebooks: {
+    schema: {
+      all: { initial: {} },
+      poller: { initial: null },
+      fetched: { initial: null },
+      fetching: { initial: false },
+      options: { initial: {} },
+      lastParameters: { initial: null }
+    }
+  },
+  filters: {
+    schema: {
+      namespace: { initial: null },
+      project: { initial: null },
+      branch: { initial: {} },
+      commit: { initial: {} },
+      discard: { initial: false },
+      options: { initial: {} },
+
+      includeMergedBranches: { initial: false },
+      displayedCommits: { initial: 10 },
+    }
+  },
+  pipelines: {
+    schema: {
+      main: { initial: {} },
+      poller: { initial: null },
+      fetched: { initial: null },
+      fetching: { initial: false },
+
+      lastParameters: { initial: null },
+      lastMainId: { initial: null },
+    }
+  },
+  data: {
+    schema: {
+      commits: { initial: [] }, // ! TODO: move to Project pages, shouldn't be here
+      fetched: { initial: null },
+      fetching: { initial: false },
+    }
+  }
+});
+
 export { userSchema, metaSchema, displaySchema, newProjectSchema, projectSchema, forkProjectSchema };
+export { notebooksSchema };

--- a/src/model/index.js
+++ b/src/model/index.js
@@ -1,0 +1,29 @@
+/*!
+ * Copyright 2019 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  model/index.js
+ *  Model and schema for storing Renku data.
+ */
+
+import { Schema, StateModel, StateKind, SubModel, SpecialPropVal, StatusHelper } from './Model'
+import { globalSchema } from './GlobalSchema';
+
+export { globalSchema, Schema, StateModel, StateKind, SubModel, SpecialPropVal, StatusHelper }

--- a/src/notebooks/Notebooks.present.js
+++ b/src/notebooks/Notebooks.present.js
@@ -396,7 +396,7 @@ class StartNotebookServer extends Component {
 
     return (
       <Row>
-        <Col xs={12} sm={10} md={8} lg={6}>
+        <Col sm={12} md={10} lg={8}>
           <h3>Start a new interactive environment</h3>
           <Form>
             <StartNotebookBranches {...this.props} />

--- a/src/notebooks/Notebooks.test.js
+++ b/src/notebooks/Notebooks.test.js
@@ -19,7 +19,7 @@
 /**
  *  renku-ui
  *
- * Tests for the notebook server component
+ * Tests for the interactive environment components
  */
 
 import React from 'react';
@@ -28,8 +28,11 @@ import { MemoryRouter } from 'react-router-dom';
 
 import { NotebooksHelper, Notebooks, StartNotebookServer, CheckNotebookStatus } from './index';
 import { ExpectedAnnotations } from './Notebooks.state';
+import { StateModel, globalSchema } from '../model'
 import { testClient as client } from '../api-client'
 
+
+const model = new StateModel(globalSchema);
 
 describe('notebook server clean annotation', () => {
   const baseAnnotations = ExpectedAnnotations["renku.io"].default;
@@ -87,25 +90,31 @@ describe('rendering', () => {
   };
 
   it('renders Notebooks', () => {
+    const props = {
+      client,
+      model
+    }
+
     const div = document.createElement('div');
     document.body.appendChild(div);
     ReactDOM.render(
       <MemoryRouter>
-        <Notebooks client={client} standalone={true} />
+        <Notebooks {...props} standalone={true} />
       </MemoryRouter>, div);
     ReactDOM.render(
       <MemoryRouter>
-        <Notebooks client={client} standalone={false} />
+        <Notebooks {...props} standalone={false} />
       </MemoryRouter>, div);
     ReactDOM.render(
       <MemoryRouter>
-        <Notebooks client={client} standalone={true} scope={scope} />
+        <Notebooks {...props} standalone={true} scope={scope} />
       </MemoryRouter>, div);
   });
 
   it('renders StartNotebookServer without crashing', () => {
     const props = {
-      client: client,
+      client,
+      model,
       branches: [],
       autosaved: [],
       refreshBranches: () => { },
@@ -125,7 +134,8 @@ describe('rendering', () => {
 
   it('renders CheckNotebookStatus', () => {
     const props = {
-      client: client,
+      client,
+      model,
       scope,
       launchNotebookUrl: "/projects/abc/def/launchNotebook",
       filePath: "notebook.ypynb"

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -632,8 +632,9 @@ class ProjectNotebookServers extends Component {
   render() {
     const content = (
       <Notebooks key="notebooks"
-        standalone={false}
         client={this.props.client}
+        model={this.props.model}
+        standalone={false}
         urlNewEnvironment={this.props.launchNotebookUrl}
         scope={{ namespace: this.props.core.namespace_path, project: this.props.core.project_path }} />
     );
@@ -651,10 +652,11 @@ class ProjectStartNotebookServer extends Component {
   render() {
     let content = (<StartNotebookServer
       client={this.props.client}
+      model={this.props.model}
       branches={this.props.system.branches}
       autosaved={this.props.system.autosaved}
       refreshBranches={this.props.fetchBranches}
-      scope={{namespace: this.props.core.namespace_path, project: this.props.core.project_path}}
+      scope={{ namespace: this.props.core.namespace_path, project: this.props.core.project_path }}
       externalUrl={this.props.externalUrl}
       successUrl={this.props.notebookServersUrl}
       history={this.props.history}


### PR DESCRIPTION
This PR starts the re-organization of the code to have a single redux store.

* creates a single global model that is instantiated in `src/index.js` and passed down as a property (`client` may be also merged there?)
* move environments schema to `RenkuModel` and add it as a sub-model `notebooks`
* convert `NotebooksModel` as `NotebooksCoordinator` and adapt the
container components
* adapt the test and fixes a couple of minor bugs

Adding the function `NotebooksCoordinator.reset` was needed because the state is not reset anymore when a component is instantiated and the functions were created without that in mind (e.g. the filters for the `/servers` query are stored in the state) -- this may be improved later.

How to test: try the pages where the components are used: global environments, project environments, project files (on notebook files preview)

Preview available at: https://lorenzotest.dev.renku.ch/

fix #627
