### PR TITLE
feat(environments): show kubernetes log per server

### DIFF
--- a/src/api-client/notebook-servers.js
+++ b/src/api-client/notebook-servers.js
@@ -87,6 +87,19 @@ function addNotebookServersMethods(client) {
       return resp.data;
     });
   }
+
+  client.getNotebookServerLogs = (serverName) => {
+    const headers = client.getBasicHeaders();
+    headers.append('Accept', 'text/plain');
+    const url = `${client.baseUrl}/notebooks/logs/${serverName}`;
+
+    return client.clientFetch(url, {
+      method: 'GET',
+      headers
+    }, "text").then((resp) => {
+      return resp;
+    });
+  }
 }
 
 export default addNotebookServersMethods;

--- a/src/model/RenkuModels.js
+++ b/src/model/RenkuModels.js
@@ -199,6 +199,13 @@ const notebooksSchema = new Schema({
       fetched: { initial: null },
       fetching: { initial: false },
     }
+  },
+  logs: {
+    schema: {
+      data: { initial: [] },
+      fetched: { initial: null },
+      fetching: { initial: false },
+    }
   }
 });
 

--- a/src/notebooks/Notebooks.container.js
+++ b/src/notebooks/Notebooks.container.js
@@ -50,9 +50,15 @@ class Notebooks extends Component {
       this.coordinator.setNotebookFilters(props.scope, true);
     }
 
+    this.state = {
+      showingLogs: false
+    };
+
     this.handlers = {
-      stopNotebook: this.stopNotebook.bind(this)
-    }
+      stopNotebook: this.stopNotebook.bind(this),
+      fetchLogs: this.fetchLogs.bind(this),
+      toggleLogs: this.toggleLogs.bind(this)
+    };
   }
 
   componentDidMount() {
@@ -67,11 +73,24 @@ class Notebooks extends Component {
     this.coordinator.stopNotebook(serverName, force);
   }
 
+  fetchLogs(serverName) {
+    this.coordinator.fetchLogs(serverName);
+  }
+
+  toggleLogs(serverName) {
+    const nextState = !this.state.showingLogs
+    this.setState({ showingLogs: nextState });
+
+    if (nextState)
+      this.fetchLogs(serverName)
+  }
+
   mapStateToProps(state, ownProps) {
     return {
       handlers: this.handlers,
-      ...state.notebooks
-    }
+      ...state.notebooks,
+      logs: { ...state.notebooks.logs, show: this.state.showingLogs }
+    };
   }
 
   render() {

--- a/src/notebooks/Notebooks.container.js
+++ b/src/notebooks/Notebooks.container.js
@@ -78,7 +78,11 @@ class Notebooks extends Component {
   }
 
   toggleLogs(serverName) {
-    const nextState = !this.state.showingLogs
+    let nextState;
+    if (this.state.showingLogs !== serverName)
+      nextState = serverName;
+    else
+      nextState = false;
     this.setState({ showingLogs: nextState });
 
     if (nextState)

--- a/src/notebooks/Notebooks.css
+++ b/src/notebooks/Notebooks.css
@@ -13,3 +13,33 @@
   font-size: 70%;
   font-style: italic;
 }
+
+/* Modals with dynamic width */
+
+.modal-dynamic-width.modal-dialog {
+  max-width: 1140px;
+}
+
+@media (max-width: 1200px) {
+  .modal-dynamic-width.modal-dialog {
+    margin-left: 1.75rem;
+    margin-right: 1.75rem;
+  }
+}
+
+@media (max-width: 576px) {
+  .modal-dynamic-width.modal-dialog {
+    margin-left: 0.75rem;
+    margin-right: 0.75rem;
+  }
+}
+
+/* Modals body personalizations */
+
+.modal-body .no-overflow {
+  overflow: unset;
+}
+
+.modal-body wrap-word {
+  white-space: pre-line;
+}

--- a/src/notebooks/Notebooks.css
+++ b/src/notebooks/Notebooks.css
@@ -1,0 +1,6 @@
+.alternateToggleStyle {
+  white-space: nowrap;
+  border-radius: 0.2rem !important;
+  padding-right: 0.5625rem;
+  padding-left: 0.5625rem;
+}

--- a/src/notebooks/Notebooks.css
+++ b/src/notebooks/Notebooks.css
@@ -4,3 +4,12 @@
   padding-right: 0.5625rem;
   padding-left: 0.5625rem;
 }
