### PR TITLE
fix: update first step tutorial links

### DIFF
--- a/src/help/Help.present.js
+++ b/src/help/Help.present.js
@@ -129,7 +129,7 @@ class HelpTutorials extends Component {
           If you are here for the first time or you are not sure how to use Renku, we recommend you
           to go through our{" "}
           <a
-            href="https://renku.readthedocs.io/en/latest/user/firststeps.html"
+            href="https://renku.readthedocs.io/en/latest/tutorials/firststeps.html"
             target="_blank"
             rel="noreferrer noopener"
           >

--- a/src/landing/Landing.present.js
+++ b/src/landing/Landing.present.js
@@ -227,7 +227,7 @@ class AnonymousHome extends Component {
       <Row key="tutorial" className="mb-3">
         <Col>
           Want to learn more? Create an account
-          and <a href="https://renku.readthedocs.io/en/latest/user/firststeps.html">follow the tutorial</a>.
+          and <a href="https://renku.readthedocs.io/en/latest/tutorials/firststeps.html">follow the tutorial</a>.
         </Col>
       </Row>
       <Row key="closing">


### PR DESCRIPTION
Update the hardcoded links to the first step tutorial.
The reference issue implies these links need to be updated also in the `ops-*` repositories for the affected environments.

re SwissDataScienceCenter/renku#875