### PR TITLE
Add support for sentry

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -20,7 +20,8 @@ echo "==================================================="
 echo " Configuration:"
 echo " GATEWAY_URL=${GATEWAY_URL:-http://gateway.renku.build}"
 echo " BASE_URL=${BASE_URL:-http://renku.build}"
-echo " SENTRY_DNS=${SENTRY_DNS}"
+echo " SENTRY_URL=${SENTRY_URL}"
+echo " SENTRY_NAMESPACE=${SENTRY_NAMESPACE}"
 echo " RENKU_TEMPLATES_URL=${RENKU_TEMPLATES_URL}"
 echo " RENKU_TEMPLATES_REF=${RENKU_TEMPLATES_REF}"
 echo "==================================================="
@@ -30,7 +31,8 @@ tee > /usr/share/nginx/html/config.json << EOF
   "BASE_URL": "${BASE_URL:-http://renku.build}",
   "GATEWAY_URL": "${GATEWAY_URL:-http://gateway.renku.build}",
   "WELCOME_PAGE": "${WELCOME_PAGE}",
-  "SENTRY_DNS": "${SENTRY_DNS}",
+  "SENTRY_URL": "${SENTRY_URL}",
+  "SENTRY_NAMESPACE": "${SENTRY_NAMESPACE}",
   "RENKU_TEMPLATES_URL": "${RENKU_TEMPLATES_URL}",
   "RENKU_TEMPLATES_REF": "${RENKU_TEMPLATES_REF}"
 }

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -20,6 +20,7 @@ echo "==================================================="
 echo " Configuration:"
 echo " GATEWAY_URL=${GATEWAY_URL:-http://gateway.renku.build}"
 echo " BASE_URL=${BASE_URL:-http://renku.build}"
+echo " SENTRY_DNS=${SENTRY_DNS}"
 echo " RENKU_TEMPLATES_URL=${RENKU_TEMPLATES_URL}"
 echo " RENKU_TEMPLATES_REF=${RENKU_TEMPLATES_REF}"
 echo "==================================================="
@@ -29,6 +30,7 @@ tee > /usr/share/nginx/html/config.json << EOF
   "BASE_URL": "${BASE_URL:-http://renku.build}",
   "GATEWAY_URL": "${GATEWAY_URL:-http://gateway.renku.build}",
   "WELCOME_PAGE": "${WELCOME_PAGE}",
+  "SENTRY_DNS": "${SENTRY_DNS}",
   "RENKU_TEMPLATES_URL": "${RENKU_TEMPLATES_URL}",
   "RENKU_TEMPLATES_REF": "${RENKU_TEMPLATES_REF}"
 }

--- a/helm-chart/renku-ui/templates/deployment.yaml
+++ b/helm-chart/renku-ui/templates/deployment.yaml
@@ -34,6 +34,8 @@ spec:
               value: {{ .Values.gatewayUrl | default (printf "%s://gateway.%s" (include "ui.protocol" .) .Values.global.renku.domain) | quote }}
             - name: WELCOME_PAGE
               value: {{ .Values.welcomePage.text | b64enc | quote }}
+            - name: SENTRY_DNS
+              value: {{ .Values.sentryDns | quote }}
             - name: RENKU_TEMPLATES_URL
               value: {{ required "templateRepository.url must be specified, e.g., https://github.com/repos/SwissDataScienceCenter/renku-project-template" .Values.templatesRepository.url | quote }}
             - name: RENKU_TEMPLATES_REF

--- a/helm-chart/renku-ui/templates/deployment.yaml
+++ b/helm-chart/renku-ui/templates/deployment.yaml
@@ -34,8 +34,12 @@ spec:
               value: {{ .Values.gatewayUrl | default (printf "%s://gateway.%s" (include "ui.protocol" .) .Values.global.renku.domain) | quote }}
             - name: WELCOME_PAGE
               value: {{ .Values.welcomePage.text | b64enc | quote }}
-            - name: SENTRY_DNS
-              value: {{ .Values.sentryDns | quote }}
+              {{- if .Values.sentry.enabled }}
+            - name: SENTRY_URL
+              value: {{ .Values.sentry.url | quote }}
+            - name: SENTRY_NAMESPACE
+              value: {{ .Values.sentry.namespace | default (printf "%s" .Release.Namespace) | quote }}
+              {{- end }}
             - name: RENKU_TEMPLATES_URL
               value: {{ required "templateRepository.url must be specified, e.g., https://github.com/repos/SwissDataScienceCenter/renku-project-template" .Values.templatesRepository.url | quote }}
             - name: RENKU_TEMPLATES_REF

