### PR TITLE
fix(datasets): the list of datasets is reloaded after dataset create

### DIFF
--- a/src/dataset/Dataset.present.js
+++ b/src/dataset/Dataset.present.js
@@ -200,7 +200,7 @@ export default function DatasetView(props) {
   if (dataset === null) {
     return (
       <Alert color="danger">
-        Error 404: The dataset that was selected does not exist or could not
+        The dataset that was selected does not exist or could not
         be accessed.<br /> <br /> If you just created the dataset
         try <Button color="danger" size="sm" onClick={
           () => window.location.reload()

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -546,18 +546,12 @@ class ProjectViewOverview extends Component {
 
 class ProjectDatasetsNav extends Component {
 
-  componentDidMount() {
-    this.props.fetchDatasets();
-  }
-
   render() {
-    const loading = isRequestPending(this.props, "datasets");
     const allDatasets = this.props.core.datasets || [];
-    if (loading && (allDatasets.length < 1 || this.props.core.datasets === undefined))
-      return <Loader />;
 
     if (allDatasets.length === 0)
       return null;
+
     return <DatasetsListView
       datasets={this.props.core.datasets}
       datasetsUrl={this.props.datasetsUrl}
@@ -582,8 +576,18 @@ class ProjectViewDatasets extends Component {
 
 class ProjectViewDatasetsList extends Component {
 
+  componentDidMount() {
+    if (this.props.core.datasets === undefined
+      || (this.props.location.state && this.props.location.state.datasets))
+      this.props.fetchDatasets();
+  }
+
   render() {
-    const loading = isRequestPending(this.props, "datasets");
+    const loading = this.props.core.datasets === SpecialPropVal.UPDATING;
+    const incomingDatasets = this.props.location.state && this.props.location.state.datasets
+      ? this.props.location.state.datasets : [];
+    if (loading || this.props.core.datasets === undefined || incomingDatasets.length > this.props.core.datasets.length)
+      return <Loader />;
     const progress = this.props.webhook.progress;
     const kgLoading = progress == null
       || progress === GraphIndexingStatus.NO_WEBHOOK

--- a/src/project/datasets/new/DatasetNew.present.js
+++ b/src/project/datasets/new/DatasetNew.present.js
@@ -55,31 +55,30 @@ function DatasetNew(props) {
 
    props.client.postDataset(props.httpProjectUrl, dataset)
    .then(dataset => {
-     if (dataset.data.error !== undefined) {
+    if (dataset.data.error !== undefined) {
       setSubmitLoader(false);
       setServerErrors(dataset.data.error.reason);
-     }
- else {
-      let waitForDatasetInKG = setInterval(
-        () => {
-props.client.getProjectDatasetsFromKG(props.projectPathWithNamespace)
-        .then(datasets => {
-          // eslint-disable-next-line
-          let new_dataset = datasets.find( ds => ds.name === dataset.data.result.dataset_name);
-          if (new_dataset !== undefined) {
-            setSubmitLoader(false);
-            props.datasetFormSchema.name.value = props.datasetFormSchema.name.initial;
-            props.datasetFormSchema.description.value = props.datasetFormSchema.description.initial;
-            props.datasetFormSchema.files.value = props.datasetFormSchema.files.initial;
-            clearInterval(waitForDatasetInKG);
-            props.history.push(
-              { pathname: `/projects/${props.projectPathWithNamespace}/datasets/${new_dataset.identifier}/`
-            });
-          }
-      });
-}
-      , 6000);
-     }
+    }
+    else {
+      let waitForDatasetInKG = setInterval(() => {
+        props.client.getProjectDatasetsFromKG(props.projectPathWithNamespace)
+          .then(datasets => {
+            // eslint-disable-next-line
+            let new_dataset = datasets.find( ds => ds.name === dataset.data.result.dataset_name);
+            if (new_dataset !== undefined) {
+              setSubmitLoader(false);
+              props.datasetFormSchema.name.value = props.datasetFormSchema.name.initial;
+              props.datasetFormSchema.description.value = props.datasetFormSchema.description.initial;
+              props.datasetFormSchema.files.value = props.datasetFormSchema.files.initial;
+              clearInterval(waitForDatasetInKG);
+              props.history.push({
+                pathname: `/projects/${props.projectPathWithNamespace}/datasets/${new_dataset.identifier}/`,
+                state: { datasets: datasets }
+              });
+            }
+        });
+      }, 6000);
+    }
   });
   };
 


### PR DESCRIPTION
There was an error after the dataset create that was NOT on the KG.

It was on the UI, after a dataset was created we where waiting until the dataset was on the KG and then redirecting the user to the datasets list, on this process we where getting the new datasets list but since this was taking some time (and we weren't waiting for the list to be there) we where displaying a message as if the dataset wasn't there. 

We now update the list (only when necessary).

There is also a change on the error message that is displayed so is not so strong. (I removed the Error 404 from it.

Docker image for testing: virfried/renku-ui:0.8.1-192a720
