### PR TITLE
feat(state): allow using immutability-helper commands on model objects

### DIFF
--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -459,8 +459,6 @@ function nestedPropertyAccess(propAccessorString, obj) {
   return leaf;
 }
 
-window["callImmutableUpdate"] = immutableUpdate;
-
 // A redux reducer that will handle immutability-helper
 // updates.
 function modelUpdateReducer(state, action) {

--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -422,11 +422,14 @@ function updateObjectFromObject(obj, currentObject){
     if (obj[prop] instanceof Object && currentObject[prop]) {
       updateObj[prop] = updateObjectFromObject(obj[prop], currentObject[prop])
     }
+    else if (prop[0] === "$" && prop.length && prop.length > 1) {
+      updateObj[prop] = obj[prop];
+    }
     else {
-      updateObj[prop] = {$set: obj[prop]}
+      updateObj[prop] = { $set: obj[prop] };
     }
   });
-  return updateObj
+  return updateObj;
 }
 
 // Create a mongodb-style update object from a plain
@@ -455,6 +458,8 @@ function nestedPropertyAccess(propAccessorString, obj) {
   });
   return leaf;
 }
+
+window["callImmutableUpdate"] = immutableUpdate;
 
 // A redux reducer that will handle immutability-helper
 // updates.

--- a/src/notebooks/Notebooks.state.js
+++ b/src/notebooks/Notebooks.state.js
@@ -231,17 +231,22 @@ class NotebooksCoordinator {
     return this.client.getNotebookServerLogs(serverName).then((data) => {
       const lines = data.split("\n");
       this.model.setObject({
-        logs: { fetched: new Date(), fetching: false }
+        logs: {
+          fetched: new Date(),
+          fetching: false,
+          data: { $set: lines }
+        }
       });
-      this.model.set('logs.data', lines)
-
       return data;
     }).catch((e) => {
       const response = ["Logs currently not available. Try again in a minute..."];
       this.model.setObject({
-        logs: { fetched: new Date(), fetching: false }
+        logs: {
+          fetched: new Date(),
+          fetching: false,
+          data: { $set: response }
+        }
       });
-      this.model.set('logs.data', response)
       return response;
     });
   }
@@ -286,9 +291,8 @@ class NotebooksCoordinator {
     pipelinesState.fetched = new Date();
     if (pipelines.length === 0) {
       pipelinesState.lastMainId = null;
-      pipelinesState.main = mainPipeline;
+      pipelinesState.main = { $set: mainPipeline };
       this.model.setObject({ pipelines: pipelinesState });
-      this.model.set('pipelines.main', {}); // reset pipelines.main attributes
       return mainPipeline;
     }
 


### PR DESCRIPTION
Allow using any command available from the immutability-helper library https://github.com/kolodny/immutability-helper#available-commands

This enables to use `.setObject()` to perform atomic updates to the store even when trying to remove object attributes or array items, without forcing to invoke `.set()`. A few examples of ` notebooks` model changes are provided in the second commit.

Unexpected behavior may happen when trying to update attributes starting with `$`, but this doesn't look to be a big deal.

### How to test
A bit tricky, it requires to run the PR through telepresence
* Start 2 interactive environments
* Don't perform any operation on the first, do something on the second (open it and try a command in the command line)
* Click on the action "Get logs". With this PR in place, the logs are the same as visualized on rancher/kubectl. By changing the code on Notebooks.state.js from `data: { $set: lines }` to `data: lines`, the logs for the first notebook appear mixed with the second one's logs, because the `data` variables is not cleaned properly as defined by the`$set` command.

fix #631 