### PR TITLE
feat(environments): add requested resources info

### DIFF
--- a/src/notebooks/Notebooks.present.js
+++ b/src/notebooks/Notebooks.present.js
@@ -256,7 +256,7 @@ class NotebookServerRowFull extends Component {
     const branch = (<td className="align-middle">{annotations["branch"]}</td>);
     const commit = (<td className="align-middle">{annotations["commit-sha"].substring(0, 8)}</td>);
     const resourceList = Object.keys(resources).map(name => {
-      return (<div key={name} className="text-nowrap">{name}: {resources[name]}</div>);
+      return (<div key={name} className="text-nowrap">{resources[name]} <i>{name}</i></div>);
     });
     const resourceObject = (<td>{resourceList}</td>);
     const statusOut = (<td className="align-middle">


### PR DESCRIPTION
In the environments pages, a new column shows the resources allocated for every environment

A preview is available here: https://lorenzotest.dev.renku.ch/

***How to test***
Start an environment in any project. After it is up and running, the environments table should show the requested resources in the new `Resources` column 

![Screenshot_20200313_161603](https://user-images.githubusercontent.com/43481553/76634022-f8d3cb80-6545-11ea-9a07-3aceaebcc900.png)


This requires SwissDataScienceCenter/renku-notebooks#261
fix #788