### PR TITLE
Fix notebook display issues

### DIFF
--- a/src/file/File.container.js
+++ b/src/file/File.container.js
@@ -26,6 +26,7 @@ import { ACCESS_LEVELS } from "../api-client";
 import { StatusHelper } from "../model/Model";
 import { API_ERRORS } from "../api-client";
 import { RenkuMarkdown } from "../utils/UIComponents";
+import { CardBody } from "reactstrap";
 
 const IMAGE_EXTENSIONS = ["jpg", "jpeg", "png", "tiff", "pdf", "gif"];
 const CODE_EXTENSIONS = [
@@ -76,46 +77,65 @@ class FilePreview extends React.Component {
     if (this.fileIsImage()) {
       if (atob(this.props.file.content).includes("https://git-lfs.github.com/"))
         return "The image can't be previewed because it's stored in Git LFS.";
-      return <img
-        className="image-preview"
-        alt={this.props.file.file_name}
-        src={"data:image;base64," + this.props.file.content}
-      />;
+      return (
+        <CardBody key="file preview">
+          <img
+            className="image-preview"
+            alt={this.props.file.file_name}
+            src={"data:image;base64," + this.props.file.content}
+          />
+        </CardBody>
+      );
     }
     // Code with syntax highlighting
     if (this.fileIsCode()) {
       return (
-        <pre className={`hljs ${this.getFileExtension()}`}>
-          <code>{atobUTF8(this.props.file.content)}</code>
-        </pre>
+        <CardBody key="file preview">
+          <pre className={`hljs ${this.getFileExtension()}`}>
+            <code>{atobUTF8(this.props.file.content)}</code>
+          </pre>
+        </CardBody>
       );
     }
     // Markdown
     if (this.getFileExtension() === "md") {
       let content = atobUTF8(this.props.file.content);
-      return <RenkuMarkdown markdownText={content} />;
+      return (
+        <CardBody key="file preview">
+          <RenkuMarkdown markdownText={content} />{" "}
+        </CardBody>
+      );
     }
 
     // Jupyter Notebook
     if (this.getFileExtension() === "ipynb") {
-      return <JupyterNotebookContainer
-        key="notebook-body"
-        notebook={JSON.parse(atobUTF8(this.props.file.content))}
-        filePath={this.props.file.file_path}
-        {...this.props}
-      />;
+      return (
+        // Do not wrap in a CardBody, the notebook container does that itself
+        <JupyterNotebookContainer
+          key="notebook-body"
+          notebook={JSON.parse(atobUTF8(this.props.file.content))}
+          filePath={this.props.file.file_path}
+          {...this.props}
+        />
+      );
     }
 
     if (this.fileHasNoExtension()) {
       return (
-        <pre className={`hljs ${this.getFileExtension()}`}>
-          <code>{atobUTF8(this.props.file.content)}</code>
-        </pre>
+        <CardBody key="file preview">
+          <pre className={`hljs ${this.getFileExtension()}`}>
+            <code>{atobUTF8(this.props.file.content)}</code>
+          </pre>
+        </CardBody>
       );
     }
 
     // File extension not supported
-    return <p>{`Unable to preview file with extension .${this.getFileExtension()}`}</p>;
+    return (
+      <CardBody key="file preview">
+        <p>{`Unable to preview file with extension .${this.getFileExtension()}`}</p>
+      </CardBody>
+    );
   }
 }
 

