### PR TITLE
chore: update react-autosuggest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7212,6 +7212,11 @@
         "es6-symbol": "^3.1.1"
       }
     },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+    },
     "es6-symbol": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
@@ -15808,13 +15813,14 @@
       }
     },
     "react-autosuggest": {
-      "version": "9.4.3",
-      "resolved": "https://registry.npmjs.org/react-autosuggest/-/react-autosuggest-9.4.3.tgz",
-      "integrity": "sha512-wFbp5QpgFQRfw9cwKvcgLR8theikOUkv8PFsuLYqI2PUgVlx186Cz8MYt5bLxculi+jxGGUUVt+h0esaBZZouw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/react-autosuggest/-/react-autosuggest-10.0.0.tgz",
+      "integrity": "sha512-WFCeRuYv6YCY9Ch4BodXPASWJXDh32ehQQHA2eLNhOBhu3Xcank+5W4wcEN+oqdAX1fvKROZRQRF2fpNZaZaxA==",
       "requires": {
-        "prop-types": "^15.5.10",
-        "react-autowhatever": "^10.1.2",
-        "shallow-equal": "^1.0.0"
+        "es6-promise": "^4.2.8",
+        "prop-types": "^15.7.2",
+        "react-autowhatever": "^10.2.1",
+        "shallow-equal": "^1.2.1"
       }
     },
     "react-autowhatever": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "popper.js": "^1.16.0",
     "query-string": "^6.8.3",
     "react": "^16.11.0",
-    "react-autosuggest": "^9.4.3",
+    "react-autosuggest": "^10.0.0",
     "react-clipboard.js": "^2.0.16",
     "react-collapse": "^5.0.0",
     "react-dom": "^16.11.0",


### PR DESCRIPTION
Minor update. It removes the warning due to the use of the deprecated react function `componentWillReceiveProps`. The last component that still has that issue is `@nteract/notebook-render`