### PR TITLE
fix(datasets): dataset has all folders from unziped file

### DIFF
--- a/src/project/datasets/edit/DatasetEdit.present.js
+++ b/src/project/datasets/edit/DatasetEdit.present.js
@@ -55,7 +55,6 @@ function DatasetEdit(props) {
     const dataset = {};
     dataset.name = props.datasetFormSchema.name.value;
     dataset.description = props.datasetFormSchema.description.value;
-
     dataset.files = [].concat.apply([], props.datasetFormSchema.files.value.map(f => f.file_id))
       .map(f => ({ "file_id": f }));
 

--- a/src/project/datasets/edit/DatasetEdit.present.js
+++ b/src/project/datasets/edit/DatasetEdit.present.js
@@ -55,7 +55,9 @@ function DatasetEdit(props) {
     const dataset = {};
     dataset.name = props.datasetFormSchema.name.value;
     dataset.description = props.datasetFormSchema.description.value;
-    dataset.files = props.datasetFormSchema.files.value.map(f => ({ "file_id": f.file_id }));
+
+    dataset.files = [].concat.apply([], props.datasetFormSchema.files.value.map(f => f.file_id))
+      .map(f => ({ "file_id": f }));
 
     props.client.addFilesToDataset(props.httpProjectUrl, dataset.name, dataset.files)
       .then(response => {

--- a/src/project/datasets/new/DatasetNew.container.js
+++ b/src/project/datasets/new/DatasetNew.container.js
@@ -45,7 +45,8 @@ function NewDataset(props) {
     const dataset = {};
     dataset.name = datasetFormSchema.name.value;
     dataset.description = datasetFormSchema.description.value;
-    dataset.files = datasetFormSchema.files.value.map(f => ({ "file_id": f.file_id }));
+    dataset.files = [].concat.apply([], datasetFormSchema.files.value.map(f => f.file_id))
+      .map(f => ({ "file_id": f }));
 
     props.client.postDataset(props.httpProjectUrl, dataset)
       .then(dataset => {
@@ -58,7 +59,7 @@ function NewDataset(props) {
             props.client.getProjectDatasetsFromKG(props.projectPathWithNamespace)
               .then(datasets => {
                 // eslint-disable-next-line
-            let new_dataset = datasets.find( ds => ds.name === dataset.data.result.short_name);
+                let new_dataset = datasets.find( ds => ds.name === dataset.data.result.short_name);
                 if (new_dataset !== undefined) {
                   setSubmitLoader(false);
                   clearInterval(waitForDatasetInKG);

--- a/src/utils/FileExplorer.js
+++ b/src/utils/FileExplorer.js
@@ -19,9 +19,9 @@ function buildTree(parts, treeNode, jsonObj, hash, currentPath, foldersOpenOnLoa
 
   let newNode;
   if (parts[0] === jsonObj.name)
-    newNode = { "name": parts[0], "children": [], "jsonObj": jsonObj, "path": currentPath };
+    newNode = { "name": parts[0], "children": [], "jsonObj": jsonObj, "path": currentPath, "id": jsonObj.id };
   else
-    newNode = { "name": parts[0], "children": [], "jsonObj": null, "path": currentPath };
+    newNode = { "name": parts[0], "children": [], "jsonObj": null, "path": currentPath, "id": jsonObj.id };
 
   const currentNode = treeNode.filter(node => node.name === newNode.name);
 
@@ -171,13 +171,24 @@ function FilesTreeView(props) {
   );
 }
 
+/**
+ * Generic files tree generator.
+ * Some things are left to do to make it more generic.
+ * @param {*} props.files This is a list of files with atLocation containing the file path (this is optional)
+ * @param {*} props.filesTree This is the already built fileTree (optional)
+ * @param {*} props.foldersOpenOnLoad Number of folders that should apear open already when displaying the tree
+ * @param {*} props.lineageUrl Should be replaced for URL, this is the link for the file (when clicked) (optional)
+ * * @param {*} props.insideProject Boolean to be set true if the display is inside a project
+ */
 function FileExplorer(props) {
   const [filesTree, setFilesTree] = useState(undefined);
 
   useEffect(() => {
-    if (props.files !== undefined)
+    if (props.filesTree !== undefined)
+      setFilesTree(props.filesTree);
+    else if (props.files !== undefined)
       setFilesTree(getFilesTree(props.files, props.foldersOpenOnLoad));
-  }, [props.files, props.foldersOpenOnLoad]);
+  }, [props.files, props.filesTree, props.foldersOpenOnLoad]);
 
   const setOpenFolder = (filePath) => {
     filesTree.hash[filePath].childrenOpen = !filesTree.hash[filePath].childrenOpen;
@@ -199,3 +210,4 @@ function FileExplorer(props) {
 }
 
 export default FileExplorer;
+export { getFilesTree };

--- a/src/utils/FileExplorer.js
+++ b/src/utils/FileExplorer.js
@@ -30,7 +30,9 @@ function buildTree(parts, treeNode, jsonObj, hash, currentPath, foldersOpenOnLoa
     hash[newNode.path] = {
       "name": parts[0],
       "selected": false,
-      "childrenOpen": foldersOpenOnLoad > 0, "path": currentPath
+      "childrenOpen": foldersOpenOnLoad > 0,
+      "path": currentPath,
+      "isLeaf": parts.length === 1
     };
     buildTree(parts.splice(1, parts.length), newNode.children, jsonObj, hash, currentPath,
       foldersOpenOnLoad > 0 ? foldersOpenOnLoad - 1 : 0);
@@ -53,7 +55,7 @@ function getFilesTree(files, foldersOpenOnLoad) {
     const dir = list[i].atLocation.split("/");
     buildTree(dir, tree, list[i], hash, "", foldersOpenOnLoad);
   }
-  const treeObj = { tree: tree, hash: hash };
+  const treeObj = { tree: tree, hash: hash, leafs: Object.values(hash).filter(file => file.isLeaf) };
   return treeObj;
 }
 

--- a/src/utils/UIComponents.js
+++ b/src/utils/UIComponents.js
@@ -40,7 +40,7 @@ import { faCopy } from "@fortawesome/free-regular-svg-icons";
 import { faCheck, faExternalLinkAlt, faEllipsisV, faUser, faSyncAlt } from "@fortawesome/free-solid-svg-icons";
 
 import { sanitizedHTMLFromMarkdown, simpleHash } from "./HelperFunctions";
-import FileExplorer from "./FileExplorer";
+import FileExplorer, { getFilesTree } from "./FileExplorer";
 
 /**
  * Show user avatar
@@ -719,4 +719,4 @@ export { UserAvatar, TimeCaption, FieldGroup, RenkuNavLink, Pagination, RenkuMar
 export { ExternalLink, ExternalDocsLink, ExternalIconLink, IconLink, RefreshButton };
 export { Loader, InfoAlert, SuccessAlert, WarnAlert, ErrorAlert, JupyterIcon };
 export { Clipboard, ThrottledTooltip, TooltipToggleButton, ProjectAvatar };
-export { ButtonWithMenu, FileExplorer };
+export { ButtonWithMenu, FileExplorer, getFilesTree };

--- a/src/utils/formgenerator/fields/FileUploaderInput.js
+++ b/src/utils/formgenerator/fields/FileUploaderInput.js
@@ -69,9 +69,10 @@ function getFileStatus(id, error, status) {
   return FILE_STATUS.UPLOADING;
 }
 
-function getFileObject(name, size, id, error, alias, controller, uncompress, folderStructure, status) {
+function getFileObject(name, path, size, id, error, alias, controller, uncompress, folderStructure, status) {
   return {
     file_name: name,
+    file_path: path,
     file_size: size,
     file_id: id,
     file_error: error,
@@ -97,16 +98,17 @@ function FileuploaderInput({ name, label, alert, value, setInputs, help, disable
   const [errorOnDrop, setErrorOnDrop] = useState("");
   const [initialized, setInitialized] = useState(false);
   const [initialFilesTree, setInitialFilesTree] = useState(undefined);
+  const [partialFilesPath, setPartialFilesPath] = useState("");
   const $input = useRef(null);
 
   useEffect(() => {
-    if (value !== undefined && !initialized) {
-      let openFolders = value.length > 0 ?
-        ( value[0].atLocation.startsWith("data/") ? 2 : 1 )
-        : 0;
+    if (value !== undefined && !initialized && value.length > 0) {
+      let openFolders = value[value.length - 1].atLocation.startsWith("data/") ? 2 : 1;
+      let lastElement = value[value.length - 1].atLocation.split("/");
+      if (lastElement[0] === "data")
+        setPartialFilesPath(lastElement[0] + "/" + lastElement[1] + "/");
+      else setPartialFilesPath(lastElement[0] + "/");
       setInitialFilesTree(getFilesTree(value, openFolders));
-      // setDisplayFiles(value.map(file => getFileObject(
-      //   file.atLocation, null, undefined, undefined, undefined, undefined, undefined, undefined, FILE_STATUS.ADDED)));
     }
     setInitialized(true);
   }, [value, initialized]);
@@ -123,6 +125,7 @@ function FileuploaderInput({ name, label, alert, value, setInputs, help, disable
         if (uploadingFile !== undefined) {
           return getFileObject(
             uploadingFile.file_name,
+            partialFilesPath + uploadingFile.file_name,
             uploadingFile.file_size,
             uploadingFile.file_id,
             filesErrors.find(file => file.file_name === uploadingFile.file_name),
@@ -144,8 +147,8 @@ function FileuploaderInput({ name, label, alert, value, setInputs, help, disable
         let errorFile = filesErrors.find(eFile => eFile.file_name === dFile.file_name);
         if (errorFile !== undefined) {
           return getFileObject(
-            errorFile.file_name, errorFile.file_size, null, errorFile.file_error, errorFile.file_alias,
-            errorFile.file_controller, errorFile.file_uncompress, errorFile.folder_structure);
+            errorFile.file_name, errorFile.file_path, errorFile.file_size, null, errorFile.file_error,
+            errorFile.file_alias, errorFile.file_controller, errorFile.file_uncompress, errorFile.folder_structure);
         }
         return dFile;
       })
@@ -158,7 +161,7 @@ function FileuploaderInput({ name, label, alert, value, setInputs, help, disable
       response.json().then((body) => {
         if (body.error) {
           setFilesErrors(prevFilesErrors => [...prevFilesErrors,
-            getFileObject(file.name, file.size, undefined, body.error.reason, undefined,
+            getFileObject(file.name, partialFilesPath + file.name, file.size, undefined, body.error.reason, undefined,
               file.file_controller, file.file_uncompress, file.folder_structure)]
           );
           return [];
@@ -172,29 +175,12 @@ function FileuploaderInput({ name, label, alert, value, setInputs, help, disable
             ({ "atLocation": file.relative_path.replace(folderPath, ""),
               "id": file.file_id
             })));
-          let folderStructure = <div>
-            <Button className="pr-0 pl-0 pt-0 pb-0 mb-1" color="link" id={body.result.files[0].id + "collapse"}>
-              <small>Show un-ziped files</small>
-            </Button>
-            <UncontrolledCollapse
-              key={"#" + body.result.files[0].id + "key"}
-              toggler={"#" + body.result.files[0].id + "collapse"}
-              className="pt-2">
-              <small>
-                <FileExplorer
-                  filesTree={filesTree}
-                  lineageUrl={" "}
-                  insideProject={false}
-                  foldersOpenOnLoad={0}
-                /></small>
-            </UncontrolledCollapse>
-          </div>;
 
           let newFileDraft = getFileObject(
-            file.name, 0, [], undefined, file_alias, response.controller,
-            file.file_uncompress, folderStructure);
+            file.name, partialFilesPath + file.name, 0, [], undefined, file_alias, response.controller,
+            file.file_uncompress, filesTree);
 
-          newFileDraft.file_size = body.result.files ? body.result.files[0].file_size : "0MB";
+          newFileDraft.file_size = body.result.files ? body.result.files[0].file_size : 0;
           newFileDraft.file_id = filesTree.tree.map(file => file.id);
           setUploadedFiles(prevUploadedFiles => [...prevUploadedFiles, newFileDraft]);
           return newFileDraft;
@@ -202,8 +188,8 @@ function FileuploaderInput({ name, label, alert, value, setInputs, help, disable
         let newFileObj = body.result.files[0];
         if (newFileObj.file_name !== undefined && newFileObj.file_name !== file.name) {
           newFileObj = getFileObject(
-            file.name, newFileObj.file_size, [newFileObj.file_id], undefined, newFileObj.file_name,
-            response.controller, file.file_uncompress, undefined);
+            file.name, partialFilesPath + file.name, newFileObj.file_size, [newFileObj.file_id],
+            undefined, newFileObj.file_name, response.controller, file.file_uncompress, undefined);
         }
         else {
           newFileObj.file_id = [newFileObj.file_id];
@@ -214,8 +200,8 @@ function FileuploaderInput({ name, label, alert, value, setInputs, help, disable
     }).catch((error) => {
       if (error.code !== DOMException.ABORT_ERR) {
         setFilesErrors(prevFilesErrors => [...prevFilesErrors,
-          getFileObject(file.name, file.size, undefined, "Error uploading the file", undefined,
-            file.file_controller, file.file_uncompress, file.folder_structure)]);
+          getFileObject(file.name, partialFilesPath + file.name, file.size, undefined, "Error uploading the file",
+            undefined, file.file_controller, file.file_uncompress, file.folder_structure)]);
         return [];
       }
     });
@@ -240,9 +226,11 @@ function FileuploaderInput({ name, label, alert, value, setInputs, help, disable
       nonCompressedFiles.map(file => uploadFile(file, file.file_controller));
       const newDisplayFiles = droppedFiles.map(file=> {
         return file.type === "application/zip" ?
-          getFileObject(file.name, file.size, null, undefined, undefined, file.file_controller, FILE_COMPRESSED.WAITING)
+          getFileObject(file.name, partialFilesPath + file.name, file.size, null,
+            undefined, undefined, file.file_controller, FILE_COMPRESSED.WAITING)
           :
-          getFileObject(file.name, file.size, null, undefined, undefined, file.file_controller);
+          getFileObject(file.name, partialFilesPath + file.name, file.size, null,
+            undefined, undefined, file.file_controller);
       });
 
       filesOnUploader.current = displayFiles.filter(file => file.file_status !== FILE_STATUS.ADDED).length
@@ -270,8 +258,8 @@ function FileuploaderInput({ name, label, alert, value, setInputs, help, disable
       if (retryFile !== undefined) {
         const displayFilesFiltered = displayFiles.map(file => {
           if (file.file_name === file_name) {
-            return getFileObject(retryFile.name, retryFile.size, null, undefined, retryFile.file_alias,
-              retryFile.file_controller, file.file_uncompress, file.folder_structure);
+            return getFileObject(retryFile.name, partialFilesPath + retryFile.name, retryFile.size, null,
+              undefined, retryFile.file_alias, retryFile.file_controller, file.file_uncompress, file.folder_structure);
           }
           return file;
         });
@@ -288,8 +276,8 @@ function FileuploaderInput({ name, label, alert, value, setInputs, help, disable
       if (compressedFile !== undefined) {
         const displayFilesFiltered = displayFiles.map(file => {
           if (file.file_name === file_name) {
-            return getFileObject(compressedFile.name, compressedFile.size, null, undefined,
-              compressedFile.file_alias, compressedFile.file_controller, compressedFile === true ?
+            return getFileObject(compressedFile.name, partialFilesPath + compressedFile.name, compressedFile.size,
+              null, undefined, compressedFile.file_alias, compressedFile.file_controller, uncompress === true ?
                 FILE_COMPRESSED.UNCOMPRESS_YES : FILE_COMPRESSED.UNCOMPRESS_NO );
           }
           return file;
@@ -319,7 +307,7 @@ function FileuploaderInput({ name, label, alert, value, setInputs, help, disable
     return filteredFiles;
   };
 
-  let getFileStatusComp = (file) => {
+  const getFileStatusComp = (file) => {
     switch (file.file_status) {
       case FILE_STATUS.ADDED:
         return <span> in dataset</span>;
@@ -351,6 +339,35 @@ function FileuploaderInput({ name, label, alert, value, setInputs, help, disable
       default:
         return null;
     }
+  };
+
+  const fileWillBeOverwritten = (file) => {
+    if (initialFilesTree === undefined) return false;
+    if (file.file_uncompress === FILE_COMPRESSED.WAITING)
+      return null;
+    if (file.file_uncompress === FILE_COMPRESSED.UNCOMPRESS_NO || file.file_uncompress === undefined ) {
+      return initialFilesTree.hash[file.file_path] ? <small><br></br>
+        <span className="text-info">
+          &nbsp;*This file will be skipped because
+          &nbsp;there is a file with the same name inside the dataset.
+        </span>
+      </small> : null;
+    }
+    if (file.folder_structure !== undefined) {
+      const repeatedFiles = file.folder_structure.leafs
+        .filter(file => {
+          let suspectedRep = initialFilesTree.hash[partialFilesPath + file.path];
+          return (suspectedRep !== undefined) ? suspectedRep.isLeaf : false;
+        });
+      return repeatedFiles.length > 0 ?
+        <small><br></br>
+          <span className="text-info">&nbsp;*
+            { repeatedFiles.length > 1 ?
+                `${repeatedFiles.length} files are already in the dataset and will be skipped.` :
+                `${repeatedFiles[0].name} is already in the dataset and will be skipped.`}
+          </span></small> : null;
+    }
+    return null;
   };
 
   return (
@@ -396,16 +413,33 @@ function FileuploaderInput({ name, label, alert, value, setInputs, help, disable
                 <td>
                   <span>{file.file_name}</span>
                   {
-                    file.folder_structure ? <div>
-                      {file.folder_structure}
-                    </div> : null
-                  }
-                  {
                     file.file_alias ? <small><br></br>
                       <span className="text-danger"> *The name of this file contains
                         disallowed characters; it has been renamed to <i> {file.file_alias}</i>
                       </span></small>
                       : null
+                  }
+                  {
+                    fileWillBeOverwritten(file)
+                  }
+                  {
+                    file.folder_structure ? <div>
+                      <Button className="pr-0 pl-0 pt-0 pb-0 mb-1" color="link" id={"filescollapse" + (index + 1)}>
+                        <small>Show unzipped files</small>
+                      </Button>
+                      <UncontrolledCollapse
+                        key={"#" + (index + 1) + "key"}
+                        toggler={"#filescollapse" + (index + 1)}
+                        className="pt-2">
+                        <small>
+                          <FileExplorer
+                            filesTree={file.folder_structure}
+                            lineageUrl={" "}
+                            insideProject={false}
+                            foldersOpenOnLoad={0}
+                          /></small>
+                      </UncontrolledCollapse>
+                    </div> : null
                   }
                 </td>
                 <td>{file.file_size ? formatBytes(file.file_size) : "-"}</td>


### PR DESCRIPTION
Fixes #896

(Luis made a good explanation of the problem on the issue)

Now the folder looks like this: 
![image](https://user-images.githubusercontent.com/42647877/78828195-9a82f700-79e4-11ea-8e5b-89f7d810eed9.png)
There is still a small problem since there is an extra file there that wasn't on the folder structure.

Also, the redirect after the operation is finished isn't working well now.

(We weren't sending all the id's for unzipped files and now we are)