### PR TITLE
Updated templates tag

### DIFF
--- a/helm-chart/renku-ui/values.yaml
+++ b/helm-chart/renku-ui/values.yaml
@@ -60,4 +60,4 @@ welcomePage:
 
 templatesRepository:
   url: https://github.com/SwissDataScienceCenter/renku-project-template
-  ref: 0.1.4
+  ref: 0.1.5


### PR DESCRIPTION
Updated the project templates tag.
Currently used in Renku 0.5.0.