### PR TITLE
feat: add basic page for namespaces

### DIFF
--- a/src/api-client/test-client.js
+++ b/src/api-client/test-client.js
@@ -108,6 +108,16 @@ const methods = {
     response: {
       data: []
     }
+  },
+  getGroupByPath: {
+    response: {
+      data: {}
+    }
+  },
+  getUserByPath: {
+    response: {
+      data: []
+    }
   }
 };
 

--- a/src/namespace/Namespace.container.js
+++ b/src/namespace/Namespace.container.js
@@ -1,0 +1,97 @@
+/*!
+ * Copyright 2020 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  Namespace.container.js
+ *  Namespace container components.
+ */
+
+import React, { useState, useEffect } from 'react';
+
+import { NamespaceProjectsPresent } from '.';
+import { API_ERRORS } from '../api-client/errors';
+
+const userModel = {
+  data: null,
+  fetching: false,
+  fetched: false
+};
+const groupModel = { ...userModel };
+
+/**
+ * Verify if a namespace exists as a user or group and suggest a redirect
+ *
+ * @param {string} namespace - target namespace
+ * @param {Object} client - api-client used to query the gateway
+ */
+const NamespaceProjects = (props) => {
+  const [user, setUser] = useState(userModel);
+  const [group, setGroup] = useState(groupModel);
+
+  // fetch user and group data
+  useEffect(() => {
+    let aborted = false;
+    setUser({ fetching: true });
+    setGroup({ fetching: true });
+    props.client.getGroupByPath(props.namespace)
+      .catch(error => {
+        if (error.case === API_ERRORS.notFoundError)
+          return { data: {} };
+        throw error;
+      })
+      .then(resp => {
+        if (aborted)
+          return;
+        const { data } = resp;
+        setGroup({
+          data: data,
+          fetching: false,
+          fetched: new Date()
+        });
+      });
+    props.client.getUserByPath(props.namespace)
+      .then(resp => {
+        if (aborted)
+          return;
+
+        const data = resp.data && resp.data.length ?
+          resp.data[0] :
+          {};
+        setUser({
+          data: data,
+          fetching: false,
+          fetched: new Date()
+        });
+      });
+
+    const cleanup = () => { aborted = true; }
+    return cleanup;
+  }, [props.namespace, props.client]);
+
+  return (
+    <NamespaceProjectsPresent
+      namespace={props.namespace}
+      user={user}
+      group={group}
+    />
+  );
+}
+
+export { NamespaceProjects };

