### PR TITLE
feat(environments): read project level notebook options

### DIFF
--- a/src/file/File.container.js
+++ b/src/file/File.container.js
@@ -28,7 +28,7 @@ import { API_ERRORS } from '../api-client';
 import { RenkuMarkdown } from '../utils/UIComponents';
 
 const IMAGE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'tiff', 'pdf', 'gif'];
-const CODE_EXTENSIONS = ['py', 'js', 'json', 'sh', 'r', 'txt', 'yml', 'csv', 'parquet', 'cwl', 'job', 'prn', 'rout', 'dcf', 'rproj', 'rst', 'bat'];
+const CODE_EXTENSIONS = ['py', 'js', 'json', 'sh', 'r', 'txt', 'yml', 'csv', 'parquet', 'cwl', 'job', 'prn', 'rout', 'dcf', 'rproj', 'rst', 'bat', 'ini'];
 
 // FIXME: Unify the file viewing for issues (embedded) and independent file viewing.
 // FIXME: Javascript highlighting is broken for large files.

--- a/src/model/RenkuModels.js
+++ b/src/model/RenkuModels.js
@@ -165,7 +165,6 @@ const notebooksSchema = new Schema({
       poller: { initial: null },
       fetched: { initial: null },
       fetching: { initial: false },
-      options: { initial: {} },
       lastParameters: { initial: null }
     }
   },
@@ -182,6 +181,16 @@ const notebooksSchema = new Schema({
       displayedCommits: { initial: 10 },
     }
   },
