### PR TITLE
feat(lineage): adapt to the lineage endpoint update

### DIFF
--- a/src/api-client/graph.js
+++ b/src/api-client/graph.js
@@ -74,7 +74,7 @@ function addGraphMethods(client) {
     const query = gql`
       query getLineage($projectPath: ProjectPath!, $filePath: FilePath!) {
         lineage(projectPath: $projectPath, filePath: $filePath) {
-          nodes { id, label, type },
+          nodes { id, label, type, location },
           edges { source, target }
         }
       }

--- a/src/api-client/graph.js
+++ b/src/api-client/graph.js
@@ -65,22 +65,21 @@ function addGraphMethods(client) {
    * Get the lineage nodes and edges
    *
    * @param {string} projectPath   project slug (username/projectname)
-   * @param {string} commitId   full commit id in string format
    * @param {string} filePath   full file path
    * @example client.getFileLineage("myGitlabUser/myGitlabProject",
    *  "3bf1c3c424833228708087686584afb77899f702",
    *  "figs/grid_plot.png")
    */
-  client.getFileLineage = (projectPath, commitId, filePath) => {
+  client.getFileLineage = (projectPath, filePath) => {
     const query = gql`
-      query getLineage($projectPath: ProjectPath!, $commitId: CommitId!, $filePath: FilePath!) {
-        lineage(projectPath: $projectPath, commitId: $commitId, filePath: $filePath) {
-          nodes { id, label },
+      query getLineage($projectPath: ProjectPath!, $filePath: FilePath!) {
+        lineage(projectPath: $projectPath, filePath: $filePath) {
+          nodes { id, label, type },
           edges { source, target }
         }
       }
     `;
-    const variables = { projectPath, commitId, filePath };
+    const variables = { projectPath, filePath };
 
     return client.graphqlFetch(query, variables).then(data => data.lineage, d => null);
   }

--- a/src/file/Lineage.container.js
+++ b/src/file/Lineage.container.js
@@ -52,15 +52,12 @@ class FileLineage extends Component {
   }
 
   parseNodeIds(graph) {
-    // regex to split /<type>/<commitSha><path>
-    const nodeRegex = /\/([^/]*)\/([^/]*)(.*)/;
     if (!graph)
       return { edges: [], nodes: [] };
     graph.nodes.forEach(node => {
-      const matches = nodeRegex.exec(node.id)
-      node.type = matches[1]
-      node.commitSha = matches[2]
-      if (matches[3]) node.filePath = matches[3]
+      if (node.type === "Directory" || node.type === "File") {
+        node.filePath = node.label.substring(0, node.label.indexOf("@"));
+      }
     })
     return graph;
   }
@@ -127,8 +124,7 @@ class FileLineage extends Component {
   async retrieveGraph() {
     if (!this.props.projectPath) return;
     try {
-      const fileMeta = await this.props.client.getRepositoryFileMeta(this.props.projectId, this.props.path, 'master')
-      this.props.client.getFileLineage(this.props.projectPath, fileMeta.lastCommitId, this.props.path)
+      this.props.client.getFileLineage(this.props.projectPath, this.props.path)
         .then(graph => this.parseNodeIds(graph))
         .then(graph => {
           if (this._isMounted) this.setState({ graph });
@@ -153,7 +149,7 @@ class FileLineage extends Component {
       error={this.state.error} 
       createWebhook={this.createWebhook.bind(this)}
       webhookJustCreated={this.state.webhookJustCreated}
-      filePath={this.props.match.url+'/files/blob/'+this.props.path} 
+      filePath={`/projects/${this.props.projectPathWithNamespace}/files/blob/${this.props.path}`} 
       accessLevel={this.props.accessLevel}
       {...this.props} />
   }

--- a/src/file/Lineage.container.js
+++ b/src/file/Lineage.container.js
@@ -17,19 +17,21 @@
  */
 
 import React, { Component } from 'react';
+
 import { API_ERRORS } from '../api-client';
 import { GraphIndexingStatus } from '../project/Project';
-
 import { FileLineage as FileLineagePresent } from './Lineage.present';
 
 class FileLineage extends Component {
-  constructor(props){
+  constructor(props) {
     super(props);
     this.state = {
       error: null,
       graphStatusPoller: null,
       graphStatusWaiting: false,
-      webhookJustCreated: null
+      webhookJustCreated: null,
+      graph: null,
+      currentNode: { id: null, type: null }
     };
   }
 
@@ -51,17 +53,6 @@ class FileLineage extends Component {
     this._isMounted = false;
   }
 
-  parseNodeIds(graph) {
-    if (!graph)
-      return { edges: [], nodes: [] };
-    graph.nodes.forEach(node => {
-      if (node.type === "Directory" || node.type === "File") {
-        node.filePath = node.label.substring(0, node.label.indexOf("@"));
-      }
-    })
-    return graph;
-  }
-
   async startPollingProgress() {
     if (this._isMounted && !this.state.graphStatusPoller) {
       this.props.fetchGraphStatus().then((progress) => {
@@ -69,27 +60,26 @@ class FileLineage extends Component {
           progress !== GraphIndexingStatus.MAX_VALUE &&
           progress !== GraphIndexingStatus.NO_WEBHOOK) {
           const poller = setInterval(this.checkStatus, 2000);
-          this.setState({graphStatusPoller: poller});
+          this.setState({ graphStatusPoller: poller });
         }
       });
     }
   }
 
   stopPollingProgress() {
-    const {graphStatusPoller} = this.state;
+    const { graphStatusPoller } = this.state;
     if (this._isMounted && graphStatusPoller) {
       clearTimeout(graphStatusPoller);
-      this.setState({graphStatusPoller: null});
+      this.setState({ graphStatusPoller: null });
     }
   }
 
-
   checkStatus = () => {
     if (this._isMounted && !this.state.graphStatusWaiting) {
-      this.setState({graphStatusWaiting: true});
+      this.setState({ graphStatusWaiting: true });
       this.props.fetchGraphStatus().then((progress) => {
         if (this._isMounted) {
-          this.setState({graphStatusWaiting: false});
+          this.setState({ graphStatusWaiting: false });
           if (progress === GraphIndexingStatus.MAX_VALUE || progress === GraphIndexingStatus.NO_WEBHOOK) {
             this.stopPollingProgress();
             if (progress === GraphIndexingStatus.MAX_VALUE) {
@@ -102,7 +92,7 @@ class FileLineage extends Component {
   }
 
   createWebhook(e) {
-    this.setState({webhookJustCreated: true});
+    this.setState({ webhookJustCreated: true });
     this.props.createGraphWebhook(e).then((data) => {
       if (this._isMounted) {
         // remember that the graph status endpoint is not updated instantly, better adding a short timeout
@@ -114,7 +104,7 @@ class FileLineage extends Component {
         // updating this state slightly later avoids UI flickering
         setTimeout(() => {
           if (this._isMounted) {
-            this.setState({webhookJustCreated: false});
+            this.setState({ webhookJustCreated: false });
           }
         }, 1500);
       }
@@ -122,34 +112,49 @@ class FileLineage extends Component {
   }
 
   async retrieveGraph() {
-    if (!this.props.projectPath) return;
+    if (!this.props.projectPath)
+      return;
     try {
       this.props.client.getFileLineage(this.props.projectPath, this.props.path)
-        .then(graph => this.parseNodeIds(graph))
         .then(graph => {
-          if (this._isMounted) this.setState({ graph });
-        })
+          if (this._isMounted) {
+            if (!graph) {
+              this.setState({ graph: { edges: [], nodes: [] } });
+            }
+            else {
+              let currentNode = { id: null, type: null };
+              graph.nodes.forEach(node => {
+                if ((node.type === "Directory" || node.type === "File") && node.location === this.props.path) {
+                  currentNode = node;
+                }
+              })
+              this.setState({ graph, currentNode });
+            }
+          }
+        });
     } catch (error) {
-      if (error.case === API_ERRORS.notFoundError) {
-        console.error("load graph:", error);
-        if (this._isMounted)
-          this.setState({ error: 'ERROR 404: Could not load lineage. The file with path ' + this.props.filePath + ' does not exist."' });
-      } else {
-        console.error("load graph:", error);
-        if (this._isMounted)
+      if (this._isMounted) {
+        if (error.case === API_ERRORS.notFoundError) {
+          this.setState({
+            error: 'ERROR 404: Could not load lineage. The file with path ' + this.props.filePath + ' does not exist."'
+          });
+        }
+        else {
           this.setState({ error: 'Could not load lineage.' });
+        }
       }
     }
   }
 
   render() {
-    return <FileLineagePresent 
+    return <FileLineagePresent
       retrieveGraph={this.retrieveGraph.bind(this)}
-      graph={this.state.graph} 
-      error={this.state.error} 
+      graph={this.state.graph}
+      error={this.state.error}
       createWebhook={this.createWebhook.bind(this)}
       webhookJustCreated={this.state.webhookJustCreated}
-      filePath={`/projects/${this.props.projectPathWithNamespace}/files/blob/${this.props.path}`} 
+      filePath={`/projects/${this.props.projectPathWithNamespace}/files/blob/${this.props.path}`}
+      currentNode={this.state.currentNode}
       accessLevel={this.props.accessLevel}
       {...this.props} />
   }

--- a/src/file/Lineage.css
+++ b/src/file/Lineage.css
@@ -38,15 +38,14 @@ g.workflow polygon {
 }
 
 svg {
-  height: 65vh;
-  width: 80vw;
+  height: 60vh;
+  width: 100%;
   cursor:pointer;
 }
 
 .zoomButtons{
   position: absolute;
-  right: 0;
-  padding-right: 20px;
+  right: 20px;
 }
 
 .btn-group-left{

--- a/src/file/Lineage.present.js
+++ b/src/file/Lineage.present.js
@@ -17,17 +17,14 @@
  */
 
 import React, { Component } from 'react';
-
+import { Card, CardHeader, CardBody, Badge } from 'reactstrap';
 import graphlib from 'graphlib';
 import dagreD3 from 'dagre-d3';
 import * as d3 from 'd3';
-
 import { faFile } from '@fortawesome/free-solid-svg-icons';
 import { faGitlab } from '@fortawesome/free-brands-svg-icons';
 
-import { Card, CardHeader, CardBody, Badge } from 'reactstrap';
-
-import KnowledgeGraphStatus  from './KnowledgeGraphStatus.container';
+import KnowledgeGraphStatus from './KnowledgeGraphStatus.container';
 import { GraphIndexingStatus } from '../project/Project';
 import { JupyterButton } from './index';
 import { ExternalIconLink, IconLink } from '../utils/UIComponents';
@@ -35,8 +32,8 @@ import { ExternalIconLink, IconLink } from '../utils/UIComponents';
 import './Lineage.css';
 
 function cropLabelStart(limit, label) {
-  if(label.length > limit)
-    return "..."+label.substr(label.length-limit)
+  if (label.length > limit)
+    return "..." + label.substr(label.length - limit)
   return label;
 }
 
@@ -52,20 +49,20 @@ function getNodeLabel(node, NODE_COUNT, lineagesUrl) {
 
   if (node.type === "Directory" || node.type === "File") {
     const LABEL_LIMIT = NODE_COUNT > 15 ? 20 : 40;
-    const ref = `${lineagesUrl}/${node.filePath}`
+    const ref = `${lineagesUrl}/${node.location}`
     return '<text><tspan xml:space="preserve" dy="1em" x="1" data-href=' + ref + '>'
-      + cropLabelStart(LABEL_LIMIT, node.filePath) +
+      + cropLabelStart(LABEL_LIMIT, node.location) +
       '</tspan></text>';
   }
 }
 
-function nodeToClass(node, centralNode, label) {
+function nodeToClass(node, currentNodeId, label) {
   const nodeId = node.id;
   const nodeType = node.type;
   const FORMATS = { 'py': true, 'r': true, 'ipynb': true }
   const nodeClasses = [];
 
-  if (nodeId === centralNode)
+  if (nodeId === currentNodeId)
     nodeClasses.push('central');
   else
     nodeClasses.push('normal');
@@ -74,7 +71,7 @@ function nodeToClass(node, centralNode, label) {
     nodeClasses.push('doubleLine');
 
   if (node.type === "Directory" || node.type === "File") {
-    if (node.filePath.includes('.') && FORMATS[node.filePath.split('.').pop()])
+    if (node.location.includes('.') && FORMATS[node.location.split('.').pop()])
       nodeClasses.push('code');
     else
       nodeClasses.push('data');
@@ -107,31 +104,25 @@ class FileLineageGraph extends Component {
       })
       .setDefaultEdgeLabel(function () { return {}; });
 
-    graph.nodes.forEach(node => {
-      if (node.id.endsWith(`/${this.props.path}`)) {
-        graph.centralNode = node.id;
-      }
-    })
-
     graph.nodes.forEach(n => {
       const label = getNodeLabel(n, NODE_COUNT, this.props.lineagesUrl);
       subGraph.setNode(n.id, {
         id: n.id,
         labelType: 'html',
         label,
-        class: nodeToClass(n, graph.centralNode, label),
+        class: nodeToClass(n, this.props.currentNode.id, label),
         shape: n.type === "ProcessRun" ? "diamond" : "rect"
       });
     });
     graph.edges.forEach(e => { subGraph.setEdge(e.source, e.target) });
 
-    return subGraph
+    return subGraph;
   }
 
-  hasLink(nodeId, centralNode) {
+  hasLink(nodeId, currentNodeId) {
     return this.props.graph.nodes
       .filter(function (node) {
-        return (node.id === nodeId && node.id !== centralNode && (node.type === "Directory" || node.type === "File"))
+        return (node.id === nodeId && node.id !== currentNodeId && (node.type === "Directory" || node.type === "File"));
       })[0];
   }
 
@@ -144,10 +135,13 @@ class FileLineageGraph extends Component {
     // Set up an SVG group so that we can translate the final graph.
     const svg = d3.select(this._vizRoot).select('svg');
     let svgGroup;
-    if(this.appended === false){
+    if (this.appended === false) {
       svgGroup = svg.append('g');
       this.appended = true;
-    } else{  svgGroup= svg.select('g')}
+    }
+    else {
+      svgGroup = svg.select('g')
+    }
 
     const history = this.props.history;
 
@@ -155,43 +149,41 @@ class FileLineageGraph extends Component {
 
     // Set up zoom support
     const zoom = d3.zoom()
-      .on("zoom", function() {
+      .on("zoom", function () {
         svgGroup.attr("transform", d3.event.transform);
       });
     svg.call(zoom);
 
-    d3.selectAll('g.node').filter((d,i)=>{ return this.hasLink(d, this.props.graph.centralNode)})
-      .select("tspan").on("mouseover", function() {
-        d3.select(this).style("cursor","pointer").attr('r', 25)
+    d3.selectAll('g.node').filter((d, i) => { return this.hasLink(d, this.props.currentNode.id) })
+      .select("tspan").on("mouseover", function () {
+        d3.select(this).style("cursor", "pointer").attr('r', 25)
           .style("text-decoration-line", "underline");
       })
-      .on("mouseout", function() {
+      .on("mouseout", function () {
         d3.select(this).attr('r', 25)
           .style("text-decoration-line", "unset");
       })
-      .on("click", function(){
+      .on("click", function () {
         history.push(d3.select(this).attr("data-href"));
       });
 
     // Center the graph
     const bbox = document.getElementsByClassName('graphContainer')[0].lastChild.getBBox();
-    svg.attr('viewBox', '0 0 '+bbox.width+' '+bbox.height)
+    svg.attr('viewBox', '0 0 ' + bbox.width + ' ' + bbox.height);
 
-    d3.select("#zoom_in").on("click", function() {
+    d3.select("#zoom_in").on("click", function () {
       zoom.scaleBy(svg.transition().duration(750), 1.5);
     });
-    d3.select("#zoom_out").on("click", function() {
+    d3.select("#zoom_out").on("click", function () {
       zoom.scaleBy(svg.transition().duration(750), 0.75);
     });
 
-    var initialScale = 0.80;
-    svg.call(zoom.transform,
-      d3.zoomIdentity.translate((bbox.width - g.graph().width * initialScale) / 2, 20)
-        .scale(initialScale));
+    const initialScale = 0.90;
+    svg.call(zoom.transform, d3.zoomIdentity.scale(initialScale));
   }
 
   render() {
-    return this.subGraph()._nodeCount >1 ?
+    return this.subGraph()._nodeCount > 1 ?
       <div className="graphContainer" ref={(r) => this._vizRoot = r}>
         <div className="float-right zoomButtons">
           <button className="btn btn-light btn-group-left" id="zoom_in">+</button>
@@ -206,9 +198,9 @@ class FileLineageGraph extends Component {
 
 class FileLineage extends Component {
   render() {
-    const { progress } = this.props;
+    const { progress, currentNode, filePath, graph } = this.props;
 
-    if(progress == null
+    if (progress == null
       || progress === GraphIndexingStatus.NO_WEBHOOK
       || progress === GraphIndexingStatus.NO_PROGRESS
       || (progress >= GraphIndexingStatus.MIN_VALUE && progress < GraphIndexingStatus.MAX_VALUE)
@@ -222,13 +214,13 @@ class FileLineage extends Component {
         progress={this.props.progress}
       />;
 
-    const graphObj = this.props.graph;
-    const graph = (graphObj) ?
+    const graphComponent = (graph) ?
       <FileLineageGraph
         path={this.props.path}
-        graph={graphObj}
+        graph={graph}
+        currentNode={currentNode}
         lineagesUrl={this.props.lineagesUrl}
-        history={this.props.history}/> :
+        history={this.props.history} /> :
       (this.props.error) ?
         <p>{this.props.error}</p> :
         <p>Loading...</p>;
@@ -238,14 +230,14 @@ class FileLineage extends Component {
     const isLFSBadge = isLFS ?
       <Badge className="lfs-badge" color="light">LFS</Badge> : null;
 
-    let buttonFile = this.props.filePath !== undefined ?
-      <IconLink tooltip="File View" icon={faFile} to={this.props.filePath} /> :
+    let buttonFile = filePath !== undefined && currentNode.type !== "Directory" ?
+      <IconLink tooltip="File View" icon={faFile} to={filePath} /> :
       null;
 
     let buttonGit = <ExternalIconLink tooltip="Open in GitLab" icon={faGitlab} to={externalFileUrl} />
 
     let buttonJupyter = null;
-    if (this.props.filePath.endsWith(".ipynb"))
+    if (filePath.endsWith(".ipynb"))
       buttonJupyter = (
         <JupyterButton {...this.props}
           file={{ file_path: this.props.path }}
@@ -264,7 +256,7 @@ class FileLineage extends Component {
         </div>
       </CardHeader>
       <CardBody className="scroll-x">
-        {graph}
+        {graphComponent}
       </CardBody>
     </Card>
   }

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -726,16 +726,15 @@ class ProjectViewFiles extends Component {
 
   render() {
     return [
-      <Col key="files" sm={12} md={4} lg={2}>
-        <ProjectFilesNav
-          {...this.props} />
+      <Col key="files" sm={12} md={4} lg={3} xl={2}>
+        <ProjectFilesNav {...this.props} />
       </Col>,
-      <Col key="content" sm={12} md={8} lg={10}>
+      <Col key="content" sm={12} md={8} lg={9} xl={10}>
         <Switch>
           <Route path={this.props.lineageUrl}
             render={p => this.props.lineageView(p)} />
           <Route path={this.props.fileContentUrl}
-            render={props => this.props.fileView(props)}/>
+            render={props => this.props.fileView(props)} />
         </Switch>
       </Col>
     ]


### PR DESCRIPTION
The UI lineage needs to be adapted to prevent it from failing due to the new nodes id format.
SwissDataScienceCenter/renku-graph#248 adds extra properties to the lineage query we can use in order to stop guessing nodes properties from the id.

I mixed a few fixes in this PR
* Update lineage query to get more data and stop guessing nodes properties from the id
* Fix location issues that prevented switching correctly between files and lineage
* Allow viewing folders lineage
* Remove unnecessary scrollbar on svg elements

Please take some time to check the lineage of a few projects.
Preview available here:  https://lorenzotest.dev.renku.ch/