--- a/src/namespace/Namespace.present.js
+++ b/src/namespace/Namespace.present.js
@@ -1,0 +1,145 @@
+/*!
+ * Copyright 2020 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  Namespace.present.js
+ *  Namespace presentational components.
+ */
+
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Row, Col, Container } from 'reactstrap';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
+
+import { Loader, InfoAlert, ExternalLink } from '../utils/UIComponents';
+
+const NamespaceProjects = (props) => {
+  const { namespace } = props;
+  // TODO: I should get the URLs from the redux store: #779
+  const searchUrl = "/projects/search";
+  const searchProjectUrl = (project) => { return `${searchUrl}?q=${project}`; };
+  const searchUserUrl = (user) => { return `${searchUrl}?searchIn=users&q=${user}`; };
+  const searchGroupUrl = (group) => { return `${searchUrl}?searchIn=groups&q=${group}`; };
+
+  let checking = null;
+  if (props.user.fetching || props.group.fetching)
+    checking = (<div>
+      <p>Searching for {namespace}...</p>
+      <Loader />
+    </div>);
+
+  let outcome = null;
+  let userOrGroup = "";
+  if (checking == null) {
+    if (props.user.fetched && props.user.data.id) {
+      userOrGroup = "User";
+      const projectsUrl = searchUserUrl(props.user.data.username);
+      const gitlabUrl = props.user.data.web_url;
+      outcome = (
+        <NamespaceUserActions namespace={namespace} projectsUrl={projectsUrl} gitlabUrl={gitlabUrl} />
+      );
+    }
+    else if (props.group.fetched && props.group.data.id) {
+      userOrGroup = "Group";
+      const projectsUrl = searchGroupUrl(props.group.data.full_path);
+      const gitlabUrl = props.group.data.web_url;
+      outcome = (
+        <NamespaceGroupActions namespace={namespace} projectsUrl={projectsUrl} gitlabUrl={gitlabUrl} />
+      );
+    }
+    else {
+      const userUrl = searchUserUrl(namespace);
+      const groupUrl = searchGroupUrl(namespace);
+      const projectUrl = searchProjectUrl(namespace);
+      outcome = (
+        <NamespaceNotfoundActions namespace={namespace} userUrl={userUrl} groupUrl={groupUrl} projectUrl={projectUrl} />
+      );
+    }
+  }
+
+  return (
+    <Container fluid>
+      <Row>
+        <Col>
+          <h3>{userOrGroup} {props.namespace}</h3>
+          <div>&nbsp;</div>
+          {checking}
+          {outcome}
+        </Col>
+      </Row>
+    </Container>
+  );
+}
+
+const NamespaceUserActions = (props) => {
+  return (<div>
+    <p>What would you like to do?</p>
+    <ul className="mb-0">
+      <li className="mb-1">
+        Browse user&apos;s <Link
+          className="btn btn-primary btn-sm" role="button" to={props.projectsUrl}>projects
+        </Link>
+      </li>
+      <li>
+        Visit user&apos;s <ExternalLink url={props.gitlabUrl} size="sm" title="GitLab page" />
+      </li>
+    </ul>
+  </div>);
+}
+
+const NamespaceGroupActions = (props) => {
+  return (<div>
+    <p>What would you like to do?</p>
+    <ul className="mb-0">
+      <li className="mb-1">
+        Browse group&apos;s <Link
+          className="btn btn-primary btn-sm" role="button" to={props.projectsUrl}>projects
+        </Link>
+      </li>
+      <li>
+        Visit group&apos;s <ExternalLink url={props.gitlabUrl} size="sm" title="GitLab page" />
+      </li>
+    </ul>
+  </div>);
+}
+
+const NamespaceNotfoundActions = (props) => {
+  return (<div>
+    <p>We could not find a user or group with name <i>{props.namespace}</i>.</p>
+
+    <InfoAlert timeout={0}>
+      <p>
+        <FontAwesomeIcon icon={faInfoCircle} /> If you know what you were looking for, you can try
+        using our search feature.
+      </p>
+      <p>
+        I was looking for...
+      </p>
+      <div>
+        <Link className="btn btn-primary btn-sm mr-1" role="button" to={props.projectUrl}>A project</Link>
+        <Link className="btn btn-primary btn-sm mr-1" role="button" to={props.userUrl}>A user</Link>
+        <Link className="btn btn-primary btn-sm mr-1" role="button" to={props.groupUrl}>A group</Link>
+      </div>
+    </InfoAlert>
+  </div>);
+}
+
+export { NamespaceProjects };

--- a/src/namespace/Namespace.test.js
+++ b/src/namespace/Namespace.test.js
@@ -1,0 +1,49 @@
+/*!
+ * Copyright 2020 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  Namespace.test.js
+ *  Tests for namesace.
+ */
+
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import ReactDOM from 'react-dom';
+import { MemoryRouter } from 'react-router-dom';
+
+import { NamespaceProjects } from './index';
+import { testClient as client } from '../api-client'
+
+describe('rendering', () => {
+  it('renders NamespaceProjects', async () => {
+    const props = {
+      client,
+      namespace: "test"
+    }
+
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    await act(async () => {
+      ReactDOM.render(<MemoryRouter>
+        <NamespaceProjects {...props} />
+      </MemoryRouter>, div);
+    })
+  });
+});

--- a/src/namespace/index.js
+++ b/src/namespace/index.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2017 - Swiss Data Science Center (SDSC)
+ * Copyright 2018 - Swiss Data Science Center (SDSC)
  * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
  * Eidgenössische Technische Hochschule Zürich (ETHZ).
  *
@@ -16,29 +16,14 @@
  * limitations under the License.
  */
 
-import { RETURN_TYPES } from './utils';
+/**
+ * renku-ui
+ *
+ * Components for namespaces
+ *
+ */
 
+import { NamespaceProjects } from './Namespace.container';
+import { NamespaceProjects as NamespaceProjectsPresent } from './Namespace.present';
 
