### PR TITLE
ci: fix chartpress version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_install:
 
 install:
   - travis_retry pip install -U pip
-  - travis_retry pip install "chartpress>=0.2.1" "ruamel.yaml==0.15.54"
+  - travis_retry pip install "chartpress==0.3.2" "ruamel.yaml==0.15.54"
   # Installing Helm
   - wget -q ${HELM_URL}/${HELM_TGZ}
   - tar xzfv ${HELM_TGZ}


### PR DESCRIPTION
pin chartpress version to avoid using the new charts naming convention as defined here
https://github.com/jupyterhub/chartpress/pull/52/files#diff-1b186cf0a304f81b305251eb344e0c47R241
and ultimately avoid deploy issues like this https://concourse.dev.renku.ch/teams/renku/pipelines/renku/jobs/check-renku-ui/builds/471 