### PR TITLE
ci: add github test action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on: [push]
+
+jobs:
+  cleanup-runs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: rokroskar/workflow-run-cleanup-action@master
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+    if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up node ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: '8.11'
+    - name: Install dependencies and build
+      run: |
+        npm install
+        npm run-script build
+      env:
+        NODE_OPTIONS: '--max-old-space-size=4096'
+    - name: Run test
+      run: npm test
+      env:
+        CI: true
+    - name: Run lint
+      run: npm run lint


### PR DESCRIPTION
This is the first step in moving from Travis CI to GitHub actions.
It runs Jest test and ESlint linting. We could keep both sets of actions for a while to verify if the result is similar.

Partially address #772