### PR TITLE
fix: remove conditional statemens from template files

### DIFF
--- a/src/api-client/project.js
+++ b/src/api-client/project.js
@@ -559,7 +559,6 @@ function getPayload(projectName, renkuTemplatesUrl, renkuTemplatesRef, projectTe
   }
 
   function evaluateTemplate(content, projectName) {
-
     const now = new Date();
     const templatedVariables = {
       "name": projectName,
@@ -568,9 +567,10 @@ function getPayload(projectName, renkuTemplatesUrl, renkuTemplatesRef, projectTe
     };
 
     const newContent = content.replace(/{{\s?([^\s]*)\s?}}/g, (match, group) => {
-      return templatedVariables[group];
+      return templatedVariables[group] ? templatedVariables[group] : "";
     });
-    return newContent;
+    const cleanedContent = newContent.replace(/{%\s?(if \S* | endif)\s?%}\s*/g, "");
+    return cleanedContent;
   }
 
 }


### PR DESCRIPTION
A quick fix to avoid any unknown jinja variable and jinja `if-endif` statement to generate problems during project creation.
E.G: SwissDataScienceCenter/renku-project-template#72

***How to test***
Please use an environment deployed using a `values.ymal` file containing the following setting -- it should be standard (otherwise please add them and re-deploy):
```
ui:
  templatesRepository:
    url: https://github.com/SwissDataScienceCenter/renku-project-template
    ref: master
```
Creating a new `Python basic` project will result in a wrong README file (notice the `udefined` value and the `{ if` ) without this PR.
You can either use telepresence and switch between this branch and `master`, or use this image for the current branch `lorenzocavazzitech/renku-ui:0.9.2-4161b4a`

