### PR TITLE
feat(datasets): implement pagination

### DIFF
--- a/src/api-client/dataset.js
+++ b/src/api-client/dataset.js
@@ -1,11 +1,13 @@
 export default function addDatasetMethods(client) {
 
-  client.searchDatasets = (query) => {
-    let url = `${client.baseUrl}/knowledge-graph/datasets?query=${query}`;
-    url = url.replace('/api','');//The url should change in the backend so we don't have to do this
+  client.searchDatasets = (queryParams = { query: '' }) => {
+    const url = `${client.baseUrl.replace('/api', '')}/knowledge-graph/datasets`;
     const headers = client.getBasicHeaders();
-    return client.clientFetch(url, {method:'GET', headers}).then((resp) => {
-      return resp.data;
-    });
+
+    return client.clientFetch(url, {
+      method: 'GET',
+      headers,
+      queryParams
+    })
   }
 }

--- a/src/api-client/pagination.js
+++ b/src/api-client/pagination.js
@@ -32,18 +32,25 @@ const NUMERICAL_X_HEADERS = {
   'X-Total-Pages': 'totalPages',
 }
 
+const NUMERICAL_PAGINATION_HEADERS = {
+  'Next-Page': 'nextPage',
+  'Page': 'currentPage',
+  'Per-Page': 'perPage',
+  'Total': 'totalItems',
+  'Total-Pages': 'totalPages',
+}
+
 // In this function we just parse the pagination related header
 // information. The idea that methods performing the the request to
 // to fetch the next page has been dropped because we prefer to
 // keep the state of the corresponding components serializable.
 function processPaginationHeaders(client, headers) {
-
   let paginationDetail = {};
 
   // Parse the link header if it exists
   if (headers.get('Link')) {
     const paginationLinks = processLinkHeader(headers.get('Link'))
-    paginationDetail = {...paginationDetail, ...paginationLinks}
+    paginationDetail = { ...paginationDetail, ...paginationLinks }
   }
 
   // Parse the pagination related X-... headers
@@ -51,6 +58,14 @@ function processPaginationHeaders(client, headers) {
     paginationDetail[NUMERICAL_X_HEADERS[header]] =
       parseInt(headers.get(header), 10) || undefined
   })
+
+  // Parse the pagination releated hedares (non-X)
+  if (!headers.get('X-Page')) {
+    Object.keys(NUMERICAL_PAGINATION_HEADERS).forEach((header) => {
+      paginationDetail[NUMERICAL_PAGINATION_HEADERS[header]] =
+        parseInt(headers.get(header), 10) || undefined
+    })
+  }
 
   return paginationDetail
 }


### PR DESCRIPTION
Handle pagination according to the specifications from the knowledge-graph endpoint. Please note that
pagination headers are different from the GitLab ones.

Preview available here: https://lorenzotest.dev.renku.ch/datasets

fix #713