### PR TITLE
fix(datasets): dataset displays folder information

### DIFF
--- a/src/dataset/Dataset.present.js
+++ b/src/dataset/Dataset.present.js
@@ -33,7 +33,7 @@ function DisplayFiles(props) {
 
   return <Card key="datasetDetails">
     <CardHeader className="align-items-baseline">
-      <span className="caption align-baseline">Dataset files</span>
+      <span className="caption align-baseline">Dataset files ({props.files.length})</span>
     </CardHeader>
     <CardBody>
       <FileExplorer

--- a/src/dataset/Dataset.present.js
+++ b/src/dataset/Dataset.present.js
@@ -19,11 +19,11 @@
 import React, { useState, useEffect } from "react";
 import { Row, Col, Card, CardHeader, CardBody, Table, Alert, Button } from "reactstrap";
 import { Link } from "react-router-dom";
-import { Loader } from "../utils/UIComponents";
+import { Loader, FileExplorer } from "../utils/UIComponents";
 import DOMPurify from "dompurify";
 import { API_ERRORS } from "../api-client";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faFile, faProjectDiagram, faExternalLinkAlt, faPen } from "@fortawesome/free-solid-svg-icons";
+import { faExternalLinkAlt, faPen } from "@fortawesome/free-solid-svg-icons";
 import { GraphIndexingStatus } from "../project/Project";
 import KnowledgeGraphStatus from "../file/KnowledgeGraphStatus.container";
 import Time from "../utils/Time";
@@ -36,34 +36,11 @@ function DisplayFiles(props) {
       <span className="caption align-baseline">Dataset files</span>
     </CardHeader>
     <CardBody>
-      <Table size="sm" borderless>
-        <thead>
-          <tr>
-            <th>Name</th>
-            {props.insideProject ? <th className="text-center">File</th> : null}
-            {props.insideProject ? <th className="text-center">Lineage</th> : null}
-          </tr>
-        </thead>
-        <tbody>
-          {props.files.map((file) =>
-            <tr key={file.atLocation}>
-              <td className="text-break">{file.name}</td>
-              {props.insideProject ?
-                <td className="text-center">
-                  <Link to={`${props.fileContentUrl}/${file.atLocation}`}>
-                    <FontAwesomeIcon icon={faFile} />
-                  </Link>
-                </td> : null}
-              {props.insideProject ?
-                <td className="text-center">
-                  <Link to={`${props.lineagesUrl}/${file.atLocation}`}>
-                    <FontAwesomeIcon icon={faProjectDiagram} />
-                  </Link>
-                </td> : null}
-            </tr>
-          )}
-        </tbody>
-      </Table>
+      <FileExplorer
+        files={props.files}
+        lineageUrl={props.lineagesUrl}
+        insideProject={props.insideProject}
+      />
     </CardBody>
   </Card>;
 }