--- a/helm-chart/renku-ui/values.yaml
+++ b/helm-chart/renku-ui/values.yaml
@@ -17,7 +17,7 @@ replicaCount: 1
 
 image:
   repository: renku/renku-ui
-  tag: '0.2.0'
+  tag: '0.7.4'
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.
@@ -61,3 +61,8 @@ welcomePage:
 templatesRepository:
   url: https://github.com/SwissDataScienceCenter/renku-project-template
   ref: 0.1.5
+
+sentry:
+  enabled: false
+  url: ''
+  namespace: ''

--- a/package-lock.json
+++ b/package-lock.json
@@ -2010,6 +2010,63 @@
         "styled-components": "^4.1.3"
       }
     },
+    "@sentry/browser": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.12.1.tgz",
+      "integrity": "sha512-Zl7VdppUxctyaoqMSEhnDJp2rrupx8n8N2n3PSooH74yhB2Z91nt84mouczprBsw3JU1iggGyUw9seRFzDI1hw==",
+      "requires": {
+        "@sentry/core": "5.12.0",
+        "@sentry/types": "5.12.0",
+        "@sentry/utils": "5.12.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/core": {
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.12.0.tgz",
+      "integrity": "sha512-wY4rsoX71QsGpcs9tF+OxKgDPKzIFMRvFiSRcJoPMfhFsTilQ/CBMn/c3bDtWQd9Bnr/ReQIL6NbnIjUsPHA4Q==",
+      "requires": {
+        "@sentry/hub": "5.12.0",
+        "@sentry/minimal": "5.12.0",
+        "@sentry/types": "5.12.0",
+        "@sentry/utils": "5.12.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/hub": {
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.12.0.tgz",
+      "integrity": "sha512-3k7yE8BEVJsKx8mR4LcI4IN0O8pngmq44OcJ/fRUUBAPqsT38jsJdP2CaWhdlM1jiNUzUDB1ktBv6/lY+VgcoQ==",
+      "requires": {
+        "@sentry/types": "5.12.0",
+        "@sentry/utils": "5.12.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/minimal": {
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.12.0.tgz",
+      "integrity": "sha512-fk73meyz4k4jCg9yzbma+WkggsfEIQWI2e2TWfYsRGcrV3RnlSrXyM4D91/A8Bjx10SNezHPUFHjasjlHXOkyA==",
+      "requires": {
+        "@sentry/hub": "5.12.0",
+        "@sentry/types": "5.12.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/types": {
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.12.0.tgz",
+      "integrity": "sha512-aZbBouBLrKB8wXlztriIagZNmsB+wegk1Jkl6eprqRW/w24Sl/47tiwH8c5S4jYTxdAiJk+SAR10AAuYmIN3zg=="
+    },
+    "@sentry/utils": {
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.12.0.tgz",
+      "integrity": "sha512-fYUadGLbfTCbs4OG5hKCOtv2jrNE4/8LHNABy9DwNJ/t5DVtGqWAZBnxsC+FG6a3nVqCpxjFI9AHlYsJ2wsf7Q==",
+      "requires": {
+        "@sentry/types": "5.12.0",
+        "tslib": "^1.9.3"
+      }
+    },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-4.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.11.2",
     "@fortawesome/react-fontawesome": "^0.1.7",
     "@nteract/notebook-render": "^5.0.4-alpha.0",
+    "@sentry/browser": "^5.12.1",
     "ajv": "^6.10.2",
     "apollo-boost": "^0.4.4",
     "bootstrap": "^4.0.0",

--- a/run-telepresence.sh
+++ b/run-telepresence.sh
@@ -60,17 +60,20 @@ fi
 # set sentry dns if explicitly required by the user
 if [[ $SENTRY = 1 ]]
 then
-  SENTRY_DNS=https://7539e48042f9425380fc31a04746a044@sentry.dev.renku.ch/5
+  SENTRY_URL="https://7539e48042f9425380fc31a04746a044@sentry.dev.renku.ch/5"
+  SENTRY_NAMESPACE="${DEV_NAMESPACE}"
 else
   echo "Errors won't be sent to sentry by default. To enable sentry, use 'SENTRY=1 ./run-telepresence.sh'"
 fi
 
 tee > ./public/config.json << EOF
 {
+  "TELEPRESENCE": "true",
   "BASE_URL": "${BASE_URL}",
   "GATEWAY_URL": "${BASE_URL}/api",
   "WELCOME_PAGE": "${WELCOME_PAGE}",
-  "SENTRY_DNS": "${SENTRY_DNS}",
+  "SENTRY_URL": "${SENTRY_URL}",
+  "SENTRY_NAMESPACE": "${SENTRY_NAMESPACE}",
   "RENKU_TEMPLATES_URL": "https://github.com/SwissDataScienceCenter/renku-project-template",
   "RENKU_TEMPLATES_REF": "master"
 }

--- a/run-telepresence.sh
+++ b/run-telepresence.sh
@@ -57,11 +57,20 @@ else
   SERVICE_NAME=${DEV_NAMESPACE}-renku-ui
 fi
 
+# set sentry dns if explicitly required by the user
+if [[ $SENTRY = 1 ]]
+then
+  SENTRY_DNS=https://7539e48042f9425380fc31a04746a044@sentry.dev.renku.ch/5
+else
+  echo "Errors won't be sent to sentry by default. To enable sentry, use 'SENTRY=1 ./run-telepresence.sh'"
+fi
+
 tee > ./public/config.json << EOF
 {
   "BASE_URL": "${BASE_URL}",
   "GATEWAY_URL": "${BASE_URL}/api",
   "WELCOME_PAGE": "${WELCOME_PAGE}",
+  "SENTRY_DNS": "${SENTRY_DNS}",
   "RENKU_TEMPLATES_URL": "https://github.com/SwissDataScienceCenter/renku-project-template",
   "RENKU_TEMPLATES_REF": "master"
 }

--- a/src/index.js
+++ b/src/index.js
@@ -24,11 +24,22 @@ configPromise.then((res) => {
 
     // Query user data
     const userCoordinator = new UserCoordinator(client, model.subModel('user'));
-    userCoordinator.fetchUser();
+    let userPromise = userCoordinator.fetchUser();
 
     // configure Sentry
-    if (params.SENTRY_DNS)
-      Sentry.init({ dsn: params.SENTRY_DNS });
+    if (params.SENTRY_URL) {
+      Sentry.init({ dsn: params.SENTRY_URL });
+      Sentry.configureScope(scope => { scope.setTag("environment", params.SENTRY_NAMESPACE) });
+      userPromise.then(data => {
+        let user = { logged: false, id: 0, username: null };
+        if (data && data.id) {
+          user.logged = true;
+          user.id = data.id;
+          user.username = data.username;
+        }
+        Sentry.configureScope(scope => { scope.setUser(user); });
+      });
+    }
 
     // Map redux data to react - note we are mapping the model, not its whole content (only user)
     // Use model.get("something") and map it wherever needed

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { connect } from 'react-redux'
+import * as Sentry from '@sentry/browser';
 // Use our version of bootstrap, not the one in import 'bootstrap/dist/css/bootstrap.css';
 import './styles/index.css';
 import './index.css';
@@ -24,6 +25,10 @@ configPromise.then((res) => {
     // Query user data
     const userCoordinator = new UserCoordinator(client, model.subModel('user'));
     userCoordinator.fetchUser();
+
+    // configure Sentry
+    if (params.SENTRY_DNS)
+      Sentry.init({ dsn: params.SENTRY_DNS });
 
     // Map redux data to react - note we are mapping the model, not its whole content (only user)
     // Use model.get("something") and map it wherever needed


### PR DESCRIPTION
This PR introduces the support for tracking expectations in Sentry.
It works, but any suggestions for improvements are welcome :slightly_smiling_face: 

**How to test**
The errors are reported here https://sentry.dev.renku.ch/swissdatasciencecenter/renku-ui/

* Using telepresence: execute the telepresence script with "SENTRY=1" `SENTRY=1 ./run-telepresence.sh`. Generate any error, e.g. by adding `throw Error("fake")` in `index.js` **after** `// configure Sentry`
* On a deployment: you can deploy it to any namespace after updating the value file as per SwissDataScienceCenter/sdsc-dev-docs#57 . Remember to add a fake error as pointed out above.
* It is temporarily possible to generate fake errors by visiting https://lorenzo.dev.renku.ch/
The errors take up to one or two minutes to show up.

fix #393