### PR TITLE
fix: use path instead of name when working with namespaces

### DIFF
--- a/src/project/fork/ProjectFork.container.js
+++ b/src/project/fork/ProjectFork.container.js
@@ -58,7 +58,7 @@ class Fork extends Component {
         return;
       }
       const username = this.props.user.username;
-      const namespace = namespaces.data.filter(n => n.name === username)
+      const namespace = namespaces.data.filter(n => n.path === username)
       if (namespace.length > 0) this.forkProject.set('meta.projectNamespace', namespace[0]);
       this.forkProject.set('display.namespaces', namespaces)
     }
@@ -153,7 +153,7 @@ class Fork extends Component {
       let escapedValue = this.escapeRegexCharacters(search.trim());
       if (escapedValue === '') escapedValue = '.*';
       const regex = new RegExp(escapedValue, 'i');
-      return Promise.resolve(namespaces.data.filter(namespace => regex.test(namespace.name)))
+      return Promise.resolve(namespaces.data.filter(namespace => regex.test(namespace.path)))
     }
   }
 

--- a/src/project/fork/ProjectFork.container.js
+++ b/src/project/fork/ProjectFork.container.js
@@ -49,12 +49,12 @@ class Fork extends Component {
   }
 
   async fetchAllNamespaces() {
-    if(!this.forkProject.get('display.namespacesFetched')){
+    if (!this.forkProject.get('display.namespacesFetched')) {
       this.forkProject.set('display.namespacesFetched', true)
       const namespaces = await this.fetchNamespaces();
       if (namespaces == null) {
         // This seems to break in a test on Travis, but this code is not necessary locally. Need to investigate.
-        this.forkProject.set('display.namespaces',[])
+        this.forkProject.set('display.namespaces', [])
         return;
       }
       const username = this.props.user.username;
@@ -64,8 +64,8 @@ class Fork extends Component {
     }
   }
 
-  setProjectTitle(title){
-    this.forkProject.set('display.title',title);
+  setProjectTitle(title) {
+    this.forkProject.set('display.title', title);
     this.forkProject.set('display.slug', slugFromTitle(title));
   }
 
@@ -80,7 +80,7 @@ class Fork extends Component {
     }
 
     this.forkProject.set('display.loading', true);
-    this.props.client.forkProject(this.forkProject.get() , this.props.history)
+    this.props.client.forkProject(this.forkProject.get(), this.props.history)
       .catch(error => {
         let display_messages = [];
         if (error.errorData && error.errorData.message) {
@@ -88,7 +88,7 @@ class Fork extends Component {
           const messages = Object.keys(all_messages)
             .filter(mex => all_messages[mex].length)
             .reduce((obj, mex) => { obj[mex] = all_messages[mex]; return obj; }, {});
-          
+
           // the most common error is the duplicate name, we can rewrite it for readability
           if (Object.keys(messages).includes("name") && /already.+taken/.test(messages["name"].join("; "))) {
             display_messages = [`title: ${messages["name"].join("; ")}`];
@@ -118,22 +118,22 @@ class Fork extends Component {
   onProjectNamespaceAccept() {
     const namespace = this.forkProject.get('meta.projectNamespace');
     if (namespace.kind !== 'group') {
-      this.forkProject.set('display.namespaceGroup',null)
+      this.forkProject.set('display.namespaceGroup', null)
       return;
     }
 
     this.props.client.getGroupByPath(namespace.full_path).then(r => {
       const group = r.data;
-      this.forkProject.set('display.namespaceGroup',group)
+      this.forkProject.set('display.namespaceGroup', group)
     })
   }
 
   doMapStateToProps(state, ownProps) {
     const model = this.forkProject.mapStateToProps(state, ownProps);
-    return {model}
+    return { model }
   }
 
-  fetchNamespaces(search=null) {
+  fetchNamespaces(search = null) {
     const queryParams = {};
     if (search != null) queryParams['search'] = search;
     return this.props.client.getNamespaces(queryParams);
@@ -145,10 +145,10 @@ class Fork extends Component {
   }
 
   async fetchMatchingNamespaces(search) {
-    if(this.forkProject.get('display.namespaces')){
+    if (this.forkProject.get('display.namespaces')) {
       const namespaces = this.forkProject.get('display.namespaces');
-      if ( namespaces.pagination.totalPages > 1) return this.fetchNamespaces(search).then(r => r.data);
-  
+      if (namespaces.pagination.totalPages > 1) return this.fetchNamespaces(search).then(r => r.data);
+
       // We have all the data, just filter in the browser
       let escapedValue = this.escapeRegexCharacters(search.trim());
       if (escapedValue === '') escapedValue = '.*';
@@ -157,13 +157,13 @@ class Fork extends Component {
     }
   }
 
-  toogleForkModal(e){
+  toogleForkModal(e) {
     if (this.forkProject.get('display.errors')) {
       this.forkProject.set('display.errors', []);
     }
     this.props.toogleForkModal(e);
   }
- 
+
   render() {
     const ConnectedForkProject = connect(this.mapStateToProps)(ForkProjectModal);
     return <ConnectedForkProject

--- a/src/project/fork/ProjectFork.present.js
+++ b/src/project/fork/ProjectFork.present.js
@@ -30,13 +30,13 @@ import React, { Component } from 'react';
 import Autosuggest from 'react-autosuggest';
 
 import { Row, Col, Button, FormGroup, FormText, Label } from 'reactstrap';
-import {  InputGroup, InputGroupAddon, InputGroupText } from 'reactstrap';
+import { InputGroup, InputGroupAddon, InputGroupText } from 'reactstrap';
 import { Alert } from 'reactstrap';
 
 import collection from 'lodash/collection';
 import { FieldGroup, Loader } from '../../utils/UIComponents'
 import '../new/Project.style.css'
-import {Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
+import { Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
 
 
 class ProjectPath extends Component {
@@ -54,13 +54,13 @@ class ProjectPath extends Component {
     };
   }
 
-  componentDidMount(){
+  componentDidMount() {
     this.props.fetchAllNamespaces();
   }
 
   componentDidUpdate(prevProps, prevState, snapshot) {
     if (this.props.namespace.path !== prevProps.namespace.path) {
-      this.setState({input: this.props.namespace.path});
+      this.setState({ input: this.props.namespace.path });
     }
   }
 
@@ -82,19 +82,19 @@ class ProjectPath extends Component {
     return section.namespaces;
   }
 
-  doBlur(event, {highlightedSuggestion}) {
+  doBlur(event, { highlightedSuggestion }) {
     // Take the highlighted suggestion or return to the selected namespace
     if (null != highlightedSuggestion) {
       this.props.onChange(highlightedSuggestion);
       this.props.onAccept();
     }
-    this.setState({input: this.props.namespace.path})
+    this.setState({ input: this.props.namespace.path })
   }
 
   doChange(event, { newValue, method }) {
     // If the user typed, store it as local input, otherwise set the selection
     if (method === 'type') {
-      this.setState({input: newValue});
+      this.setState({ input: newValue });
     } else {
       this.props.onChange(newValue)
     }
@@ -121,7 +121,7 @@ class ProjectPath extends Component {
 
     // Show current as first on input-focused, otherwise do not show
     if (reason === 'input-focused') {
-      const current = {kind: 'current', namespaces: [this.props.namespace]};
+      const current = { kind: 'current', namespaces: [this.props.namespace] };
       suggestions.splice(0, 0, current);
     }
     this.setState({ suggestions });
@@ -143,23 +143,23 @@ class ProjectPath extends Component {
     };
     // See https://github.com/moroshko/react-autosuggest#themeProp
     const defaultTheme = {
-      container:                'react-autosuggest__container',
-      containerOpen:            'react-autosuggest__container--open',
-      input:                    'react-autosuggest__input',
-      inputOpen:                'react-autosuggest__input--open',
-      inputFocused:             'react-autosuggest__input--focused',
-      suggestionsContainer:     'react-autosuggest__suggestions-container',
+      container: 'react-autosuggest__container',
+      containerOpen: 'react-autosuggest__container--open',
+      input: 'react-autosuggest__input',
+      inputOpen: 'react-autosuggest__input--open',
+      inputFocused: 'react-autosuggest__input--focused',
+      suggestionsContainer: 'react-autosuggest__suggestions-container',
       suggestionsContainerOpen: 'react-autosuggest__suggestions-container--open',
-      suggestionsList:          'react-autosuggest__suggestions-list',
-      suggestion:               'react-autosuggest__suggestion',
-      suggestionFirst:          'react-autosuggest__suggestion--first',
-      suggestionHighlighted:    'react-autosuggest__suggestion--highlighted',
-      sectionContainer:         'react-autosuggest__section-container',
-      sectionContainerFirst:    'react-autosuggest__section-container--first',
-      sectionTitle:             'react-autosuggest__section-title'
+      suggestionsList: 'react-autosuggest__suggestions-list',
+      suggestion: 'react-autosuggest__suggestion',
+      suggestionFirst: 'react-autosuggest__suggestion--first',
+      suggestionHighlighted: 'react-autosuggest__suggestion--highlighted',
+      sectionContainer: 'react-autosuggest__section-container',
+      sectionContainerFirst: 'react-autosuggest__section-container--first',
+      sectionTitle: 'react-autosuggest__section-title'
     };
     // Override the input theme to match our visual style
-    const theme = {...defaultTheme, ...{input: 'form-control'}};
+    const theme = { ...defaultTheme, ...{ input: 'form-control' } };
     return <FormGroup>
       <Label>Project Home</Label>
       <InputGroup>
@@ -189,69 +189,69 @@ class ProjectPath extends Component {
 
 class ForkProjectModal extends Component {
 
-  componentDidMount(){
+  componentDidMount() {
     this.props.handlers.setProjectTitle(this.props.title);
   }
 
   render() {
     const titleHelp = this.props.model.display.slug.length > 0 ? `Id: ${this.props.model.display.slug}` : null;
     return <div>
-      <Modal 
-        isOpen={this.props.forkModalOpen !== undefined && this.props.forkModalOpen !== false} 
-        toggle={this.props.handlers.toogleForkModal} 
+      <Modal
+        isOpen={this.props.forkModalOpen !== undefined && this.props.forkModalOpen !== false}
+        toggle={this.props.handlers.toogleForkModal}
         className={this.props.className}>
         <ModalHeader toggle={this.props.handlers.toogleForkModal}>Fork Project</ModalHeader>
         <ModalBody>
           <FieldGroup id="title" type="text" label="Title" placeholder="A brief name to identify the project"
             help={titleHelp} value={this.props.model.display.title}
-            feedback={this.props.model.display.title} 
+            feedback={this.props.model.display.title}
             onChange={this.props.handlers.onTitleChange} />
-          <ProjectPath 
+          <ProjectPath
             slug={this.props.model.display.slug}
             namespace={this.props.model.meta.projectNamespace}
             namespaces={this.props.namespaces}
             onChange={this.props.handlers.onProjectNamespaceChange}
             onAccept={this.props.handlers.onProjectNamespaceAccept}
-            fetchMatchingNamespaces={this.props.handlers.fetchMatchingNamespaces} 
-            fetchAllNamespaces={this.props.handlers.fetchAllNamespaces}/>
+            fetchMatchingNamespaces={this.props.handlers.fetchMatchingNamespaces}
+            fetchAllNamespaces={this.props.handlers.fetchAllNamespaces} />
           <SubmitErrors errors={this.props.model.display.errors} />
           <SubmitLoader loading={this.props.model.display.loading} />
         </ModalBody>
         <ModalFooter>
-          <Button 
-            color="primary" 
-            disabled={ this.props.model.display.loading } 
+          <Button
+            color="primary"
+            disabled={this.props.model.display.loading}
             onClick={this.props.handlers.onSubmit}>
             Fork
           </Button>{' '}
-          <Button 
-            color="secondary" 
-            disabled={ this.props.model.display.loading } 
+          <Button
+            color="secondary"
+            disabled={this.props.model.display.loading}
             onClick={this.props.handlers.toogleForkModal}>
             Cancel
           </Button>
         </ModalFooter>
       </Modal>
     </div>
-      
+
   }
 }
 
 class SubmitLoader extends Component {
   render() {
     if (!this.props.loading) return null;
-    return(
+    return (
       <FormText color="primary">
-        <Loader size="16" inline="true" margin="2"/>
+        <Loader size="16" inline="true" margin="2" />
         The project is being forked...
-      </FormText> )
+      </FormText>)
   }
 }
 
 class SubmitErrors extends Component {
   render() {
     if (!this.props.errors || !this.props.errors.length) return null;
-    return(
+    return (
       <div>
         <Alert color="danger">
           <Col>

--- a/src/project/fork/ProjectFork.present.js
+++ b/src/project/fork/ProjectFork.present.js
@@ -50,7 +50,7 @@ class ProjectPath extends Component {
 
     this.state = {
       suggestions: [],
-      input: this.props.namespace.name
+      input: this.props.namespace.path
     };
   }
 
@@ -59,8 +59,8 @@ class ProjectPath extends Component {
   }
 
   componentDidUpdate(prevProps, prevState, snapshot) {
-    if (this.props.namespace.name !== prevProps.namespace.name) {
-      this.setState({input: this.props.namespace.name});
+    if (this.props.namespace.path !== prevProps.namespace.path) {
+      this.setState({input: this.props.namespace.path});
     }
   }
 
@@ -69,7 +69,7 @@ class ProjectPath extends Component {
   }
 
   renderSuggestion(suggestion) {
-    return <span>{suggestion.name}</span>;
+    return <span>{suggestion.path}</span>;
   }
 
   renderSectionTitle(section) {
@@ -88,7 +88,7 @@ class ProjectPath extends Component {
       this.props.onChange(highlightedSuggestion);
       this.props.onAccept();
     }
-    this.setState({input: this.props.namespace.name})
+    this.setState({input: this.props.namespace.path})
   }
 
   doChange(event, { newValue, method }) {

--- a/src/project/new/ProjectNew.container.js
+++ b/src/project/new/ProjectNew.container.js
@@ -86,7 +86,7 @@ class New extends Component {
       return;
     }
     const username = this.props.user.username;
-    const namespace = namespaces.data.filter(n => n.name === username)
+    const namespace = namespaces.data.filter(n => n.path === username)
     if (namespace.length > 0) this.newProject.set('meta.projectNamespace', namespace[0]);
     this.setState({namespaces});
 
@@ -222,7 +222,7 @@ class New extends Component {
     let escapedValue = this.escapeRegexCharacters(search.trim());
     if (escapedValue === '') escapedValue = '.*';
     const regex = new RegExp(escapedValue, 'i');
-    return Promise.resolve(namespaces.data.filter(namespace => regex.test(namespace.name)))
+    return Promise.resolve(namespaces.data.filter(namespace => regex.test(namespace.path)))
   }
 
   render() {

--- a/src/project/new/ProjectNew.container.js
+++ b/src/project/new/ProjectNew.container.js
@@ -40,22 +40,23 @@ function groupVisibilitySupportsVisibility(groupVisibility, visibility) {
   return (groupVisibility === 'public');
 }
 
-function projectVisibilitiesForGroupVisibility(groupVisibility='public') {
+function projectVisibilitiesForGroupVisibility(groupVisibility = 'public') {
   const visibilities = [];
-  visibilities.push({name: "Private", value: "private"});
+  visibilities.push({ name: "Private", value: "private" });
   if (groupVisibilitySupportsVisibility(groupVisibility, 'internal'))
-    visibilities.push({name: "Internal", value: "internal"});
+    visibilities.push({ name: "Internal", value: "internal" });
   if (groupVisibilitySupportsVisibility(groupVisibility, 'public'))
-    visibilities.push({name: "Public", value: "public"});
+    visibilities.push({ name: "Public", value: "public" });
   return visibilities
 }
 
 class New extends Component {
   constructor(props) {
     super(props);
-    
+
     this.newProject = new StateModel(newProjectSchema, StateKind.REDUX);
-    this.state = {statuses: [], namespaces: [], namespaceGroup: null,
+    this.state = {
+      statuses: [], namespaces: [], namespaceGroup: null,
       visibilities: projectVisibilitiesForGroupVisibility(), templates: []
     };
 
@@ -74,7 +75,7 @@ class New extends Component {
     this.mapStateToProps = this.doMapStateToProps.bind(this);
   }
 
-  async fetchProjectTemplates(){
+  async fetchProjectTemplates() {
     return this.props.client.getProjectTemplates(this.props.renkuTemplatesUrl, this.props.renkuTemplatesRef);
   }
 
@@ -82,26 +83,26 @@ class New extends Component {
     const namespaces = await this.fetchNamespaces();
     if (namespaces == null) {
       // This seems to break in a test on Travis, but this code is not necessary locally. Need to investigate.
-      this.setState({namespaces: []});
+      this.setState({ namespaces: [] });
       return;
     }
     const username = this.props.user.username;
     const namespace = namespaces.data.filter(n => n.path === username)
     if (namespace.length > 0) this.newProject.set('meta.projectNamespace', namespace[0]);
-    this.setState({namespaces});
+    this.setState({ namespaces });
 
     const templates = await this.fetchProjectTemplates();
     if (templates == null) {
-      this.setState({templates: []});
+      this.setState({ templates: [] });
       return;
     }
-    this.setState({templates})
+    this.setState({ templates })
     if (templates.length > 0) this.newProject.set('meta.template', templates[0].folder);
-    
+
   }
 
   refreshUserProjects(client, userStateDispatch) {
-    client.getProjects({membership: true, order_by: 'last_activity_at'})
+    client.getProjects({ membership: true, order_by: 'last_activity_at' })
       .then(p => userStateDispatch(UserState.reSetMember(p)));
   }
 
@@ -125,7 +126,7 @@ class New extends Component {
             const messages = Object.keys(all_messages)
               .filter(mex => all_messages[mex].length)
               .reduce((obj, mex) => { obj[mex] = all_messages[mex]; return obj; }, {});
-            
+
             // the most common error is the duplicate name, we can rewrite it for readability
             if (Object.keys(messages).includes("name") && /already.+taken/.test(messages["name"].join("; "))) {
               display_messages = [`title: ${messages["name"].join("; ")}`];
@@ -147,7 +148,7 @@ class New extends Component {
   validate() {
     const validation = this.newProject.validate()
     if (!validation.result) {
-      this.setState({statuses: validation.errors});
+      this.setState({ statuses: validation.errors });
     }
     return validation;
   }
@@ -158,7 +159,7 @@ class New extends Component {
   }
 
   onDescriptionChange(e) { this.newProject.set('display.description', e.target.value); }
-  
+
   onVisibilityChange(e) {
     this.newProject.set('meta.visibility', e.target.value);
     if (e.target.value !== "private") {
@@ -182,7 +183,7 @@ class New extends Component {
     const namespace = this.newProject.get('meta.projectNamespace');
     if (namespace.kind !== 'group') {
       const visibilities = projectVisibilitiesForGroupVisibility();
-      this.setState({namespaceGroup: null, visibilities});
+      this.setState({ namespaceGroup: null, visibilities });
       return;
     }
 
@@ -194,16 +195,16 @@ class New extends Component {
         // Default to the highest available visibility
         this.newProject.set('meta.visibility', visibilities[visibilities.length - 1].value);
       }
-      this.setState({namespaceGroup: group, visibilities});
+      this.setState({ namespaceGroup: group, visibilities });
     })
   }
 
   doMapStateToProps(state, ownProps) {
     const model = this.newProject.mapStateToProps(state, ownProps);
-    return {model}
+    return { model }
   }
 
-  fetchNamespaces(search=null) {
+  fetchNamespaces(search = null) {
     const queryParams = {};
     if (search != null) queryParams['search'] = search;
     return this.props.client.getNamespaces(queryParams);
@@ -228,7 +229,7 @@ class New extends Component {
   render() {
     const ConnectedNewProject = connect(this.mapStateToProps)(ProjectNew);
     const statuses = {}
-    this.state.statuses.forEach((d) => { Object.keys(d).forEach(k => statuses[k] = d[k])});
+    this.state.statuses.forEach((d) => { Object.keys(d).forEach(k => statuses[k] = d[k]) });
     return <ConnectedNewProject
       statuses={statuses}
       namespaces={this.state.namespaces.data}

--- a/src/project/new/ProjectNew.present.js
+++ b/src/project/new/ProjectNew.present.js
@@ -59,7 +59,7 @@ class ProjectPath extends Component {
 
   componentDidUpdate(prevProps, prevState, snapshot) {
     if (this.props.namespace.path !== prevProps.namespace.path) {
-      this.setState({input: this.props.namespace.path});
+      this.setState({ input: this.props.namespace.path });
     }
   }
 
@@ -81,19 +81,19 @@ class ProjectPath extends Component {
     return section.namespaces;
   }
 
-  doBlur(event, {highlightedSuggestion}) {
+  doBlur(event, { highlightedSuggestion }) {
     // Take the highlighted suggestion or return to the selected namespace
     if (null != highlightedSuggestion) {
       this.props.onChange(highlightedSuggestion);
       this.props.onAccept();
     }
-    this.setState({input: this.props.namespace.path})
+    this.setState({ input: this.props.namespace.path })
   }
 
   doChange(event, { newValue, method }) {
     // If the user typed, store it as local input, otherwise set the selection
     if (method === 'type') {
-      this.setState({input: newValue});
+      this.setState({ input: newValue });
     } else {
       this.props.onChange(newValue)
     }
@@ -120,7 +120,7 @@ class ProjectPath extends Component {
 
     // Show current as first on input-focused, otherwise do not show
     if (reason === 'input-focused') {
-      const current = {kind: 'current', namespaces: [this.props.namespace]};
+      const current = { kind: 'current', namespaces: [this.props.namespace] };
       suggestions.splice(0, 0, current);
     }
     this.setState({ suggestions });
@@ -142,23 +142,23 @@ class ProjectPath extends Component {
     };
     // See https://github.com/moroshko/react-autosuggest#themeProp
     const defaultTheme = {
-      container:                'react-autosuggest__container',
-      containerOpen:            'react-autosuggest__container--open',
-      input:                    'react-autosuggest__input',
-      inputOpen:                'react-autosuggest__input--open',
-      inputFocused:             'react-autosuggest__input--focused',
-      suggestionsContainer:     'react-autosuggest__suggestions-container',
+      container: 'react-autosuggest__container',
+      containerOpen: 'react-autosuggest__container--open',
+      input: 'react-autosuggest__input',
+      inputOpen: 'react-autosuggest__input--open',
+      inputFocused: 'react-autosuggest__input--focused',
+      suggestionsContainer: 'react-autosuggest__suggestions-container',
       suggestionsContainerOpen: 'react-autosuggest__suggestions-container--open',
-      suggestionsList:          'react-autosuggest__suggestions-list',
-      suggestion:               'react-autosuggest__suggestion',
-      suggestionFirst:          'react-autosuggest__suggestion--first',
-      suggestionHighlighted:    'react-autosuggest__suggestion--highlighted',
-      sectionContainer:         'react-autosuggest__section-container',
-      sectionContainerFirst:    'react-autosuggest__section-container--first',
-      sectionTitle:             'react-autosuggest__section-title'
+      suggestionsList: 'react-autosuggest__suggestions-list',
+      suggestion: 'react-autosuggest__suggestion',
+      suggestionFirst: 'react-autosuggest__suggestion--first',
+      suggestionHighlighted: 'react-autosuggest__suggestion--highlighted',
+      sectionContainer: 'react-autosuggest__section-container',
+      sectionContainerFirst: 'react-autosuggest__section-container--first',
+      sectionTitle: 'react-autosuggest__section-title'
     };
     // Override the input theme to match our visual style
-    const theme = {...defaultTheme, ...{input: 'form-control'}};
+    const theme = { ...defaultTheme, ...{ input: 'form-control' } };
     return <FormGroup>
       <Label>Project Home</Label>
       <InputGroup>
@@ -192,9 +192,9 @@ class DataVisibility extends Component {
     const vizExplanation = (visibilities.length === 3) ?
       "" :
       "The project home's visibility setting limits the project visibility options.";
-      const options = visibilities.map(v =>
-        <option key={v.value} value={v.value}>{v.name}</option>
-      )
+    const options = visibilities.map(v =>
+      <option key={v.value} value={v.value}>{v.name}</option>
+    )
     let content = [
       <FormGroup key="visibility">
         <Label>Visibility</Label>
@@ -209,7 +209,7 @@ class DataVisibility extends Component {
     if (this.props.visibilityValue === "private") {
       const optout = (
         <FormGroup key="optout">
-          <Label check style={{marginLeft:"1.25rem"}}>
+          <Label check style={{ marginLeft: "1.25rem" }}>
             <Input type="checkbox" id="myCheckbox"
               value={this.props.optoutKgValue}
               onChange={this.props.onOptoutKgChange} />
@@ -235,10 +235,10 @@ class DataVisibility extends Component {
 
 
 class TemplatesDropdown extends Component {
-  
+
   render() {
     const templates = this.props.templates;
-    let selected = this.props.templates.filter(v=> v.folder === this.props.templateValue)
+    let selected = this.props.templates.filter(v => v.folder === this.props.templateValue)
 
     const options = templates.map(v =>
       <option key={v.folder} value={v.folder}>{v.name}</option>
@@ -253,7 +253,7 @@ class TemplatesDropdown extends Component {
           {options}
         </Input>
         <FormText color="muted">
-          {selected!== undefined && selected.length > 0 ? selected[0].description : "" }
+          {selected !== undefined && selected.length > 0 ? selected[0].description : ""}
         </FormText>
       </FormGroup>
     ]
@@ -295,7 +295,7 @@ class ProjectNew extends Component {
             optoutKgValue={this.props.model.meta.optoutKg}
             onVisibilityChange={this.props.handlers.onVisibilityChange}
             onOptoutKgChange={this.props.handlers.onOptoutKgChange} />
-          <br/>
+          <br />
           <SubmitErrors errors={this.props.model.display.errors} />
           <Button color="primary" onClick={this.props.handlers.onSubmit} disabled={this.props.model.display.loading}>
             Create
@@ -310,14 +310,14 @@ class ProjectNew extends Component {
 class SubmitLoader extends Component {
   render() {
     if (!this.props.loading) return null;
-    return(<Loader size="16" inline="true" margin="2" />)
+    return (<Loader size="16" inline="true" margin="2" />)
   }
 }
 
 class SubmitErrors extends Component {
   render() {
     if (!this.props.errors || !this.props.errors.length) return null;
-    return(
+    return (
       <div>
         <Alert color="danger">
           <Col>

--- a/src/project/new/ProjectNew.present.js
+++ b/src/project/new/ProjectNew.present.js
@@ -53,13 +53,13 @@ class ProjectPath extends Component {
 
     this.state = {
       suggestions: [],
-      input: this.props.namespace.name
+      input: this.props.namespace.path
     };
   }
 
   componentDidUpdate(prevProps, prevState, snapshot) {
-    if (this.props.namespace.name !== prevProps.namespace.name) {
-      this.setState({input: this.props.namespace.name});
+    if (this.props.namespace.path !== prevProps.namespace.path) {
+      this.setState({input: this.props.namespace.path});
     }
   }
 
@@ -68,7 +68,7 @@ class ProjectPath extends Component {
   }
 
   renderSuggestion(suggestion) {
-    return <span>{suggestion.name}</span>;
+    return <span>{suggestion.path}</span>;
   }
 
   renderSectionTitle(section) {
@@ -87,7 +87,7 @@ class ProjectPath extends Component {
       this.props.onChange(highlightedSuggestion);
       this.props.onAccept();
     }
-    this.setState({input: this.props.namespace.name})
+    this.setState({input: this.props.namespace.path})
   }
 
   doChange(event, { newValue, method }) {
@@ -192,9 +192,9 @@ class DataVisibility extends Component {
     const vizExplanation = (visibilities.length === 3) ?
       "" :
       "The project home's visibility setting limits the project visibility options.";
-    const options = visibilities.map(v =>
-      <option key={v.value} value={v.value}>{v.name}</option>
-    )
+      const options = visibilities.map(v =>
+        <option key={v.value} value={v.value}>{v.name}</option>
+      )
     let content = [
       <FormGroup key="visibility">
         <Label>Visibility</Label>


### PR DESCRIPTION
Using `path` instead of `name` when dealing with namespaces seems a good solution to avoid users name personalization issues https://docs.gitlab.com/ee/api/namespaces.html

fix #635 
