### PR TITLE
Close pop-up after successful fork operation

### DIFF
--- a/src/model/RenkuModels.js
+++ b/src/model/RenkuModels.js
@@ -157,7 +157,8 @@ const projectSchema = new Schema({
   },
   transient: {
     schema: {
-      requests: {initial: {}}
+      requests: {initial: {}},
+      forkModalOpen: {initial: false}
     }
   },
   webhook: {
@@ -203,7 +204,7 @@ const notebooksSchema = new Schema({
       fetching: { initial: false },
       warnings: { initial: [] }
     }
-  },  
+  },
   pipelines: {
     schema: {
       main: { initial: {} },

--- a/src/project/Project.js
+++ b/src/project/Project.js
@@ -184,6 +184,7 @@ class View extends Component {
     const pathComps = splitProjectSubRoute(this.props.match.url);
     if (prevPathComps.projectPathWithNamespace !== pathComps.projectPathWithNamespace) {
       this.fetchAll();
+      this.eventHandlers.closeForkModal();
     }
   }
 
@@ -341,7 +342,7 @@ class View extends Component {
     const forked = (forkedData != null && Object.keys(forkedData).length > 0) ?
       true :
       false;
-    const forkModalOpen = this.projectState.get('forkModalOpen');
+    const forkModalOpen = this.projectState.get('transient.forkModalOpen');
     const projectPathWithNamespace = this.projectState.get('core.path_with_namespace');
     // Access to the project state could be given to the subComponents by connecting them here to
     // the projectStore. This is not yet necessary.
@@ -466,7 +467,8 @@ class View extends Component {
         projectId={projectId}
         title={this.projectState.get('core.title')}
         forkModalOpen={forkModalOpen}
-        toogleForkModal={this.eventHandlers.toogleForkModal}
+        toggleForkModal={this.eventHandlers.toggleForkModal}
+        closeForkModal={this.eventHandlers.closeForkModal}
         history={this.props.history}
         client={this.props.client}
         user={this.props.user} />
@@ -493,9 +495,14 @@ class View extends Component {
         }
       });
     },
-    toogleForkModal: (e) => {
+    toggleForkModal: (e) => {
       e.preventDefault();
-      this.projectState.toogleForkModal();
+      this.projectState.toggleForkModal();
+    },
+    closeForkModal: () => {
+      // Only toggle if it is currently open
+      if (this.projectState.get('transient.forkModalOpen') === true)
+        this.projectState.toggleForkModal();
     },
     onCreateMergeRequest: (branch) => {
       const core = this.projectState.get('core');
@@ -554,7 +561,7 @@ class View extends Component {
     const suggestedMRBranches = this.getMrSuggestions();
     const externalUrl = this.projectState.get('core.external_url');
     const canCreateMR = state.visibility.accessLevel >= ACCESS_LEVELS.DEVELOPER;
-    const forkModalOpen = this.projectState.get('forkModalOpen');
+    const forkModalOpen = this.projectState.get('transient.forkModalOpen');
 
     return {
       ...this.projectState.get(),

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -248,7 +248,7 @@ class ProjectViewHeaderOverview extends Component {
               <div className={`fixed-width-6em pr-1`}>
                 <form className="input-group input-group-sm">
                   <div className="input-group-prepend">
-                    <button className="btn btn-outline-primary" onClick={this.props.toogleForkModal}>
+                    <button className="btn btn-outline-primary" onClick={this.props.toggleForkModal}>
                       <FontAwesomeIcon icon={forkIcon} /> {forkButtonText}
                     </button>
                   </div>
@@ -526,7 +526,7 @@ class ProjectDatasetsNav extends Component {
 class ProjectViewDatasets extends Component {
   render(){
     return <Switch>
-        <Route exact path={this.props.newDatasetUrl} 
+        <Route exact path={this.props.newDatasetUrl}
           render={p => this.props.newDataset(p)} />
         <Route path={this.props.editDatasetUrl} 
           render={p => this.props.editDataset(p)} />
@@ -549,12 +549,12 @@ class ProjectViewDatasetsList extends Component {
     if(!loading && !kgLoading && this.props.core.datasets !== undefined && this.props.core.datasets.length === 0){
       return <Col sm={12} md={8} lg={10}>
         <Alert timeout={0} color="primary">
-					No datasets found for this project. <br /><br /> 
+					No datasets found for this project. <br /><br />
 					<FontAwesomeIcon icon={faInfoCircle} />  If you recently activated the knowledge graph or added the datasets try refreshing the page. <br /><br />
 					You can also click on the button to create a <Link className="btn btn-primary btn-sm" to={this.props.newDatasetUrl}>New Dataset</Link>
         </Alert>
       </Col>;
-    }	    
+    }
 
     return [
       kgLoading ? null
@@ -839,7 +839,7 @@ class ProjectNotebookServers extends Component {
     return (notebookLauncher(this.props.user.id,
       this.props.visibility.accessLevel,
       content,
-      this.props.toogleForkModal,
+      this.props.toggleForkModal,
       this.props.location.pathname,
       this.props.externalUrl));
   }
@@ -862,7 +862,7 @@ class ProjectStartNotebookServer extends Component {
     return (notebookLauncher(this.props.user.id,
       this.props.visibility.accessLevel,
       content,
-      this.props.toggleModalFork,
+      this.props.toggleForkModal,
       this.props.location.pathname,
       this.props.externalUrl));
   }

--- a/src/project/Project.state.js
+++ b/src/project/Project.state.js
@@ -327,9 +327,10 @@ class ProjectModel extends StateModel {
     });
   }
 
-  toogleForkModal() {
-    let forkModalOpen = this.get('forkModalOpen');
-    this.set("forkModalOpen", forkModalOpen === undefined || forkModalOpen === false ? true : false);
+  toggleForkModal() {
+    const forkModalOpen = this.get('transient.forkModalOpen');
+    const forkModalFlipped = forkModalOpen === false ? true : false;
+    this.set("transient.forkModalOpen", forkModalFlipped);
   }
 
   star(client, starred) {

--- a/src/project/fork/ProjectFork.container.js
+++ b/src/project/fork/ProjectFork.container.js
@@ -41,7 +41,7 @@ class Fork extends Component {
       onProjectNamespaceAccept: this.onProjectNamespaceAccept.bind(this),
       fetchMatchingNamespaces: this.fetchMatchingNamespaces.bind(this),
       fetchAllNamespaces: this.fetchAllNamespaces.bind(this),
-      toogleForkModal: this.toogleForkModal.bind(this),
+      toggleForkModal: this.toggleForkModal.bind(this),
       onTitleChange: this.onTitleChange.bind(this),
       setProjectTitle: this.setProjectTitle.bind(this)
     };
@@ -158,11 +158,11 @@ class Fork extends Component {
     }
   }
 
-  toogleForkModal(e) {
+  toggleForkModal(e) {
     if (this.forkProject.get('display.errors')) {
       this.forkProject.set('display.errors', []);
     }
-    this.props.toogleForkModal(e);
+    this.props.toggleForkModal(e);
   }
 
   render() {

--- a/src/project/fork/ProjectFork.present.js
+++ b/src/project/fork/ProjectFork.present.js
@@ -197,10 +197,10 @@ class ForkProjectModal extends Component {
     const titleHelp = this.props.model.display.slug.length > 0 ? `Id: ${this.props.model.display.slug}` : null;
     return <div>
       <Modal
-        isOpen={this.props.forkModalOpen !== undefined && this.props.forkModalOpen !== false}
-        toggle={this.props.handlers.toogleForkModal}
+        isOpen={this.props.forkModalOpen === true}
+        toggle={this.props.handlers.toggleForkModal}
         className={this.props.className}>
-        <ModalHeader toggle={this.props.handlers.toogleForkModal}>Fork Project</ModalHeader>
+        <ModalHeader toggle={this.props.handlers.toggleForkModal}>Fork Project</ModalHeader>
         <ModalBody>
           <FieldGroup id="title" type="text" label="Title" placeholder="A brief name to identify the project"
             help={titleHelp} value={this.props.model.display.title}
@@ -227,7 +227,7 @@ class ForkProjectModal extends Component {
           <Button
             color="secondary"
             disabled={this.props.model.display.loading}
-            onClick={this.props.handlers.toogleForkModal}>
+            onClick={this.props.handlers.toggleForkModal}>
             Cancel
           </Button>
         </ModalFooter>


### PR DESCRIPTION
Fix #723

Solution available for testing on https://sekhar.dev.renku.ch

To test -- fork a project and see that
1. The fork popup dialog disappears when the fork succeeds
1.1 The dialog remains until the browser has loaded the new forked project
2. The dialog stays around when the fork fails and notifies the user of the problem.

Check on at least two browsers, as the behavior was different before on Chrome vs. Safari or Firefox.