### PR TITLE
feat: convert links to anchor automatically on markdown files

### DIFF
--- a/src/utils/HelperFunctions.js
+++ b/src/utils/HelperFunctions.js
@@ -50,7 +50,7 @@ function splitAutosavedBranches(branches) {
 }
 
 function sanitizedHTMLFromMarkdown(markdown) {
-  const converter = new showdown.Converter();
+  const converter = new showdown.Converter({ simplifiedAutoLink: true });
   const htmlFromMarkdown = converter.makeHtml(markdown);
   return DOMPurify.sanitize(htmlFromMarkdown);
 }


### PR DESCRIPTION
We support GitHub style markdown on `.md` files preview, but links are not automatically converted to `<a>` elements if not contained in the proper brakes `< >`.
Since also the GitLab preview supports it, we should have consistent behavior.
https://github.com/showdownjs/showdown/wiki/Showdown's-Markdown-syntax#links

**How to test**: Look at the difference in how the link on the second line is rendered here
* https://lorenzotest.dev.renku.ch/projects/lorenzo.cavazzi.tech/basic_python_project
* https://dev.renku.ch/projects/lorenzo.cavazzi.tech/basic_python_project 