### PR TITLE
refactor: add log in button on 404 page warning for anonymous users

### DIFF
--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -962,10 +962,13 @@ class ProjectViewNotFound extends Component {
       </InfoAlert>
     }
     else {
+      const postLoginUrl = this.props.location.pathname;
+      console.log(postLoginUrl)
+      const to = { "pathname": "/login", "state": { previous: postLoginUrl } };
       tip = <InfoAlert timeout={0}>
         <p className="mb-0">
           <FontAwesomeIcon icon={faInfoCircle} /> You might need to be logged in to see this project.
-          Please try to log in.
+          Please try to <Link className="btn btn-primary btn-sm" to={to} previous={postLoginUrl}>Log in</Link>
         </p>
       </InfoAlert>
     }
@@ -1027,7 +1030,12 @@ class ProjectView extends Component {
     }
     else if (available === false || (available === null && this.props.projectId !== null)) {
       const { logged } = this.props.user;
-      return <ProjectViewNotFound projectPathWithNamespace={projectPathWithNamespaceOrId} logged={logged} />
+      return (
+        <ProjectViewNotFound
+          projectPathWithNamespace={projectPathWithNamespaceOrId}
+          logged={logged}
+          location={this.props.location} />
+      );
     }
     else {
       return [

--- a/src/project/Project.test.js
+++ b/src/project/Project.test.js
@@ -70,7 +70,6 @@ describe('rendering', () => {
         <Project.List
           client={client}
           model={model}
-          history={fakeHistory}
           store={model.reduxStore}
           user={anonymousUser}
           history={fakeHistory}
@@ -101,6 +100,7 @@ describe('rendering', () => {
           user={anonymousUser}
           model={model}
           history={fakeHistory}
+          location={fakeHistory.location}
           match={{ params: { id: "1" }, url: "/projects/1/" }} />
       </MemoryRouter>
       , div);


### PR DESCRIPTION
For anonymous users, both the environments and the 404 pages suggest to log in. The former one shows a login button, the latter doesn't (see picture below). This PR adds the button to the latter.

<kbd>
<img border=1 src="https://user-images.githubusercontent.com/43481553/73255504-8fc80c80-41c0-11ea-9232-4c7a8fb01ca7.png" />
</kbd>

re #SwissDataScienceCenter/renku#730

**HOW TO TEST**
A preview is available at https://lorenzotest.dev.renku.ch/projects

Try to access a non-existing project *as anonymous user*, e.g. https://lorenzotest.dev.renku.ch/projects/noname/fakeproject
Compare with https://dev.renku.ch/projects/noname/fakeproject