### PR TITLE
fix(environments): skip autosaves for unprivileged users

### DIFF
--- a/src/notebooks/Notebooks.container.js
+++ b/src/notebooks/Notebooks.container.js
@@ -335,13 +335,23 @@ class StartNotebookServer extends Component {
     this.selectCommit();
   }
 
+  filterAutosavedBranches(branches, username) {
+    if (!username || !branches)
+      return [];
+    return branches.filter(branch => branch.autosave.username === username);
+  }
+
   mapStateToProps(state, ownProps) {
+    const username = state.user.logged ?
+      state.user.data.username :
+      null;
+    const ownAutosaved = this.filterAutosavedBranches([...ownProps.inherited.autosaved], username);
     const augmentedState = {
       ...state.notebooks,
       data: {
         ...state.notebooks.data,
         branches: ownProps.inherited.branches,
-        autosaved: ownProps.inherited.autosaved
+        autosaved: ownAutosaved
       },
       externalUrl: ownProps.inherited.externalUrl
     };

--- a/src/utils/HelperFunctions.js
+++ b/src/utils/HelperFunctions.js
@@ -42,7 +42,7 @@ function splitAutosavedBranches(branches) {
     .map(branch => {
       let autosave = {};
       const autosaveData = branch.name.replace(AUTOSAVED_PREFIX, "").split("/");
-      [ autosave.namespace, autosave.branch, autosave.commit, autosave.finalCommit ] = autosaveData;
+      [autosave.username, autosave.branch, autosave.commit, autosave.finalCommit] = autosaveData;
       return { ...branch, autosave };
     });
   const standard = branches.filter(branch => !branch.name.startsWith(AUTOSAVED_PREFIX));

--- a/src/utils/Utils.test.js
+++ b/src/utils/Utils.test.js
@@ -194,8 +194,8 @@ describe("Helper functions", () => {
     const splittedBranches = splitAutosavedBranches(branches);
     expect(splittedBranches.standard.length).toEqual(1);
     expect(splittedBranches.autosaved.length).toEqual(1);
-    const [ namespace, branch, commit, finalCommit ] = branches[1].name.replace("renku/autosave/", "").split("/");
-    expect(splittedBranches.autosaved[0].autosave.namespace).toEqual(namespace);
+    const [username, branch, commit, finalCommit] = branches[1].name.replace("renku/autosave/", "").split("/");
+    expect(splittedBranches.autosaved[0].autosave.username).toEqual(username);
     expect(splittedBranches.autosaved[0].autosave.branch).toEqual(branch);
     expect(splittedBranches.autosaved[0].autosave.commit).toEqual(commit);
     expect(splittedBranches.autosaved[0].autosave.finalCommit).toEqual(finalCommit);


### PR DESCRIPTION
This filters autosaved branches based on the username.
Preview temporarily available on https://lorenzo.dev.renku.ch/

***How to test***
* Generate an autosaved branch: go to any public project, start an environment, do any change and stop the environment without committing/pushing
* Verify that trying to start an environment from the same project will show you the autosaved branch popup -- don't start it!
* Log out and try to start an environment as an anonymous user or using another user without developer privileges on the project. This time you shouldn't see any popup.

fix #906