### PR TITLE
fix(datasets): search calls KG once and paging problem fixed

### DIFF
--- a/src/dataset/list/DatasetList.container.js
+++ b/src/dataset/list/DatasetList.container.js
@@ -163,6 +163,7 @@ class List extends Component {
 
   onSearchSubmit(e) {
     e.preventDefault();
+    this.model.resetBeforeNewSearch();
     this.model.performSearch();
     this.pushNewSearchToHistory();
   }

--- a/src/dataset/list/DatasetList.present.js
+++ b/src/dataset/list/DatasetList.present.js
@@ -125,7 +125,7 @@ class DatasetSearchForm extends Component {
         <Button color="primary" onClick={this.props.handlers.onSearchSubmit}>Search</Button>
       </Form>,
       <FormText key="help" color="muted">
-        {this.props.errorMessage} If you are not finding whatyou are looking
+        {this.props.errorMessage} If you are not finding what you are looking
         for, <Button className="pr-0 pl-0 pt-0 pb-0 mb-1" color="link" id="toggler">
           <small>click here for help.</small>
         </Button>

--- a/src/dataset/list/DatasetList.state.js
+++ b/src/dataset/list/DatasetList.state.js
@@ -92,6 +92,13 @@ class DatasetListModel extends StateModel {
     this.performSearch();
   }
 
+  resetBeforeNewSearch() {
+    this.setObject({
+      currentPage: 1,
+      pages: { $set: [] }
+    });
+  }
+
   getSorting() {
     const searchOrder = this.get("orderSearchAsc") === true ? "asc" : "desc";
     switch (this.get("orderBy")) {
@@ -121,6 +128,7 @@ class DatasetListModel extends StateModel {
   }
 
   performSearch() {
+    if (this.get("loading")) return;
     this.set("loading", true);
     const searchParams = {
       query: this.get("query"),


### PR DESCRIPTION
Closes #757 

- When pressing search /datasets endpoint is invoked only 1 time.
- Fixed a small typo error under the search bar.
- Fix pagination problem (there are only 3 dataset's in renkulab so i can't test this) 

Testing: https://virginiatest.dev.renku.ch