--- a/src/utils/FileExplorer.js
+++ b/src/utils/FileExplorer.js
@@ -1,0 +1,196 @@
+
+import React, { Component, useState, useEffect } from "react";
+import { Link } from "react-router-dom";
+import { Loader } from "../utils/UIComponents";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faFile, faFolder, faFolderOpen } from "@fortawesome/free-solid-svg-icons";
+
+function buildTree(parts, treeNode, jsonObj, hash, currentPath) {
+  if (parts.length === 0)
+    return;
+  currentPath = currentPath === "" ? parts[0] : currentPath + "/" + parts[0];
+
+  for (let i = 0; i < treeNode.length; i++) {
+    if (parts[0] === treeNode[i].text) {
+      buildTree(parts.splice(1, parts.length), treeNode[i].children, jsonObj, hash, currentPath + "/" + parts[0]);
+      return;
+    }
+  }
+
+  let newNode;
+  if (parts[0] === jsonObj.name)
+    newNode = { "name": parts[0], "children": [], "jsonObj": jsonObj, "path": currentPath };
+  else
+    newNode = { "name": parts[0], "children": [], "jsonObj": null, "path": currentPath };
+
+  const currentNode = treeNode.filter(node => node.name === newNode.name);
+
+  if (currentNode.length === 0) {
+    treeNode.push(newNode);
+    hash[newNode.path] = { "name": parts[0], "selected": false, "childrenOpen": false, "path": currentPath };
+    buildTree(parts.splice(1, parts.length), newNode.children, jsonObj, hash, currentPath);
+  }
+  else {
+    for (let j = 0; j < newNode.children.length; j++)
+      currentNode[0].children.push(newNode.children[j]);
+
+    buildTree(parts.splice(1, parts.length), currentNode[0].children, jsonObj, hash, currentPath);
+  }
+}
+
+
+function getFilesTree(files) {
+  let list = files;
+  let tree = [];
+  let hash = {};
+  for (let i = 0; i < list.length; i++) {
+    const dir = list[i].atLocation.split("/");
+    dir.shift();
+    buildTree(dir, tree, list[i], hash, "");
+  }
+  const treeObj = { tree: tree, hash: hash };
+  return treeObj;
+}
+
+class TreeNode extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isSelected: false,
+      childrenOpen: this.props.childrenOpen
+    };
+    this.handleIconClick = this.handleIconClick.bind(this);
+  }
+
+  handleIconClick(e) {
+    this.props.setOpenFolder(this.props.path);
+    this.setState((prevState) => ({ childrenOpen: !prevState.childrenOpen }));
+  }
+
+  render() {
+    const icon = this.props.node.children.length ?
+      (this.state.childrenOpen === false ?
+        <FontAwesomeIcon className="icon-purple" icon={faFolder} />
+        : <FontAwesomeIcon className="icon-purple" icon={faFolderOpen} />)
+      : <FontAwesomeIcon className="icon-grey" icon={faFile} />;
+
+    const order = this.props.node.children.length ? "order-seccond" : "order-third";
+    const hidden = this.props.node.name.startsWith(".") ? " hidden-folder " : "";
+
+    const children = this.props.node.children ?
+      this.props.node.children.map((node, index) => {
+        return <TreeNode
+          path={node.path}
+          key={node.path}
+          node={node}
+          childrenOpen={this.props.hash[node.path].childrenOpen}
+          projectUrl={this.props.projectUrl}
+          lineageUrl={this.props.lineageUrl}
+          setOpenFolder={this.props.setOpenFolder}
+          hash={this.props.hash}
+          insideProject={this.props.insideProject}
+        />;
+      })
+      : null;
+
+    let elementToRender;
+    const eltClassName = order + " " + hidden;
+    if (this.props.node.jsonObj !== null) {
+      elementToRender = this.props.insideProject ?
+        <div className={eltClassName}>
+          <Link to= {`${this.props.lineageUrl}/${this.props.node.jsonObj.atLocation}`} >
+            <div className="fs-element">
+              {icon} {this.props.node.name}
+            </div>
+          </Link>
+        </div>
+        :
+        <div className={eltClassName}>
+          <div className="fs-element" style={{ cursor: "default" }}>
+            {icon} {this.props.node.name}
+          </div>
+        </div>
+      ;
+    }
+    else {
+      elementToRender = this.state.childrenOpen ?
+        <div className={eltClassName} >
+          <div className="fs-element" onClick={this.handleIconClick} >
+            {icon} {this.props.node.name}
+          </div>
+          <div className="pl-3">
+            {children}
+          </div>
+        </div>
+        :
+        <div className={eltClassName} >
+          <div className="fs-element" onClick={this.handleIconClick}>
+            {icon} {this.props.node.name}
+          </div>
+        </div>;
+    }
+    return elementToRender;
+  }
+}
+
+function FilesTreeView(props) {
+
+  const [tree, setTree] = useState(undefined);
+
+  useEffect(()=>{
+    if (props.data.tree && tree === undefined) {
+      setTree(
+        props.data.tree.map((node, index) => {
+          return <TreeNode
+            key={node.path}
+            node={node}
+            childrenOpen={props.data.hash[node.path].childrenOpen}
+            setOpenFolder={props.setOpenFolder}
+            path={node.path}
+            hash={props.data.hash}
+            lineageUrl={props.lineageUrl}
+            insideProject={props.insideProject}
+          />;
+        })
+      );
+    }
+  }, [props.data, tree, props.setOpenFolder, props.lineageUrl, props.insideProject]);
+
+  if (props.data.tree === undefined)
+    return <Loader />;
+
+  return (
+    <div className="tree-container">
+      {tree}
+    </div>
+  );
+}
+
+function FileExplorer(props) {
+  const [filesTree, setFilesTree] = useState(undefined);
+
+  useEffect(() => {
+    if (props.files !== undefined)
+      setFilesTree(getFilesTree(props.files));
+  }, [props.files]);
+
+  const setOpenFolder = (filePath) => {
+    filesTree.hash[filePath].childrenOpen = !filesTree.hash[filePath].childrenOpen;
+    setFilesTree(filesTree);
+  };
+
+  const loading = filesTree === undefined;
+
+  if (loading)
+    return <Loader />;
+
+  return <FilesTreeView
+    data={filesTree}
+    setOpenFolder={setOpenFolder}
+    hash={filesTree.hash}
+    lineageUrl={props.lineageUrl}
+    insideProject={props.insideProject}
+  />;
+}
+
+export default FileExplorer;

--- a/src/utils/UIComponents.js
+++ b/src/utils/UIComponents.js
@@ -39,6 +39,7 @@ import { faCopy } from "@fortawesome/free-regular-svg-icons";
 import { faCheck, faUser, faEllipsisV } from "@fortawesome/free-solid-svg-icons";
 
 import { sanitizedHTMLFromMarkdown } from "./HelperFunctions";
+import FileExplorer from "./FileExplorer";
 
 /**
  * Show user avatar
@@ -631,4 +632,4 @@ function ButtonWithMenu(props) {
 export { UserAvatar, TimeCaption, FieldGroup, RenkuNavLink, Pagination, RenkuMarkdown };
 export { ExternalLink, Loader, InfoAlert, SuccessAlert, WarnAlert, ErrorAlert, JupyterIcon };
 export { Clipboard, ExternalIconLink, IconLink, ThrottledTooltip, TooltipToggleButton, ProjectAvatar };
-export { ButtonWithMenu };
+export { ButtonWithMenu, FileExplorer };


### PR DESCRIPTION
The datasets display folder information now...

![image](https://user-images.githubusercontent.com/42647877/76863620-0a77e480-6860-11ea-9af7-def88d5dcfa6.png)

I deleted the links to the file and graph display but we could potentially add them next to the file name or something similar...

Testing: https://virginiatest.dev.renku.ch/datasets/9b3b47b7-277e-4368-87bd-c66513701dc5/