### PR TITLE
feat(dataset): users can unzip files in the backend #849 #796

### DIFF
--- a/src/api-client/dataset.js
+++ b/src/api-client/dataset.js
@@ -11,7 +11,7 @@ export default function addDatasetMethods(client) {
     });
   };
 
-  client.uploadFile = (file, controller) => {
+  client.uploadFile = (file, controller, unpack_archive = false) => {
     const data = new FormData();
     data.append("file", file);
     data.append("file_name", file.name);
@@ -31,7 +31,8 @@ export default function addDatasetMethods(client) {
 
     if (controller) queryParams.signal = controller.signal;
 
-    return fetch(`${client.baseUrl}/renku/cache.files_upload?override_existing=true`, queryParams)
+    return fetch(`${client.baseUrl}/renku/cache.files_upload?override_existing=true&unpack_archive=${unpack_archive}`,
+      queryParams)
       .then(response => {
         if (controller !== undefined)
           response.controller = controller;

--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -55,7 +55,8 @@ const PropertyName = {
   HELP: "help",
   OPTIONS: "options",
   PLACEHOLDER: "placeholder",
-  OUTPUTTYPE: "outputType"
+  OUTPUTTYPE: "outputType",
+  FILESONUPLOADER: "filesOnUploader"
 };
 
 // Named consts for the bindings to the store.

--- a/src/model/RenkuModels.js
+++ b/src/model/RenkuModels.js
@@ -270,7 +270,7 @@ const datasetFormSchema = new Schema({
     validators: [{
       id: "files-length",
       isValidFun: expression => FormGenerator.Validators.filesReady(expression),
-      alert: "There are files in unready state."
+      alert: "Some queued files have not finished uploading. Please see the status messages and reply to any questions."
     }]
   }
 });

--- a/src/model/RenkuModels.js
+++ b/src/model/RenkuModels.js
@@ -266,10 +266,11 @@ const datasetFormSchema = new Schema({
     edit: true,
     type: FormGenerator.FieldTypes.FILES,
     uploadFileFunction: undefined,
+    filesOnUploader: undefined,
     validators: [{
       id: "files-length",
-      //isValidFun: expression => FormGenerator.Validators.isNotEmpty(expression, 1),
-      alert: "Datasets should have at least 1 file"
+      isValidFun: expression => FormGenerator.Validators.filesReady(expression),
+      alert: "There are files in unready state."
     }]
   }
 });

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -604,8 +604,8 @@ class ProjectViewDatasetsList extends Component {
           <FontAwesomeIcon icon={faInfoCircle} />  If you recently activated the knowledge graph or
           added the datasets try refreshing the page. <br /><br />
           You can also click on the button to create a
-          <Link className="btn btn-primary btn-sm" to={this.props.newDatasetUrl}>New Dataset</Link>
-          or <Link className="btn btn-primary btn-sm" to={this.props.importDatasetUrl}>Import Dataset</Link>
+          &nbsp;<Link className="btn btn-primary btn-sm" to={this.props.newDatasetUrl}>New Dataset</Link>
+          &nbsp;or <Link className="btn btn-primary btn-sm" to={this.props.importDatasetUrl}>Import a Dataset</Link>
         </Alert>
       </Col>;
     }

--- a/src/project/datasets/edit/DatasetEdit.present.js
+++ b/src/project/datasets/edit/DatasetEdit.present.js
@@ -24,7 +24,7 @@
  */
 
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { Row, Col, Alert, Button } from "reactstrap";
 import { FormPanel } from "../../../utils/formgenerator";
 import { ACCESS_LEVELS } from "../../../api-client";
@@ -38,6 +38,7 @@ function DatasetEdit(props) {
   const [submitLoader, setSubmitLoader] = useState(false);
   const [initialized, setInitialized] = useState(false);
   const [initalFiles, setInitialFiles] = useState([]);
+  props.datasetFormSchema.files.filesOnUploader = useRef(0);
 
   const onCancel = e => {
     props.datasetFormSchema.name.value = props.datasetFormSchema.name.initial;
@@ -67,7 +68,7 @@ function DatasetEdit(props) {
               props.client.fetchDatasetFromKG(props.client.baseUrl.replace(
                 "api", "knowledge-graph/datasets/") + props.datasetId)
                 .then(response => {
-                  if (response.hasPart.length === (dataset.files.length + initalFiles.length)) {
+                  if (response.hasPart.length >= (dataset.files.length + initalFiles.length)) {
                     setSubmitLoader(false);
                     props.datasetFormSchema.name.value = props.datasetFormSchema.name.initial;
                     props.datasetFormSchema.description.value = props.datasetFormSchema.description.initial;
@@ -79,7 +80,7 @@ function DatasetEdit(props) {
                   }
                   else {
                     counter++;
-                    if (counter > 10) {
+                    if (counter > 15) {
                       clearInterval(waitForFilesInKG);
                       setSubmitLoader(false);
                       setServerErrors("There was an error, please try again.");

--- a/src/project/datasets/new/DatasetNew.present.js
+++ b/src/project/datasets/new/DatasetNew.present.js
@@ -24,7 +24,7 @@
  */
 
 
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 import { Row, Col, Alert, Button } from "reactstrap";
 import { FormPanel } from "../../../utils/formgenerator";
 import { ACCESS_LEVELS } from "../../../api-client";
@@ -37,6 +37,7 @@ function DatasetNew(props) {
   const [serverErrors, setServerErrors] = useState(undefined);
   const [submitLoader, setSubmitLoader] = useState(false);
   props.datasetFormSchema.files.uploadFileFunction = props.client.uploadFile;
+  props.datasetFormSchema.files.filesOnUploader = useRef(0);
 
   const onCancel = e => {
     props.datasetFormSchema.name.value = props.datasetFormSchema.name.initial;

--- a/src/utils/formgenerator/FormGenerator.css
+++ b/src/utils/formgenerator/FormGenerator.css
@@ -65,3 +65,12 @@
 	background-color: #e9ecef;
 	cursor: pointer;
 }
+
+.text-button{
+	margin-left: 5px;
+}
+
+.text-button:hover{
+	text-decoration: underline;
+	font-weight: bold;
+}

--- a/src/utils/formgenerator/FormGenerator.test.js
+++ b/src/utils/formgenerator/FormGenerator.test.js
@@ -99,15 +99,15 @@ describe("rendering on modify", () => {
 
 describe("validators", () => {
   it("checks at least length true", () => {
-    expect(FormGenerator.Validators.isAtLeastLength("Hello World", 3)).toEqual(true);
+    expect(FormGenerator.Validators.isAtLeastLength({ value: "Hello World" }, 3)).toEqual(true);
   });
   it("checks at least length false", () => {
-    expect(FormGenerator.Validators.isAtLeastLength("He", 3)).toEqual(false);
+    expect(FormGenerator.Validators.isAtLeastLength({ value: "He" }, 3 )).toEqual(false);
   });
   it("checks that is filled true", () => {
-    expect(FormGenerator.Validators.isNotEmpty("asdfasdf")).toEqual(true);
+    expect(FormGenerator.Validators.isNotEmpty({ value: "asdfasdf" })).toEqual(true);
   });
   it("checks that is filled false", () => {
-    expect(FormGenerator.Validators.isNotEmpty("")).toEqual(false);
+    expect(FormGenerator.Validators.isNotEmpty({ value: "" })).toEqual(false);
   });
 });

--- a/src/utils/formgenerator/UseForm.js
+++ b/src/utils/formgenerator/UseForm.js
@@ -50,7 +50,7 @@ const useForm = (initModel, submitCallback) => {
   const validateInput = input => {
     let alert = null;
     input.validators && input.validators.forEach(
-      v => alert = v.isValidFun && !v.isValidFun(input.value) ? v.alert : alert);
+      v => alert = v.isValidFun && !v.isValidFun(input) ? v.alert : alert);
     input.alert = alert;
   };
 

--- a/src/utils/formgenerator/fields/FileUploaderInput.js
+++ b/src/utils/formgenerator/fields/FileUploaderInput.js
@@ -284,11 +284,11 @@ function FileuploaderInput({ name, label, alert, value, setInputs, help, disable
         </div>;
       case FILE_STATUS.UPLOADING:
         if (file.file_uncompress === FILE_COMPRESSED.WAITING) {
-          return <div>
-            <span>unzip on upload? </span>
+          return <div className="bg-warning font-weight-bold p-1">
+            <span>Unzip on upload? </span>
             <span className="mr-2">
               <span className="text-primary text-button" style={{ whiteSpace: "nowrap", cursor: "pointer" }}
-                onClick={() => uploadCompressedFile(file.file_name, true)}>Yes</span>
+                onClick={() => uploadCompressedFile(file.file_name, true)}>Yes</span> or
               <span className="text-primary  text-button" style={{ whiteSpace: "nowrap", cursor: "pointer" }}
                 onClick={() => uploadCompressedFile(file.file_name, false)}>No</span>
             </span>

--- a/src/utils/formgenerator/fields/FileUploaderInput.js
+++ b/src/utils/formgenerator/fields/FileUploaderInput.js
@@ -27,7 +27,8 @@ import { FormGroup, Label, Table, Spinner } from "reactstrap";
 import ValidationAlert from "./ValidationAlert";
 import HelpText from "./HelpText";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faCheck, faTimes, faTrashAlt, faSyncAlt } from "@fortawesome/free-solid-svg-icons";
+import { faCheck, faTimes, faTrashAlt, faSyncAlt, faExclamationTriangle, faFolder }
+  from "@fortawesome/free-solid-svg-icons";
 import { formatBytes } from "./../../HelperFunctions";
 
 const FILE_STATUS = {
@@ -284,9 +285,10 @@ function FileuploaderInput({ name, label, alert, value, setInputs, help, disable
         </div>;
       case FILE_STATUS.UPLOADING:
         if (file.file_uncompress === FILE_COMPRESSED.WAITING) {
-          return <div className="bg-warning font-weight-bold p-1">
-            <span>Unzip on upload? </span>
-            <span className="mr-2">
+          return <div style={{ fontWeight: "600" }}>
+            <FontAwesomeIcon color="var(--warning)" icon={faExclamationTriangle} />
+            <span className="ml-1">Unzip on upload?</span>
+            <span className="mr-1">
               <span className="text-primary text-button" style={{ whiteSpace: "nowrap", cursor: "pointer" }}
                 onClick={() => uploadCompressedFile(file.file_name, true)}>Yes</span> or
               <span className="text-primary  text-button" style={{ whiteSpace: "nowrap", cursor: "pointer" }}
@@ -365,7 +367,13 @@ function FileuploaderInput({ name, label, alert, value, setInputs, help, disable
               <td colSpan="5">
                 Drag and Drop files or click <span className="text-primary"
                   style={{ cursor: "pointer" }}>here</span> to open file dialog.
-                <br /><small className="text-muted">NOTE: We are still working on the
+                <br />
+                <span className="text-muted font-italic">
+                  <FontAwesomeIcon className="pr-1" color="var(--primary)" icon={faFolder} />
+                  If you want to upload a folder you can do this using a zip file, we can unzip it for you on upload.
+                </span>
+                <br></br>
+                <small className="text-muted">NOTE: We are still working on the
                   UI upload of big files, we encourage you to use our CLI for uploading big files.
                 </small>
               </td>

--- a/src/utils/formgenerator/services/InputValidator.js
+++ b/src/utils/formgenerator/services/InputValidator.js
@@ -28,6 +28,7 @@ function checkAtLeastLength(input, length) {
 }
 
 export default {
-  isNotEmpty: input => checkAtLeastLength(input, 1),
-  isAtLeastLength: (input, minLength) => checkAtLeastLength(input, minLength)
+  isNotEmpty: input => checkAtLeastLength(input.value, 1),
+  isAtLeastLength: (input, minLength) => checkAtLeastLength(input.value, minLength),
+  filesReady: (input) => input.value.length === input.filesOnUploader.current
 };


### PR DESCRIPTION
Closes #849 

When a user uploads a zip file we ask the user if they want to unzip the file:

![image](https://user-images.githubusercontent.com/42647877/77146145-a8e78e00-6a8a-11ea-86b4-b8eca8ba7b6c.png)

After they choose all work as normal.

Possible modification: we can see if the user chose or not, at the moment all files that are not in ready state are dismissed on form submit.

Testing available in: virginiatest.dev.renku.ch