### PR TITLE
fix: consider falsy string values for maintenance page

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,8 +17,9 @@ const configPromise = fetch("/config.json");
 
 configPromise.then((res) => {
   res.json().then((params) => {
-    if (params["MAINTENANCE"]) {
-      ReactDOM.render(<Maintenance info={params["MAINTENANCE"]} />, document.getElementById("root"));
+    const maintenace = params["MAINTENANCE"];
+    if (maintenace && maintenace !== "false" && maintenace !== "0") {
+      ReactDOM.render(<Maintenance info={maintenace} />, document.getElementById("root"));
       return;
     }
 


### PR DESCRIPTION
The maintenance feature in the UI has shown its limits during the last maintenance and we may want to overhaul it soon.
Anyway, in the current form, it's safer to consider the strings "0" and "false" as if they were `0` and `false` to allow ops people to change values on the fly on rancher.