### PR TITLE
fix: show all group's descendants

### DIFF
--- a/src/api-client/project.js
+++ b/src/api-client/project.js
@@ -121,6 +121,8 @@ function addProjectMethods(client) {
   }
 
   client.getProjectsBy = (searchIn, userOrGroupId, queryParams) => {
+    if (searchIn === "groups")
+      queryParams.include_subgroups = true;
     let headers = client.getBasicHeaders();
     return client.clientFetch(`${client.baseUrl}/${searchIn}/${userOrGroupId}/projects`, {
       method: 'GET',


### PR DESCRIPTION
fix #724

how to test: search for project filtering by groups and use `sub`. Clicking on `cav-sub-level1` doesn't show the projects without this fix