-function addUserMethods(client) {
-  client.getUser = () => {
-    let headers = client.getBasicHeaders();
-    return client.clientFetch(
-      `${client.baseUrl}/user`, {
-        method: 'GET',
-        headers: headers
-      },
-      RETURN_TYPES.json, false, false).then(response => response.data);
-  }
-
-  client.getUserByPath = (path) => {
-    const headers = client.getBasicHeaders();
-    const queryParams = { username: encodeURIComponent(path) };
-    return client.clientFetch(`${client.baseUrl}/users`, {
-      method: 'GET',
-      headers,
-      queryParams
-    })
-  }
-}
-
-export default addUserMethods;
+export { NamespaceProjects, NamespaceProjectsPresent };

--- a/src/project/Project-Route.test.js
+++ b/src/project/Project-Route.test.js
@@ -31,51 +31,61 @@ describe('basic route extraction', () => {
     const pathComponents = splitProjectSubRoute("/projects/namespace/project-name");
     expect(pathComponents.projectPathWithNamespace).toEqual('namespace/project-name');
     expect(pathComponents.baseUrl).toEqual('/projects/namespace/project-name');
+    expect(pathComponents.namespace).toEqual('namespace');
   });
   it('handles project-with-namespace sub routes', () => {
     const pathComponents = splitProjectSubRoute("/projects/namespace/project-name/overview");
     expect(pathComponents.projectPathWithNamespace).toEqual('namespace/project-name');
     expect(pathComponents.baseUrl).toEqual('/projects/namespace/project-name');
+    expect(pathComponents.namespace).toEqual('namespace');
   });
   it('handles project-with-namespace 2-level sub routes', () => {
     const pathComponents = splitProjectSubRoute("/projects/namespace/project-name/overview/stats");
     expect(pathComponents.projectPathWithNamespace).toEqual('namespace/project-name');
     expect(pathComponents.baseUrl).toEqual('/projects/namespace/project-name');
+    expect(pathComponents.namespace).toEqual('namespace');
   });
   it('handles project-with-namespace file paths 1', () => {
     const pathComponents = splitProjectSubRoute("/projects/namespace/project-name/files/blob/README.md");
     expect(pathComponents.projectPathWithNamespace).toEqual('namespace/project-name');
     expect(pathComponents.baseUrl).toEqual('/projects/namespace/project-name');
+    expect(pathComponents.namespace).toEqual('namespace');
   });
   it('handles project-with-namespace file paths 2', () => {
     const pathComponents = splitProjectSubRoute("/projects/namespace/project-name/files/blob/root/sub1/sub2/foo.txt");
     expect(pathComponents.projectPathWithNamespace).toEqual('namespace/project-name');
     expect(pathComponents.baseUrl).toEqual('/projects/namespace/project-name');
+    expect(pathComponents.namespace).toEqual('namespace');
   });
   it('handles project-with-namespace issues listing', () => {
     const pathComponents = splitProjectSubRoute("/projects/namespace/project-name/collaboration/issues");
     expect(pathComponents.projectPathWithNamespace).toEqual('namespace/project-name');
     expect(pathComponents.baseUrl).toEqual('/projects/namespace/project-name');
+    expect(pathComponents.namespace).toEqual('namespace');
   });
   it('handles project-with-namespace issue display', () => {
     const pathComponents = splitProjectSubRoute("/projects/namespace/project-name/collaboration/issues/1/");
     expect(pathComponents.projectPathWithNamespace).toEqual('namespace/project-name');
     expect(pathComponents.baseUrl).toEqual('/projects/namespace/project-name');
+    expect(pathComponents.namespace).toEqual('namespace');
   });
   it('handles project-with-namespace datasets listing', () => {
     const pathComponents = splitProjectSubRoute("/projects/namespace/project-name/datasets/issues");
     expect(pathComponents.projectPathWithNamespace).toEqual('namespace/project-name');
     expect(pathComponents.baseUrl).toEqual('/projects/namespace/project-name');
+    expect(pathComponents.namespace).toEqual('namespace');
   });
   it('handles project-with-namespace dataset display', () => {
     const pathComponents = splitProjectSubRoute("/projects/namespace/project-name/datasets/1/");
     expect(pathComponents.projectPathWithNamespace).toEqual('namespace/project-name');
     expect(pathComponents.baseUrl).toEqual('/projects/namespace/project-name');
+    expect(pathComponents.namespace).toEqual('namespace');
   });
   it('handles project-with-namespace dataset modify', () => {
     const pathComponents = splitProjectSubRoute("/projects/namespace/project-name/datasets/1/modify");
     expect(pathComponents.projectPathWithNamespace).toEqual('namespace/project-name');
     expect(pathComponents.baseUrl).toEqual('/projects/namespace/project-name');
+    expect(pathComponents.namespace).toEqual('namespace');
   });
 })
 
