### PR TITLE
feat: show markdown extract in issues list preview

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -52,6 +52,12 @@ body {
   color: #AAA;
 }
 
+.children-no-spacing * {
+  margin: 0 !important;
+  padding: 0 !important;
+  border: 0 !important;
+}
+
 .comment-block {
   display: inline
 }

--- a/src/issue/Issue.js
+++ b/src/issue/Issue.js
@@ -324,9 +324,7 @@ class IssueListRow extends Component {
                   {title}
                 </span>
               </b><br />
-              <span className="issues-description">
-                <RenkuMarkdown markdownText={this.props.description} singleLine={true} />
-              </span>
+              <RenkuMarkdown markdownText={this.props.description} singleLine={true} />
             </div>
           </div>
         </Col>

--- a/src/issue/Issue.js
+++ b/src/issue/Issue.js
@@ -325,7 +325,7 @@ class IssueListRow extends Component {
                 </span>
               </b><br />
               <span className="issues-description">
-                {this.props.description}
+                <RenkuMarkdown markdownText={this.props.description} singleLine={true} />
               </span>
             </div>
           </div>

--- a/src/utils/HelperFunctions.js
+++ b/src/utils/HelperFunctions.js
@@ -49,7 +49,7 @@ function splitAutosavedBranches(branches) {
   return { standard, autosaved };
 }
 
-function sanitizedHTMLFromMarkdown(markdown) {
+function sanitizedHTMLFromMarkdown(markdown, singleLine = false) {
   // Reference: https://github.com/showdownjs/showdown/wiki/Showdown-Options
   const showdownOptions = {
     ghCompatibleHeaderId: true,
@@ -73,8 +73,15 @@ function sanitizedHTMLFromMarkdown(markdown) {
   }));
 
   const converter = new showdown.Converter({ ...showdownOptions, extensions: [...bindings] });
+  if (singleLine) {
+    const lineBreakers = ["<br>", "<br />", "<br/>", "\n"];
+    const breakPosition = Math.max(...lineBreakers.map(elem => markdown.indexOf(elem)));
+    if (breakPosition !== -1)
+      markdown = markdown.substring(0, breakPosition);
+  }
   const htmlFromMarkdown = converter.makeHtml(markdown);
-  return DOMPurify.sanitize(htmlFromMarkdown);
+  const sanitized = DOMPurify.sanitize(htmlFromMarkdown);
+  return sanitized;
 }
 
 function simpleHash(str) {

--- a/src/utils/UIComponents.js
+++ b/src/utils/UIComponents.js
@@ -390,8 +390,13 @@ class ErrorAlert extends Component {
 
 class RenkuMarkdown extends Component {
   render() {
-    return <div className="text-break"
-      dangerouslySetInnerHTML={{ __html: sanitizedHTMLFromMarkdown(this.props.markdownText, this.props.singleLine) }}>
+    const { singleLine } = this.props;
+    let className = "text-break";
+    if (singleLine)
+      className += " children-no-spacing";
+
+    return <div className={className}
+      dangerouslySetInnerHTML={{ __html: sanitizedHTMLFromMarkdown(this.props.markdownText, singleLine) }}>
     </div>;
   }
 }

--- a/src/utils/UIComponents.js
+++ b/src/utils/UIComponents.js
@@ -391,7 +391,8 @@ class ErrorAlert extends Component {
 class RenkuMarkdown extends Component {
   render() {
     return <div className="text-break"
-      dangerouslySetInnerHTML={{ __html: sanitizedHTMLFromMarkdown(this.props.markdownText) }}></div>;
+      dangerouslySetInnerHTML={{ __html: sanitizedHTMLFromMarkdown(this.props.markdownText, this.props.singleLine) }}>
+    </div>;
   }
 }
 


### PR DESCRIPTION
The issues list now correctly parse the markdown text shown as a preview.

The markdown preview is ideally limited to a single line, but this may fail in some cases (e.g. if the issue starts with a table, no content is visible).

PREVIEW: https://lorenzotest.dev.renku.ch
EXAMPLE: https://lorenzotest.dev.renku.ch/projects/lorenzo.cavazzi.tech/test/collaboration/issues
    --> compare with https://dev.renku.ch/projects/lorenzo.cavazzi.tech/test/collaboration/issues

fix #847