### PR TITLE
fix: update the jupyter button used in file view

### DIFF
--- a/src/file/File.container.js
+++ b/src/file/File.container.js
@@ -22,7 +22,6 @@ import hljs from "highlight.js";
 
 import { atobUTF8 } from "../utils/Encoding";
 import { StyledNotebook, JupyterButtonPresent, ShowFile as ShowFilePresent } from "./File.present";
-import { ACCESS_LEVELS } from "../api-client";
 import { StatusHelper } from "../model/Model";
 import { API_ERRORS } from "../api-client";
 import { RenkuMarkdown } from "../utils/UIComponents";
@@ -136,7 +135,7 @@ class JupyterNotebookContainer extends Component {
  * Jupyter button container component
  *
  * @param {Object} client - api-client used to query the gateway
- * @param {number} accessLevel - current project access level
+ * @param {Object} Object - user object
  * @param {Object} branches - branches data, likely to change in a future release
  * @param {Object} branches.all - list of available branches
  * @param {Object} branches.fetch - function to invoke to refresh branches
@@ -147,7 +146,7 @@ class JupyterNotebookContainer extends Component {
  */
 class JupyterButton extends React.Component {
   componentDidMount() {
-    if (this.props.accessLevel >= ACCESS_LEVELS.MAINTAINER) {
+    if (this.props.user.logged) {
       const { branches } = this.props;
       if (branches && branches.all && !branches.all.length && !StatusHelper.isUpdating(branches.all))
         branches.fetch();
@@ -178,8 +177,14 @@ class JupyterButton extends React.Component {
   }
 
   render() {
-    if (this.props.accessLevel < ACCESS_LEVELS.MAINTAINER)
-      return (<JupyterButtonPresent access={false} launchNotebookUrl={this.props.launchNotebookUrl} />);
+    if (!this.props.user.logged) {
+      return (
+        <JupyterButtonPresent
+          access={false}
+          launchNotebookUrl={this.props.launchNotebookUrl}
+        />
+      );
+    }
 
     const { file, branches } = this.props;
     let updating = false;
@@ -202,6 +207,7 @@ class JupyterButton extends React.Component {
         scope={this.getScope()}
         filePath={filePath}
         updating={updating}
+        location={this.props.location}
         launchNotebookUrl={this.props.launchNotebookUrl} />
     );
   }

--- a/src/file/File.present.js
+++ b/src/file/File.present.js
@@ -201,6 +201,7 @@ class JupyterButtonPresent extends React.Component {
         client={this.props.client}
         model={this.props.model}
         scope={this.props.scope}
+        location={this.props.location}
         launchNotebookUrl={this.props.launchNotebookUrl}
         filePath={this.props.filePath} />
     );

--- a/src/file/File.present.js
+++ b/src/file/File.present.js
@@ -320,7 +320,8 @@ class JupyterButtonPresent extends React.Component {
     if (!this.props.access)
       return <CheckNotebookIcon fetched={true} launchNotebookUrl={this.props.launchNotebookUrl} />;
 
-    if (this.props.updating) return <Loader size="16" inline="true" />;
+    if (this.props.updating)
+      return (<span style={{ verticalAlign: "text-bottom" }}><Loader size="19" inline="true" /></span>);
 
     return (
       <CheckNotebookStatus

--- a/src/notebooks/Notebooks.container.js
+++ b/src/notebooks/Notebooks.container.js
@@ -134,8 +134,8 @@ class Notebooks extends Component {
  * @param {string} scope.project - path of the reference project
  * @param {string} externalUrl - GitLabl repository url
  * @param {boolean} blockAnonymous - When true, block non logged in users
- * @param {Object} [location] - react location object
- * @param {string} [successUrl] - redirect url to be used when a notebook is succesfully started
+ * @param {Object} [location] - react location object. Use location.state.successUrl to inidcate the
+ *     redirect url to be used when a notebook is succesfully started
  * @param {Object} [history] - mandatory if successUrl is provided
  * @param {string} [message] - provide a useful information or warning message
  */
@@ -315,12 +315,12 @@ class StartNotebookServer extends Component {
   startServer() {
     //* Data from notebooks/servers endpoint needs some time to update properly.
     //* To avoid flickering UI, just set a temporary state and display a loading wheel.
-    const { successUrl, history } = this.props;
+    const { location, history } = this.props;
     this.setState({ "starting": true });
     this.coordinator.startServer().then(() => {
       this.setState({ "starting": false });
-      if (successUrl && history)
-        history.push(successUrl);
+      if (history && location && location.state && location.state.successUrl)
+        history.push(location.state.successUrl);
     });
   }
 
@@ -379,13 +379,15 @@ class StartNotebookServer extends Component {
  * @param {string} scope.project - path of the reference project
  * @param {string} scope.branch - branch name
  * @param {string} scope.commit - commit full id or "latest"
+ * @param {Object} [location] - react location object
  * @param {number} [pollingInterval] - polling timeout interval in seconds
  */
 class CheckNotebookStatus extends Component {
   constructor(props) {
     super(props);
     this.model = props.model.subModel("notebooks");
-    this.coordinator = new NotebooksCoordinator(props.client, this.model);
+    this.userModel = props.model.subModel("user");
+    this.coordinator = new NotebooksCoordinator(props.client, this.model, this.userModel);
     // temporarily reset data since notebooks model was not designed to be static
     this.coordinator.reset();
 

--- a/src/notebooks/Notebooks.present.js
+++ b/src/notebooks/Notebooks.present.js
@@ -1348,8 +1348,9 @@ class AutosavedDataModal extends Component {
 class CheckNotebookIcon extends Component {
   render() {
     const { fetched, notebook, location } = this.props;
+    const loader = (<span style={{ verticalAlign: "text-bottom" }}><Loader size="19" inline="true" /></span>);
     if (!fetched)
-      return (<Loader size="16" inline="true" />);
+      return loader;
 
     let tooltip, link, icon;
     if (notebook) {
@@ -1361,8 +1362,8 @@ class CheckNotebookIcon extends Component {
         link = (<a href={url} role="button" target="_blank" rel="noreferrer noopener">{icon}</a>);
       }
       else if (status === "pending") {
-        tooltip = "Interactive environment status is changing, please wait...";
-        icon = (<JupyterIcon svgClass="svg-inline--fa fa-w-16 icon-link" greyscale={true} />);
+        tooltip = "Interactive environment is either starting or stopping, please wait...";
+        icon = loader;
         link = (<span>{icon}</span>);
       }
       else {

--- a/src/notebooks/Notebooks.present.js
+++ b/src/notebooks/Notebooks.present.js
@@ -1347,7 +1347,7 @@ class AutosavedDataModal extends Component {
 // * CheckNotebookIcon code * //
 class CheckNotebookIcon extends Component {
   render() {
-    const { fetched, notebook } = this.props;
+    const { fetched, notebook, location } = this.props;
     if (!fetched)
       return (<Loader size="16" inline="true" />);
 
@@ -1372,9 +1372,16 @@ class CheckNotebookIcon extends Component {
       }
     }
     else {
+      const successUrl = location ?
+        location.pathname :
+        null;
+      const target = {
+        pathname: this.props.launchNotebookUrl,
+        state: { successUrl }
+      };
       tooltip = "Start an interactive environment";
       icon = (<JupyterIcon svgClass="svg-inline--fa fa-w-16 icon-link" greyscale={true} />);
-      link = (<Link to={this.props.launchNotebookUrl}>{icon}</Link>);
+      link = (<Link to={target}>{icon}</Link>);
     }
 
     return (

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -905,15 +905,25 @@ class ProjectNotebookServers extends Component {
 class ProjectStartNotebookServer extends Component {
   render() {
     const {
-      client, model, user, visibility, toggleForkModal, location, externalUrl, system,
+      client, model, user, visibility, toggleForkModal, externalUrl, system, location,
       fetchBranches, notebookServersUrl, history, blockAnonymous
     } = this.props;
     const warning = notebookWarning(
       user.logged, visibility.accessLevel, toggleForkModal, location.pathname, externalUrl
     );
 
+    const locationEnhanced = location && location.state && location.state.successUrl ?
+      location :
+      {
+        ...this.props.location,
+        state: {
+          ...this.props.location.state,
+          successUrl: notebookServersUrl
+        }
+      };
+
     return (
-      <StartNotebookServer client={client} model={model} history={history} location={location}
+      <StartNotebookServer client={client} model={model} history={history} location={locationEnhanced}
         message={warning}
         branches={system.branches}
         autosaved={system.autosaved}


### PR DESCRIPTION
This fixes the `CheckNotebookStatus` component by correctly setting the `"user"` subModel in the constructor and showing the normal commands also to unprivileged users.

It goes further by adding basic support for being re-directed back to the notebook page when starting an environment from there. That part needs polishing but it will be addressed in the proper issue.

Preview: https://lorenzotest.dev.renku.ch/

***How to test***
Go to a project containing a notebook, click on the "Start environment" Jupyter icon. This should now work again and bring you back to the original page when done, even if the feedback you get there is still poor.
https://lorenzotest.dev.renku.ch/projects/lorenzo.cavazzi.tech/zurich-bikes-tutorial/files/blob/notebooks/zhbikes-notebook.ipynb