### PR TITLE
fix(datasets): dataset_name changed to short_name

### DIFF
--- a/src/api-client/dataset.js
+++ b/src/api-client/dataset.js
@@ -64,7 +64,7 @@ export default function addDatasetMethods(client) {
           method: "POST",
           headers: headers,
           body: JSON.stringify({
-            "dataset_name": datasetName,
+            "short_name": datasetName,
             "files": filesList,
             "project_id": response.data.result.project_id
           })
@@ -97,7 +97,7 @@ export default function addDatasetMethods(client) {
         method: "POST",
         headers: headers,
         body: JSON.stringify({
-          "dataset_name": renkuDataset.name,
+          "short_name": renkuDataset.name,
           "description": renkuDataset.description,
           "project_id": project_id
         })
@@ -111,7 +111,7 @@ export default function addDatasetMethods(client) {
             method: "POST",
             headers: headers,
             body: JSON.stringify({
-              "dataset_name": renkuDataset.name,
+              "short_name": renkuDataset.name,
               "files": renkuDataset.files,
               "project_id": project_id
             })

--- a/src/project/datasets/new/DatasetNew.container.js
+++ b/src/project/datasets/new/DatasetNew.container.js
@@ -58,7 +58,7 @@ function NewDataset(props) {
             props.client.getProjectDatasetsFromKG(props.projectPathWithNamespace)
               .then(datasets => {
                 // eslint-disable-next-line
-            let new_dataset = datasets.find( ds => ds.name === dataset.data.result.dataset_name);
+            let new_dataset = datasets.find( ds => ds.name === dataset.data.result.short_name);
                 if (new_dataset !== undefined) {
                   setSubmitLoader(false);
                   clearInterval(waitForDatasetInKG);


### PR DESCRIPTION
"dataset_name" inside the core service changed to "short_name" this will allow us to use in the future for "dataset_name" a proper title with spaces and short name would be the title that we have now.

For testing this in your own env you need to have the latest version of renku-core(0.10.3-cf08d03)