### PR TITLE
feat(datasets): users can add datasets that are inside renku to other projects

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -129,6 +129,7 @@ class App extends Component {
                   projectsUrl="/projects"
                   selectedDataset={p.match.params.datasetId}
                   logged={this.props.user.logged}
+                  model={this.props.model}
                 />}
               />
               <Route path="/datasets" render={

--- a/src/App.js
+++ b/src/App.js
@@ -128,6 +128,7 @@ class App extends Component {
                   client={this.props.client}
                   projectsUrl="/projects"
                   selectedDataset={p.match.params.datasetId}
+                  logged={this.props.user.logged}
                 />}
               />
               <Route path="/datasets" render={

--- a/src/api-client/dataset.js
+++ b/src/api-client/dataset.js
@@ -120,7 +120,7 @@ export default function addDatasetMethods(client) {
       });
   };
 
-  client.datasetImport = (projectUrl, renkuDataset) => {
+  client.datasetImport = (projectUrl, datasetUrl) => {
     let headers = client.getBasicHeaders();
     headers.append("Content-Type", "application/json");
     headers.append("X-Requested-With", "XMLHttpRequest");
@@ -144,7 +144,7 @@ export default function addDatasetMethods(client) {
         method: "POST",
         headers: headers,
         body: JSON.stringify({
-          "dataset_uri": renkuDataset.uri,
+          "dataset_uri": datasetUrl,
           "project_id": project_id
         })
       });

--- a/src/api-client/project.js
+++ b/src/api-client/project.js
@@ -107,6 +107,35 @@ function addProjectMethods(client) {
     });
   };
 
