### PR TITLE
Link to renku documentation in the UI

### DIFF
--- a/src/help/Help.container.js
+++ b/src/help/Help.container.js
@@ -34,7 +34,7 @@ class Help extends Component {
     return {
       base: baseUrl,
       getting: `${baseUrl}/getting`,
-      tutorials: `${baseUrl}/tutorials`,
+      documentation: `${baseUrl}/docs`,
       features: `${baseUrl}/features`,
       setup: `${baseUrl}/setup`,
     };

--- a/src/help/Help.present.js
+++ b/src/help/Help.present.js
@@ -40,7 +40,7 @@ class HelpNav extends Component {
           <RenkuNavLink to={this.props.url.base} alternate={this.props.url.getting} title="Getting Help" />
         </NavItem>
         <NavItem>
-          <RenkuNavLink to={this.props.url.tutorials} title="Tutorials" />
+          <RenkuNavLink to={this.props.url.documentation} title="Documentation" />
         </NavItem>
         <NavItem>
           <RenkuNavLink to={this.props.url.features} title="Features" />
@@ -103,22 +103,32 @@ class HelpGetting extends Component {
   }
 }
 
-class HelpTutorials extends Component {
+class HelpDocumentation extends Component {
   render() {
     return (
       <div>
-        <h2>First steps</h2>
+        <h2>
+          <ExternalDocsLink url="https://renku.readthedocs.io/en/latest/tutorials/firststeps.html"
+            title="Tutorial" />
+        </h2>
         <p>
           If you are here for the first time or you are not sure how to use Renku, we recommend you
-          to go through our{" "}
-          <a
-            href="https://renku.readthedocs.io/en/latest/tutorials/firststeps.html"
-            target="_blank"
-            rel="noreferrer noopener"
-          >
-            tutorial
-          </a>
-          .
+          to go through our {" "}
+          <ExternalDocsLink url="https://renku.readthedocs.io/en/latest/tutorials/firststeps.html" title="tutorial" />.
+        </p>
+        <h2>
+          <ExternalDocsLink url="https://renku.readthedocs.io/en/latest/"
+            title="Renku" /> and {" "}
+          <ExternalDocsLink url="https://renku-python.readthedocs.io/en/latest/"
+            title="Renku CLI" /> Documentation
+        </h2>
+        <p>
+          Documentation on the Renku project in general is at {" "}
+          <ExternalDocsLink url="https://renku.readthedocs.io/en/latest/" title="renku.readthedocs.io" />.
+        </p>
+        <p>
+          The command-line-interface is documented in detail at {" "}
+          <ExternalDocsLink url="https://renku-python.readthedocs.io/en/latest/" title="renku-python.readthedocs.io" />.
         </p>
       </div>
     );
@@ -224,9 +234,9 @@ class HelpContent extends Component {
         render={props => <HelpGetting key="getting" {...this.props} />}
       />,
       <Route
-        path={this.props.url.tutorials}
-        key="tutorials"
-        render={props => <HelpTutorials key="tutorials" {...this.props} />}
+        path={this.props.url.documentation}
+        key="documentation"
+        render={props => <HelpDocumentation key="documentation" {...this.props} />}
       />,
       <Route
         path={this.props.url.features}

--- a/src/help/Help.present.js
+++ b/src/help/Help.present.js
@@ -108,13 +108,14 @@ class HelpDocumentation extends Component {
     return (
       <div>
         <h2>
-          <ExternalDocsLink url="https://renku.readthedocs.io/en/latest/tutorials/firststeps.html"
+          <ExternalDocsLink url="https://renku.readthedocs.io/en/latest/tutorials/01_firststeps.html"
             title="Tutorial" />
         </h2>
         <p>
           If you are here for the first time or you are not sure how to use Renku, we recommend you
           to go through our {" "}
-          <ExternalDocsLink url="https://renku.readthedocs.io/en/latest/tutorials/firststeps.html" title="tutorial" />.
+          <ExternalDocsLink url="https://renku.readthedocs.io/en/latest/tutorials/01_firststeps.html"
+            title="tutorial" />.
         </p>
         <h2>
           <ExternalDocsLink url="https://renku.readthedocs.io/en/latest/"

--- a/src/help/Help.present.js
+++ b/src/help/Help.present.js
@@ -106,32 +106,39 @@ class HelpGetting extends Component {
 class HelpDocumentation extends Component {
   render() {
     return (
-      <div>
-        <h2>
-          <ExternalDocsLink url="https://renku.readthedocs.io/en/latest/tutorials/01_firststeps.html"
-            title="Tutorial" />
-        </h2>
-        <p>
-          If you are here for the first time or you are not sure how to use Renku, we recommend you
-          to go through our {" "}
-          <ExternalDocsLink url="https://renku.readthedocs.io/en/latest/tutorials/01_firststeps.html"
-            title="tutorial" />.
-        </p>
-        <h2>
-          <ExternalDocsLink url="https://renku.readthedocs.io/en/latest/"
-            title="Renku" /> and {" "}
-          <ExternalDocsLink url="https://renku-python.readthedocs.io/en/latest/"
-            title="Renku CLI" /> Documentation
-        </h2>
-        <p>
-          Documentation on the Renku project in general is at {" "}
-          <ExternalDocsLink url="https://renku.readthedocs.io/en/latest/" title="renku.readthedocs.io" />.
-        </p>
-        <p>
-          The command-line-interface is documented in detail at {" "}
-          <ExternalDocsLink url="https://renku-python.readthedocs.io/en/latest/" title="renku-python.readthedocs.io" />.
-        </p>
-      </div>
+      <Row>
+        <Col md={8}>
+          <h2>
+            <ExternalDocsLink url="https://renku.readthedocs.io/en/latest/tutorials/01_firststeps.html"
+              title="Tutorial" />
+          </h2>
+          <p>
+            If you are here for the first time or you are not sure how to use Renku, we recommend you
+            to go through our {" "}
+            <ExternalDocsLink url="https://renku.readthedocs.io/en/latest/tutorials/01_firststeps.html"
+              title="tutorial" />.
+          </p>
+          <h2>
+            <ExternalDocsLink url="https://renku.readthedocs.io/en/latest/"
+              title="Renku" />
+          </h2>
+          <p>
+            The <ExternalDocsLink url="https://renku.readthedocs.io/en/latest/"
+              title="Renku project documentation" /> explains Renku as a whole. It describes
+            the parts that make it up, how they fit together, and how to use Renku in your
+            data-science projects to work more effectively.
+          </p>
+          <h2>
+            <ExternalDocsLink url="https://renku-python.readthedocs.io/en/latest/"
+              title="Renku CLI" />
+          </h2>
+          <p>
+            The <ExternalDocsLink url="https://renku-python.readthedocs.io/en/latest/"
+              title="command-line-interface (CLI) documentation" /> details the commands of the
+            CLI, their parameters and options, and their behavior.
+          </p>
+        </Col>
+      </Row>
     );
   }
 }

--- a/src/landing/Landing.present.js
+++ b/src/landing/Landing.present.js
@@ -227,7 +227,7 @@ class AnonymousHome extends Component {
       <Row key="tutorial" className="mb-3">
         <Col>
           Want to learn more? Create an account
-          and <a href="https://renku.readthedocs.io/en/latest/tutorials/firststeps.html">follow the tutorial</a>.
+          and <a href="https://renku.readthedocs.io/en/latest/tutorials/01_firststeps.html">follow the tutorial</a>.
         </Col>
       </Row>
       <Row key="closing">

--- a/src/landing/NavBar.js
+++ b/src/landing/NavBar.js
@@ -137,9 +137,9 @@ function RenkuToolbarHelpMenu(props) {
     <div key="help-menu" className="dropdown-menu dropdown-menu-right" aria-labelledby="help-menu">
       <Link className="dropdown-item" to="/help">Help</Link>
       <DropdownItem divider />
-      <ExternalDocsLink url="https://renku.readthedocs.io/en/latest/" title="Renku Project" className="dropdown-item" />
+      <ExternalDocsLink url="https://renku.readthedocs.io/en/latest/" title="Renku Docs" className="dropdown-item" />
       <ExternalDocsLink url="https://renku-python.readthedocs.io/en/latest/"
-        title="Renku CLI" className="dropdown-item" />
+        title="Renku CLI Docs" className="dropdown-item" />
       <DropdownItem divider />
       <ExternalDocsLink url="https://renku.discourse.group" title="Forum" className="dropdown-item" />
       <ExternalDocsLink url="https://gitter.im/SwissDataScienceCenter/renku" title="Gitter" className="dropdown-item" />

--- a/src/landing/NavBar.js
+++ b/src/landing/NavBar.js
@@ -137,6 +137,10 @@ function RenkuToolbarHelpMenu(props) {
     <div key="help-menu" className="dropdown-menu dropdown-menu-right" aria-labelledby="help-menu">
       <Link className="dropdown-item" to="/help">Help</Link>
       <DropdownItem divider />
+      <ExternalDocsLink url="https://renku.readthedocs.io/en/latest/" title="Renku Project" className="dropdown-item" />
+      <ExternalDocsLink url="https://renku-python.readthedocs.io/en/latest/"
+        title="Renku CLI" className="dropdown-item" />
+      <DropdownItem divider />
       <ExternalDocsLink url="https://renku.discourse.group" title="Forum" className="dropdown-item" />
       <ExternalDocsLink url="https://gitter.im/SwissDataScienceCenter/renku" title="Gitter" className="dropdown-item" />
       <ExternalDocsLink url="https://github.com/SwissDataScienceCenter/renku"


### PR DESCRIPTION
Fix #892

Menu now looks like: 
![image](https://user-images.githubusercontent.com/1196411/79957629-26cff800-8482-11ea-91b5-1cbba9e67a5c.png)

Help page looks like:
![image](https://user-images.githubusercontent.com/1196411/79957758-5da60e00-8482-11ea-8884-b8c262ef6bd9.png)



Try it out at https://sekhar.dev.renku.ch/help