### PR TITLE
feat(environments): allow all users to start interactive environments

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -25,6 +25,7 @@ echo " SENTRY_NAMESPACE=${SENTRY_NAMESPACE}"
 echo " RENKU_TEMPLATES_URL=${RENKU_TEMPLATES_URL}"
 echo " RENKU_TEMPLATES_REF=${RENKU_TEMPLATES_REF}"
 echo " MAINTENANCE=${MAINTENANCE}"
+echo " ANONYMOUS_SESSIONS=${ANONYMOUS_SESSIONS}"
 echo "==================================================="
 
 tee > /usr/share/nginx/html/config.json << EOF
@@ -36,7 +37,8 @@ tee > /usr/share/nginx/html/config.json << EOF
   "SENTRY_NAMESPACE": "${SENTRY_NAMESPACE}",
   "RENKU_TEMPLATES_URL": "${RENKU_TEMPLATES_URL}",
   "RENKU_TEMPLATES_REF": "${RENKU_TEMPLATES_REF}",
-  "MAINTENANCE": "${MAINTENANCE}"
+  "MAINTENANCE": "${MAINTENANCE}",
+  "ANONYMOUS_SESSIONS": "${ANONYMOUS_SESSIONS}"
 }
 EOF
 

--- a/helm-chart/minikube-values.yaml
+++ b/helm-chart/minikube-values.yaml
@@ -1,6 +1,8 @@
 global:
   renku:
     domain: renku.build
+  anonymousSessions:
+    enabled: false
 
 baseUrl: "http://localhost:3000"
 

--- a/helm-chart/renku-ui/templates/deployment.yaml
+++ b/helm-chart/renku-ui/templates/deployment.yaml
@@ -48,6 +48,8 @@ spec:
             - name: MAINTENANCE
               value: {{ .Values.maintenance | default (printf "false") | quote }}
               {{- end }}
+            - name: ANONYMOUS_SESSIONS
+              value: {{ .Values.global.anonymousSessions.enabled | default (printf "false") | quote }}
           livenessProbe:
             httpGet:
               path: /

--- a/run-telepresence.sh
+++ b/run-telepresence.sh
@@ -75,7 +75,8 @@ tee > ./public/config.json << EOF
   "SENTRY_URL": "${SENTRY_URL}",
   "SENTRY_NAMESPACE": "${SENTRY_NAMESPACE}",
   "RENKU_TEMPLATES_URL": "https://github.com/SwissDataScienceCenter/renku-project-template",
-  "RENKU_TEMPLATES_REF": "master"
+  "RENKU_TEMPLATES_REF": "master",
+  "ANONYMOUS_SESSIONS": "true"
 }
 EOF
 

--- a/src/App.js
+++ b/src/App.js
@@ -52,6 +52,10 @@ class App extends Component {
       );
     }
 