+  client.getAllProjects = (extraParams = [],
+    { recursive = false, per_page = 20, page = 1, previousResults = [] } = {}
+  ) => {
+    let headers = client.getBasicHeaders();
+
+    const queryParams = {
+      recursive,
+      per_page,
+      page,
+      ...extraParams
+    };
+
+    return client.clientFetch(`${client.baseUrl}/projects`, {
+      method: "GET",
+      headers,
+      queryParams,
+    }).then(response => {
+      if (response.pagination.nextPageLink !== undefined) {
+        return client.getAllProjects(extraParams, {
+          recursive,
+          per_page,
+          previousResults: previousResults.concat(response.data),
+          page: response.pagination.nextPage
+        });
+      }
+      return previousResults.concat(response.data);
+    });
+  };
+
   client.getAvatarForNamespace = (namespaceId = {}) => {
     let headers = client.getBasicHeaders();
     return client.clientFetch(`${client.baseUrl}/groups/${namespaceId}`, {

--- a/src/dataset/Dataset.container.js
+++ b/src/dataset/Dataset.container.js
@@ -36,5 +36,6 @@ export default function ShowDataset(props) {
     selectedDataset={props.selectedDataset}
     history={props.history}
     logged={props.logged}
+    model={props.model}
   />;
 }

--- a/src/dataset/Dataset.container.js
+++ b/src/dataset/Dataset.container.js
@@ -34,5 +34,7 @@ export default function ShowDataset(props) {
     client={props.client}
     datasets={props.datasets}
     selectedDataset={props.selectedDataset}
+    history={props.history}
+    logged={props.logged}
   />;
 }

--- a/src/dataset/Dataset.present.js
+++ b/src/dataset/Dataset.present.js
@@ -168,7 +168,7 @@ export default function DatasetView(props) {
 
   return <Col>
     <Row>
-      <Col md={7} sm={12}>
+      <Col md={8} sm={12}>
         {
           dataset.published !== undefined && dataset.published.datePublished !== undefined ?
             <small style={{ display: "block", paddingBottom: "8px" }} className="font-weight-light font-italic">
@@ -178,30 +178,29 @@ export default function DatasetView(props) {
         }
         <h4 key="datasetTitle">
           {dataset.name}
+          { dataset.url && (props.insideProject || dataset.sameAs.includes("doi.org")) ?
+            <a href={dataset.url} target="_blank" rel="noreferrer noopener">
+              <Button size="sm" color="link" style={{ color: "rgba(0, 0, 0, 0.5)" }}>
+                <FontAwesomeIcon icon={faExternalLinkAlt} color="dark" /> Go to source
+              </Button>
+            </a>
+            : null
+          }
         </h4>
       </Col>
-      <Col md={5} sm={12}>
+      <Col md={4} sm={12}>
         { props.logged ?
-          <Button className="float-right" size="sm" outline color="dark" onClick={()=>setAddDatasetModalOpen(true)}>
+          <Button className="float-right mb-1" size="sm" color="primary" onClick={()=>setAddDatasetModalOpen(true)}>
             <FontAwesomeIcon icon={faPlus} color="dark" /> Add to project
           </Button>
           : null
         }
         {props.insideProject && props.maintainer ?
-          <Link className="float-right mr-1" to={{ pathname: "modify", state: { dataset: dataset } }} >
-            <Button size="sm" outline color="dark" >
+          <Link className="float-right mr-1 mb-1" to={{ pathname: "modify", state: { dataset: dataset } }} >
+            <Button size="sm" color="primary" >
               <FontAwesomeIcon icon={faPen} color="dark" /> Modify
             </Button>
           </Link>
-          : null
-        }
-        { dataset.url &&
-        (props.insideProject || dataset.sameAs.includes("doi.org")) ?
-          <a className="float-right mr-1" href={dataset.url} target="_blank" rel="noreferrer noopener">
-            <Button size="sm" outline color="dark" >
-              <FontAwesomeIcon icon={faExternalLinkAlt} color="dark" /> Go to source
-            </Button>
-          </a>
           : null
         }
       </Col>

--- a/src/dataset/Dataset.present.js
+++ b/src/dataset/Dataset.present.js
@@ -168,7 +168,7 @@ export default function DatasetView(props) {
 
   return <Col>
     <Row>
-      <Col md={8} sm={12}>
+      <Col md={7} sm={12}>
         {
           dataset.published !== undefined && dataset.published.datePublished !== undefined ?
             <small style={{ display: "block", paddingBottom: "8px" }} className="font-weight-light font-italic">

--- a/src/dataset/Dataset.present.js
+++ b/src/dataset/Dataset.present.js
@@ -23,8 +23,9 @@ import { Loader, FileExplorer } from "../utils/UIComponents";
 import DOMPurify from "dompurify";
 import { API_ERRORS } from "../api-client";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faExternalLinkAlt, faPen } from "@fortawesome/free-solid-svg-icons";
+import { faExternalLinkAlt, faPen, faPlus } from "@fortawesome/free-solid-svg-icons";
 import Time from "../utils/Time";
+import AddDataset from "./addtoproject/DatasetAdd.container";
 
 function DisplayFiles(props) {
   if (props.files === undefined) return null;
@@ -98,6 +99,7 @@ export default function DatasetView(props) {
 
   const [dataset, setDataset] = useState(undefined);
   const [fetchError, setFetchError] = useState(null);
+  const [addDatasetModalOpen, setAddDatasetModalOpen] = useState(false);
 
   useEffect(() => {
     let unmounted = false;
@@ -166,7 +168,7 @@ export default function DatasetView(props) {
 
   return <Col>
     <Row>
-      <Col md={8} sm={12}>
+      <Col md={7} sm={12}>
         {
           dataset.published !== undefined && dataset.published.datePublished !== undefined ?
             <small style={{ display: "block", paddingBottom: "8px" }} className="font-weight-light font-italic">
@@ -178,9 +180,15 @@ export default function DatasetView(props) {
           {dataset.name}
         </h4>
       </Col>
-      <Col md={4} sm={12}>
+      <Col md={5} sm={12}>
+        { props.logged ?
+          <Button className="float-right" size="sm" outline color="dark" onClick={()=>setAddDatasetModalOpen(true)}>
+            <FontAwesomeIcon icon={faPlus} color="dark" /> Add to project
+          </Button>
+          : null
+        }
         {props.insideProject && props.maintainer ?
-          <Link className="float-right" to={{ pathname: "modify", state: { dataset: dataset } }} >
+          <Link className="float-right mr-1" to={{ pathname: "modify", state: { dataset: dataset } }} >
             <Button size="sm" outline color="dark" >
               <FontAwesomeIcon icon={faPen} color="dark" /> Modify
             </Button>
@@ -194,7 +202,6 @@ export default function DatasetView(props) {
               <FontAwesomeIcon icon={faExternalLinkAlt} color="dark" /> Go to source
             </Button>
           </a>
-
           : null
         }
       </Col>
@@ -234,5 +241,17 @@ export default function DatasetView(props) {
       projects={dataset.isPartOf}
       projectsUrl={props.projectsUrl}
     />
+    {
+      props.logged ?
+        <AddDataset
+          dataset={dataset}
+          modalOpen={addDatasetModalOpen}
+          setModalOpen={setAddDatasetModalOpen}
+          history={props.history}
+          client={props.client}
+          user={props.user} />
+        : null
+    }
+
   </Col>;
 }

--- a/src/dataset/Dataset.present.js
+++ b/src/dataset/Dataset.present.js
@@ -168,7 +168,7 @@ export default function DatasetView(props) {
 
   return <Col>
     <Row>
-      <Col md={7} sm={12}>
+      <Col md={8} sm={12}>
         {
           dataset.published !== undefined && dataset.published.datePublished !== undefined ?
             <small style={{ display: "block", paddingBottom: "8px" }} className="font-weight-light font-italic">

--- a/src/dataset/Dataset.present.js
+++ b/src/dataset/Dataset.present.js
@@ -26,6 +26,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faExternalLinkAlt, faPen, faPlus } from "@fortawesome/free-solid-svg-icons";
 import Time from "../utils/Time";
 import AddDataset from "./addtoproject/DatasetAdd.container";
+import { ProjectsCoordinator } from "../project/shared";
 
 function DisplayFiles(props) {
   if (props.files === undefined) return null;
@@ -246,6 +247,8 @@ export default function DatasetView(props) {
           dataset={dataset}
           modalOpen={addDatasetModalOpen}
           setModalOpen={setAddDatasetModalOpen}
+          projectsCoordinator={new ProjectsCoordinator(props.client, props.model.subModel("projects"))}
+          model={props.model}
           history={props.history}
           client={props.client}
           user={props.user} />

--- a/src/dataset/addtoproject/DatasetAdd.container.js
+++ b/src/dataset/addtoproject/DatasetAdd.container.js
@@ -37,7 +37,7 @@ function AddDataset(props) {
 
   const closeModal = () =>{
     if (!submitLoader) {
-      addDatasetToProjectSchema.project.value = undefined;
+      addDatasetToProjectSchema.project.value = "";
       addDatasetToProjectSchema.project.options = [];
       props.setModalOpen(false);
     }
@@ -48,7 +48,7 @@ function AddDataset(props) {
       oldDatasetsList.find(ods => ds.identifier === ods.identifier) === undefined);
     if (new_dataset.length > 0) {
       setSubmitLoader(false);
-      addDatasetToProjectSchema.project.value = undefined;
+      addDatasetToProjectSchema.project.value = "";
       addDatasetToProjectSchema.project.options = [];
       clearInterval(waitForDatasetInKG);
       props.history.push({
@@ -141,7 +141,7 @@ function AddDataset(props) {
 
   useEffect(()=> {
     if (addDatasetToProjectSchema.project.options.length === 0) {
-      props.client.getProjects({ min_access_level: ACCESS_LEVELS.MAINTAINER, order_by: "last_activity_at" })
+      props.client.getProjects({ min_access_level: ACCESS_LEVELS.MAINTAINER })
         .then((projectResponse) => {
           const projectsDropdown = projectResponse.data.map((project) => {
             return {
@@ -149,8 +149,11 @@ function AddDataset(props) {
               "name": project.path_with_namespace
             };
           });
-          addDatasetToProjectSchema.project.value = projectsDropdown[0].value;
-          addDatasetToProjectSchema.project.options = projectsDropdown;
+          addDatasetToProjectSchema.project.value = "";
+          addDatasetToProjectSchema.project.options = projectsDropdown.sort(
+            (a, b) => (a.name > b.name) ? 1 :
+              ((b.name > a.name) ? -1 : 0));
+
         });
     }
   });

--- a/src/dataset/addtoproject/DatasetAdd.container.js
+++ b/src/dataset/addtoproject/DatasetAdd.container.js
@@ -28,12 +28,13 @@ import React, { useState, useEffect } from "react";
 import { addDatasetToProjectSchema } from "../../model/RenkuModels";
 import { ACCESS_LEVELS } from "../../api-client";
 import DatasetAdd from "./DatasetAdd.present";
+import { ImportStateMessage } from "../../utils/Dataset";
 
 function AddDataset(props) {
 
   const [serverErrors, setServerErrors] = useState(undefined);
   const [submitLoader, setSubmitLoader] = useState(false);
-  const [submitLoaderText, setSubmitLoaderText] = useState("Please wait, dataset import will start soon.");
+  const [submitLoaderText, setSubmitLoaderText] = useState(ImportStateMessage.ENQUEUED);
 
   const closeModal = () =>{
     if (!submitLoader) {
@@ -72,31 +73,30 @@ function AddDataset(props) {
   function handleJobResponse(job, monitorJob, cont, oldDatasetsList, projectPath) {
     switch (job.state) {
       case "ENQUEUED":
-        setSubmitLoaderText("Dataset import will start soon.");
+        setSubmitLoaderText(ImportStateMessage.ENQUEUED);
         break;
       case "IN_PROGRESS":
-        setSubmitLoaderText("Importing dataset.");
+        setSubmitLoaderText(ImportStateMessage.IN_PROGRESS);
         break;
       case "COMPLETED":
-        setSubmitLoaderText("Dataset was imported, you will be redirected soon.");
+        setSubmitLoaderText(ImportStateMessage.COMPLETED);
         clearInterval(monitorJob);
         findDatasetInKgAnRedirect(oldDatasetsList, projectPath);
         break;
       case "FAILED":
         setSubmitLoader(false);
-        setServerErrors("Dataset import failed: " + job.extras.error);
+        setServerErrors(ImportStateMessage.FAILED + job.extras.error);
         clearInterval(monitorJob);
         break;
       default:
         setSubmitLoader(false);
-        setServerErrors("Dataset import failed, plaease try again");
+        setServerErrors(ImportStateMessage.FAILED_NO_INFO);
         clearInterval(monitorJob);
         break;
     }
     if (cont === 100) {
       setSubmitLoader(false);
-      setServerErrors("Dataset import is taking too long, please check if the dataset was imported" +
-      " and if it wasn't try again.");
+      setServerErrors(ImportStateMessage.TOO_LONG);
       clearInterval(monitorJob);
     }
   }

--- a/src/dataset/addtoproject/DatasetAdd.container.js
+++ b/src/dataset/addtoproject/DatasetAdd.container.js
@@ -141,7 +141,10 @@ function AddDataset(props) {
 
   useEffect(()=> {
     if (addDatasetToProjectSchema.project.options.length === 0) {
-      props.client.getProjects({ min_access_level: ACCESS_LEVELS.MAINTAINER })
+      props.client.getProjects({
+        min_access_level: ACCESS_LEVELS.MAINTAINER,
+        order_by: "last_activity_at",
+        per_page: "100" })
         .then((projectResponse) => {
           const projectsDropdown = projectResponse.data.map((project) => {
             return {

--- a/src/dataset/addtoproject/DatasetAdd.container.js
+++ b/src/dataset/addtoproject/DatasetAdd.container.js
@@ -141,7 +141,7 @@ function AddDataset(props) {
 
   useEffect(()=> {
     if (addDatasetToProjectSchema.project.options.length === 0) {
-      props.client.getProjects({ min_access_level: ACCESS_LEVELS.MAINTAINER, order_by: "last_activity_at" })
+      props.client.getProjects({ min_access_level: ACCESS_LEVELS.MAINTAINER })
         .then((projectResponse) => {
           const projectsDropdown = projectResponse.data.map((project) => {
             return {

--- a/src/dataset/addtoproject/DatasetAdd.container.js
+++ b/src/dataset/addtoproject/DatasetAdd.container.js
@@ -141,7 +141,7 @@ function AddDataset(props) {
 
   useEffect(()=> {
     if (addDatasetToProjectSchema.project.options.length === 0) {
-      props.client.getProjects({ min_access_level: ACCESS_LEVELS.MAINTAINER })
+      props.client.getProjects({ min_access_level: ACCESS_LEVELS.MAINTAINER, order_by: "last_activity_at" })
         .then((projectResponse) => {
           const projectsDropdown = projectResponse.data.map((project) => {
             return {

--- a/src/dataset/addtoproject/DatasetAdd.present.js
+++ b/src/dataset/addtoproject/DatasetAdd.present.js
@@ -1,0 +1,59 @@
+/*!
+ * Copyright 2020 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  DatasetAdd.present.js
+ *  Presentational components.
+ */
+
+
+import React from "react";
+import { Row, Col, Modal, ModalHeader, ModalBody } from "reactstrap";
+import { FormPanel } from "../../utils/formgenerator";
+
+function DatasetAdd(props) {
+
+  return (
+    <Modal
+      isOpen={props.modalOpen}
+      toggle={props.closeModal}
+    >
+      <ModalHeader toggle={props.closeModal}>
+        Add dataset to project
+      </ModalHeader>
+      <ModalBody>
+        <Row className="mb-3">
+          <Col>
+            <FormPanel
+              btnName={"Add dataset"}
+              submitCallback={props.submitCallback}
+              model={props.addDatasetToProjectSchema}
+              serverErrors={props.serverErrors}
+              submitLoader={{ value: props.submitLoader, text: props.submitLoaderText }}
+              onCancel={props.closeModal} />
+          </Col>
+        </Row>
+      </ModalBody>
+    </Modal>
+  );
+
+}
+
+export default DatasetAdd;

--- a/src/dataset/addtoproject/index.js
+++ b/src/dataset/addtoproject/index.js
@@ -1,0 +1,28 @@
+/*!
+ * Copyright 2020 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  dataset/add
+ *  Components for the add dataset to project
+ */
+
+import AddToProject from "./AddToProject.container";
+
+export default AddToProject;

--- a/src/model/RenkuModels.js
+++ b/src/model/RenkuModels.js
@@ -332,6 +332,19 @@ const datasetImportFormSchema = new Schema({
   }
 });
 
+const addDatasetToProjectSchema = new Schema({
+  project: {
+    initial: undefined,
+    name: "project",
+    label: "Project",
+    type: FormGenerator.FieldTypes.SELECT,
+    options: [
+    ],
+    validators: []
+  }
+});
+
 
 export { userSchema, metaSchema, displaySchema, newProjectSchema, projectSchema, forkProjectSchema };
 export { notebooksSchema, projectsSchema, datasetFormSchema, issueFormSchema, datasetImportFormSchema };
+export { addDatasetToProjectSchema };

--- a/src/model/RenkuModels.js
+++ b/src/model/RenkuModels.js
@@ -334,13 +334,21 @@ const datasetImportFormSchema = new Schema({
 
 const addDatasetToProjectSchema = new Schema({
   project: {
-    initial: undefined,
+    initial: "",
     name: "project",
     label: "Project",
-    type: FormGenerator.FieldTypes.SELECT,
+    placeholder: "Select a project...",
+    type: FormGenerator.FieldTypes.SELECTAUTOSUGGEST,
+    parseFun: expression => FormGenerator.Parsers.slugFromTitle(expression),
     options: [
     ],
-    validators: []
+    validators: [
+      {
+        id: "valid-option",
+        isValidFun: expression => FormGenerator.Validators.optionExists(expression),
+        alert: "Selected project is not valid"
+      }
+    ]
   }
 });
 

--- a/src/model/RenkuModels.js
+++ b/src/model/RenkuModels.js
@@ -339,7 +339,6 @@ const addDatasetToProjectSchema = new Schema({
     label: "Project",
     placeholder: "Select a project...",
     type: FormGenerator.FieldTypes.SELECTAUTOSUGGEST,
-    parseFun: expression => FormGenerator.Parsers.slugFromTitle(expression),
     options: [
     ],
     validators: [

--- a/src/project/Project.js
+++ b/src/project/Project.js
@@ -431,6 +431,7 @@ class View extends Component {
         selectedDataset={p.match.params.datasetId}
         history={this.props.history}
         logged={this.props.user.logged}
+        model={this.props.model}
       />,
 
       newDataset: (p) => <NewDataset

--- a/src/project/Project.js
+++ b/src/project/Project.js
@@ -429,6 +429,8 @@ class View extends Component {
         fileContentUrl={subUrls.fileContentUrl}
         projectsUrl={subUrls.projectsUrl}
         selectedDataset={p.match.params.datasetId}
+        history={this.props.history}
+        logged={this.props.user.logged}
       />,
 
       newDataset: (p) => <NewDataset

--- a/src/project/datasets/import/DatasetImport.container.js
+++ b/src/project/datasets/import/DatasetImport.container.js
@@ -26,12 +26,13 @@
 import React, { useState, useEffect } from "react";
 import { datasetImportFormSchema } from "../../../model/RenkuModels";
 import DatasetImport from "./DatasetImport.present";
+import { ImportStateMessage } from "../../../utils/Dataset";
 
 function ImportDataset(props) {
 
   const [serverErrors, setServerErrors] = useState(undefined);
   const [submitLoader, setSubmitLoader] = useState(false);
-  const [submitLoaderText, setSubmitLoaderText] = useState("Please wait, dataset import will start soon.");
+  const [submitLoaderText, setSubmitLoaderText] = useState(ImportStateMessage.ENQUEUED);
 
   const onCancel = e => {
     props.history.push({ pathname: `/projects/${props.projectPathWithNamespace}/datasets` });
@@ -64,31 +65,30 @@ function ImportDataset(props) {
   function handleJobResponse(job, monitorJob, cont, oldDatasetsList) {
     switch (job.state) {
       case "ENQUEUED":
-        setSubmitLoaderText("Dataset import will start soon.");
+        setSubmitLoaderText(ImportStateMessage.ENQUEUED);
         break;
       case "IN_PROGRESS":
-        setSubmitLoaderText("Importing dataset.");
+        setSubmitLoaderText(ImportStateMessage.IN_PROGRESS);
         break;
       case "COMPLETED":
-        setSubmitLoaderText("Dataset was imported, you will be redirected soon.");
+        setSubmitLoaderText(ImportStateMessage.COMPLETED);
         clearInterval(monitorJob);
         findDatasetInKgAnRedirect(oldDatasetsList);
         break;
       case "FAILED":
         setSubmitLoader(false);
-        setServerErrors("Dataset import failed: " + job.extras.error);
+        setServerErrors(ImportStateMessage.FAILED + job.extras.error);
         clearInterval(monitorJob);
         break;
       default:
         setSubmitLoader(false);
-        setServerErrors("Dataset import failed, plaease try again");
+        setServerErrors(ImportStateMessage.FAILED_NO_INFO);
         clearInterval(monitorJob);
         break;
     }
     if (cont === 100) {
       setSubmitLoader(false);
-      setServerErrors("Dataset import is taking too long, please check if the dataset was imported" +
-      " and if it wasn't try again.");
+      setServerErrors(ImportStateMessage.TOO_LONG);
       clearInterval(monitorJob);
     }
   }

--- a/src/project/new/Project.style.css
+++ b/src/project/new/Project.style.css
@@ -34,6 +34,8 @@
   border-bottom-left-radius: 4px;
   border-bottom-right-radius: 4px;
   z-index: 2;
+  max-height: 560px;
+  overflow-y: auto;
 }
 
 .react-autosuggest__suggestions-list {

--- a/src/project/shared/Projects.state.js
+++ b/src/project/shared/Projects.state.js
@@ -30,6 +30,13 @@ class ProjectsCoordinator {
   }
 
   _starredProjectMetadata(project) {
+    let accessLevel = 0;
+    if (project.permissions && project.permissions.project_access)
+      accessLevel = Math.max(accessLevel, project.permissions.project_access.access_level);
+
+    if (project.permissions && project.permissions.group_access)
+      accessLevel = Math.max(accessLevel, project.permissions.group_access.access_level);
+
     return {
       id: project.id,
       path_with_namespace: project.path_with_namespace,
@@ -37,7 +44,9 @@ class ProjectsCoordinator {
       tag_list: project.tag_list,
       star_count: project.star_count,
       owner: project.owner,
-      last_activity_at: project.last_activity_at
+      last_activity_at: project.last_activity_at,
+      access_level: accessLevel,
+      http_url_to_repo: project.http_url_to_repo
     };
   }
 
@@ -53,9 +62,9 @@ class ProjectsCoordinator {
       .catch((error) => {
         this.model.set("starredProjects", []);
       });
-    const promiseMember = this.client.getProjects({ membership: true, order_by: "last_activity_at" })
+    const promiseMember = this.client.getAllProjects({ membership: true, order_by: "last_activity_at" })
       .then((projectResponse) => {
-        const projects = projectResponse.data.map((project) => this._starredProjectMetadata(project));
+        const projects = projectResponse.map((project) => this._starredProjectMetadata(project));
         return projects;
       })
       .catch((error) => {

--- a/src/utils/Dataset.js
+++ b/src/utils/Dataset.js
@@ -1,0 +1,35 @@
+/*!
+ * Copyright 2020 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  utils/Dataset.js
+ *  Dataset utils
+ */
+
+const ImportStateMessage = {
+  ENQUEUED: "Dataset import will start soon...",
+  IN_PROGRESS: "Importing dataset...",
+  COMPLETED: "Dataset was imported, you will be redirected soon...",
+  FAILED: "Dataset import failed: ",
+  FAILED_NO_INFO: "Dataset import failed, please try again.",
+  TOO_LONG: "Dataset import is taking too long, please check if the dataset was imported, and if it wasn't, try again."
+};
+
+export { ImportStateMessage };

--- a/src/utils/Dataset.js
+++ b/src/utils/Dataset.js
@@ -29,7 +29,9 @@ const ImportStateMessage = {
   COMPLETED: "Dataset was imported, you will be redirected soon...",
   FAILED: "Dataset import failed: ",
   FAILED_NO_INFO: "Dataset import failed, please try again.",
-  TOO_LONG: "Dataset import is taking too long, please check if the dataset was imported, and if it wasn't, try again."
+  TOO_LONG: "Dataset import is taking too long, please check if the dataset was imported, and if it wasn't, try again.",
+  KG_TOO_LONG: "The knowledge graph update has not yet finished." +
+  " The dataset was imported and should be visible in a short time."
 };
 
 export { ImportStateMessage };

--- a/src/utils/HelperFunctions.js
+++ b/src/utils/HelperFunctions.js
@@ -138,5 +138,24 @@ function formatBytes(bytes, decimals = 2) {
   return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + " " + sizes[i];
 }
 
+/**
+ * Function to group an array per key getter, returns a grouped map
+ * @param {*} list array to be grouped
+ * @param {*} keyGetter function that returns the key from an item inside the list
+ */
+function groupBy(list, keyGetter) {
+  const map = new Map();
+  list.forEach((item) => {
+    const key = keyGetter(item);
+    const collection = map.get(key);
+    if (!collection)
+      map.set(key, [item]);
+    else
+      collection.push(item);
+
+  });
+  return map;
+}
+
 export { slugFromTitle, getActiveProjectPathWithNamespace, splitAutosavedBranches, sanitizedHTMLFromMarkdown };
-export { simpleHash, parseINIString, formatBytes };
+export { simpleHash, parseINIString, formatBytes, groupBy };

--- a/src/utils/formgenerator/FormPanel.js
+++ b/src/utils/formgenerator/FormPanel.js
@@ -47,7 +47,9 @@ function FormPanel({ title, btnName, submitCallback, model, serverErrors, submit
 
   return (
     <Col>
-      <h3 className="uk-heading-divider uk-text-center pb-2">{title}</h3>
+      { title !== undefined ?
+        <h3 className="uk-heading-divider uk-text-center pb-2">{title}</h3>
+        : null }
       <Form onSubmit={setSubmit}>
         <div>
           {inputs.map(input => renderInput(input))}

--- a/src/utils/formgenerator/FormPanel.js
+++ b/src/utils/formgenerator/FormPanel.js
@@ -29,6 +29,7 @@ import useForm from "./UseForm";
 import TextInput from "./fields/TextInput";
 import TextareaInput from "./fields/TexAreaInput";
 import SelectInput from "./fields/SelectInput";
+import SelectautosuggestInput from "./fields/SelectAutosuggestInput";
 import CktextareaInput from "./fields/CKEditorTextArea";
 import FileuploaderInput from "./fields/FileUploaderInput";
 import { Loader } from "../../utils/UIComponents";
@@ -37,7 +38,14 @@ import "./FormGenerator.css";
 function FormPanel({ title, btnName, submitCallback, model, serverErrors, submitLoader, onCancel, edit }) {
   const modelValues = Object.values(model);
   const [inputs, setInputs, setSubmit] = useForm(modelValues, submitCallback);
-  const Components = { TextInput, TextareaInput, CktextareaInput, FileuploaderInput, SelectInput };
+  const Components = {
+    TextInput,
+    TextareaInput,
+    CktextareaInput,
+    FileuploaderInput,
+    SelectInput,
+    SelectautosuggestInput
+  };
   const capitalize = expression => expression.charAt(0).toUpperCase() + expression.slice(1);
   const renderInput = input => {
     const Component = Components[capitalize(input.type) + "Input"];

--- a/src/utils/formgenerator/UseForm.js
+++ b/src/utils/formgenerator/UseForm.js
@@ -42,7 +42,7 @@ const useForm = (initModel, submitCallback) => {
   const handleSubmit = e => {
     e && e.preventDefault();
     inputs.forEach(i => validateInput(i));
-    inputs.some(i => i.alert) ? setInputs([...inputs]) : submitCallback();
+    inputs.some(i => i.alert) ? setInputs([...inputs]) : submitCallback(e);
   };
 
   const parseInput = input => input.value = input.parseFun ? input.parseFun(input.value) : input.value;

--- a/src/utils/formgenerator/fields/SelectAutosuggestInput.js
+++ b/src/utils/formgenerator/fields/SelectAutosuggestInput.js
@@ -1,0 +1,132 @@
+/*!
+ * Copyright 2018 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  SelectInput.js
+ *  Presentational components.
+ */
+
+import * as React from "react";
+import { useState } from "react";
+import ValidationAlert from "./ValidationAlert";
+import HelpText from "./HelpText";
+import { FormGroup, Label } from "reactstrap";
+import Autosuggest from "react-autosuggest";
+
+function SelectautosuggestInput(
+  { name, label, type, value, alert, options, initial, placeholder, setInputs, help, disabled = false }) {
+
+  const [localValue, setLocalValue] = useState("");
+  const [suggestions, setSuggestions ] = useState([]);
+
+  const getSuggestions = (value, reason) => {
+    const inputValue = value.trim().toLowerCase();
+    const inputLength = inputValue.length;
+
+    return inputLength === 0 ? options : options.filter(lang =>
+      lang.name.toLowerCase().includes(inputValue)
+    );
+  };
+
+  const getSuggestionValue = suggestion => suggestion.name;
+
+  const renderSuggestion = suggestion => (
+    <span>
+      {suggestion.name}
+    </span>
+  );
+
+  const onSuggestionSelected = (event, { method }) => {
+    if (method === "enter")
+      event.preventDefault();
+  };
+
+  const onChange = (event, { newValue, method }) => {
+    // If the user typed, store it as local input, otherwise set the selection
+    setLocalValue(newValue);
+    const selectedOption = options.find(option => option.name === newValue );
+    const artifitialEvent = {
+      target: { name: name, value: selectedOption !== undefined ? selectedOption.value : "" },
+      isPersistent: () => false
+    };
+    setInputs(artifitialEvent);
+  };
+
+  // Autosuggest will call this function every time you need to update suggestions.
+  // You already implemented this logic above, so just use it.
+  const onSuggestionsFetchRequested = ({ value, reason }) => {
+    setSuggestions( getSuggestions(value, reason));
+  };
+
+  // Autosuggest will call this function every time you need to clear suggestions.
+  const onSuggestionsClearRequested = () => {
+    setSuggestions([]);
+  };
+
+  // Autosuggest will pass through all these props to the input.
+  const inputProps = {
+    placeholder: placeholder,
+    value: localValue || "",
+    onChange: onChange,
+    disabled: disabled
+  };
+
+  // See https://github.com/moroshko/react-autosuggest#themeProp
+  const defaultTheme = {
+    container: "react-autosuggest__container",
+    containerOpen: "react-autosuggest__container--open",
+    input: "react-autosuggest__input",
+    inputOpen: "react-autosuggest__input--open",
+    inputFocused: "react-autosuggest__input--focused",
+    suggestionsContainer: "react-autosuggest__suggestions-container",
+    suggestionsContainerOpen: "react-autosuggest__suggestions-container--open",
+    suggestionsList: "react-autosuggest__suggestions-list",
+    suggestion: "react-autosuggest__suggestion",
+    suggestionFirst: "react-autosuggest__suggestion--first",
+    suggestionHighlighted: "react-autosuggest__suggestion--highlighted",
+    sectionContainer: "react-autosuggest__section-container",
+    sectionContainerFirst: "react-autosuggest__section-container--first",
+    sectionTitle: "react-autosuggest__section-title"
+  };
+
+  // Override the input theme to match our visual style
+  const theme = { ...defaultTheme, ...{ input: "form-control" } };
+
+
+  return <FormGroup>
+    <Label htmlFor={name}>{label}</Label>
+    <Autosuggest
+      id={name}
+      suggestions={suggestions}
+      onSuggestionsFetchRequested={onSuggestionsFetchRequested}
+      onSuggestionsClearRequested={onSuggestionsClearRequested}
+      getSuggestionValue={getSuggestionValue}
+      renderSuggestion={renderSuggestion}
+      inputProps={inputProps}
+      theme={theme}
+      shouldRenderSuggestions={(v) => true}
+      onSuggestionSelected={onSuggestionSelected}
+    />
+    <HelpText content={help} />
+    <ValidationAlert content={alert} />
+  </FormGroup>;
+}
+
+export default SelectautosuggestInput;

--- a/src/utils/formgenerator/fields/SelectAutosuggestInput.js
+++ b/src/utils/formgenerator/fields/SelectAutosuggestInput.js
@@ -45,7 +45,7 @@ function SelectautosuggestInput({ name, label, type, value, alert, options, init
     );
   };
 
-  const getSuggestionValue = suggestion => suggestion.name;
+  const getSuggestionValue = suggestion => suggestion;
 
   const renderSuggestion = suggestion => (
     <span>
@@ -59,14 +59,25 @@ function SelectautosuggestInput({ name, label, type, value, alert, options, init
   };
 
   const onChange = (event, { newValue, method }) => {
-    // If the user typed, store it as local input, otherwise set the selection
-    setLocalValue(newValue);
-    const selectedOption = options.find(option => option.name === newValue );
-    const artifitialEvent = {
-      target: { name: name, value: selectedOption !== undefined ? selectedOption.value : "" },
-      isPersistent: () => false
-    };
-    setInputs(artifitialEvent);
+    if (method !== "type") {
+      setLocalValue(newValue.name);
+      const artifitialEvent = {
+        target: { name: name, value: newValue !== undefined ? newValue.value : "" },
+        isPersistent: () => false
+      };
+      setInputs(artifitialEvent);
+    }
+    else {
+      // If the user typed, store it as local input, otherwise set the selection
+      setLocalValue(newValue);
+      const selectedOption = options.find(option => option.name === newValue );
+      const artifitialEvent = {
+        target: { name: name, value: selectedOption !== undefined ? selectedOption.value : "" },
+        isPersistent: () => false
+      };
+      setInputs(artifitialEvent);
+    }
+
   };
 
   // Autosuggest will call this function every time you need to update suggestions.

--- a/src/utils/formgenerator/fields/SelectAutosuggestInput.js
+++ b/src/utils/formgenerator/fields/SelectAutosuggestInput.js
@@ -30,8 +30,8 @@ import HelpText from "./HelpText";
 import { FormGroup, Label } from "reactstrap";
 import Autosuggest from "react-autosuggest";
 
-function SelectautosuggestInput(
-  { name, label, type, value, alert, options, initial, placeholder, setInputs, help, disabled = false }) {
+function SelectautosuggestInput({ name, label, type, value, alert, options, initial,
+  placeholder, setInputs, help, customHandlers, disabled = false }) {
 
   const [localValue, setLocalValue] = useState("");
   const [suggestions, setSuggestions ] = useState([]);
@@ -71,13 +71,25 @@ function SelectautosuggestInput(
 
   // Autosuggest will call this function every time you need to update suggestions.
   // You already implemented this logic above, so just use it.
+  // TODO allow custom handlers for more events
   const onSuggestionsFetchRequested = ({ value, reason }) => {
-    setSuggestions( getSuggestions(value, reason));
+    if (customHandlers.onSuggestionsFetchRequested)
+      customHandlers.onSuggestionsFetchRequested(value, reason, setSuggestions);
+    else
+      setSuggestions( getSuggestions(value, reason));
   };
 
   // Autosuggest will call this function every time you need to clear suggestions.
   const onSuggestionsClearRequested = () => {
     setSuggestions([]);
+  };
+
+  const getSectionSuggestions = (section)=>{
+    return section.suggestions;
+  };
+
+  const renderSectionTitle = (section)=>{
+    return <strong>{section.title}</strong>;
   };
 
   // Autosuggest will pass through all these props to the input.
@@ -109,12 +121,15 @@ function SelectautosuggestInput(
   // Override the input theme to match our visual style
   const theme = { ...defaultTheme, ...{ input: "form-control" } };
 
-
+  /* TODO: allow grouped and non grouped field */
   return <FormGroup>
     <Label htmlFor={name}>{label}</Label>
     <Autosuggest
       id={name}
       suggestions={suggestions}
+      multiSection={true}
+      renderSectionTitle={renderSectionTitle}
+      getSectionSuggestions={getSectionSuggestions}
       onSuggestionsFetchRequested={onSuggestionsFetchRequested}
       onSuggestionsClearRequested={onSuggestionsClearRequested}
       getSuggestionValue={getSuggestionValue}

--- a/src/utils/formgenerator/fields/index.js
+++ b/src/utils/formgenerator/fields/index.js
@@ -29,6 +29,7 @@ export default {
     TEXT_AREA: "textarea",
     TEXT_EDITOR: "cktextarea",
     FILES: "fileuploader",
-    SELECT: "select"
+    SELECT: "select",
+    SELECTAUTOSUGGEST: "selectautosuggest"
   }
 };

--- a/src/utils/formgenerator/services/InputValidator.js
+++ b/src/utils/formgenerator/services/InputValidator.js
@@ -30,5 +30,6 @@ function checkAtLeastLength(input, length) {
 export default {
   isNotEmpty: input => checkAtLeastLength(input.value, 1),
   isAtLeastLength: (input, minLength) => checkAtLeastLength(input.value, minLength),
-  filesReady: (input) => input.value.length === input.filesOnUploader.current
+  filesReady: (input) => input.value.length === input.filesOnUploader.current,
+  optionExists: (input) => input.options.find(option => option.value === input.value) !== undefined
 };


### PR DESCRIPTION
Closes #527 

### **Needs testing!!!**

I added a button in the datasets (for users that are logged in) so users can add datasets to projects.

![image](https://user-images.githubusercontent.com/42647877/77573283-b8266b80-6ed0-11ea-8ded-8c72a51f3e35.png)
(I don't really like the way this buttons looks, maybe we could do something to improve them
---> I know i was the one creating them haha)

After the user presses on the button a modal opens, and they can select a project from the list of projects where they are MAINTAINER.
![image](https://user-images.githubusercontent.com/42647877/77573655-48fd4700-6ed1-11ea-8bca-c236ca4414b4.png)

![image](https://user-images.githubusercontent.com/42647877/77573611-397dfe00-6ed1-11ea-98dc-e53f5fcd3295.png)


They press Add dataset, they wait and they are redirected to the project/new-dataset

I am not 100% sure it works on datasets with unzipped files. (If this is the case it would be a backend issue)