+
+.header-multiline h5 {
+  line-height: 1.2;
+}
+
+.header-multiline small {
+  font-size: 70%;
+  font-style: italic;
+}

--- a/src/notebooks/Notebooks.present.js
+++ b/src/notebooks/Notebooks.present.js
@@ -469,7 +469,8 @@ class EnvironmentLogs extends Component {
       }
       else {
         if (logs.data && logs.data.length) {
-          body = (<pre style={{ whiteSpace: "preLine" }}>{logs.data.join("\n")}</pre>);
+          body = (<pre className="small" style={{ whiteSpace: "preLine" }}>
+            {logs.data.join("\n")}</pre>);
         }
         else {
           body = (<div>
@@ -484,7 +485,7 @@ class EnvironmentLogs extends Component {
     return (
       <Modal
         isOpen={logs.show}
-        size="lg"
+        size="xl"
         toggle={() => { toggleLogs(name) }}>
         <ModalHeader toggle={() => { toggleLogs(name) }}>Logs</ModalHeader>
         <ModalBody>{body}</ModalBody>

--- a/src/notebooks/Notebooks.present.js
+++ b/src/notebooks/Notebooks.present.js
@@ -27,6 +27,7 @@ import { Badge } from 'reactstrap';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import { faStopCircle, faExternalLinkAlt, faInfoCircle, faSyncAlt } from '@fortawesome/fontawesome-free-solid';
 import { faCogs, faCog, faEllipsisV, faExclamationTriangle, faRedo } from '@fortawesome/fontawesome-free-solid';
+import { faSave } from '@fortawesome/fontawesome-free-solid';
 import { faFileAlt } from '@fortawesome/fontawesome-free-solid';
 import { faTimesCircle } from '@fortawesome/fontawesome-free-solid';
 import { faCheckCircle } from '@fortawesome/fontawesome-free-regular';
@@ -458,6 +459,15 @@ class NotebookServerRowAction extends Component {
  * @param {object} annotations - list of cleaned annotations
  */
 class EnvironmentLogs extends Component {
+  save() {
+    const elem = document.createElement("a");
+    const file = new Blob([this.props.logs.data.join("\n")], { type: "text/plain" });
+    elem.href = URL.createObjectURL(file);
+    elem.download = `Logs_${this.props.name}.txt`;
+    document.body.appendChild(elem);
+    elem.click();
+  }
+
   render() {
     const { logs, name, toggleLogs, fetchLogs, annotations } = this.props;
     if (!logs.show || logs.show !== name)
@@ -500,7 +510,12 @@ class EnvironmentLogs extends Component {
         </ModalHeader>
         <ModalBody>{body}</ModalBody>
         <ModalFooter>
-          <Button color="primary" onClick={() => { fetchLogs(name) }}>Refresh</Button>
+          <Button color="primary" onClick={() => { this.save() }}>
+            <FontAwesomeIcon icon={faSave} /> Download
+          </Button>
+          <Button color="primary" onClick={() => { fetchLogs(name) }}>
+            <FontAwesomeIcon icon={faRedo} /> Refresh
+          </Button>
         </ModalFooter>
       </Modal>
     );

--- a/src/notebooks/Notebooks.present.js
+++ b/src/notebooks/Notebooks.present.js
@@ -256,6 +256,7 @@ class NotebookServerRowFull extends Component {
         toggleLogs={this.props.toggleLogs}
         logs={this.props.logs}
         name={this.props.name}
+        annotations={annotations}
       />
     </td>);
 
@@ -312,6 +313,7 @@ class NotebookServerRowCompact extends Component {
         toggleLogs={this.props.toggleLogs}
         logs={this.props.logs}
         name={this.props.name}
+        annotations={annotations}
       />
     </span>);
 
@@ -453,10 +455,11 @@ class NotebookServerRowAction extends Component {
  * @param {function} toggleLogs - toggle logs visibility and fetch logs on show
  * @param {object} logs - log object from redux store enhanced with `show` property
  * @param {string} name - server name
+ * @param {object} annotations - list of cleaned annotations
  */
 class EnvironmentLogs extends Component {
   render() {
-    const { logs, name, toggleLogs, fetchLogs } = this.props;
+    const { logs, name, toggleLogs, fetchLogs, annotations } = this.props;
     if (!logs.show || logs.show !== name)
       return null;
 
@@ -490,7 +493,11 @@ class EnvironmentLogs extends Component {
         isOpen={logs.show ? true : false}
         size="xl"
         toggle={() => { toggleLogs(name) }}>
-        <ModalHeader toggle={() => { toggleLogs(name) }}>Logs</ModalHeader>
+        <ModalHeader toggle={() => { toggleLogs(name) }} className="header-multiline">
+          Logs
+          <br /><small>{annotations["namespace"]}/{annotations["projectName"]}</small>
+          <br /><small>{annotations["branch"]}@{annotations["commit-sha"].substring(0, 8)}</small>
+        </ModalHeader>
         <ModalBody>{body}</ModalBody>
         <ModalFooter>
           <Button color="primary" onClick={() => { fetchLogs(name) }}>Refresh</Button>

--- a/src/notebooks/Notebooks.present.js
+++ b/src/notebooks/Notebooks.present.js
@@ -485,8 +485,7 @@ class EnvironmentLogs extends Component {
       }
       else {
         if (logs.data && logs.data.length) {
-          body = (<pre className="small" style={{ whiteSpace: "preLine" }}>
-            {logs.data.join("\n")}</pre>);
+          body = (<pre className="small no-overflow wrap-word">{logs.data.join("\n")}</pre>);
         }
         else {
           body = (<div>
@@ -502,6 +501,8 @@ class EnvironmentLogs extends Component {
       <Modal
         isOpen={logs.show ? true : false}
         size="xl"
+        className="modal-dynamic-width"
+        scrollable={true}
         toggle={() => { toggleLogs(name) }}>
         <ModalHeader toggle={() => { toggleLogs(name) }} className="header-multiline">
           Logs

--- a/src/notebooks/Notebooks.present.js
+++ b/src/notebooks/Notebooks.present.js
@@ -500,7 +500,6 @@ class EnvironmentLogs extends Component {
     return (
       <Modal
         isOpen={logs.show ? true : false}
-        size="xl"
         className="modal-dynamic-width"
         scrollable={true}
         toggle={() => { toggleLogs(name) }}>

--- a/src/notebooks/Notebooks.present.js
+++ b/src/notebooks/Notebooks.present.js
@@ -457,6 +457,9 @@ class NotebookServerRowAction extends Component {
 class EnvironmentLogs extends Component {
   render() {
     const { logs, name, toggleLogs, fetchLogs } = this.props;
+    if (!logs.show || logs.show !== name)
+      return null;
+
     let body;
     if (logs.fetching) {
       body = (<Loader />);
@@ -484,7 +487,7 @@ class EnvironmentLogs extends Component {
 
     return (
       <Modal
-        isOpen={logs.show}
+        isOpen={logs.show ? true : false}
         size="xl"
         toggle={() => { toggleLogs(name) }}>
         <ModalHeader toggle={() => { toggleLogs(name) }}>Logs</ModalHeader>

--- a/src/notebooks/Notebooks.present.js
+++ b/src/notebooks/Notebooks.present.js
@@ -39,6 +39,7 @@ import { Loader, InfoAlert, ExternalLink, JupyterIcon } from '../utils/UICompone
 import Time from '../utils/Time';
 import Sizes from '../utils/Media';
 
+import './Notebooks.css';
 
 // * Notebooks code * //
 class Notebooks extends Component {
@@ -429,15 +430,10 @@ class NotebookServerRowAction extends Component {
       defaultAction = (<Button {...classes} onClick={() => this.props.toggleLogs(name)}>Get logs</Button>);
     }
 
-    const alternateToggleStyle = {
-      whiteSpace: "nowrap", borderRadius: "0.2rem",
-      paddingRight: "0.5625rem", paddingLeft: "0.5625rem"
-    };
-
     return (
       <UncontrolledButtonDropdown size="sm">
         {defaultAction}
-        <DropdownToggle color="primary" style={alternateToggleStyle}>
+        <DropdownToggle color="primary" className="alternateToggleStyle">
           <FontAwesomeIcon icon={faEllipsisV} style={{ color: 'white', backgroundColor: "#5561A6" }} />
         </DropdownToggle>
         <DropdownMenu right={true}>

--- a/src/notebooks/Notebooks.state.js
+++ b/src/notebooks/Notebooks.state.js
@@ -221,7 +221,7 @@ class NotebooksCoordinator {
 
   fetchLogs(serverName) {
     let logs = { fetching: true };
-    if (this.model.get("logs.reference") !== serverName) {
+    if (this.model.get('logs.reference') !== serverName) {
       logs.reference = serverName;
       logs.data = [];
       logs.fetched = null;
@@ -231,12 +231,9 @@ class NotebooksCoordinator {
     return this.client.getNotebookServerLogs(serverName).then((data) => {
       const lines = data.split("\n");
       this.model.setObject({
-        logs: {
-          fetched: new Date(),
-          fetching: false,
-          data: lines
-        }
+        logs: { fetched: new Date(), fetching: false }
       });
+      this.model.set('logs.data', lines)
 
       return data;
     });

--- a/src/notebooks/Notebooks.state.js
+++ b/src/notebooks/Notebooks.state.js
@@ -219,6 +219,29 @@ class NotebooksCoordinator {
     });
   }
 
+  fetchLogs(serverName) {
+    let logs = { fetching: true };
+    if (this.model.get("logs.reference") !== serverName) {
+      logs.reference = serverName;
+      logs.data = [];
+      logs.fetched = null;
+    }
+    this.model.setObject({ logs });
+
+    return this.client.getNotebookServerLogs(serverName).then((data) => {
+      const lines = data.split("\n");
+      this.model.setObject({
+        logs: {
+          fetched: new Date(),
+          fetching: false,
+          data: lines
+        }
+      });
+
+      return data;
+    });
+  }
+
   async fetchPipeline() {
     // check if already fetching data
     const fetching = this.model.get('pipelines.fetching');

--- a/src/notebooks/Notebooks.state.js
+++ b/src/notebooks/Notebooks.state.js
@@ -236,6 +236,13 @@ class NotebooksCoordinator {
       this.model.set('logs.data', lines)
 
       return data;
+    }).catch((e) => {
+      const response = ["Logs currently not available. Try again in a minute..."];
+      this.model.setObject({
+        logs: { fetched: new Date(), fetching: false }
+      });
+      this.model.set('logs.data', response)
+      return response;
     });
   }
 

--- a/src/notebooks/index.js
+++ b/src/notebooks/index.js
@@ -25,6 +25,6 @@
 
 import { Notebooks, StartNotebookServer, CheckNotebookStatus } from './Notebooks.container';
 import { CheckNotebookIcon } from './Notebooks.present';
-import { NotebooksHelper } from './Notebooks.state'
+import { NotebooksHelper } from './Notebooks.state';
 
-export { Notebooks, StartNotebookServer, NotebooksHelper, CheckNotebookStatus, CheckNotebookIcon }
+export { Notebooks, StartNotebookServer, NotebooksHelper, CheckNotebookStatus, CheckNotebookIcon };


### PR DESCRIPTION
This adds the possibility to fetch and show the kubernetes logs for each environment. In this first implementation, I used a simple modal to display logs. I know it's not one of @ciyer favorite solutions, we can discuss it and visualize them in a different way
Sadly, it's not possible to get logs during some spawn phases. This means that, usually, there aren't logs for hanging pods, making this addition less useful than expected.

Preview available at https://lorenzotest.dev.renku.ch/

How to test: start an environment, use the "get logs" button during any phase.

fix #414