+  options: {
+    schema: {
+      global: { initial: {} },
+
+      project: { initial: {} },
+      fetched: { initial: null },
+      fetching: { initial: false },
+      warnings: { initial: [] }
+    }
+  },  
   pipelines: {
     schema: {
       main: { initial: {} },

--- a/src/notebooks/Notebooks.present.js
+++ b/src/notebooks/Notebooks.present.js
@@ -938,6 +938,14 @@ class StartNotebookOptions extends Component {
   }
 }
 
+function Warning(props) {
+  return <div style={{fontSize: "smaller", paddingTop: "5px"}}>
+    <WarnAlert>
+      <FontAwesomeIcon icon={faInfoCircle} /> {props.children}
+  </WarnAlert>
+  </div>
+}
+
 class StartNotebookOptionsRunning extends Component {
   render() {
     const { all } = this.props.notebooks;
@@ -989,17 +997,17 @@ class StartNotebookServerOptions extends Component {
         };
         const warning = !warnings.includes(key)
           ? null
-          : <WarnAlert>
-            <FontAwesomeIcon icon={faInfoCircle} /> Cannot set {serverOption.displayName} to
-            its project default &quot;{projectOptions[key]}&quot; in this Renkulab deployment.
-          </WarnAlert>
+          : <Warning>
+              Cannot set <b>{serverOption.displayName}</b> to
+              the project default value <i>{projectOptions[key]}</i> in this Renkulab deployment.
+            </Warning>
 
         switch (serverOption.type) {
         case 'enum':
           return <FormGroup key={key} className={serverOption.options.length === 1 ? 'mb-0' : ''}>
             <Label>{serverOption.displayName}</Label>
-            {warning}
             <ServerOptionEnum {...serverOption} onChange={onChange} />
+            {warning}
           </FormGroup>;
 
         case 'int':
@@ -1027,12 +1035,11 @@ class StartNotebookServerOptions extends Component {
 
     const unmatchedWarnings = warnings.filter(x => !sortedOptionKeys.includes(x));
     const globalWarning = unmatchedWarnings && unmatchedWarnings.length
-      ? <WarnAlert key="globalWarning">
-        <FontAwesomeIcon icon={faInfoCircle} /> Unknown project
-        variable{unmatchedWarnings.length > 1 ? "s" : ""} &quot;
-        {unmatchedWarnings.join("&quot;, &quot;")}&quot;
-        in this Renkulab deployment.
-      </WarnAlert>
+      ? <Warning key="globalWarning">
+        Project environment default contains
+        variable{unmatchedWarnings.length > 1 ? "s" : ""} {unmatchedWarnings.map((w, i) => <span key={i}>&ldquo;{w}&rdquo;, </span>)}
+        which {unmatchedWarnings.length > 1 ? "are" : "is"} not known in this Renkulab deployment.
+      </Warning>
       : null;
 
     return renderedServerOptions.length ?
@@ -1132,6 +1139,12 @@ class ServerOptionLaunch extends Component {
   }
 
   render() {
+    const { warnings } = this.props.options;
+    const globalNotification = (warnings.length < 1) ? null :
+    <Warning key="globalNotification">
+      The environment cannot be configured exactly as requested for this project.
+      You can still start one, but some things may not work correctly.
+    </Warning>
     return [
       <Button key="button" color="primary" onClick={this.checkServer}>
         Start environment
@@ -1141,7 +1154,8 @@ class ServerOptionLaunch extends Component {
         showModal={this.state.showModal}
         currentBranch={this.state.current}
         {...this.props}
-      />
+      />,
+      globalNotification
     ];
   }
 }

--- a/src/notebooks/Notebooks.present.js
+++ b/src/notebooks/Notebooks.present.js
@@ -1047,7 +1047,7 @@ class ServerOptionEnum extends Component {
     let { options } = this.props;
 
     if (selected && options && options.length && !options.includes(selected))
-      options.push(selected);
+      options = options.concat(selected);
     if (options.length === 1)
       return (<label>: {this.props.selected}</label>);
 

--- a/src/notebooks/Notebooks.present.js
+++ b/src/notebooks/Notebooks.present.js
@@ -1028,7 +1028,7 @@ class StartNotebookServerOptions extends Component {
     const unmatchedWarnings = warnings.filter(x => !sortedOptionKeys.includes(x));
     const globalWarning = unmatchedWarnings && unmatchedWarnings.length
       ? <WarnAlert key="globalWarning">
-        <FontAwesomeIcon icon={faInfoCircle} /> Unknowun project
+        <FontAwesomeIcon icon={faInfoCircle} /> Unknown project
         variable{unmatchedWarnings.length > 1 ? "s" : ""} &quot;
         {unmatchedWarnings.join("&quot;, &quot;")}&quot;
         in this Renkulab deployment.
@@ -1071,11 +1071,14 @@ class ServerOptionEnum extends Component {
 
 class ServerOptionBoolean extends Component {
   render() {
+    // The double negation solves an annoying problem happening when checked=undefined
+    // https://stackoverflow.com/a/39709700/1303090
+    const selected = !!this.props.selected;
     return (
       <Input
         type="checkbox"
         id={this.props.id}
-        value={this.props.selected}
+        checked={selected}
         onChange={this.props.onChange}
       />
     );

--- a/src/notebooks/Notebooks.state.js
+++ b/src/notebooks/Notebooks.state.js
@@ -99,7 +99,8 @@ class NotebooksCoordinator {
         namespace: null,
         project: null,
         branch: { $set: {} },
-        commit: { $set: {} }
+        commit: { $set: {} },
+        options: { $set: {} }
       },
       pipelines: {
         fetched: null,
@@ -258,10 +259,10 @@ class NotebooksCoordinator {
             if (parsedOption === "default_url")
               option = "defaultUrl";
             let value = parsedOptions[parsedOption];
-            if (value === "true") {
+            if (value && value.toLowerCase() === "true") {
               value = true;
             }
-            else if (value === "false") {
+            else if (value && value.toLowerCase() === "false") {
               value = false;
             }
             else if (!isNaN(value)) {
@@ -326,11 +327,10 @@ class NotebooksCoordinator {
     let warnings = [];
     Object.keys(projectOptions).forEach(option => {
       const optionValue = projectOptions[option];
-      if ((globalOptions[option]
-        && globalOptions[option].options
-        && globalOptions[option].options.length
-        && globalOptions[option].options.includes(optionValue))
-        || option === "defaultUrl"
+      if (
+        (globalOptions[option] && globalOptions[option].type !== "enum") ||
+        (globalOptions[option] && globalOptions[option].options && globalOptions[option].options.length && globalOptions[option].options.includes(optionValue)) ||
+        (option === "defaultUrl")
       ) {
         filterOptions[option] = optionValue;
       }

--- a/src/notebooks/Notebooks.state.js
+++ b/src/notebooks/Notebooks.state.js
@@ -335,7 +335,7 @@ class NotebooksCoordinator {
         filterOptions[option] = optionValue;
       }
       else {
-        warnings.push(option);
+        warnings = warnings.concat(option);
       }
     });
     this.model.setObject({

--- a/src/utils/HelperFunctions.js
+++ b/src/utils/HelperFunctions.js
@@ -63,5 +63,35 @@ function simpleHash(str) {
   return ("0000000" + (hval >>> 0).toString(16)).substr(-8);
 }
 
+function parseINIString(data) {
+  const regex = {
+    section: /^\s*\[\s*([^\]]*)\s*\]\s*$/,
+    param: /^\s*([^=]+?)\s*=\s*(.*?)\s*$/,
+    comment: /^\s*;.*$/
+  };
+  const lines = data.split(/[\r\n]+/);
+  let section = null;
+  let value = {};
+  lines.forEach(function (line) {
+    if (regex.comment.test(line)) {
+      return;
+    } else if (regex.param.test(line)) {
+      let match = line.match(regex.param);
+      if (section) {
+        value[section][match[1]] = match[2];
+      } else {
+        value[match[1]] = match[2];
+      }
+    } else if (regex.section.test(line)) {
+      let match = line.match(regex.section);
+      value[match[1]] = {};
+      section = match[1];
+    } else if (line.length === 0 && section) {
+      section = null;
+    }
+  });
+  return value;
+}
+
 export { slugFromTitle, getActiveProjectPathWithNamespace, splitAutosavedBranches, sanitizedHTMLFromMarkdown }
-export { simpleHash }
+export { simpleHash, parseINIString }


### PR DESCRIPTION
When starting a new interactive environment, the UI now checks for project options available in the `.renku/renku.ini` file, it tries to apply the settings and it displays popup warnings where needed.
More info in the docs here: SwissDataScienceCenter/renku#723

**HOW TO TEST**
A preview is available at https://lorenzotest.dev.renku.ch/
This is a project with some already defined custom options: https://lorenzotest.dev.renku.ch/projects/lorenzo.cavazzi.tech/projectoptions

fix #481

![Screenshot_20200110_172044](https://user-images.githubusercontent.com/43481553/72168590-bcf97a00-33cd-11ea-8ef7-304f835dc822.png)
