### PR TITLE
feat: handle limit-reached errors on new project creation

### DIFF
--- a/src/project/fork/ProjectFork.container.js
+++ b/src/project/fork/ProjectFork.container.js
@@ -85,18 +85,19 @@ class Fork extends Component {
         let display_messages = [];
         if (error.errorData && error.errorData.message) {
           const all_messages = error.errorData.message;
-          const messages = Object.keys(all_messages)
-            .filter(mex => all_messages[mex].length)
-            .reduce((obj, mex) => { obj[mex] = all_messages[mex]; return obj; }, {});
-
-          // the most common error is the duplicate name, we can rewrite it for readability
-          if (Object.keys(messages).includes("name") && /already.+taken/.test(messages["name"].join("; "))) {
-            display_messages = [`title: ${messages["name"].join("; ")}`];
+          if (all_messages instanceof Object) {
+            const messages = Object.keys(all_messages)
+              .reduce((obj, mex) => { obj[mex] = all_messages[mex]; return obj; }, {});
+            // the most common error is the duplicate name, we can rewrite it for readability
+            if (Object.keys(messages).includes("name") && /already.+taken/.test(messages["name"].join("; "))) {
+              display_messages = [`title: ${messages["name"].join("; ")}`];
+            }
+            else {
+              display_messages = Object.keys(messages).map(mex => `${mex}: ${messages[mex].join("; ")}`);
+            }
           }
           else {
-            console.log(messages)
-            display_messages = Object.keys(messages)
-              .map(mex => `${mex}: ${messages[mex].join("; ")}`);
+            display_messages = [all_messages];
           }
         }
         else {


### PR DESCRIPTION
On project creation, errors without a description were filtered out. This sometimes ended up in misleading error messages. This PR introduces the following

* include errors without description in the error message
* makes the message for users without project creation permission more understandable
* remove error message after changing any data
* fix a minor issue on error handling while forking a project

Preview available here: https://lorenzotest.dev.renku.ch/

Testing requires an account with limited permission, like john.doe@mail.org
Log in and try to create a new project
![Screenshot_20191029_161141](https://user-images.githubusercontent.com/43481553/67780717-cded4d00-fa66-11e9-9180-fb3284fb6470.png)

fix #636 