### PR TITLE
fix: prevent 404 pages

### DIFF
--- a/src/project/Project.js
+++ b/src/project/Project.js
@@ -146,15 +146,11 @@ class View extends Component {
     }
   }
 
-  UNSAFE_componentWillMount() {
+  componentDidMount() {
     const pathComponents = splitProjectSubRoute(this.props.match.url);
     if (pathComponents.projectPathWithNamespace == null && pathComponents.projectId != null) {
       this.redirectProjectWithNumericId(pathComponents.projectId);
     }
-  }
-
-  componentDidMount() {
-    const pathComponents = splitProjectSubRoute(this.props.match.url);
     if (pathComponents.projectPathWithNamespace != null) {
       // fetch only if user data are already loaded
       if (this.props.user.fetched) {

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -1018,10 +1018,13 @@ class ProjectViewNotFound extends Component {
 
 class ProjectViewLoading extends Component {
   render() {
+    const info = this.props.projectId ?
+      <h3>Identifying project number {this.props.projectId}...</h3> :
+      <h3>Loading project {this.props.projectPathWithNamespace}...</h3>;
     return <Container fluid>
       <Row>
         <Col>
-          <h3>Loading project {this.props.projectPathWithNamespace}...</h3>
+          {info}
           <Loader />
         </Col>
       </Row>
@@ -1053,10 +1056,14 @@ class ProjectView extends Component {
     const projectPathWithNamespaceOrId = this.props.projectPathWithNamespace ?
       this.props.projectPathWithNamespace
       : this.props.projectId;
-    if ((available === null && this.props.projectId === null) || available === SpecialPropVal.UPDATING) {
-      return <ProjectViewLoading projectPathWithNamespace={projectPathWithNamespaceOrId} />
+    if (available == null || available === SpecialPropVal.UPDATING || this.props.projectId) {
+      return (
+        <ProjectViewLoading
+          projectPathWithNamespace={this.props.projectPathWithNamespace}
+          projectId={this.props.projectId} />
+      );
     }
-    else if (available === false || (available === null && this.props.projectId !== null)) {
+    else if (available === false) {
       const { logged } = this.props.user;
       return (
         <ProjectViewNotFound

--- a/src/project/new/ProjectNew.container.js
+++ b/src/project/new/ProjectNew.container.js
@@ -116,7 +116,7 @@ class New extends Component {
         .then((project) => {
           this.refreshUserProjects();
           this.newProject.set('display.loading', false);
-          this.props.history.push(`/projects/${project.id}`);
+          this.props.history.push(`/projects/${project.path_with_namespace}`);
         })
         .catch(error => {
           let display_messages = [];


### PR DESCRIPTION
This PR address 2 issues

* prevent 404 page when loading projects by id (fix #716 )
* redirect to `/projects/<namespace>` on new project creation instead of `/projects/<id>` (fix #766 )

Preview: https://lorenzotest.dev.renku.ch/

***How to test***
Open a new project by id and verify that the 404 page doesn't appear. Compare it with `dev`
fixed: https://lorenzotest.dev.renku.ch/projects/95
previous: https://dev.renku.ch/projects/95

The same applies when creating a new project.