### PR TITLE
feat: prevent downloading empty logs

### DIFF
--- a/src/notebooks/Notebooks.present.js
+++ b/src/notebooks/Notebooks.present.js
@@ -502,6 +502,16 @@ class EnvironmentLogs extends Component {
       }
     }
 
+    const canDownload = (logs) => {
+      if (logs.fetching)
+        return false;
+      if (!logs.data || !logs.data.length)
+        return false;
+      if (logs.data.length === 1 && logs.data[0].startsWith("Logs unavailable"))
+        return false;
+      return true;
+    };
+
     return (
       <Modal
         isOpen={logs.show ? true : false}
@@ -515,7 +525,7 @@ class EnvironmentLogs extends Component {
         </ModalHeader>
         <ModalBody>{body}</ModalBody>
         <ModalFooter>
-          <Button color="primary" disabled={logs.fetching} onClick={() => { this.save() }}>
+          <Button color="primary" disabled={!canDownload(logs)} onClick={() => { this.save() }}>
             <FontAwesomeIcon icon={faSave} /> Download
           </Button>
           <Button color="primary" disabled={logs.fetching} onClick={() => { fetchLogs(name) }}>


### PR DESCRIPTION
This PR follows up #721 by disabling the logs download button when no logs are available.

Preview here: https://lorenzotest.dev.renku.ch

***How to test***
Start any environments, try to get the logs immediately after. As long as the logs are unavailable, it's not possible to click on download.

![Screenshot_20200121_150430](https://user-images.githubusercontent.com/43481553/72811381-d7e6ac80-3c5f-11ea-8896-31e7d5c0a237.png)


