### PR TITLE
feat(dataset): fetch datasets without 404 and delete identifier modification

### DIFF
--- a/src/dataset/Dataset.present.js
+++ b/src/dataset/Dataset.present.js
@@ -139,7 +139,7 @@ export default function DatasetView(props){
           });
       } else if(!unmounted) setDataset(null);
     } else {
-      if(dataset === undefined){
+      if(dataset === undefined && props.identifier !== undefined){
         props.client.fetchDatasetFromKG(props.client.baseUrl.replace('api','knowledge-graph/datasets/')+props.identifier)
           .then((datasetInfo) => {
             if(!unmounted && dataset === undefined && datasetInfo !== undefined){

--- a/src/project/Project.state.js
+++ b/src/project/Project.state.js
@@ -214,21 +214,11 @@ class ProjectModel extends StateModel {
     this.setUpdating({transient:{requests:{datasets: true}}});
     return client.getProjectDatasetsFromKG(this.get('core.path_with_namespace'))
       .then(datasets => {
-        datasets = datasets.map(dataset => {
-          dataset.identifier = dataset.identifier.split('-').join("");
-          return dataset;
-        } )
         const updatedState = { datasets: datasets, transient:{requests:{datasets: false}} };
         this.set('core.datasets', datasets);
         this.setObject(updatedState);
         return datasets;
-      }).catch(error => {
-        if (error.case === API_ERRORS.notFoundError) {
-          const updatedState = { datasets: [], transient:{requests:{datasets: false}} };
-          this.set('core.datasets', []);
-          this.setObject(updatedState);
-        }
-      });
+      })
   }
 
   fetchProjectDatasetsFromMetadata(client){


### PR DESCRIPTION
Closes #706 

Testing: https://virginia.dev.renku.ch 
--> you will see using the debugging tools that before we where receiving a 404 when a project had no datasets and now we get a 200 with an empty array.