@@ -85,30 +95,35 @@ describe('id route extraction', () => {
     expect(pathComponents.projectPathWithNamespace).toEqual(null);
     expect(pathComponents.projectId).toEqual('1');
     expect(pathComponents.baseUrl).toEqual('/projects/1');
+    expect(pathComponents.namespace).toEqual(null);
   });
   it('handles project-id sub routes', () => {
     const pathComponents = splitProjectSubRoute("/projects/1/overview");
     expect(pathComponents.projectPathWithNamespace).toEqual(null);
     expect(pathComponents.projectId).toEqual('1');
     expect(pathComponents.baseUrl).toEqual('/projects/1');
+    expect(pathComponents.namespace).toEqual(null);
   });
   it('handles project-id 2-level sub routes', () => {
     const pathComponents = splitProjectSubRoute("/projects/1/overview/stats");
     expect(pathComponents.projectPathWithNamespace).toEqual(null);
     expect(pathComponents.projectId).toEqual('1');
     expect(pathComponents.baseUrl).toEqual('/projects/1');
+    expect(pathComponents.namespace).toEqual(null);
   });
   it('handles project-id file paths 1', () => {
     const pathComponents = splitProjectSubRoute("/projects/1/files/blob/README.md");
     expect(pathComponents.projectPathWithNamespace).toEqual(null);
     expect(pathComponents.projectId).toEqual('1');
     expect(pathComponents.baseUrl).toEqual('/projects/1');
+    expect(pathComponents.namespace).toEqual(null);
   });
   it('handles project-id file paths 2', () => {
     const pathComponents = splitProjectSubRoute("/projects/1/files/blob/root/sub1/sub2/foo.txt");
     expect(pathComponents.projectPathWithNamespace).toEqual(null);
     expect(pathComponents.projectId).toEqual('1');
     expect(pathComponents.baseUrl).toEqual('/projects/1');
+    expect(pathComponents.namespace).toEqual(null);
   });
 })
 
@@ -116,14 +131,17 @@ describe('nested route extraction', () => {
   it('handles project-with-namespace-only routes', () => {
     const pathComponents = splitProjectSubRoute("/projects/namespace/subgroup/project-name");
     expect(pathComponents.projectPathWithNamespace).toEqual('namespace/subgroup/project-name');
+    expect(pathComponents.namespace).toEqual("namespace/subgroup");
   });
   it('handles project-with-namespace sub routes', () => {
     const pathComponents = splitProjectSubRoute("/projects/namespace/subgroup/project-name/overview");
     expect(pathComponents.projectPathWithNamespace).toEqual('namespace/subgroup/project-name');
+    expect(pathComponents.namespace).toEqual("namespace/subgroup");
   });
   it('handles project-with-namespace 2-level sub routes', () => {
     const pathComponents = splitProjectSubRoute("/projects/namespace/subgroup/project-name/overview/stats");
     expect(pathComponents.projectPathWithNamespace).toEqual('namespace/subgroup/project-name');
+    expect(pathComponents.namespace).toEqual("namespace/subgroup");
   });
 })
 
@@ -131,9 +149,11 @@ describe('tricky route extraction', () => {
   it('handles project named "overview" project-with-namespace-only routes', () => {
     const pathComponents = splitProjectSubRoute("/projects/namespace/overview");
     expect(pathComponents.projectPathWithNamespace).toEqual('namespace/overview');
+    expect(pathComponents.namespace).toEqual("namespace");
   });
   it('handles project named "overview" project-with-namespace sub routes', () => {
     const pathComponents = splitProjectSubRoute("/projects/namespace/overview/overview");
     expect(pathComponents.projectPathWithNamespace).toEqual('namespace/overview');
+    expect(pathComponents.namespace).toEqual("namespace");
   });
 })

