### PR TITLE
fix(environments): reset commits data correctly on branch change

### DIFF
--- a/src/notebooks/Notebooks.state.js
+++ b/src/notebooks/Notebooks.state.js
@@ -93,8 +93,8 @@ class NotebooksCoordinator {
       filters: {
         namespace: null,
         project: null,
-        branch: { name: null }, // TODO: remove sub-property when "force" parameter will be available for setObject
-        commit: { id: null }
+        branch: { $set: {} },
+        commit: { $set: {} }
       },
       pipelines: {
         fetched: null,
@@ -129,14 +129,18 @@ class NotebooksCoordinator {
   }
 
   setBranch(branch) {
-    this.model.set('notebooks.fetched', null);
-    this.model.set('filters.branch', branch);
+    this.model.setObject({
+      notebooks: { fetched: null },
+      filters: { branch: { $set: branch } }
+    });
     this.fetchNotebooks();
   }
 
   setCommit(commit) {
-    this.model.set('notebooks.fetched', null);
-    this.model.set('filters.commit', commit);
+    this.model.setObject({
+      notebooks: { fetched: null },
+      filters: { commit: { $set: commit } }
+    });
     this.fetchNotebooks();
   }
 
@@ -187,7 +191,7 @@ class NotebooksCoordinator {
           const filters = this.getQueryFilters();
           if (this.model.get('notebooks.lastParameters') === JSON.stringify(filters)) {
             updatedNotebooks.fetched = new Date();
-            this.model.set('notebooks.all', resp.data);
+            updatedNotebooks.all = { $set: resp.data };
           }
           // TODO: re-invoke `fetchNotebooks()` immediatly if parameters are outdated
         }
@@ -223,7 +227,7 @@ class NotebooksCoordinator {
     let logs = { fetching: true };
     if (this.model.get('logs.reference') !== serverName) {
       logs.reference = serverName;
-      logs.data = [];
+      logs.data = { $set: [] };
       logs.fetched = null;
     }
     this.model.setObject({ logs });
@@ -430,7 +434,7 @@ class NotebooksCoordinator {
           data: {
             fetching: false,
             fetched: new Date(),
-            commits: resp.data
+            commits: { $set: resp.data }
           }
         })
         return resp.data;

--- a/src/project/Project.state.js
+++ b/src/project/Project.state.js
@@ -272,14 +272,18 @@ class ProjectModel extends StateModel {
       .then(data => {
         // split away autosaved branches and add external url
         const { standard, autosaved } = splitAutosavedBranches(data);
-        this.set('system.branches', standard);
         const externalUrl = this.get('core.external_url');
         const autosavedUrl = autosaved.map(branch => {
           const url = `${externalUrl}/tree/${branch.name}`;
           branch.autosave.url = url;
           return branch;
         });
-        this.set('system.autosaved', autosavedUrl);
+        this.setObject({
+          system: {
+            branches: { $set: standard },
+            autosaved: { $set: autosavedUrl }
+          }
+        });
 
         return standard;
       })


### PR DESCRIPTION
It turns out that the `.setObject` function doesn't handle well overwriting arrays. When updating the commits, it happened that switching from a branch with `n` commits to another with `m<n` commits left old data behind.

This PR fixes that problem and makes atomic a few other environments related state updates. 

Fix #663

EDIT:
~It requires #655 to be merged.~ --> merged
Preview: https://lorenzotest.dev.renku.ch
