### PR TITLE
fix(projects): changes on project naming and search to make it more user friendly

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -74,7 +74,7 @@ class App extends Component {
                     {...p} />} />
                 <Route path="/help" render={
                   p => <Help key="help" {...p} {...this.props} />} />
-                <Route exact path={["/projects", "/projects/starred", "/projects/search"]} render={
+                <Route exact path={["/projects", "/projects/starred", "/projects/all"]} render={
                   p => <Project.List
                     key="projects"
                     user={this.props.user}

--- a/src/landing/Landing.js
+++ b/src/landing/Landing.js
@@ -35,7 +35,7 @@ function urlMap() {
   return {
     projectsUrl: "/projects",
     projectNewUrl: "/project_new",
-    projectsSearchUrl: "/projects/search",
+    projectsSearchUrl: "/projects/all",
     projectsStarredUrl: "/projects/starred",
   };
 }

--- a/src/namespace/Namespace.present.js
+++ b/src/namespace/Namespace.present.js
@@ -34,7 +34,7 @@ import { Loader, InfoAlert, ExternalLink } from "../utils/UIComponents";
 const NamespaceProjects = (props) => {
   const { namespace } = props;
   // TODO: I should get the URLs from the redux store: #779
-  const searchUrl = "/projects/search";
+  const searchUrl = "/projects/all";
   const searchProjectUrl = (project) => { return `${searchUrl}?q=${project}`; };
   const searchUserUrl = (user) => { return `${searchUrl}?searchIn=users&q=${user}`; };
   const searchGroupUrl = (group) => { return `${searchUrl}?searchIn=groups&q=${group}`; };

--- a/src/project/list/ProjectList.container.js
+++ b/src/project/list/ProjectList.container.js
@@ -43,7 +43,7 @@ const searchScopesValuesMap = {
 
 const urlMap = {
   projectsUrl: "/projects",
-  projectsSearchUrl: "/projects/search",
+  projectsSearchUrl: "/projects/all",
   projectNewUrl: "/project_new",
   starred: "/projects/starred",
   yourProjects: "/projects/your_projects"
@@ -198,13 +198,13 @@ class AvailableUserList extends Component {
   getSearchText() {
     switch (this.model.get("searchIn")) {
       case searchInValuesMap.PROJECTNAME:
-        return "Search by project name";
+        return "Filter by project name";
       case searchInValuesMap.USERNAME:
-        return "Search by user name";
+        return "Filter by user name";
       case searchInValuesMap.GROUPNAME:
-        return "Search by group name";
+        return "Filter by group name";
       default:
-        return "Search Text";
+        return "Filter Text";
     }
   }
 

--- a/src/project/list/ProjectList.present.js
+++ b/src/project/list/ProjectList.present.js
@@ -69,35 +69,35 @@ class ProjectSearchForm extends Component {
           value={this.props.searchQuery} onChange={this.props.handlers.onSearchQueryChange}
           className="border-primary" />
         <Label for="searchQuery" hidden>Query</Label>
-        <InputGroupButtonDropdown addonType="append"
-          toggle={this.props.handlers.onSearchInDropdownToogle} isOpen={this.props.searchInDropdownOpen} >
-          <DropdownToggle outline caret color="primary" >
-            Search by: {this.props.searchInLabel}
-          </DropdownToggle>
-          <DropdownMenu>
-            <DropdownItem value={this.props.searchInValuesMap.PROJECTNAME}
-              onClick={this.props.handlers.changeSearchDropdownFilter}>
-              {this.props.searchIn === this.props.searchInValuesMap.PROJECTNAME ?
-                <FontAwesomeIcon icon={faCheck} /> : null} Project Name
-            </DropdownItem>
-            {
-              this.props.urlMap.projectsSearchUrl === this.props.currentTab || this.props.hasUser === false ?
-                [<DropdownItem key={this.props.searchInValuesMap.USERNAME}
+        {
+          this.props.urlMap.projectsSearchUrl === this.props.currentTab || this.props.hasUser === false ?
+            <InputGroupButtonDropdown addonType="append"
+              toggle={this.props.handlers.onSearchInDropdownToogle} isOpen={this.props.searchInDropdownOpen} >
+              <DropdownToggle outline caret color="primary" >
+                Filter by: {this.props.searchInLabel}
+              </DropdownToggle>
+              <DropdownMenu>
+                <DropdownItem value={this.props.searchInValuesMap.PROJECTNAME}
+                  onClick={this.props.handlers.changeSearchDropdownFilter}>
+                  {this.props.searchIn === this.props.searchInValuesMap.PROJECTNAME ?
+                    <FontAwesomeIcon icon={faCheck} /> : null} Project Name
+                </DropdownItem>
+                <DropdownItem key={this.props.searchInValuesMap.USERNAME}
                   value={this.props.searchInValuesMap.USERNAME}
                   onClick={this.props.handlers.changeSearchDropdownFilter}>
                   {this.props.searchIn === this.props.searchInValuesMap.USERNAME ?
                     <FontAwesomeIcon icon={faCheck} /> : null} User Name
-                </DropdownItem>,
-                  <DropdownItem key={this.props.searchInValuesMap.GROUPNAME}
+                </DropdownItem>
+                <DropdownItem key={this.props.searchInValuesMap.GROUPNAME}
                   value={this.props.searchInValuesMap.GROUPNAME}
                   onClick={this.props.handlers.changeSearchDropdownFilter}>
-                    {this.props.searchIn === this.props.searchInValuesMap.GROUPNAME ?
-                      <FontAwesomeIcon icon={faCheck} /> : null} Group Name
-                  </DropdownItem>]
-                : null
-            }
-          </DropdownMenu>
-        </InputGroupButtonDropdown>
+                  {this.props.searchIn === this.props.searchInValuesMap.GROUPNAME ?
+                    <FontAwesomeIcon icon={faCheck} /> : null} Group Name
+                </DropdownItem>
+              </DropdownMenu>
+            </InputGroupButtonDropdown>
+            : null
+        }
         <InputGroupButtonDropdown addonType="append"
           toggle={this.props.handlers.onOrderByDropdownToogle} isOpen={this.props.orderByDropdownOpen} >
           <Button outline color="primary" onClick={this.props.handlers.toogleSearchSorting}>
@@ -132,11 +132,11 @@ class ProjectSearchForm extends Component {
       </InputGroup>
       &nbsp;
       <Button color="primary" onClick={this.props.handlers.onSearchSubmit}>
-        Search
+        Filter
       </Button>
     </Form>,
     this.props.searchIn === this.props.searchInValuesMap.PROJECTNAME ?
-      <FormText key="help" color="muted">Search with empty text to browse all projects.</FormText>
+      <FormText key="help" color="muted">Leave emtpy to browse all projects.</FormText>
       : null
     ];
   }
@@ -160,7 +160,7 @@ class ProjectNavTabs extends Component {
                     <RenkuNavLink exact={false} to={this.props.urlMap.starred} title="Starred Projects" />
                   </NavItem>
                   <NavItem>
-                    <RenkuNavLink exact={false} to={this.props.urlMap.projectsSearchUrl} title="Search" />
+                    <RenkuNavLink exact={false} to={this.props.urlMap.projectsSearchUrl} title="All Projects" />
                   </NavItem>
                 </Nav>,
                 <div key="bottom-space">&nbsp;</div>]

--- a/src/project/list/ProjectList.test.js
+++ b/src/project/list/ProjectList.test.js
@@ -39,7 +39,7 @@ const fakeHistory = createMemoryHistory({
   initialIndex: 0,
 });
 fakeHistory.push({
-  pathname: "/projects/search",
+  pathname: "/projects/all",
   search: "?page=1"
 });
 

--- a/src/utils/quicknav/QuickNav.container.js
+++ b/src/utils/quicknav/QuickNav.container.js
@@ -101,14 +101,14 @@ class QuickNavContainerWithRouter extends Component {
     const suggestions = [];
     if (value.length > 0) {
       suggestions.push({
-        title: "Search",
+        title: "Search in All Projects",
         suggestions: [{ query: value, id: -1, path: value, url: this.searchUrlForValue(value) }]
       });
     }
     const hitKeys = Object.keys(hits);
     if (hitKeys.length > 0) {
       suggestions.push({
-        title: "Projects",
+        title: "Your Projects",
         suggestions: hitKeys.sort().map(k => ({ path: k, id: hits[k].id, url: `/projects/${hits[k].id}` }))
       });
     }
@@ -117,7 +117,7 @@ class QuickNavContainerWithRouter extends Component {
   }
 
   searchUrlForValue(value) {
-    return (value != null) ? `/projects/search?q=${value}` : null;
+    return (value != null) ? `/projects/all?q=${value}` : null;
   }
 
   onSuggestionsClearRequested() {

--- a/src/utils/quicknav/QuickNav.style.css
+++ b/src/utils/quicknav/QuickNav.style.css
@@ -2,9 +2,11 @@
   position: fixed;
   top: 50px;
   background-color: white;
-  z-index: 1;
-  padding: 10px 0;
+  z-index: 3;
+  padding-top: 30px;
+  box-shadow: 0 15px 20px rgba(0, 0, 0, 0.3);
 }
+
 
 .searchBarSuggestionsContainer > div {
   padding: 2px 10px;


### PR DESCRIPTION
Implemented changes suggested by @ciyer in the issue #771 

It's basically this:
![image](https://user-images.githubusercontent.com/42647877/75907195-32228200-5e48-11ea-91bf-072f17d686ee.png)

I have a small suggestion to add to that, i can implemented if you think is good, i think we should add a shadow to the autosuggest list... 

Now:
![image](https://user-images.githubusercontent.com/42647877/75907680-0227ae80-5e49-11ea-9e5c-489b5ebe1ad7.png)


With shadow:
![image](https://user-images.githubusercontent.com/42647877/75907611-e4f2e000-5e48-11ea-8da6-14e9dab8777c.png)

Change to add the shadow:
```
.searchBarSuggestionsContainer {
  position: fixed;
  top: 50px;
  background-color: white;
  z-index: 3;
  padding-top: 30px;
  box-shadow: 0 15px 20px rgba(0, 0, 0, 0.3);
}

```

Closes #771