--- a/src/project/Project.js
+++ b/src/project/Project.js
@@ -98,13 +98,20 @@ function accumulateIntoProjectPath(projectPathWithNamespace, comps) {
 }
 
 function splitProjectSubRoute(subUrl) {
-  const result = {projectPathWithNamespace: null, projectId: null, baseUrl: null };
-  if (subUrl == null) return result;
+  let result = {
+    namespace: null,
+    projectPathWithNamespace: null,
+    projectId: null,
+    baseUrl: null
+  };
+  if (subUrl == null)
+    return result;
 
   const baseUrl = subUrl.endsWith('/') ? subUrl.slice(0, -1) : subUrl;
   const projectSubRoute = baseUrl.startsWith("/projects/") ? baseUrl.slice(10) : baseUrl;
   const comps = projectSubRoute.split("/");
-  if (comps.length < 1) return result;
+  if (comps.length < 1)
+    return result;
 
   // This could be a route that just provides a projectId
   if (projectIdRegex.test(comps[0])) {
@@ -112,21 +119,25 @@ function splitProjectSubRoute(subUrl) {
     result.baseUrl = `/projects/${result.projectId}`;
     return result;
   }
-  if (comps.length < 2) return result;
+  if (comps.length < 2) {
+    result.namespace = comps[0];
+    return result;
+  }
 
   result.projectPathWithNamespace = comps.slice(0, 2).join("/");
   if (comps.length > 2) {
     // We need to check if we need to accumulate more components into the projectPathWithNamespace
-    result.projectPathWithNamespace = accumulateIntoProjectPath(result.projectPathWithNamespace, comps.slice(2));	
+    result.projectPathWithNamespace = accumulateIntoProjectPath(result.projectPathWithNamespace, comps.slice(2));
   }
 
   if (result.projectId != null) {
-    result.baseUrl = `/projects/${result.projectId}`
+    result.baseUrl = `/projects/${result.projectId}`;
   } else {
-    result.baseUrl = `/projects/${result.projectPathWithNamespace}`
+    result.baseUrl = `/projects/${result.projectPathWithNamespace}`;
+    result.namespace = result.projectPathWithNamespace.slice(0, result.projectPathWithNamespace.lastIndexOf("/"));
   }
- 
-  return result
+
+  return result;
 }
 
 

--- a/src/project/Project.js
+++ b/src/project/Project.js
@@ -584,6 +584,7 @@ class View extends Component {
       ...ownProps,
       projectPathWithNamespace: pathComponents.projectPathWithNamespace,
       projectId: pathComponents.projectId,
+      namespace: pathComponents.namespace,
       ...this.getSubUrls(),
       ...this.subComponents.bind(this)(internalId, ownProps),
       starred,

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -49,6 +49,7 @@ import FilesTreeView from './filestreeview/FilesTreeView';
 import DatasetsListView from './datasets/DatasetsListView';
 import { ACCESS_LEVELS } from '../api-client';
 import { GraphIndexingStatus } from './Project';
+import { NamespaceProjects } from '../namespace';
 
 import './Project.css';
 
@@ -1060,13 +1061,21 @@ class NotFoundInsideProject extends Component {
 }
 
 class ProjectView extends Component {
-
   render() {
     const available = this.props.core ? this.props.core.available : null;
     const projectPathWithNamespaceOrId = this.props.projectPathWithNamespace ?
       this.props.projectPathWithNamespace
       : this.props.projectId;
-    if (available == null || available === SpecialPropVal.UPDATING || this.props.projectId) {
+
+    if (this.props.namespace && !this.props.projectPathWithNamespace) {
+      return (
+        <NamespaceProjects
+          namespace={this.props.namespace}
+          client={this.props.client}
+        />
+      );
+    }
+    else if (available == null || available === SpecialPropVal.UPDATING || this.props.projectId) {
       return (
         <ProjectViewLoading
           projectPathWithNamespace={this.props.projectPathWithNamespace}


### PR DESCRIPTION
Users and groups are not first-class citizens yet. Since users may try to reach the `/projects/<namespace>` url anyway, we want to provide useful information when hitting that route.

With this PR, the existence of the `<namespace>` is tested and, according to the result (user, group or non-existing), actions are suggested to the user.

fix #750

Preview: https://lorenzotest.dev.renku.ch/

**How to test**
Try to reach a few `/projects/<namespace>` URLs, at least one for each of the 3 following types
* User: E.G. https://lorenzotest.dev.renku.ch/projects/lorenzo.cavazzi.tech
* Group: E.G. https://lorenzotest.dev.renku.ch/projects/eurobioc2019
* Non-existing: E.G. https://lorenzotest.dev.renku.ch/projects/nonexistent