+    // check anonymous sessions settings
+    const anonymousSessions = this.props.params["ANONYMOUS_SESSIONS"] === "true";
+    const blockAnonymous = !user.logged && !anonymousSessions;
+
     return (
       <Router>
         <div>
@@ -91,6 +95,7 @@ class App extends Component {
                   params={this.props.params}
                   model={this.props.model}
                   user={this.props.user}
+                  blockAnonymous={blockAnonymous}
                   {...p}
                 />}
               />
@@ -111,6 +116,7 @@ class App extends Component {
                   standalone={true}
                   client={this.props.client}
                   model={this.props.model}
+                  blockAnonymous={blockAnonymous}
                   {...p}
                 />}
               />

--- a/src/api-client/notebook-servers.js
+++ b/src/api-client/notebook-servers.js
@@ -16,8 +16,10 @@
  * limitations under the License.
  */
 
+import { FETCH_DEFAULT } from "./index";
+
 function addNotebookServersMethods(client) {
-  client.getNotebookServers = (namespace, project, branch, commit) => {
+  client.getNotebookServers = (namespace, project, branch, commit, anonymous = false) => {
     const headers = client.getBasicHeaders();
     const url = `${client.baseUrl}/notebooks/servers`;
     let parameters = {};
@@ -26,11 +28,14 @@ function addNotebookServersMethods(client) {
     if (branch) parameters.branch = branch;
     if (commit) parameters.commit_sha = commit;
 
-    return client.clientFetch(url, {
-      method: "GET",
-      headers,
-      queryParams: parameters
-    }).then(resp => {
+    return client.clientFetch(
+      url,
+      { method: "GET", headers, queryParams: parameters },
+      FETCH_DEFAULT.returnType,
+      FETCH_DEFAULT.alertOnErr,
+      FETCH_DEFAULT.reLogin,
+      anonymous
+    ).then(resp => {
       return { "data": resp.data.servers };
     });
   };

--- a/src/landing/NavBar.js
+++ b/src/landing/NavBar.js
@@ -261,6 +261,7 @@ class AnonymousNavBar extends Component {
             <ul className="navbar-nav mr-auto">
               <RenkuNavLink to="/projects" title="Projects" />
               <RenkuNavLink to="/datasets" title="Datasets" />
+              <RenkuNavLink to="/environments" title="Environments" />
             </ul>
             <ul className="navbar-nav">
               <RenkuToolbarHelpMenu />

--- a/src/model/RenkuModels.js
+++ b/src/model/RenkuModels.js
@@ -211,6 +211,7 @@ const notebooksSchema = new Schema({
       poller: { initial: null },
       fetched: { initial: null },
       fetching: { initial: false },
+      type: { initial: null },
 
       lastParameters: { initial: null },
       lastMainId: { initial: null },

--- a/src/notebooks/Notebooks.container.js
+++ b/src/notebooks/Notebooks.container.js
@@ -20,7 +20,7 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 
 import { NotebooksCoordinator } from "./Notebooks.state";
-import { StartNotebookServer as StartNotebookServerPresent } from "./Notebooks.present";
+import { StartNotebookServer as StartNotebookServerPresent, NotebooksDisabled } from "./Notebooks.present";
 import { Notebooks as NotebooksPresent } from "./Notebooks.present";
 import { CheckNotebookIcon } from "./Notebooks.present";
 import { StatusHelper } from "../model/Model";
@@ -31,6 +31,8 @@ import { StatusHelper } from "../model/Model";
  * @param {Object} client - api-client used to query the gateway
  * @param {Object} model - global model for the ui
  * @param {boolean} standalone - Indicates whether it's displayed as standalone
+ * @param {boolean} blockAnonymous - When true, block non logged in users
+ * @param {Object} [location] - react location object
  * @param {string} [urlNewEnvironment] - url to "new environment" page
  * @param {Object} [scope] - object containing filtering parameters
  * @param {string} [scope.namespace] - full path of the reference namespace
@@ -43,7 +45,8 @@ class Notebooks extends Component {
   constructor(props) {
     super(props);
     this.model = props.model.subModel("notebooks");
-    this.coordinator = new NotebooksCoordinator(props.client, this.model);
+    this.userModel = props.model.subModel("user");
+    this.coordinator = new NotebooksCoordinator(props.client, this.model, this.userModel);
     // temporarily reset data since notebooks model was not designed to be static
     this.coordinator.reset();
 
@@ -63,7 +66,8 @@ class Notebooks extends Component {
   }
 
   componentDidMount() {
-    this.coordinator.startNotebookPolling();
+    if (!this.props.blockAnonymous)
+      this.coordinator.startNotebookPolling();
   }
 
   componentWillUnmount() {
@@ -101,6 +105,9 @@ class Notebooks extends Component {
   }
 
   render() {
+    if (this.props.blockAnonymous)
+      return <NotebooksDisabled location={this.props.location} />;
+
     const VisibleNotebooks = connect(this.mapStateToProps.bind(this))(NotebooksPresent);
 
     return <VisibleNotebooks
@@ -126,6 +133,8 @@ class Notebooks extends Component {
  * @param {string} scope.namespace - full path of the reference namespace
  * @param {string} scope.project - path of the reference project
  * @param {string} externalUrl - GitLabl repository url
+ * @param {boolean} blockAnonymous - When true, block non logged in users
+ * @param {Object} [location] - react location object
  * @param {string} [successUrl] - redirect url to be used when a notebook is succesfully started
  * @param {Object} [history] - mandatory if successUrl is provided
  * @param {string} [message] - provide a useful information or warning message
@@ -134,7 +143,8 @@ class StartNotebookServer extends Component {
   constructor(props) {
     super(props);
     this.model = props.model.subModel("notebooks");
-    this.coordinator = new NotebooksCoordinator(props.client, this.model);
+    this.userModel = props.model.subModel("user");
+    this.coordinator = new NotebooksCoordinator(props.client, this.model, this.userModel);
     // temporarily reset data since notebooks model was not designed to be static
     this.coordinator.reset();
 
@@ -162,8 +172,10 @@ class StartNotebookServer extends Component {
 
   componentDidMount() {
     this._isMounted = true;
-    this.coordinator.startNotebookPolling();
-    this.refreshBranches();
+    if (!this.props.blockAnonymous) {
+      this.coordinator.startNotebookPolling();
+      this.refreshBranches();
+    }
   }
 
   componentWillUnmount() {
@@ -341,6 +353,9 @@ class StartNotebookServer extends Component {
   }
 
   render() {
+    if (this.props.blockAnonymous)
+      return <NotebooksDisabled location={this.props.location} />;
+
     const ConnectedStartNotebookServer = connect(this.mapStateToProps.bind(this))(StartNotebookServerPresent);
 
     return <ConnectedStartNotebookServer

--- a/src/notebooks/Notebooks.container.js
+++ b/src/notebooks/Notebooks.container.js
@@ -37,6 +37,7 @@ import { StatusHelper } from "../model/Model";
  * @param {string} [scope.project] - path of the reference project
  * @param {string} [scope.branch] - branch name
  * @param {string} [scope.commit] - commit full id
+ * @param {string} [message] - provide a useful information or warning message
  */
 class Notebooks extends Component {
   constructor(props) {
@@ -107,6 +108,7 @@ class Notebooks extends Component {
       user={this.props.user}
       standalone={this.props.standalone ? this.props.standalone : false}
       scope={this.props.scope}
+      message={this.props.message}
       urlNewEnvironment={this.props.urlNewEnvironment}
     />;
   }
@@ -126,6 +128,7 @@ class Notebooks extends Component {
  * @param {string} externalUrl - GitLabl repository url
  * @param {string} [successUrl] - redirect url to be used when a notebook is succesfully started
  * @param {Object} [history] - mandatory if successUrl is provided
+ * @param {string} [message] - provide a useful information or warning message
  */
 class StartNotebookServer extends Component {
   constructor(props) {
@@ -343,6 +346,7 @@ class StartNotebookServer extends Component {
     return <ConnectedStartNotebookServer
       store={this.model.reduxStore}
       inherited={this.props}
+      message={this.props.message}
       justStarted={this.state.starting}
     />;
   }

--- a/src/notebooks/Notebooks.present.js
+++ b/src/notebooks/Notebooks.present.js
@@ -50,7 +50,7 @@ class Notebooks extends Component {
 
     return <Row>
       <Col>
-        <NotebooksTitle standalone={this.props.standalone} />
+        <NotebooksTitle standalone={this.props.standalone} message={this.props.message} />
         <NotebookServers
           servers={this.props.notebooks.all}
           standalone={this.props.standalone}
@@ -75,7 +75,14 @@ class NotebooksTitle extends Component {
   render() {
     if (this.props.standalone)
       return (<h1>Interactive Environments</h1>);
-    return (<h3>Interactive Environments</h3>);
+
+    if (!this.props.message)
+      return (<h3>Interactive Environments</h3>);
+
+    return [
+      <h3 key="title">Interactive Environments</h3>,
+      <div key="message">{this.props.message}</div>
+    ];
   }
 }
 
@@ -591,7 +598,7 @@ class StartNotebookServer extends Component {
   render() {
     const { branch, commit } = this.props.filters;
     const { branches } = this.props.data;
-    const { pipelines } = this.props;
+    const { pipelines, message } = this.props;
     const fetching = {
       branches: StatusHelper.isUpdating(branches) ? true : false,
       pipelines: pipelines.fetching,
@@ -606,10 +613,15 @@ class StartNotebookServer extends Component {
       || this.props.justStarted
     );
 
+    const messageOutput = message ?
+      (<div key="message">{message}</div>) :
+      null;
+
     return (
       <Row>
         <Col sm={12} md={10} lg={8}>
           <h3>Start a new interactive environment</h3>
+          {messageOutput}
           <Form>
             <StartNotebookBranches {...this.props} />
             {show.commits ? <StartNotebookCommits {...this.props} /> : null}

--- a/src/notebooks/Notebooks.present.js
+++ b/src/notebooks/Notebooks.present.js
@@ -40,6 +40,30 @@ import Sizes from "../utils/Media";
 
 import "./Notebooks.css";
 
+class NotebooksDisabled extends Component {
+  render() {
+    const postLoginUrl = this.props.location ? this.props.location.pathname : null;
+    const to = { "pathname": "/login", "state": { previous: postLoginUrl } };
+    const info = postLoginUrl == null ?
+      null :
+      (
+        <InfoAlert timeout={0} key="login-info">
+          <p className="mb-0">
+            <Link className="btn btn-primary btn-sm" to={to} previous={postLoginUrl}>Log in</Link> to use
+            interactive environments.
+          </p>
+        </InfoAlert>
+      );
+
+    return (
+      <div>
+        <p>This Renkulab deployment doesn&apos;t allow unauthenticated users to start Interactive Environments.</p>
+        {info}
+      </div>
+    );
+  }
+}
+
 // * Notebooks code * //
 class Notebooks extends Component {
   render() {
@@ -47,10 +71,13 @@ class Notebooks extends Component {
     const loading = this.props.notebooks.fetched ?
       false :
       true;
+    const message = this.props.message ?
+      (<div>{this.props.message}</div>) :
+      null;
 
     return <Row>
       <Col>
-        <NotebooksTitle standalone={this.props.standalone} message={this.props.message} />
+        <NotebooksTitle standalone={this.props.standalone} />
         <NotebookServers
           servers={this.props.notebooks.all}
           standalone={this.props.standalone}
@@ -59,13 +86,15 @@ class Notebooks extends Component {
           fetchLogs={this.props.handlers.fetchLogs}
           toggleLogs={this.props.handlers.toggleLogs}
           logs={this.props.logs}
-          scope={this.props.scope} />
+          scope={this.props.scope}
+        />
         <NotebooksPopup
           servers={serverNumbers}
           standalone={this.props.standalone}
           loading={loading}
           urlNewEnvironment={this.props.urlNewEnvironment}
         />
+        {serverNumbers ? null : message}
       </Col>
     </Row>;
   }
@@ -75,14 +104,7 @@ class NotebooksTitle extends Component {
   render() {
     if (this.props.standalone)
       return (<h1>Interactive Environments</h1>);
-
-    if (!this.props.message)
-      return (<h3>Interactive Environments</h3>);
-
-    return [
-      <h3 key="title">Interactive Environments</h3>,
-      <div key="message">{this.props.message}</div>
-    ];
+    return (<h3>Interactive Environments</h3>);
   }
 }
 
@@ -584,6 +606,22 @@ class EnvironmentLogs extends Component {
   }
 }
 
+function pipelineAvailable(pipelines) {
+  const { pipelineTypes } = NotebooksHelper;
+  const mainPipeline = pipelines.main;
+
+  if (pipelines.type === pipelineTypes.logged) {
+    if (mainPipeline.status === "success" || mainPipeline.status === undefined)
+      return true;
+  }
+  else if (pipelines.type === pipelineTypes.anonymous) {
+    if (mainPipeline && mainPipeline.path)
+      return true;
+  }
+
+  return false;
+}
+
 // * StartNotebookServer code * //
 class StartNotebookServer extends Component {
   constructor(props) {
@@ -604,13 +642,12 @@ class StartNotebookServer extends Component {
       pipelines: pipelines.fetching,
       commits: this.props.data.fetching
     };
+
     let show = {};
     show.commits = !fetching.branches && branch.name ? true : false;
     show.pipelines = show.commits && !fetching.commits && commit.id;
     show.options = show.pipelines && pipelines.fetched && (
-      pipelines.main.status === "success" || pipelines.main.status === undefined
-      || this.state.ignorePipeline
-      || this.props.justStarted
+      this.props.justStarted || this.state.ignorePipeline || pipelineAvailable(pipelines)
     );
 
     const messageOutput = message ?
@@ -787,19 +824,37 @@ class StartNotebookPipelines extends Component {
 
 class StartNotebookPipelinesBadge extends Component {
   render() {
+    const pipelineType = this.props.pipelines.type;
     const pipeline = this.props.pipelines.main;
+
     let color, text;
-    if (pipeline.status === "success") {
-      color = "success";
-      text = "available";
+    if (pipelineType === NotebooksHelper.pipelineTypes.logged) {
+      if (pipeline.status === "success") {
+        color = "success";
+        text = "available";
+      }
+      else if (pipeline.status === undefined) {
+        color = "danger";
+        text = "not available";
+      }
+      else if (pipeline.status === "running" || pipeline.status === "pending") {
+        color = "warning";
+        text = "building";
+      }
+      else {
+        color = "danger";
+        text = "error";
+      }
     }
-    else if (pipeline.status === undefined) {
-      color = "danger";
-      text = "not available";
-    }
-    else if (pipeline.status === "running" || pipeline.status === "pending") {
-      color = "warning";
-      text = "building";
+    else if (pipelineType === NotebooksHelper.pipelineTypes.anonymous) {
+      if (pipeline && pipeline.path) {
+        color = "success";
+        text = "available";
+      }
+      else {
+        color = "danger";
+        text = "not available";
+      }
     }
     else {
       color = "danger";
@@ -813,6 +868,32 @@ class StartNotebookPipelinesBadge extends Component {
 class StartNotebookPipelinesContent extends Component {
   render() {
     const pipeline = this.props.pipelines.main;
+    const pipelineType = this.props.pipelines.type;
+    const { pipelineTypes } = NotebooksHelper;
+
+    // anonymous
+    if (pipelineType === pipelineTypes.anonymous) {
+      if (pipeline && pipeline.path)
+        return null;
+
+      return (
+        <div>
+          <Label>
+            <p>
+              <FontAwesomeIcon icon={faExclamationTriangle} /> The image for this commit is not currently available.
+            </p>
+            <p>
+              Since building it takes a while, consider waiting a few minutes if the commit is very recent.
+              <br />Otherwise, you can either select another commit or <ExternalLink role="text" size="sm"
+                title="contact a maintainer" url={`${this.props.externalUrl}/project_members`} /> for
+              help.
+            </p>
+          </Label>
+        </div>
+      );
+    }
+
+    // logged in
     if (pipeline.status === "success")
       return null;
 
@@ -1305,4 +1386,4 @@ class CheckNotebookIcon extends Component {
   }
 }
 
-export { Notebooks, StartNotebookServer, CheckNotebookIcon };
+export { NotebooksDisabled, Notebooks, StartNotebookServer, CheckNotebookIcon };

--- a/src/notebooks/Notebooks.test.js
+++ b/src/notebooks/Notebooks.test.js
@@ -26,7 +26,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { MemoryRouter } from "react-router-dom";
 
-import { NotebooksHelper, Notebooks, StartNotebookServer, CheckNotebookStatus } from "./index";
+import { NotebooksHelper, Notebooks, StartNotebookServer, CheckNotebookStatus, NotebooksDisabled } from "./index";
 import { ExpectedAnnotations } from "./Notebooks.state";
 import { StateModel, globalSchema } from "../model";
 import { testClient as client } from "../api-client";
@@ -197,6 +197,15 @@ describe("rendering", () => {
     project: "fake",
     branch: { name: "master" }
   };
+
+  it("renders NotebooksDisabled", () => {
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    ReactDOM.render(
+      <MemoryRouter>
+        <NotebooksDisabled />
+      </MemoryRouter>, div);
+  });
 
   it("renders Notebooks", () => {
     const props = {

--- a/src/notebooks/index.js
+++ b/src/notebooks/index.js
@@ -24,7 +24,7 @@
  */
 
 import { Notebooks, StartNotebookServer, CheckNotebookStatus } from "./Notebooks.container";
-import { CheckNotebookIcon } from "./Notebooks.present";
+import { CheckNotebookIcon, NotebooksDisabled } from "./Notebooks.present";
 import { NotebooksHelper } from "./Notebooks.state";
 
-export { Notebooks, StartNotebookServer, NotebooksHelper, CheckNotebookStatus, CheckNotebookIcon };
+export { Notebooks, StartNotebookServer, NotebooksHelper, CheckNotebookStatus, CheckNotebookIcon, NotebooksDisabled };

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -209,21 +209,21 @@ class KnowledgeGraphLink extends Component {
 
 function GitLabConnectButton(props) {
   const size = (props.size) ? props.size : "md";
-  const accessLevel = props.accessLevel;
-  const gitlabIDEUrl = props.gitlabIDEUrl;
-  if (props.externalUrl === "") return null;
+  const { userLogged, gitlabIDEUrl } = props;
+  if (!props.externalUrl)
+    return null;
   const gitlabProjectButton = <ExternalLink url={props.externalUrl} title="View in GitLab" />;
 
   const onClick = () => window.open(gitlabIDEUrl, "_blank");
-  const gitlabIDEButton = (accessLevel >= ACCESS_LEVELS.DEVELOPER && gitlabIDEUrl !== null) ?
-    (<DropdownItem onClick={onClick}>View in Web IDE</DropdownItem>) :
+  const gitlabIDEButton = userLogged ?
+    (<DropdownItem onClick={onClick} size={size}>View in Web IDE</DropdownItem>) :
     null;
 
-  return <div>
-    <ButtonWithMenu default={gitlabProjectButton} size={size}>
-      {gitlabIDEButton}
-    </ButtonWithMenu>
-  </div>;
+  let button = gitlabIDEButton ?
+    (<ButtonWithMenu default={gitlabProjectButton} size={size}>{gitlabIDEButton}</ButtonWithMenu>) :
+    (<ExternalLink url={props.externalUrl} size={size} title="View in GitLab" />);
+
+  return (<div>{button}</div>);
 }
 
 class ProjectViewHeaderOverview extends Component {
@@ -307,7 +307,7 @@ class ProjectViewHeaderOverview extends Component {
               <GitLabConnectButton size="sm"
                 externalUrl={this.props.externalUrl}
                 gitlabIDEUrl={gitlabIDEUrl}
-                accessLevel={this.props.visibility.accessLevel} />
+                userLogged={this.props.user.logged} />
             </div>
           </Col>
         </Row>

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -765,26 +765,6 @@ class ProjectViewFiles extends Component {
   }
 }
 
-function notebookLauncher(userLogged, notebookLauncher, postLoginUrl) {
-  if (!userLogged) {
-    const to = { "pathname": "/login", "state": { previous: postLoginUrl } };
-    return (
-      <div>
-        <p>
-          You do not have sufficient permissions to launch an interactive environment for this project.
-        </p>
-        <InfoAlert timeout={0} key="login-info">
-          <p className="mb-0">
-            <Link className="btn btn-primary btn-sm" to={to} previous={postLoginUrl}>Log in</Link> to use
-            interactive environments.
-          </p>
-        </InfoAlert>
-      </div>
-    );
-  }
-  return (<div>{notebookLauncher}</div>);
-}
-
 class OverviewDatasetRow extends Component {
   render() {
     return <tr>
@@ -856,28 +836,29 @@ class ProjectEnvironments extends Component {
 
 function notebookWarning(userLogged, accessLevel, fork, postLoginUrl, externalUrl) {
   if (!userLogged) {
-    return null;
-
-    // TODO: draft implementation
-    // const to = { "pathname": "/login", "state": { previous: postLoginUrl } };
-    // return (
-    //   <WarnAlert timeout={0} key="permissions-warning">
-    //     <p>As an anonymous user, you can start an environment but you cannot save your work.</p>
-    //     <p className="mb-0">
-    //       <Link className="btn btn-primary btn-sm btn-warning" to={to} previous={postLoginUrl}>Log in</Link> to use
-    //       all the features we provide through <ExternalLink role="text" title="Interactive Envirnonments"
-    //         url="https://renku.readthedocs.io/en/latest/developer/services/notebooks_service.html" />
-    //       .
-    //     </p>
-    //   </WarnAlert>
-    // );
+    const to = { "pathname": "/login", "state": { previous: postLoginUrl } };
+    return (
+      <InfoAlert timeout={0} key="permissions-warning">
+        <p>
+          <FontAwesomeIcon icon={faExclamationTriangle} /> As
+          an anonymous user, you can start <ExternalLink role="text" title="Interactive Envirnonments"
+            url="https://renku.readthedocs.io/en/latest/developer/services/notebooks_service.html" />, but
+          you cannot save your work.
+        </p>
+        <p className="mb-0">
+          <Link className="btn btn-primary btn-sm" to={to} previous={postLoginUrl}>Log in</Link> for
+          full access.
+        </p>
+      </InfoAlert>
+    );
   }
   else if (accessLevel < ACCESS_LEVELS.DEVELOPER) {
     return (
       <InfoAlert timeout={0} key="permissions-warning">
         <p>
-          You have limited permissions for this project.
-          If you want to save your work, consider one of the following:
+          <FontAwesomeIcon icon={faExclamationTriangle} /> You have limited permissions for this
+          project. You can launch an interactive environment, but you will not be able to save
+          any changes. If you want to save your work, consider one of the following:
         </p>
         <ul className="mb-0">
           <li>
@@ -903,19 +884,21 @@ function notebookWarning(userLogged, accessLevel, fork, postLoginUrl, externalUr
 class ProjectNotebookServers extends Component {
   render() {
     const {
-      client, model, user, visibility, toggleForkModal, location, externalUrl, launchNotebookUrl
+      client, model, user, visibility, toggleForkModal, location, externalUrl, launchNotebookUrl,
+      blockAnonymous
     } = this.props;
     const warning = notebookWarning(
       user.logged, visibility.accessLevel, toggleForkModal, location.pathname, externalUrl
     );
 
-    let content = (
-      <Notebooks standalone={false} client={client} model={model}
+    return (
+      <Notebooks standalone={false} client={client} model={model} location={location}
         message={warning}
         urlNewEnvironment={launchNotebookUrl}
-        scope={{ namespace: this.props.core.namespace_path, project: this.props.core.project_path }} />
+        blockAnonymous={blockAnonymous}
+        scope={{ namespace: this.props.core.namespace_path, project: this.props.core.project_path }}
+      />
     );
-    return (notebookLauncher(user.logged, content, location.pathname));
   }
 }
 
@@ -923,23 +906,24 @@ class ProjectStartNotebookServer extends Component {
   render() {
     const {
       client, model, user, visibility, toggleForkModal, location, externalUrl, system,
-      fetchBranches, notebookServersUrl, history
+      fetchBranches, notebookServersUrl, history, blockAnonymous
     } = this.props;
     const warning = notebookWarning(
       user.logged, visibility.accessLevel, toggleForkModal, location.pathname, externalUrl
     );
 
-    let content = (<StartNotebookServer client={client} model={model} history={history}
-      message={warning}
-      branches={system.branches}
-      autosaved={system.autosaved}
-      refreshBranches={fetchBranches}
-      externalUrl={externalUrl}
-      successUrl={notebookServersUrl}
-      scope={{ namespace: this.props.core.namespace_path, project: this.props.core.project_path }}
-    />);
-
-    return (notebookLauncher(user.logged, content, location.pathname));
+    return (
+      <StartNotebookServer client={client} model={model} history={history} location={location}
+        message={warning}
+        branches={system.branches}
+        autosaved={system.autosaved}
+        refreshBranches={fetchBranches}
+        externalUrl={externalUrl}
+        successUrl={notebookServersUrl}
+        blockAnonymous={blockAnonymous}
+        scope={{ namespace: this.props.core.namespace_path, project: this.props.core.project_path }}
+      />
+    );
   }
 }
 

--- a/src/utils/UIComponents.js
+++ b/src/utils/UIComponents.js
@@ -217,6 +217,9 @@ function ExternalLinkButton(props) {
   if (props.disabled)
     className += " disabled";
 
+  if (props.color)
+    className += ` btn-${props.color}`;
+
   if (props.className)
     className += ` ${props.className}`;
 


### PR DESCRIPTION
Allow all users (both unprivileged and anonymous) to start environments on public projects.

* As an unprivileged user, you can start environments also in protected projects and check the pipelines/jobs status.
* As an anonymous user, only the image status will be checked without further details. You are not allowed to ignore that, so it shouldn't be possible to start environments from the wrong image.
A temporary login (not requiring name or any user action) will be triggered when accessing the environments page. This is needed to correctly associate environments to users.

Testing this PR requires an appropriate backend. A preview is available here:
https://andreas.dev.renku.ch

***How to test***
Try to access any public project and start an environment there.

supersede #865 
close #857 