--- a/src/file/File.container.js
+++ b/src/file/File.container.js
@@ -100,7 +100,7 @@ class FilePreview extends React.Component {
     if (this.getFileExtension() === "ipynb") {
       return <JupyterNotebookContainer
         key="notebook-body"
-        notebook={JSON.parse(atobUTF8(this.props.file.content), (key, value) => Object.freeze(value))}
+        notebook={JSON.parse(atobUTF8(this.props.file.content))}
         filePath={this.props.file.file_path}
         {...this.props}
       />;

--- a/src/file/File.present.js
+++ b/src/file/File.present.js
@@ -35,7 +35,6 @@ import { Time } from "../utils/Time";
 
 const commitMessageLengthLimit = 120;
 
-
 /**
  * Display the Card with file information. Has the following parameters:
  *
@@ -53,43 +52,49 @@ class FileCard extends React.Component {
     let commitHeader = null;
     if (this.props.commit) {
       const commitLinkHref = `${this.props.gitLabUrl}/commit/${this.props.commit.id}`;
-      const title = (this.props.commit.title.length > commitMessageLengthLimit) ?
-        this.props.commit.title.slice(0, commitMessageLengthLimit) + "..." :
-        this.props.commit.title;
-      commitHeader = <ListGroup flush>
-        <ListGroupItem>
-          <div className="d-flex justify-content-between flex-wrap">
-            <div>
-              <a href={commitLinkHref} target="_blank" rel="noreferrer noopener">
-                Commit: {this.props.commit.short_id}
-              </a> &nbsp;
-              {title}
+      const title =
+        this.props.commit.title.length > commitMessageLengthLimit
+          ? this.props.commit.title.slice(0, commitMessageLengthLimit) + "..."
+          : this.props.commit.title;
+      commitHeader = (
+        <ListGroup flush>
+          <ListGroupItem>
+            <div className="d-flex justify-content-between flex-wrap">
+              <div>
+                <a href={commitLinkHref} target="_blank" rel="noreferrer noopener">
+                  Commit: {this.props.commit.short_id}
+                </a>{" "}
+                &nbsp;
+                {title}
+              </div>
+              <div className="caption">
+                {this.props.commit.author_name} &nbsp;
+                {Time.toIsoString(this.props.commit.committed_date)}
+              </div>
             </div>
-            <div className="caption">
-              {this.props.commit.author_name} &nbsp;
-              {Time.toIsoString(this.props.commit.committed_date)}
-            </div>
-          </div>
-        </ListGroupItem>
-      </ListGroup>;
+          </ListGroupItem>
+        </ListGroup>
+      );
     }
-    return <Card>
-      <CardHeader className="align-items-baseline">
-        {this.props.lfsBadge}
-        {this.props.filePath}
-        &nbsp;
-        <Clipboard clipboardText={this.props.filePath} />
-        &nbsp;
-        <span className="caption align-baseline">&nbsp;File view</span>
-        <div className="float-right">
-          {this.props.buttonJupyter}
-          {this.props.buttonGit}
-          {this.props.buttonGraph}
-        </div>
-      </CardHeader>
-      {commitHeader}
-      <CardBody>{this.props.body}</CardBody>
-    </Card>;
+    return (
+      <Card>
+        <CardHeader className="align-items-baseline">
+          {this.props.lfsBadge}
+          {this.props.filePath}
+          &nbsp;
+          <Clipboard clipboardText={this.props.filePath} />
+          &nbsp;
+          <span className="caption align-baseline">&nbsp;File view</span>
+          <div className="float-right">
+            {this.props.buttonJupyter}
+            {this.props.buttonGit}
+            {this.props.buttonGraph}
+          </div>
+        </CardHeader>
+        {commitHeader}
+        <CardBody>{this.props.body}</CardBody>
+      </Card>
+    );
   }
 }
 
@@ -106,57 +111,97 @@ class FileCard extends React.Component {
  * @param {Object} error - The error object from GitLab (can be null)
  */
 class ShowFile extends React.Component {
-
   render() {
     const gitLabFilePath = this.props.gitLabFilePath;
-    const buttonGraph = this.props.lineagesPath !== undefined ?
-      <IconLink tooltip="Graph View" icon={faProjectDiagram} to={`${this.props.lineagesPath}/${gitLabFilePath}`} />
-      : null;
+    const buttonGraph =
+      this.props.lineagesPath !== undefined ? (
+        <IconLink tooltip="Graph View" icon={faProjectDiagram} to={`${this.props.lineagesPath}/${gitLabFilePath}`} />
+      ) : null;
 
-    const buttonGit = <ExternalIconLink
-      tooltip="Open in GitLab" icon={faGitlab} to={`${this.props.externalUrl}/blob/master/${gitLabFilePath}`} />;
+    const buttonGit = (
+      <ExternalIconLink
+        tooltip="Open in GitLab"
+        icon={faGitlab}
+        to={`${this.props.externalUrl}/blob/master/${gitLabFilePath}`}
+      />
+    );
 
     if (this.props.error !== null) {
-      return <FileCard gitLabUrl={this.props.externalUrl}
-        filePath={this.props.gitLabFilePath.split("\\").pop().split("/").pop()}
+      return (
+        <FileCard
+          gitLabUrl={this.props.externalUrl}
+          filePath={this.props.gitLabFilePath
+            .split("\\")
+            .pop()
+            .split("/")
+            .pop()}
+          commit={this.props.commit}
+          buttonGraph={buttonGraph}
+          buttonGit={buttonGit}
+          buttonJupyter={this.props.buttonJupyter}
+          body={this.props.error}
+          lfsBadge={null}
+        />
+      );
+    }
+
+    if (this.props.file == null) {
+      return (
+        <Card>
+          <CardHeader className="align-items-baseline">&nbsp;</CardHeader>
+          <CardBody>{"Loading..."}</CardBody>
+        </Card>
+      );
+    }
+
+    const isLFS = this.props.hashElement ? this.props.hashElement.isLfs : false;
+    const isLFSBadge = isLFS ? (
+      <Badge className="lfs-badge" color="light">
+        LFS
+      </Badge>
+    ) : null;
+
+    const body = <FilePreview file={this.props.file} {...this.props} />;
+
+    return (
+      <FileCard
+        gitLabUrl={this.props.externalUrl}
+        filePath={this.props.filePath}
         commit={this.props.commit}
         buttonGraph={buttonGraph}
         buttonGit={buttonGit}
         buttonJupyter={this.props.buttonJupyter}
-        body={this.props.error}
-        lfsBadge={null} />;
-    }
-
-    if (this.props.file == null) {
-      return <Card>
-        <CardHeader className="align-items-baseline">&nbsp;</CardHeader>
-        <CardBody>{"Loading..."}</CardBody>
-      </Card>;
-    }
-
-    const isLFS = this.props.hashElement ? this.props.hashElement.isLfs : false;
-    const isLFSBadge = isLFS ?
-      <Badge className="lfs-badge" color="light">LFS</Badge> :
-      null;
-
-    const body = <FilePreview
-      file={this.props.file}
-      {...this.props}
-    />;
-
-    return <FileCard gitLabUrl={this.props.externalUrl}
-      filePath={this.props.filePath}
-      commit={this.props.commit}
-      buttonGraph={buttonGraph}
-      buttonGit={buttonGit}
-      buttonJupyter={this.props.buttonJupyter}
-      body={body}
-      lfsBadge={isLFSBadge} />;
+        body={body}
+        lfsBadge={isLFSBadge}
+      />
+    );
   }
 }
 
-class StyledNotebook extends React.Component {
+/**
+ * Modify the notebook metadata so it is correctly processed by the renderer.
+ *
+ * @param {object} [nb] - The notebook to process
+ */
+function tweakCellMetadata(nb) {
+  // Scan the cell metadata, and, if jupyter.source_hidden === true, set hide_input = true
+  const result = { ...nb };
+  result.cells = [];
+  nb.cells.forEach(cell => {
+    if (cell.metadata.jupyter == null) {
+      result.cells.push(cell);
+    }
+    else {
+      const clone = { ...cell };
+      clone.metadata = { ...cell.metadata };
+      clone.metadata.hide_input = clone.metadata.jupyter.source_hidden;
+      result.cells.push(clone);
+    }
+  });
+  return result;
+}
 
+class StyledNotebook extends React.Component {
   componentDidMount() {
     // TODO go through the dom and modify the nodes, e.g., with D3
     //this.fixUpDom(ReactDOM.findDOMNode(this.notebook));
@@ -164,14 +209,16 @@ class StyledNotebook extends React.Component {
 
   render() {
     if (this.props.notebook == null) return <div>Loading...</div>;
+    const notebook = tweakCellMetadata(this.props.notebook);
     return [
       <NotebookPreview
         key="notebook"
-        ref={c => { this.notebook = c; }}
+        ref={c => {
+          this.notebook = c;
+        }}
         defaultStyle={false}
         loadMathjax={false}
-        notebook={this.props.notebook}
-        showCode={true}
+        notebook={notebook}
       />
     ];
   }
@@ -180,10 +227,9 @@ class StyledNotebook extends React.Component {
 class JupyterButtonPresent extends React.Component {
   render() {
     if (!this.props.access)
-      return (<CheckNotebookIcon fetched={true} launchNotebookUrl={this.props.launchNotebookUrl} />);
+      return <CheckNotebookIcon fetched={true} launchNotebookUrl={this.props.launchNotebookUrl} />;
 
-    if (this.props.updating)
-      return (<Loader size="16" inline="true" />);
+    if (this.props.updating) return <Loader size="16" inline="true" />;
 
     return (
       <CheckNotebookStatus
@@ -191,9 +237,10 @@ class JupyterButtonPresent extends React.Component {
         model={this.props.model}
         scope={this.props.scope}
         launchNotebookUrl={this.props.launchNotebookUrl}
-        filePath={this.props.filePath} />
+        filePath={this.props.filePath}
+      />
     );
   }
 }
 
-export { StyledNotebook, JupyterButtonPresent, ShowFile };
+export { StyledNotebook, JupyterButtonPresent, ShowFile, tweakCellMetadata };

--- a/src/file/File.present.js
+++ b/src/file/File.present.js
@@ -164,18 +164,7 @@ class StyledNotebook extends React.Component {
 
   render() {
     if (this.props.notebook == null) return <div>Loading...</div>;
-
-    const notebookStyle = `
-    .jupyter .output img {
-      max-width: 100%;
-      margin-left: auto;
-      margin-right: auto;
-      display: block;
-    }
-    `;
-
     return [
-      <style key="notebook-style">{notebookStyle}</style>,
       <NotebookPreview
         key="notebook"
         ref={c => { this.notebook = c; }}

--- a/src/file/File.test.js
+++ b/src/file/File.test.js
@@ -31,7 +31,7 @@ import { testClient as client } from "../api-client";
 import { generateFakeUser } from "../user/User.test";
 import { ShowFile, JupyterButton } from "./index";
 import { StateModel, globalSchema } from "../model";
-import { tweakCellMetadata } from "./File.present";
+import { NotebookSourceDisplayMode, tweakCellMetadata } from "./File.present";
 
 const model = new StateModel(globalSchema);
 
@@ -210,5 +210,116 @@ describe("cell metadata messaging", () => {
     expect(result.cells[0]).toEqual(notebook.cells[0]);
     expect(notebook.cells[1].metadata.hide_input).toEqual(undefined);
     expect(result.cells[1].metadata.hide_input).toEqual(true);
+  });
+
+  const modeNotebook = {
+    cells: [
+      {
+        cell_type: "code",
+        execution_count: 3,
+        metadata: {},
+        outputs: [
+          {
+            name: "stdout",
+            output_type: "stream",
+            text: ["show input\n"]
+          }
+        ],
+        source: ['print("show input")']
+      },
+      {
+        cell_type: "code",
+        execution_count: 4,
+        metadata: {
+          jupyter: {
+            source_hidden: true
+          },
+          papermill: {
+            duration: 0.48317,
+            end_time: "2020-03-31T08:27:03.045655",
+            exception: false,
+            start_time: "2020-03-31T08:27:02.562485",
+            status: "completed"
+          },
+          tags: []
+        },
+        outputs: [
+          {
+            name: "stdout",
+            output_type: "stream",
+            text: ["hide input\n"]
+          }
+        ],
+        source: ['print("hide input")']
+      },
+      {
+        cell_type: "code",
+        execution_count: 5,
+        metadata: {
+          hide_input: true,
+          papermill: {
+            duration: 0.48317,
+            end_time: "2020-03-31T08:27:03.045655",
+            exception: false,
+            start_time: "2020-03-31T08:27:02.562485",
+            status: "completed"
+          },
+          tags: []
+        },
+        outputs: [
+          {
+            name: "stdout",
+            output_type: "stream",
+            text: ["hide too\n"]
+          }
+        ],
+        source: ['print("hide too")']
+      }
+    ],
+    metadata: {
+      hide_input: true,
+      kernelspec: {
+        display_name: "Python 3",
+        language: "python",
+        name: "python3"
+      },
+      language_info: {
+        codemirror_mode: {
+          name: "ipython",
+          version: 3
+        },
+        file_extension: ".py",
+        mimetype: "text/x-python",
+        name: "python",
+        nbconvert_exporter: "python",
+        pygments_lexer: "ipython3",
+        version: "3.7.4"
+      }
+    },
+    nbformat: 4,
+    nbformat_minor: 4
+  };
+
+  it("handles default mode correctly", () => {
+    const result = tweakCellMetadata(modeNotebook, NotebookSourceDisplayMode.DEFAULT);
+    expect(result.cells[0]).toEqual(modeNotebook.cells[0]);
+    expect(modeNotebook.cells[1].metadata.hide_input).toEqual(undefined);
+    expect(result.cells[1].metadata.hide_input).toEqual(true);
+  });
+  it("handles hidden mode correctly", () => {
+    const result = tweakCellMetadata(modeNotebook, NotebookSourceDisplayMode.HIDDEN);
+    expect(modeNotebook.cells[0].metadata.hide_input).toEqual(undefined);
+    expect(result.cells[0].metadata.hide_input).toEqual(true);
+    expect(modeNotebook.cells[1].metadata.hide_input).toEqual(undefined);
+    expect(result.cells[1].metadata.hide_input).toEqual(true);
+  });
+  it("handles shown mode correctly", () => {
+    const result = tweakCellMetadata(modeNotebook, NotebookSourceDisplayMode.SHOWN);
+    expect(modeNotebook.cells[0].metadata.hide_input).toEqual(undefined);
+    expect(result.cells[0].metadata.hide_input).toEqual(false);
+    expect(modeNotebook.cells[1].metadata.hide_input).toEqual(undefined);
+    expect(result.cells[1].metadata.hide_input).toEqual(false);
+    expect(modeNotebook.metadata.hide_input).toEqual(true);
+    expect(result.metadata.hide_input).toEqual(false);
   });
 });

--- a/src/file/File.test.js
+++ b/src/file/File.test.js
@@ -31,7 +31,7 @@ import { testClient as client } from "../api-client";
 import { generateFakeUser } from "../user/User.test";
 import { ShowFile, JupyterButton } from "./index";
 import { StateModel, globalSchema } from "../model";
-
+import { tweakCellMetadata } from "./File.present";
 
 const model = new StateModel(globalSchema);
 
@@ -46,7 +46,7 @@ describe("rendering", () => {
     model,
     filePath: "/projects/1/files/blob/myFolder/myNotebook.ipynb",
     match: { url: "/projects/1", params: { id: "1" } },
-    launchNotebookUrl: "/projects/1/launchNotebook",
+    launchNotebookUrl: "/projects/1/launchNotebook"
   };
 
   for (let user of users) {
@@ -54,11 +54,13 @@ describe("rendering", () => {
       const div = document.createElement("div");
       // * fix for tooltips https://github.com/reactstrap/reactstrap/issues/773#issuecomment-357409863
       document.body.appendChild(div);
-      const branches = { all: [], fetch: () => { } };
+      const branches = { all: [], fetch: () => {} };
       ReactDOM.render(
         <MemoryRouter>
           <JupyterButton user={user.data} branches={branches} {...props} />
-        </MemoryRouter>, div);
+        </MemoryRouter>,
+        div
+      );
     });
 
     it(`renders ShowFile for ${user.type} user`, () => {
@@ -67,7 +69,146 @@ describe("rendering", () => {
       ReactDOM.render(
         <MemoryRouter>
           <ShowFile user={user.data} {...props} />
-        </MemoryRouter>, div);
+        </MemoryRouter>,
+        div
+      );
     });
   }
+});
+
+describe("cell metadata messaging", () => {
+  it("leaves cell metadata unmodified if not necessary", () => {
+    const notebook = {
+      cells: [
+        {
+          cell_type: "code",
+          execution_count: 3,
+          metadata: {},
+          outputs: [
+            {
+              name: "stdout",
+              output_type: "stream",
+              text: ["show input\n"]
+            }
+          ],
+          source: ['print("show input")']
+        }
+      ],
+      metadata: {
+        kernelspec: {
+          display_name: "Python 3",
+          language: "python",
+          name: "python3"
+        },
+        language_info: {
+          codemirror_mode: {
+            name: "ipython",
+            version: 3
+          },
+          file_extension: ".py",
+          mimetype: "text/x-python",
+          name: "python",
+          nbconvert_exporter: "python",
+          pygments_lexer: "ipython3",
+          version: "3.7.4"
+        }
+      },
+      nbformat: 4,
+      nbformat_minor: 4
+    };
+    const result = tweakCellMetadata(notebook);
+    expect(result).toEqual(notebook);
+  });
+  it("modifies the cells that are necessary", () => {
+    const notebook = {
+      cells: [
+        {
+          cell_type: "code",
+          execution_count: 3,
+          metadata: {},
+          outputs: [
+            {
+              name: "stdout",
+              output_type: "stream",
+              text: ["show input\n"]
+            }
+          ],
+          source: ['print("show input")']
+        },
+        {
+          cell_type: "code",
+          execution_count: 4,
+          metadata: {
+            jupyter: {
+              source_hidden: true
+            },
+            papermill: {
+              duration: 0.48317,
+              end_time: "2020-03-31T08:27:03.045655",
+              exception: false,
+              start_time: "2020-03-31T08:27:02.562485",
+              status: "completed"
+            },
+            tags: []
+          },
+          outputs: [
+            {
+              name: "stdout",
+              output_type: "stream",
+              text: ["hide input\n"]
+            }
+          ],
+          source: ['print("hide input")']
+        },
+        {
+          cell_type: "code",
+          execution_count: 5,
+          metadata: {
+            hide_input: true,
+            papermill: {
+              duration: 0.48317,
+              end_time: "2020-03-31T08:27:03.045655",
+              exception: false,
+              start_time: "2020-03-31T08:27:02.562485",
+              status: "completed"
+            },
+            tags: []
+          },
+          outputs: [
+            {
+              name: "stdout",
+              output_type: "stream",
+              text: ["hide too\n"]
+            }
+          ],
+          source: ['print("hide too")']
+        }
+      ],
+      metadata: {
+        kernelspec: {
+          display_name: "Python 3",
+          language: "python",
+          name: "python3"
+        },
+        language_info: {
+          codemirror_mode: {
+            name: "ipython",
+            version: 3
+          },
+          file_extension: ".py",
+          mimetype: "text/x-python",
+          name: "python",
+          nbconvert_exporter: "python",
+          pygments_lexer: "ipython3",
+          version: "3.7.4"
+        }
+      },
+      nbformat: 4,
+      nbformat_minor: 4
+    };
+    const result = tweakCellMetadata(notebook);
+    expect(result.cells[0]).toEqual(notebook.cells[0]);
+    expect(notebook.cells[1].metadata.hide_input).toEqual(undefined);
+    expect(result.cells[1].metadata.hide_input).toEqual(true);
+  });
 });

--- a/src/styles/_jupyter_notebook.scss
+++ b/src/styles/_jupyter_notebook.scss
@@ -1,30 +1,42 @@
+@import url('https://fonts.googleapis.com/css2?family=Source+Code+Pro:ital,wght@0,400;0,500;1,400&display=swap');
 
 .dataframe {
-    @extend .table
+  @extend .table-sm;
+  @extend .table-striped;
+  border-width: 0px;
+  border-style: none;
+  border-collapse: collapse;
+  thead {
+    border-bottom-color:rgb(189, 189, 189);
+
+    th {
+      border-style: none;
+      border-bottom-style: solid;
+      border-bottom-width: 2px;
+      border-collapse: collapse;
+    }
+  }
+  tbody {
+    th {
+      border-width: 0px;
+      border-style: none;
+      border-collapse: collapse;
+    }
+    td {
+      border-width: 0px;
+      border-style: none;
+      border-collapse: collapse;
+    }
+  }
 }
 
-.dataframe tbody td {
-  text-align: right;
+.jupyter .output img {
+  max-width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+  display: block;
 }
 
-.jupyter .output td {
-  border-bottom: 0px solid #FFF;
-  border-left: 0px solid #FFF;
-  border-right: 0px solid #FFF;
-}
-
-.jupyter .output th {
-  border-bottom: 0px solid #FFF;
-  border-left: 0px solid #FFF;
-  border-right: 0px solid #FFF;
-}
-
-
-.jupyter .output table  {
-  border: none;
-}
-
-.jupyter .output  {
-  @extend .table;
-  // border: 0px solid #FFF;
+code {
+  color: black;
 }

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -8,4 +8,4 @@
 @import 'underline_pill_nav';
 
 // Jupyter notebook styles
-// @import 'jupyter_notebook';
+@import 'jupyter_notebook';


### PR DESCRIPTION
Fix #838 (Allow hiding/showing of notebook cells)

Also:
* Use Source Code Pro for output display
* Show stdout output in black
* Style tables as bootstrap tables

## Testing (compare old/new)

See the difference in fonts and colors

* https://dev.renku.ch/projects/cramakri/notebook-rendering/files/blob/notebooks/ouput-test.ipynb
* https://sekhar.dev.renku.ch/projects/cramakri/notebook-rendering/files/blob/notebooks/ouput-test.ipynb


See how the input cells are hidden when papermill runs in report mode

* https://dev.renku.ch/projects/cramakri/notebook-rendering/files/blob/notebooks/tables-test-report.ran.ipynb
* https://sekhar.dev.renku.ch/projects/cramakri/notebook-rendering/files/blob/notebooks/tables-test-report.ran.ipynb


See how the tables look different

* https://dev.renku.ch/projects/cramakri/notebook-rendering/files/blob/notebooks/tables-test-report.ran.ipynb
* https://sekhar.dev.renku.ch/projects/cramakri/notebook-rendering/files/blob/notebooks/tables-test-report.ran.ipynb

See how you can select if code is to be shown

* https://sekhar.dev.renku.ch/projects/cramakri/notebook-rendering/files/blob/notebooks/input-hidden-test-report.ran.ipynb (default is code hidden, but can show as well)
* https://sekhar.dev.renku.ch/projects/cramakri/notebook-rendering/files/blob/notebooks/ouput-test.ipynb (default is code shown, but can hide as well)