### PR TITLE
test: fix test warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14306,9 +14306,9 @@
       }
     },
     "react-autowhatever": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/react-autowhatever/-/react-autowhatever-10.2.0.tgz",
-      "integrity": "sha512-dqHH4uqiJldPMbL8hl/i2HV4E8FMTDEdVlOIbRqYnJi0kTpWseF9fJslk/KS9pGDnm80JkYzVI+nzFjnOG/u+g==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/react-autowhatever/-/react-autowhatever-10.2.1.tgz",
+      "integrity": "sha512-5gQyoETyBH6GmuW1N1J81CuoAV+Djeg66DEo03xiZOl3WOwJHBP5LisKUvCGOakjrXU4M3hcIvCIqMBYGUmqOA==",
       "requires": {
         "prop-types": "^15.5.8",
         "react-themeable": "^1.1.0",
@@ -15933,9 +15933,9 @@
       }
     },
     "shallow-equal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.1.0.tgz",
-      "integrity": "sha512-0SW1nWo1hnabO62SEeHsl8nmTVVEzguVWZCj5gaQrgWAxz/BaCja4OWdJBWLVPDxdtE/WU7c98uUCCXyPHSCvw=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
+      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA=="
     },
     "shebang-command": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "popper.js": "^1.16.0",
     "query-string": "^6.8.3",
     "react": "^16.11.0",
-    "react-autosuggest": "^9.4.0",
+    "react-autosuggest": "^9.4.3",
     "react-clipboard.js": "^2.0.16",
     "react-collapse": "^5.0.0",
     "react-dom": "^16.11.0",

--- a/src/landing/Landing.js
+++ b/src/landing/Landing.js
@@ -57,7 +57,7 @@ class Home extends Component {
     this.store = createStore(State.Home.reduce);
   }
 
-  componentWillMount(){
+  UNSAFE_componentWillMount(){
     UserState.reSetAllProjects(this.props.client, this.props.userStateDispatch, 
       this.props.user.starredProjects, this.props.user.memberProjects);
   }

--- a/src/model/Model.test.js
+++ b/src/model/Model.test.js
@@ -201,7 +201,7 @@ describe('update react state', () => {
       this.model = new StateModel(complexSchema, StateKind.REACT, this, complexSchema.createInitialized());
     }
 
-    componentWillMount() {
+    UNSAFE_componentWillMount() {
       this.model.set('subthing.age', 1);
       this.model.set('simpleThings.0.numbers.2', 2)
     }
@@ -255,7 +255,7 @@ describe('update connected redux store', () => {
       this.model = new StateModel(complexSchema, StateKind.REACT, this);
     }
 
-    componentWillMount() {
+    UNSAFE_componentWillMount() {
       this.model.set('subthing.age', 1)
     }
 


### PR DESCRIPTION
Attempt to fix console warning on `npm test`. There are still 2 libraries responsible for throwing react related warnings

```
react-autosuggest
@nteract/notebook-render
```

Currently, no up-to-date version is available