### PR TITLE
feat(datasets): user can import datasets though the UI

### DIFF
--- a/src/dataset/Dataset.present.js
+++ b/src/dataset/Dataset.present.js
@@ -132,14 +132,13 @@ export default function DatasetView(props) {
           }).catch(error => {
             if (fetchError === null) {
               if (!unmounted && error.case === API_ERRORS.notFoundError) {
-                setFetchError(
-                  "Error 404: The dataset that was selected does not exist or could not be accessed." +
-                  "If you just created the dataset try reloading the page."
-                );
-              }
+                setFetchError("Error 404: The dataset that was selected does" +
+                " not exist or could not be accessed. If you just created or" +
+                " imported the dataset try reloading the page.");
+            }
               else if (!unmounted && error.case === API_ERRORS.internalServerError) {
                 setFetchError("Error 500: The dataset that was selected couldn't be fetched.");
-              }
+            }
             }
           });
       }
@@ -156,10 +155,8 @@ export default function DatasetView(props) {
           }).catch(error => {
             if (fetchError === null) {
               if (!unmounted && error.case === API_ERRORS.notFoundError) {
-                setFetchError(
-                  "Error 404: The dataset that was selected does not exist or could not be accessed." +
-                  "If you just created the dataset try reloading the page."
-                );
+                setFetchError("Error 404: The dataset that was selected does not exist or" +
+                " could not be accessed. If you just created or imported the dataset try reloading the page.");
               }
               else if (!unmounted && error.case === API_ERRORS.internalServerError) {
                 setFetchError("Error 500: The dataset that was selected couldn't be fetched.");
@@ -200,13 +197,14 @@ export default function DatasetView(props) {
   if (dataset === null) {
     return (
       <Alert color="danger">
-        The dataset that was selected does not exist or could not
-        be accessed.<br /> <br /> If you just created the dataset
+        The dataset that was selected does not exist or could notbe accessed.<br /> <br />
+        If you just created or imported the dataset
         try <Button color="danger" size="sm" onClick={
           () => window.location.reload()
         }>reloading</Button> the page.</Alert>
     );
   }
+
   return <Col>
     <Row>
       <Col md={8} sm={12}>

--- a/src/model/RenkuModels.js
+++ b/src/model/RenkuModels.js
@@ -314,6 +314,26 @@ const issueFormSchema = new Schema({
   }
 });
 
+const datasetImportFormSchema = new Schema({
+  uri: {
+    initial: "",
+    name: "uri",
+    label: "URI/DOI",
+    edit: false,
+    help: "This will import the dataset with the DOI (Digital Object Identifier) 10.5281/zenodo.3352150" +
+    " and make it locally available. Dataverse and Zenodo are supported, with DOIs (e.g. 10.5281/zenodo.3352150" +
+    " or doi:10.5281/zenodo.3352150) and full URLs (e.g. http://zenodo.org/record/3352150). A tag with the" +
+    " remote version of the dataset is automatically created.",
+    type: FormGenerator.FieldTypes.TEXT,
+    // parseFun: expression => FormGenerator.Parsers.slugFromTitle(expression),
+    validators: [{
+      id: "uri-length",
+      isValidFun: expression => FormGenerator.Validators.isNotEmpty(expression),
+      alert: "URI is too short"
+    }]
+  }
+});
+
 
 export { userSchema, metaSchema, displaySchema, newProjectSchema, projectSchema, forkProjectSchema };
-export { notebooksSchema, projectsSchema, datasetFormSchema, issueFormSchema };
+export { notebooksSchema, projectsSchema, datasetFormSchema, issueFormSchema, datasetImportFormSchema };

--- a/src/project/Project.js
+++ b/src/project/Project.js
@@ -42,6 +42,7 @@ import Fork from "./fork";
 import ShowDataset from "../dataset/Dataset.container";
 import NewDataset from "./datasets/new/index";
 import EditDataset from "./datasets/edit/index";
+import ImportDataset from "./datasets/import/index";
 
 
 const subRoutes = {
@@ -293,6 +294,7 @@ class View extends Component {
       overviewDatasetsUrl: `${baseUrl}/overview/datasets`,
       datasetsUrl: `${datasetsUrl}`,
       newDatasetUrl: `${datasetsUrl}/new`,
+      importDatasetUrl: `${datasetsUrl}/import`,
       datasetUrl: `${datasetsUrl}/:datasetId`,
       editDatasetUrl: `${datasetsUrl}/:datasetId/modify`,
       issueNewUrl: `${collaborationUrl}/issues/issue_new`,
@@ -463,6 +465,24 @@ class View extends Component {
         history={this.props.history}
         datasetId={p.match.params.datasetId}
         dataset={p.location.state ? p.location.state.dataset : null}
+        httpProjectUrl={httpProjectUrl}
+      />,
+
+      importDataset: (p) => <ImportDataset
+        key="datasetnew" {...subProps}
+        progress={graphProgress}
+        maintainer={maintainer}
+        accessLevel={accessLevel}
+        forked={forked}
+        insideProject={true}
+        datasets={datasets}
+        reFetchProject={this.fetchAll.bind(this)}
+        lineagesUrl={subUrls.lineagesUrl}
+        fileContentUrl={subUrls.fileContentUrl}
+        projectsUrl={subUrls.projectsUrl}
+        selectedDataset={p.match.params.datasetId}
+        client={this.props.client}
+        history={this.props.history}
         httpProjectUrl={httpProjectUrl}
       />,
 

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -556,6 +556,7 @@ class ProjectDatasetsNav extends Component {
       datasets={this.props.core.datasets}
       datasetsUrl={this.props.datasetsUrl}
       newDatasetUrl={this.props.newDatasetUrl}
+      importDatasetUrl={this.props.importDatasetUrl}
       visibility={this.props.visibility}
     />;
   }
@@ -565,9 +566,11 @@ class ProjectViewDatasets extends Component {
   render() {
     return <Switch>
       <Route exact path={this.props.newDatasetUrl}
-        render={p => this.props.newDataset(p)} />
+          render={p => this.props.newDataset(p)} />
+      <Route exact path={this.props.importDatasetUrl}
+          render={p => this.props.importDataset(p)} />
       <Route path={this.props.editDatasetUrl}
-        render={p => this.props.editDataset(p)} />
+          render={p => this.props.editDataset(p)} />
       <Route path={this.props.datasetsUrl} render={props =>
         <ProjectViewDatasetsList {...this.props} {...props} />} />
     </Switch>;
@@ -598,10 +601,11 @@ class ProjectViewDatasetsList extends Component {
       return <Col sm={12} md={8} lg={10}>
         <Alert timeout={0} color="primary">
           No datasets found for this project. <br /><br />
-          <FontAwesomeIcon icon={faInfoCircle} /> If you recently activated the knowledge graph or
+          <FontAwesomeIcon icon={faInfoCircle} />  If you recently activated the knowledge graph or
           added the datasets try refreshing the page. <br /><br />
-          You can also click on the button to create
-          a <Link className="btn btn-primary btn-sm" to={this.props.newDatasetUrl}>New Dataset</Link>
+          You can also click on the button to create a
+          <Link className="btn btn-primary btn-sm" to={this.props.newDatasetUrl}>New Dataset</Link>
+          or <Link className="btn btn-primary btn-sm" to={this.props.importDatasetUrl}>Import Dataset</Link>
         </Alert>
       </Col>;
     }

--- a/src/project/Project.state.js
+++ b/src/project/Project.state.js
@@ -208,8 +208,8 @@ class ProjectModel extends StateModel {
   }
 
   fetchProjectDatasets(client) { //from KG
-    if (this.get("transient.requests.datasets") === SpecialPropVal.UPDATING) return;
-    this.setUpdating({ transient: { requests: { datasets: true } } });
+    if (this.get("core.datasets") === SpecialPropVal.UPDATING) return;
+    this.setUpdating({ core: { datasets: true } });
     return client.getProjectDatasetsFromKG(this.get("core.path_with_namespace"))
       .then(datasets => {
         const updatedState = { datasets: datasets, transient: { requests: { datasets: false } } };

--- a/src/project/datasets/DatasetsListView.js
+++ b/src/project/datasets/DatasetsListView.js
@@ -23,19 +23,22 @@ function DatasetListRow(props) {
 
 function CreateDatasetButton(props) {
   if (props.visibility.accessLevel >= ACCESS_LEVELS.MAINTAINER) {
-return <span className="float-right throw-right-in-flex">
-  <UncontrolledButtonDropdown size="sm">
-    <DropdownToggle color="primary" className="alternateToggleStyle" caret>
-      <FontAwesomeIcon icon={faPlus} style={{ color: "white", backgroundColor: "#5561A6" }} />
-    </DropdownToggle>
-    <DropdownMenu right={false}>
-      <DropdownItem>
-        <Link to={props.newDatasetUrl}>New Dataset</Link>
-      </DropdownItem>
-    </DropdownMenu>
-  </UncontrolledButtonDropdown>
-</span>;
-}
+    return <span className="float-right throw-right-in-flex">
+      <UncontrolledButtonDropdown size="sm">
+        <DropdownToggle color="primary" className="alternateToggleStyle" caret>
+          <FontAwesomeIcon icon={faPlus} style={{ color: "white", backgroundColor: "#5561A6" }} />
+        </DropdownToggle>
+        <DropdownMenu right={false}>
+          <DropdownItem>
+            <Link to={props.newDatasetUrl}>New Dataset</Link>
+          </DropdownItem>
+          <DropdownItem>
+            <Link to={props.importDatasetUrl}>Import Dataset</Link>
+          </DropdownItem>
+        </DropdownMenu>
+      </UncontrolledButtonDropdown>
+    </span>;
+  }
   return null;
 }
 
@@ -53,7 +56,10 @@ export default function DatasetsListView(props) {
         <span className="tree-header-title text-truncate">
           Datasets List
         </span>
-        <CreateDatasetButton visibility={props.visibility} newDatasetUrl={props.newDatasetUrl}/>
+        <CreateDatasetButton
+          visibility={props.visibility}
+          newDatasetUrl={props.newDatasetUrl}
+          importDatasetUrl={props.importDatasetUrl}/>
       </div>
       <nav>
         {

--- a/src/project/datasets/edit/DatasetEdit.present.js
+++ b/src/project/datasets/edit/DatasetEdit.present.js
@@ -120,7 +120,7 @@ function DatasetEdit(props) {
     return null;
 
   if (props.accessLevel < ACCESS_LEVELS.MAINTAINER) {
-    return <Col sm={12} md={8} lg={10}>
+    return <Col sm={12} md={10} lg={8}>
       <Alert timeout={0} color="primary">
         Acces Denied. You don&apos;t have rights to edit datasets for this project.<br /><br />
         <FontAwesomeIcon icon={faInfoCircle} /> If you were recently given access to this project,

--- a/src/project/datasets/import/DatasetImport.container.js
+++ b/src/project/datasets/import/DatasetImport.container.js
@@ -1,0 +1,153 @@
+/*!
+ * Copyright 2020 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  incubator-renku-ui
+ *
+ *  DatasetImport.container.js
+ *  Container components for new dataset.
+ */
+
+import React, { useState } from "react";
+import { datasetImportFormSchema } from "../../../model/RenkuModels";
+import DatasetImport from "./DatasetImport.present";
+
+function ImportDataset(props) {
+
+  const [serverErrors, setServerErrors] = useState(undefined);
+  const [submitLoader, setSubmitLoader] = useState(false);
+  const [submitLoaderText, setSubmitLoaderText] = useState("Please wait, dataset import will start soon.");
+
+  const onCancel = e => {
+    datasetImportFormSchema.uri.value = datasetImportFormSchema.uri.initial;
+    props.history.push({ pathname: `/projects/${props.projectPathWithNamespace}/datasets` });
+  };
+
+  const redirectUserAndClearInterval = (datasets, oldDatasetsList, waitForDatasetInKG) => {
+    let new_dataset = datasets.filter(ds =>
+      oldDatasetsList.find(ods => ds.identifier === ods.identifier) === undefined);
+    if (new_dataset.length > 0) {
+      setSubmitLoader(false);
+      datasetImportFormSchema.uri.value = datasetImportFormSchema.uri.initial;
+      clearInterval(waitForDatasetInKG);
+      props.history.push({
+          pathname: `/projects/${props.projectPathWithNamespace}/datasets/${new_dataset[0].identifier}/`,
+          state: { datasets: datasets }
+        })
+      ;
+    }
+  };
+
+  const findDatasetInKgAnRedirect = (oldDatasetsList) => {
+    let waitForDatasetInKG = setInterval(() => {
+      props.client.getProjectDatasetsFromKG(props.projectPathWithNamespace)
+        .then(datasets => {
+          if (datasets.length !== oldDatasetsList.length)
+            redirectUserAndClearInterval(datasets, oldDatasetsList, waitForDatasetInKG);
+        });
+    }, 6000);
+  };
+
+  function handleJobResponse(job, monitorJob, cont, oldDatasetsList) {
+    switch (job.state) {
+      case "ENQUEUED":
+        setSubmitLoaderText("Please wait, dataset import will start soon.");
+        break;
+      case "IN_PROGRESS":
+        setSubmitLoaderText("Importing dataset, please wait.");
+        break;
+      case "COMPLETED":
+        setSubmitLoaderText("Dataset was imported successfully, you will be redirected soon.");
+        clearInterval(monitorJob);
+        findDatasetInKgAnRedirect(oldDatasetsList);
+        break;
+      case "FAILED":
+        setSubmitLoader(false);
+        setServerErrors("Dataset import failed: " + job.extras.error);
+        clearInterval(monitorJob);
+        break;
+      default:
+        setSubmitLoader(false);
+        setServerErrors("Dataset import failed, plaease try again");
+        clearInterval(monitorJob);
+        break;
+    }
+    if (cont === 100) {
+      setSubmitLoader(false);
+      setServerErrors("Dataset import is taking too long, please check if the dataset was imported" +
+      " and if it wasn't try again.");
+      clearInterval(monitorJob);
+    }
+  }
+
+  const monitorJobStatusAndHandleResponse = (job_id, oldDatasetsList) => {
+    let cont = 0;
+    let monitorJob = setInterval(() => {
+      props.client.getJobStatus(job_id)
+      .then(job => {
+        cont++;
+        if (job !== undefined || cont === 50)
+          handleJobResponse(job, monitorJob, cont, oldDatasetsList);
+      });
+    }, 10000);
+  };
+
+
+  const submitCallback = e => {
+    setServerErrors(undefined);
+    setSubmitLoader(true);
+    const dataset = {};
+    let oldDatasetsList = [];
+    dataset.uri = datasetImportFormSchema.uri.value;
+    props.client.getProjectDatasetsFromKG(props.projectPathWithNamespace)
+      .then(result => {
+        oldDatasetsList = result;
+        props.client.datasetImport(props.httpProjectUrl, dataset)
+          .then(response => {
+            if (response.data.error !== undefined) {
+              setSubmitLoader(false);
+              setServerErrors(response.data.error.reason);
+            }
+            else {
+              monitorJobStatusAndHandleResponse(
+                response.data.result.job_id,
+                oldDatasetsList);
+            }
+          });
+      });
+  };
+
+  return <DatasetImport
+    submitLoader={submitLoader}
+    submitLoaderText={submitLoaderText}
+    serverErrors={serverErrors}
+    onCancel={onCancel}
+    submitCallback={submitCallback}
+    datasetImportFormSchema={datasetImportFormSchema}
+    accessLevel={props.accessLevel}
+    // user={props.user}
+    // projectPathWithNamespace={props.projectPathWithNamespace}
+    // client={props.client}
+    // history={props.history}
+    // reFetchProject={props.reFetchProject}
+    // httpProjectUrl={props.httpProjectUrl}
+  />;
+}
+
+
+export default ImportDataset;

--- a/src/project/datasets/import/DatasetImport.present.js
+++ b/src/project/datasets/import/DatasetImport.present.js
@@ -1,0 +1,62 @@
+/*!
+ * Copyright 2020 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  DatasetImport.present.js
+ *  Presentational components.
+ */
+
+
+import React from "react";
+import { Col, Alert, Button } from "reactstrap";
+import { FormPanel } from "../../../utils/formgenerator";
+import { ACCESS_LEVELS } from "../../../api-client";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
+
+function DatasetImport(props) {
+
+  if (props.accessLevel < ACCESS_LEVELS.MAINTAINER) {
+    return <Col sm={12} md={10} lg={8}>
+      <Alert timeout={0} color="primary">
+        Acces Denied. You don&apos;t have rights to import datasets for this project.<br /><br />
+        <FontAwesomeIcon icon={faInfoCircle} />  If you were recently given access to this project,
+        you might need to <Button size="sm" color="primary" onClick={() => window.location.reload()}>
+          refresh the page</Button> first.
+      </Alert>
+    </Col>;
+  }
+
+  return (
+    <Col sm={9} md={8} lg={7} id="col-outside-form-panel">
+      <FormPanel
+        title="Import Dataset"
+        btnName="Import Dataset"
+        submitCallback={props.submitCallback}
+        model={props.datasetImportFormSchema}
+        serverErrors={props.serverErrors}
+        submitLoader={{ value: props.submitLoader, text: props.submitLoaderText }}
+        onCancel={props.onCancel} />
+    </Col>
+  );
+
+}
+
+export default DatasetImport;

--- a/src/project/datasets/import/index.js
+++ b/src/project/datasets/import/index.js
@@ -1,0 +1,28 @@
+/*!
+ * Copyright 2020 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  Dataset/import
+ *  Components for the import Dataset page
+ */
+
+import ImportDataset from "./DatasetImport.container";
+
+export default ImportDataset;

--- a/src/project/datasets/new/DatasetNew.present.js
+++ b/src/project/datasets/new/DatasetNew.present.js
@@ -83,7 +83,7 @@ function DatasetNew(props) {
   };
 
   if (props.accessLevel < ACCESS_LEVELS.MAINTAINER) {
-    return <Col sm={12} md={8} lg={10}>
+    return <Col sm={12} md={10} lg={8}>
       <Alert timeout={0} color="primary">
         Acces Denied. You don&apos;t have rights to create datasets for this project.<br /><br />
         <FontAwesomeIcon icon={faInfoCircle} /> If you were recently given access to this project,

--- a/src/utils/formgenerator/FormPanel.js
+++ b/src/utils/formgenerator/FormPanel.js
@@ -48,7 +48,7 @@ function FormPanel({ title, btnName, submitCallback, model, serverErrors, submit
   return (
     <Col>
       <h3 className="uk-heading-divider uk-text-center pb-2">{title}</h3>
-      <Form>
+      <Form onSubmit={setSubmit}>
         <div>
           {inputs.map(input => renderInput(input))}
           {serverErrors ? <UncontrolledAlert color="danger">{serverErrors}</UncontrolledAlert> : null}
@@ -59,8 +59,9 @@ function FormPanel({ title, btnName, submitCallback, model, serverErrors, submit
             </FormText>
             : null
           }
-          <Button disabled={submitLoader.value} className="float-right mt-1" color="primary"
-            onClick={setSubmit}>{btnName}</Button>
+          <Button type="submit" disabled={submitLoader.value} className="float-right mt-1" color="primary">
+            {btnName}
+          </Button>
           {
             onCancel !== undefined ?
               <Button disabled={submitLoader.value} className="float-right mt-1 mr-1"


### PR DESCRIPTION
Closes #528 

There is a new button in the UI so the user can import datasets using the UI.

There are some things to be fixed in the backend for this to properly work. 

Button:
![image](https://user-images.githubusercontent.com/42647877/75046397-4750f580-54c5-11ea-9be5-134aef482ee6.png)

Form:
![image](https://user-images.githubusercontent.com/42647877/75046273-196bb100-54c5-11ea-8530-8e0abd9fbe60.png)

Deployment: https://virginiatest.dev.renku.ch/