### PR TITLE
feat: update server logs

### DIFF
--- a/src/api-client/notebook-servers.js
+++ b/src/api-client/notebook-servers.js
@@ -88,14 +88,15 @@ function addNotebookServersMethods(client) {
     });
   }
 
-  client.getNotebookServerLogs = (serverName) => {
+  client.getNotebookServerLogs = (serverName, lines = 250) => {
     const headers = client.getBasicHeaders();
     headers.append('Accept', 'text/plain');
     const url = `${client.baseUrl}/notebooks/logs/${serverName}`;
 
     return client.clientFetch(url, {
       method: 'GET',
-      headers
+      headers,
+      queryParams: { max_lines: lines }
     }).then((resp) => {
       return resp.data;
     });

--- a/src/api-client/notebook-servers.js
+++ b/src/api-client/notebook-servers.js
@@ -96,8 +96,8 @@ function addNotebookServersMethods(client) {
     return client.clientFetch(url, {
       method: 'GET',
       headers
-    }, "text").then((resp) => {
-      return resp;
+    }).then((resp) => {
+      return resp.data;
     });
   }
 }

--- a/src/notebooks/Notebooks.container.js
+++ b/src/notebooks/Notebooks.container.js
@@ -73,8 +73,10 @@ class Notebooks extends Component {
     this.coordinator.stopNotebook(serverName, force);
   }
 
-  fetchLogs(serverName) {
-    this.coordinator.fetchLogs(serverName);
+  async fetchLogs(serverName, full = false) {
+    if (!serverName)
+      return;
+    return this.coordinator.fetchLogs(serverName, full);
   }
 
   toggleLogs(serverName) {

--- a/src/notebooks/Notebooks.present.js
+++ b/src/notebooks/Notebooks.present.js
@@ -457,10 +457,16 @@ class NotebookServerRowAction extends Component {
  * @param {object} annotations - list of cleaned annotations
  */
 class EnvironmentLogs extends Component {
-  save() {
+  async save() {
+    // get full logs
+    const { fetchLogs, name } = this.props;
+    const fullLogs = await fetchLogs(name, true);
+
+    // create the blob element to download logs as a file
     const elem = document.createElement("a");
-    const file = new Blob([this.props.logs.data.join("\n")], { type: "text/plain" });
+    const file = new Blob([fullLogs.join("\n")], { type: "text/plain" });
     elem.href = URL.createObjectURL(file);
+    this.props.fetchLogs()
     elem.download = `Logs_${this.props.name}.txt`;
     document.body.appendChild(elem);
     elem.click();
@@ -508,10 +514,10 @@ class EnvironmentLogs extends Component {
         </ModalHeader>
         <ModalBody>{body}</ModalBody>
         <ModalFooter>
-          <Button color="primary" onClick={() => { this.save() }}>
+          <Button color="primary" disabled={logs.fetching} onClick={() => { this.save() }}>
             <FontAwesomeIcon icon={faSave} /> Download
           </Button>
-          <Button color="primary" onClick={() => { fetchLogs(name) }}>
+          <Button color="primary" disabled={logs.fetching} onClick={() => { fetchLogs(name) }}>
             <FontAwesomeIcon icon={faRedo} /> Refresh
           </Button>
         </ModalFooter>

--- a/src/notebooks/Notebooks.state.js
+++ b/src/notebooks/Notebooks.state.js
@@ -233,12 +233,11 @@ class NotebooksCoordinator {
     this.model.setObject({ logs });
 
     return this.client.getNotebookServerLogs(serverName).then((data) => {
-      const lines = data.split("\n");
       this.model.setObject({
         logs: {
           fetched: new Date(),
           fetching: false,
-          data: { $set: lines }
+          data: { $set: data }
         }
       });
       return data;

--- a/src/notebooks/Notebooks.state.js
+++ b/src/notebooks/Notebooks.state.js
@@ -223,35 +223,28 @@ class NotebooksCoordinator {
     });
   }
 
-  fetchLogs(serverName) {
+  fetchLogs(serverName, full = false) {
+    let lines = 250;
+    if (full)
+      lines = 0;
     let logs = { fetching: true };
-    if (this.model.get('logs.reference') !== serverName) {
+    if (this.model.get('logs.reference') !== serverName && !full) {
       logs.reference = serverName;
       logs.data = { $set: [] };
       logs.fetched = null;
     }
     this.model.setObject({ logs });
-
-    return this.client.getNotebookServerLogs(serverName).then((data) => {
-      this.model.setObject({
-        logs: {
-          fetched: new Date(),
-          fetching: false,
-          data: { $set: data }
+    return this.client.getNotebookServerLogs(serverName, lines)
+      .catch(e => ["Logs currently not available. Try again in a minute..."])
+      .then((data) => {
+        let updatedLogs = { fetching: false };
+        if (!full) {
+          updatedLogs.fetched = new Date();
+          updatedLogs.data = { $set: data };
         }
-      });
-      return data;
-    }).catch((e) => {
-      const response = ["Logs currently not available. Try again in a minute..."];
-      this.model.setObject({
-        logs: {
-          fetched: new Date(),
-          fetching: false,
-          data: { $set: response }
-        }
-      });
-      return response;
-    });
+        this.model.setObject({ logs: updatedLogs });
+        return data;
+      })
   }
 
   async fetchPipeline() {


### PR DESCRIPTION
Server logs API now returns data in JSON format SwissDataScienceCenter/renku-notebooks#225

This PR modifies the logs functionality as follows:
* adapt to JSON response
* query by default 250 lines from the logs
* query the whole log when clicking on download

Preview available here: https://lorenzotest.dev.renku.ch/

fix #700
fix #715