### PR TITLE
feat: show commit list

### DIFF
--- a/src/api-client/repository.js
+++ b/src/api-client/repository.js
@@ -33,12 +33,18 @@ function addRepositoryMethods(client) {
   };
 
 
-  client.getCommits = (projectId, ref = "master") => {
+  client.getCommits = (projectId, ref = "master", max = 100) => {
     let headers = client.getBasicHeaders();
     headers.append("Content-Type", "application/json");
-    return client.clientFetch(`${client.baseUrl}/projects/${projectId}/repository/commits?ref_name=${ref}`, {
+
+    const queryParams = {
+      ref_name: ref,
+      per_page: max
+    };
+    return client.clientFetch(`${client.baseUrl}/projects/${projectId}/repository/commits`, {
       method: "GET",
-      headers: headers
+      headers: headers,
+      queryParams
     })
       .then(resp => {
         if (resp.data.length > 0)

--- a/src/merge-request/MergeRequest.container.js
+++ b/src/merge-request/MergeRequest.container.js
@@ -115,6 +115,8 @@ class MergeRequestContainer extends Component {
     return <MergeRequestPresent
       title={this.state.title}
       author={this.state.author}
+      location={this.props.location}
+      externalUrl={this.props.externalUrl}
       externalMRUrl={externalMRUrl}
       externalMROverviewUrl={externalMROverviewUrl}
       changes={this.state.changes}

--- a/src/merge-request/MergeRequest.present.js
+++ b/src/merge-request/MergeRequest.present.js
@@ -19,17 +19,19 @@
 import React, { Component } from "react";
 import { Row, Col, Badge, ListGroupItem, Nav, NavItem } from "reactstrap";
 import { NavLink, Switch, Route } from "react-router-dom";
-import {
-  UserAvatar, ExternalLink, TimeCaption, TooltipToggleButton, ExternalIconLink,
-  Clipboard, RenkuNavLink
-} from "../utils/UIComponents";
-import { Contribution, NewContribution } from "../contribution";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faComments, faCodeBranch, faListUl,
   faLongArrowAltLeft as faLeftArrow
 } from "@fortawesome/free-solid-svg-icons";
 import { faGitlab } from "@fortawesome/free-brands-svg-icons";
+
+import {
+  UserAvatar, ExternalLink, TimeCaption, TooltipToggleButton, ExternalIconLink, RenkuNavLink
+} from "../utils/UIComponents";
+import { Contribution, NewContribution } from "../contribution";
+import { CommitsView } from "../utils/Commits";
+
 
 function MergeRequestHeader(props) {
 
@@ -87,43 +89,6 @@ function ContributionsView(props) {
   ];
 }
 
-function SingleCommit(props) {
-  return <ListGroupItem className="pr-0 pl-0 pt-1 pb-1" style={{ border: "none" }}>
-    <Row>
-      <Col sm={9} md={9}>
-        <div className="d-flex project-list-row mb-3">
-          <div className="issue-text-crop">
-            <b>
-              <span className="issue-title">
-                {props.commit.message}
-              </span>
-            </b><br />
-            <span className="issues-description">
-              <div>
-                <TimeCaption caption={props.commit.author_name + " created"} time={props.commit.created_at} />
-              </div>
-            </span>
-          </div>
-        </div>
-      </Col>
-      <Col sm={3} md={3} className="float-right" style={{ textAlign: "end" }}>
-        <span className="text-muted">
-          <small>{props.commit.short_id}</small> <Clipboard clipboardText={props.commit.id} />
-        </span>
-      </Col>
-    </Row>
-  </ListGroupItem>;
-}
-
-function CommitsView(props) {
-  const commits = props.commits
-    .map(commit => <SingleCommit key={commit.id} commit={commit} {...props} />);
-  return <Row key="simple"><Col>
-    <br />
-    {commits}
-  </Col></Row>;
-}
-
 function ChangesView(props) {
 
   const opaqueChanges = props.changes
@@ -154,8 +119,8 @@ class MergeRequestPresent extends Component {
       <Row key="description" className="pb-2">
         <Col sm={11}>
           <p key="lead" className="lead">
-            {this.props.author.name} wants to merge changes from branch
-            <em><strong>{this.props.source_branch}</strong></em> into
+            {this.props.author.name} wants to merge changes from branch&nbsp;
+            <em><strong>{this.props.source_branch}</strong></em> into&nbsp;
             <em><strong>{this.props.target_branch}</strong></em>.
           </p>
         </Col>
@@ -170,7 +135,15 @@ class MergeRequestPresent extends Component {
             <ChangesView {...this.props} />
           } />
           <Route path={this.props.mergeRequestCommitsUrl} render={props =>
-            <CommitsView {...this.props} />
+            <div style={{ paddingTop: "20px" }}>
+              <CommitsView
+                commits={this.props.commits}
+                fetched={true}
+                fetching={false}
+                urlRepository={this.props.externalUrl}
+                urlDiff={`${this.props.externalMRUrl}?commit_id=`}
+              />
+            </div>
           } />
         </Switch>
       </Col>

--- a/src/model/GlobalSchema.js
+++ b/src/model/GlobalSchema.js
@@ -24,12 +24,13 @@
  */
 
 import { Schema } from "./index";
-import { notebooksSchema, userSchema, projectsSchema } from "./RenkuModels";
+import { notebooksSchema, userSchema, projectsSchema, projectGlobalSchema } from "./RenkuModels";
 
 const globalSchema = new Schema({
   notebooks: { schema: notebooksSchema },
   user: { schema: userSchema },
   projects: { schema: projectsSchema },
+  project: { schema: projectGlobalSchema }
 });
 
 export { globalSchema };

--- a/src/model/RenkuModels.js
+++ b/src/model/RenkuModels.js
@@ -172,6 +172,37 @@ const projectSchema = new Schema({
   }
 });
 
+const projectGlobalSchema = new Schema({
+  metadata: {
+    schema: {
+      exists: { initial: null, mandatory: true },
+
+      id: { initial: null, mandatory: true }, // id
+      namespace: { initial: null, mandatory: true }, // namespace.full_path
+      path: { initial: null, mandatory: true }, // path
+      pathWithNamespace: { initial: null, mandatory: true }, // path_with_namespace
+      repositoryUrl: { initial: null, mandatory: true }, // web_url
+
+      fetched: { initial: null },
+      fetching: { initial: false },
+    }
+  },
+  commits: {
+    schema: {
+      list: { initial: [], mandatory: true },
+
+      fetched: { initial: null },
+      fetching: { initial: false },
+    }
+  },
+  filters: {
+    schema: {
+      branch: { initial: { name: "master" }, mandatory: true },
+      commit: { initial: { id: "latest" }, mandatory: true },
+    }
+  }
+});
+
 const notebooksSchema = new Schema({
   notebooks: {
     schema: {
@@ -352,6 +383,8 @@ const addDatasetToProjectSchema = new Schema({
 });
 
 
-export { userSchema, metaSchema, displaySchema, newProjectSchema, projectSchema, forkProjectSchema };
-export { notebooksSchema, projectsSchema, datasetFormSchema, issueFormSchema, datasetImportFormSchema };
-export { addDatasetToProjectSchema };
+export {
+  userSchema, metaSchema, displaySchema, newProjectSchema, projectSchema, forkProjectSchema, notebooksSchema,
+  projectsSchema, datasetFormSchema, issueFormSchema, datasetImportFormSchema, projectGlobalSchema,
+  addDatasetToProjectSchema
+};

--- a/src/model/index.js
+++ b/src/model/index.js
@@ -25,5 +25,9 @@
 
 import { Schema, StateModel, StateKind, SubModel, SpecialPropVal, StatusHelper } from "./Model";
 import { globalSchema } from "./GlobalSchema";
+import { projectGlobalSchema, projectSchema } from "./RenkuModels";
 
-export { globalSchema, Schema, StateModel, StateKind, SubModel, SpecialPropVal, StatusHelper };
+export {
+  globalSchema, Schema, StateModel, StateKind, SubModel, SpecialPropVal, StatusHelper, projectGlobalSchema,
+  projectSchema
+};

--- a/src/notebooks/Notebooks.container.js
+++ b/src/notebooks/Notebooks.container.js
@@ -24,6 +24,7 @@ import { StartNotebookServer as StartNotebookServerPresent, NotebooksDisabled } 
 import { Notebooks as NotebooksPresent } from "./Notebooks.present";
 import { CheckNotebookIcon } from "./Notebooks.present";
 import { StatusHelper } from "../model/Model";
+import { ProjectCoordinator } from "../project";
 
 /**
  * Display the list of Notebook servers
@@ -145,6 +146,9 @@ class StartNotebookServer extends Component {
     this.model = props.model.subModel("notebooks");
     this.userModel = props.model.subModel("user");
     this.coordinator = new NotebooksCoordinator(props.client, this.model, this.userModel);
+    // TODO: this should go away when moving all project content to projectCoordinator
+    this.projectModel = props.model.subModel("project");
+    this.projectCoordinator = new ProjectCoordinator(props.client, props.model.subModel("project"));
     // temporarily reset data since notebooks model was not designed to be static
     this.coordinator.reset();
 
@@ -243,13 +247,19 @@ class StartNotebookServer extends Component {
 
   async refreshCommits() {
     if (this._isMounted) {
-      if (this.model.get("data.fetching"))
-        return;
+      if (!this.projectModel.get("commits.fetching"))
+        await this.projectCoordinator.fetchCommits();
+      this.selectCommitWhenReady();
+    }
+  }
 
-      await this.coordinator.fetchCommits();
-      if (this._isMounted)
+  // TODO: ugly workaround until branches and commits will be unified in projectCoordinator
+  async selectCommitWhenReady() {
+    if (this._isMounted) {
+      if (this.projectModel.get("commits.fetching"))
+        setTimeout(() => { this.selectCommitWhenReady(); }, 100);
+      else
         this.selectCommit();
-
     }
   }
 
@@ -258,8 +268,8 @@ class StartNotebookServer extends Component {
       // filter the list of commits according to the constraints
       const maximum = this.model.get("filters.displayedCommits");
       const commits = maximum && parseInt(maximum) > 0 ?
-        this.model.get("data.commits").slice(0, maximum) :
-        this.model.get("data.commits");
+        this.projectModel.get("commits.list").slice(0, maximum) :
+        this.projectModel.get("commits.list");
       let commit = commits[0];
 
       // find the proper commit or return
@@ -339,7 +349,9 @@ class StartNotebookServer extends Component {
     const augmentedState = {
       ...state.notebooks,
       data: {
-        ...state.notebooks.data,
+        fetched: state.project.commits.fetched,
+        fetching: state.project.commits.fetching,
+        commits: state.project.commits.list,
         branches: ownProps.inherited.branches,
         autosaved: ownProps.inherited.autosaved
       },
@@ -388,6 +400,8 @@ class CheckNotebookStatus extends Component {
     this.model = props.model.subModel("notebooks");
     this.userModel = props.model.subModel("user");
     this.coordinator = new NotebooksCoordinator(props.client, this.model, this.userModel);
+    // TODO: this should go away when moving all project content to projectCoordinator
+    this.projectCoordinator = new ProjectCoordinator(props.client, props.model.subModel("project"));
     // temporarily reset data since notebooks model was not designed to be static
     this.coordinator.reset();
 
@@ -402,7 +416,7 @@ class CheckNotebookStatus extends Component {
     if (!scope.branch || !scope.commit)
       return;
     if (scope.commit === "latest") {
-      let commits = await this.coordinator.fetchCommits();
+      let commits = await this.projectCoordinator.fetchCommits();
       scope.commit = commits[0];
       this.coordinator.setNotebookFilters(scope);
     }

--- a/src/notebooks/Notebooks.state.js
+++ b/src/notebooks/Notebooks.state.js
@@ -699,29 +699,6 @@ class NotebooksCoordinator {
         throw error;
       });
   }
-
-
-  // * Fetch commits -- to be moved * //
-  async fetchCommits() {
-    this.model.set("data.fetching", true);
-    const filters = this.model.get("filters");
-    const projectPathWithNamespace = `${encodeURIComponent(filters.namespace)}%2F${filters.project}`;
-    return this.client.getCommits(projectPathWithNamespace, filters.branch.name)
-      .then(resp => {
-        this.model.setObject({
-          data: {
-            fetching: false,
-            fetched: new Date(),
-            commits: { $set: resp.data }
-          }
-        });
-        return resp.data;
-      })
-      .catch(error => {
-        this.model.set("data.fetching", false);
-        throw error;
-      });
-  }
 }
 
 export { NotebooksHelper, ExpectedAnnotations, NotebooksCoordinator };

--- a/src/project/Project.js
+++ b/src/project/Project.js
@@ -29,7 +29,7 @@ import _ from "lodash/collection";
 
 import { StateKind } from "../model/Model";
 import Present from "./Project.present";
-import { ProjectModel, GraphIndexingStatus } from "./Project.state";
+import { ProjectModel, GraphIndexingStatus, ProjectCoordinator } from "./Project.state";
 import { ProjectsCoordinator } from "./shared";
 import Issue from "../issue/Issue";
 import { FileLineage } from "../file";
@@ -50,6 +50,7 @@ const subRoutes = {
   overview: "overview",
   stats: "overview/stats",
   overviewDatasets: "overview/datasets",
+  overviewCommits: "overview/commits",
   datasets: "datasets",
   datasetsAdd: "datasets/new",
   dataset: "datasets/:datasetId",
@@ -152,13 +153,14 @@ class View extends Component {
   constructor(props) {
     super(props);
     this.projectState = new ProjectModel(StateKind.REDUX);
+    // TODO: Could move projectsCoordinator once ProjectModel goes away
     this.projectsCoordinator = new ProjectsCoordinator(props.client, props.model.subModel("projects"));
+    this.projectCoordinator = new ProjectCoordinator(props.client, props.model.subModel("project"));
 
     // fetch useful projects data in not yet loaded
     const featured = props.model.get("projects.featured");
     if (!featured.fetched && !featured.fetching)
       this.projectsCoordinator.getFeatured();
-
   }
 
   componentDidMount() {
@@ -199,9 +201,19 @@ class View extends Component {
     }
   }
 
+  componentWillUnmount() {
+    this.projectCoordinator.resetProject();
+  }
+
   async fetchProject() {
     const pathComponents = splitProjectSubRoute(this.props.match.url);
-    return this.projectState.fetchProject(this.props.client, pathComponents.projectPathWithNamespace);
+    const projectData = this.projectState.fetchProject(this.props.client, pathComponents.projectPathWithNamespace);
+    // TODO: gradually move queries from local store projectState to shared store projectCoordinator
+    projectData.then(data => {
+      this.projectCoordinator.setProjectData(data);
+      this.projectCoordinator.fetchCommits();
+    });
+    return projectData;
   }
   async fetchReadme() { return this.projectState.fetchReadme(this.props.client); }
   async fetchMergeRequests() { return this.projectState.fetchMergeRequests(this.props.client); }
@@ -294,6 +306,7 @@ class View extends Component {
       overviewUrl: `${baseUrl}/overview`,
       statsUrl: `${baseUrl}/overview/stats`,
       overviewDatasetsUrl: `${baseUrl}/overview/datasets`,
+      overviewCommitsUrl: `${baseUrl}/overview/commits`,
       datasetsUrl: `${datasetsUrl}`,
       newDatasetUrl: `${datasetsUrl}/new`,
       datasetUrl: `${datasetsUrl}/:datasetId`,
@@ -635,10 +648,80 @@ class View extends Component {
     const ConnectedProjectView = connect(
       this.mapStateToProps.bind(this), null, null, { storeKey: "projectStore" }
     )(Present.ProjectView);
-    const props = { ...this.props, ...this.eventHandlers, projectStore: this.projectState.reduxStore };
+    const props = {
+      ...this.props,
+      ...this.eventHandlers,
+      projectStore: this.projectState.reduxStore,
+      projectCoordinator: this.projectCoordinator
+    };
     return <ConnectedProjectView {...props} />;
   }
 }
 
+
+/**
+ * Generate the appropriate mapStateToProps function to connect project components
+ *
+ * @param {Object} projectCoordinator - an instance of the projectCoordinator
+ * @param {string[]} [features] - list of project sub-categories to include. An empty array
+ *     means all categories will be included
+ * @param {string} [parentProperty] - optional parent property where to include all the
+ *     selected categories. Try to avoid it, only for compatibility with old components.
+ */
+function mapProjectFeatures(projectCoordinator, features = [], parentProperty = null) {
+  let mapStateToProps = function (state) {
+    const projectState = state.project;
+    if (!features || !features.length)
+      features = Object.keys(projectState);
+
+    // select categories
+    let properties = { ...projectState };
+    properties = features.reduce(
+      (all, category) => {
+        if (projectState[category])
+          all[category] = { ...projectState[category] };
+        return all;
+      },
+      {}
+    );
+
+    // add useful functions
+    if (properties.commits)
+      properties.commits.refresh = () => { projectCoordinator.fetchCommits(); };
+
+    // return the object
+    if (parentProperty)
+      return { [parentProperty]: { ...properties } };
+    return { ...properties };
+  };
+
+  return mapStateToProps;
+}
+
+
+/**
+ * Enhance a React component with project data mapped as properties.
+ *
+ * @param {Object} MappingComponent - component to be mapped with the project categories
+ * @param {Object} MappingComponent.props.projectCoordinator - an instance of the projectCoordinator
+ * @param {string[]} [features] - list of project sub-categories to include. An empty array
+ *     means all categories will be included
+ * @param {bool} [passProps] - weather to pass down the properties or not. Default is true
+ */
+function withProjectMapped(MappingComponent, features = [], passProps = true) {
+  return class ProjectMapped extends Component {
+    render() {
+      const projectCoordinator = this.props.projectCoordinator;
+      const mapFunction = mapProjectFeatures(projectCoordinator, features);
+      const MappedComponent = connect(mapFunction.bind(this))(MappingComponent);
+      const store = projectCoordinator.model.reduxStore;
+      const props = passProps ? this.props : {};
+
+      return (<MappedComponent store={store} {...props} />);
+    }
+  };
+}
+
+
 export default { New, View, List };
-export { GraphIndexingStatus, splitProjectSubRoute };
+export { GraphIndexingStatus, splitProjectSubRoute, mapProjectFeatures, withProjectMapped };

--- a/src/project/index.js
+++ b/src/project/index.js
@@ -24,5 +24,7 @@
  */
 
 import { ProjectListRow } from "./list";
+import { ProjectCoordinator } from "./Project.state";
+import { withProjectMapped } from "./Project";
 
-export { ProjectListRow };
+export { ProjectListRow, ProjectCoordinator, withProjectMapped };

--- a/src/utils/Commits.css
+++ b/src/utils/Commits.css
@@ -1,0 +1,18 @@
+.commit-object, .commit-date {
+  border-width: 1px 0 0 0;
+  padding: 0.50rem;
+}
+
+.commit-object .commit-cut-message {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.commit-date {
+  background-color: rgba(0, 0, 0, 0.01);
+  font-size: 80%;
+  font-weight: bold;
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+}

--- a/src/utils/Commits.js
+++ b/src/utils/Commits.js
@@ -1,0 +1,180 @@
+/*!
+ * Copyright 2020 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  Commits.js
+ *  Commits code and presentation.
+ */
+
+import React from "react";
+import { Row, Col, ListGroup, ListGroupItem, ButtonGroup, Button, UncontrolledTooltip } from "reactstrap";
+
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faFolderOpen } from "@fortawesome/free-regular-svg-icons";
+
+import { ExternalLink, TimeCaption, Clipboard, Loader } from "./UIComponents";
+import Time from "./Time";
+
+import "./Commits.css";
+
+// Constants
+const CommitElement = {
+  DATE: "date",
+  COMMIT: "commit"
+};
+
+
+// Helper functions
+function createDateObject(commit) {
+  return {
+    type: CommitElement.DATE,
+    date: Time.parseDate(commit.committed_date),
+    readableDate: Time.getReadableDate(commit.committed_date)
+  };
+}
+
+function createCommitsObjects(commits) {
+  const enhancedCommits = commits.reduce(
+    (data, commit) => {
+      if (!data.lastDate || !Time.isSameDay(data.lastDate, commit.committed_date)) {
+        data.lastDate = commit.committed_date;
+        data.list.push(createDateObject(commit));
+      }
+      data.list.push({ ...commit, type: CommitElement.COMMIT });
+
+      return data;
+    },
+    { lastDate: null, list: [] }
+  );
+
+  return enhancedCommits.list;
+}
+
+
+// React components
+
+/**
+ * Display a list of commits with links to GilLab pages
+ *
+ * @param {Object[]} props.commits - list of commits as returned by GitLab api
+ * @param {string} props.urlRepository - project's repository url
+ * @param {string} props.urlDiff - project's diff url (different based on the context where
+ *     the component is used. E.G. merge requests vs branch browsing)
+ * @param {Object} [props.fetched] - nullable date of last fetch
+ * @param {bool} [props.fetching] - whether or not it's currently fetching
+ */
+function CommitsView(props) {
+  let { fetched, fetching } = props;
+  if (!(fetched != null))
+    fetched = true;
+  if (!(fetching != null))
+    fetching = false;
+
+  if (fetching)
+    return (<Loader />);
+
+  const enhancedCommits = createCommitsObjects(props.commits);
+  const commitsView = enhancedCommits.map(commit =>
+    <SingleCommit
+      key={commit.id ? commit.id : commit.readableDate}
+      commit={commit}
+      urlBrowse={`${props.urlRepository}/tree/`}
+      urlDiff={props.urlDiff}
+    />
+  );
+  return (<ListGroup>{commitsView}</ListGroup>);
+}
+
+
+/**
+ * Create a React commit element
+ *
+ * @param {Object} props.commit - commit object as returned by GitLab api
+ * @param {string} props.url - project's repository url
+ */
+function SingleCommit(props) {
+  if (props.commit.type === CommitElement.COMMIT) {
+    const idCopyButton = `btn-commit-copy-${props.commit.id}`;
+    const idBrowseButton = `btn-commit-browse-${props.commit.id}`;
+    const idDiffButton = `btn-commit-diff-${props.commit.id}`;
+    const urlBrowse = `${props.urlBrowse}${props.commit.id}`;
+    const urlDiff = `${props.urlDiff}${props.commit.id}`;
+
+    return (
+      <ListGroupItem className="commit-object">
+        <Row>
+          <Col xs={12} md className="commit-cut-message">
+            <ExternalLink
+              id={idDiffButton}
+              role="text"
+              title={props.commit.message}
+              url={urlDiff}
+            />
+            <UncontrolledTooltip placement="top" target={idDiffButton}>
+              Diff to parent
+            </UncontrolledTooltip>
+            <br />
+            <span className="small">{props.commit.author_name} </span>
+            <TimeCaption caption={"authored"} time={props.commit.committed_date} />
+          </Col>
+          <Col xs={12} md="auto" className="d-md-flex">
+            <ButtonGroup className="text-monospace m-auto" size="sm">
+              <Button color="light" className="border" disabled>{props.commit.short_id}</Button>
+              <Button color="light" className="border" id={idCopyButton}>
+                <Clipboard clipboardText={props.commit.id} />
+              </Button>
+              <UncontrolledTooltip placement="top" target={idCopyButton}>
+                Copy commit SHA
+              </UncontrolledTooltip>
+              <ExternalLink
+                id={idBrowseButton}
+                title={<FontAwesomeIcon icon={faFolderOpen} />}
+                url={urlBrowse}
+                className="border btn-light"
+              />
+              <UncontrolledTooltip placement="top" target={idBrowseButton}>
+                Browse files
+              </UncontrolledTooltip>
+            </ButtonGroup>
+          </Col>
+        </Row>
+      </ListGroupItem>
+    );
+  }
+  return (
+    <ListGroupItem className="commit-date">
+      <Row>
+        <Col>
+          <span>{props.commit.readableDate}</span>
+        </Col>
+      </Row>
+    </ListGroupItem>
+  );
+}
+
+
+// Export
+const CommitsUtils = {
+  ElementType: CommitElement,
+  createDateObject,
+  createCommitsObjects
+};
+
+export { CommitsView, CommitsUtils };

--- a/src/utils/Time.js
+++ b/src/utils/Time.js
@@ -70,6 +70,19 @@ class Time {
     return months[date.getMonth()] + " " + date.getDate() + ", " + date.getFullYear();
   }
 
+  static isSameDay(inputDate1, inputDate2, locale = true) {
+    const date1 = this.parseDate(inputDate1);
+    const date2 = this.parseDate(inputDate2);
+
+    if (locale) {
+      return date1.getFullYear() === date2.getFullYear() &&
+        date1.getMonth() === date2.getMonth() &&
+        date1.getDate() === date2.getDate();
+    }
+    return date1.getUTCFullYear() === date2.getUTCFullYear() &&
+      date1.getUTCMonth() === date2.getUTCMonth() &&
+      date1.getUTCDate() === date2.getUTCDate();
+  }
 }
 
 export default Time;

--- a/src/utils/UIComponents.js
+++ b/src/utils/UIComponents.js
@@ -26,19 +26,20 @@
 
 import _ from "lodash/util";
 import human from "human-time";
-import React, { Component, useState, useEffect } from "react";
+import React, { Component, Fragment, useState, useEffect } from "react";
 import { Link, NavLink as RRNavLink } from "react-router-dom";
 import ReactPagination from "react-js-pagination";
 import ReactClipboard from "react-clipboard.js";
 
-import { FormFeedback, FormGroup, FormText, Input, Label, Alert, NavLink, Tooltip } from "reactstrap";
-import { ButtonDropdown, DropdownToggle, DropdownMenu } from "reactstrap";
-
+import {
+  FormFeedback, FormGroup, FormText, Input, Label, Alert, NavLink, Tooltip, Button,
+  ButtonDropdown, DropdownToggle, DropdownMenu, UncontrolledTooltip
+} from "reactstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCopy } from "@fortawesome/free-regular-svg-icons";
-import { faCheck, faExternalLinkAlt, faEllipsisV, faUser } from "@fortawesome/free-solid-svg-icons";
+import { faCheck, faExternalLinkAlt, faEllipsisV, faUser, faSyncAlt } from "@fortawesome/free-solid-svg-icons";
 
-import { sanitizedHTMLFromMarkdown } from "./HelperFunctions";
+import { sanitizedHTMLFromMarkdown, simpleHash } from "./HelperFunctions";
 import FileExplorer from "./FileExplorer";
 
 /**
@@ -98,21 +99,6 @@ function ProjectAvatar(props) {
 
   return <UserAvatar avatar={avatarUrl} />;
 }
-
-// Old FieldGroup implementation
-//
-// class FieldGroup extends Component {
-//   render() {
-//     const label = this.props.label,
-//       help = this.props.help,
-//       props = this.props;
-//     return <FormGroup>
-//       <Label>{label}</Label>
-//       <Input {...props} />
-//       {help && <FormText color="muted">{help}</FormText>}
-//     </FormGroup>
-//   }
-// }
 
 class FieldGroup extends Component {
   render() {
@@ -213,32 +199,48 @@ function ExternalLinkButton(props) {
   let className = "btn btn-primary";
   if (props.size != null)
     className += ` btn-${props.size}`;
-
   if (props.disabled)
     className += " disabled";
-
   if (props.color)
     className += ` btn-${props.color}`;
-
   if (props.className)
     className += ` ${props.className}`;
 
-  return <a href={props.url}
-    className={className} role="button" target="_blank"
-    rel="noreferrer noopener">{props.title}</a>;
+  let otherProps = {};
+  if (props.id)
+    otherProps.id = props.id;
+
+  return (
+    <a role="button" target="_blank" rel="noreferrer noopener"
+      href={props.url}
+      className={className}
+      {...otherProps}
+    >
+      {props.title}
+    </a>
+  );
 }
 
 function ExternalLinkText(props) {
   let className = "";
   if (props.disabled)
     className += " disabled";
-
   if (props.className)
     className += ` ${props.className}`;
 
-  return <a href={props.url}
-    className={className} target="_blank"
-    rel="noreferrer noopener">{props.title}</a>;
+  let otherProps = {};
+  if (props.id)
+    otherProps.id = props.id;
+
+  return (
+    <a target="_blank" rel="noreferrer noopener"
+      href={props.url}
+      className={className}
+      {...otherProps}
+    >
+      {props.title}
+    </a>
+  );
 }
 
 
@@ -250,6 +252,7 @@ function ExternalLinkText(props) {
  * @param {string} [role] - "link" or "text" to be shown as a link, null for a button
  * @param {string?} [className] - [Optional] Any classes to add, e.g., 'nav-link' or 'dropdown-item'
  * @param {boolean} [showExternalLinkIcon] - Show the icon to indicate an external link if true (default false)
+ * @param {string} [id] - main element's id
  */
 function ExternalLink(props) {
   const role = props.role;
@@ -260,8 +263,8 @@ function ExternalLink(props) {
     </span> :
     props.title;
   const myProps = { title: displayTitle, ...props };
-  if (role === "link") return ExternalLinkText(myProps);
-  if (role === "text") return ExternalLinkText(myProps);
+  if (role === "link" || role === "text")
+    return ExternalLinkText(myProps);
   return ExternalLinkButton(myProps);
 }
 
@@ -689,8 +692,31 @@ function ButtonWithMenu(props) {
   </ButtonDropdown>;
 }
 
+/**
+ * Refresh button with spinning icon.
+ *
+ * @param {function} props.action - function to trigger when clicking on the button
+ * @param {boolean} [props.updating] - pilot the spin, should be true when performing the action
+ * @param {boolean} [props.message] - tooltip message to trigger on hover
+ */
+function RefreshButton(props) {
+  const id = "button_" + simpleHash(props.action.toString());
+  const tooltip = props.message ?
+    (<UncontrolledTooltip key="tooltip" placement="top" target={id}>{props.message}</UncontrolledTooltip>) :
+    null;
+
+  return (
+    <Fragment>
+      <Button key="button" className="ml-2 p-0" color="link" size="sm" id={id} onClick={() => props.action()}>
+        <FontAwesomeIcon icon={faSyncAlt} spin={props.updating} />
+      </Button>
+      {tooltip}
+    </Fragment>
+  );
+}
+
 export { UserAvatar, TimeCaption, FieldGroup, RenkuNavLink, Pagination, RenkuMarkdown };
-export { ExternalLink, ExternalDocsLink, ExternalIconLink, IconLink };
+export { ExternalLink, ExternalDocsLink, ExternalIconLink, IconLink, RefreshButton };
 export { Loader, InfoAlert, SuccessAlert, WarnAlert, ErrorAlert, JupyterIcon };
 export { Clipboard, ThrottledTooltip, TooltipToggleButton, ProjectAvatar };
 export { ButtonWithMenu, FileExplorer };


### PR DESCRIPTION
Adds all the necessary logic to handle projects commits.

It includes a `ProjectCoordinator` component to handle storing project data to the global Redux store (#623). This created extra difficulties since we can't easily migrate all the `ProjectModel` logic at once. To simplify the temporary co-existence, I created a higher order function `withProjectMapped` to map project data from the global store to single components whenever needed.

The first commit closes #852 by adding a new "Commits" section in the project overview tab, while the second commit re-uses the `CommitsView` component in the merge request section.
The third commit injects all the commits-related logic in the environments components. We may want to clean up a little bit `Notebooks.container.js` when `branches` will be managed by `ProjectCoordinator`.

***Preview***: https://lorenzotest.dev.renku.ch
***How to test***: browse to any project, go to the new "Commits" section on the "Overview" page. Please check also the "Merge request" section and check a notebook in the "File" tab, starting also a new environment from there. This should cover all the relevant changes.

![Screenshot_20200424_194059](https://user-images.githubusercontent.com/43481553/80241253-8e916900-8663-11ea-9f37-800576d0d583.png)

