### PR TITLE
feat(ckeditor): ckeditor partially integrated inside renku

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1702,38 +1702,12 @@
         "tslib": "^1.9.0"
       }
     },
-    "@ckeditor/ckeditor5-engine": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-15.0.0.tgz",
-      "integrity": "sha512-6CGzfXmK/tw/fKdXqfp+azpu4fycbrTHKAHmj68we2opGWLvEpuuS/p0g39+PcrMNPYRIVjq+id2676Q6+QZrw==",
-      "requires": {
-        "@ckeditor/ckeditor5-utils": "^15.0.0",
-        "lodash-es": "^4.17.10"
-      }
-    },
-    "@ckeditor/ckeditor5-markdown-gfm": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-15.0.0.tgz",
-      "integrity": "sha512-Ck6xHs6BCOgOB2FLRz75Ayuy0FPqRIAemmxqfm3pDGf3nT8ynStUKbJoCiJ1SPvWOjAnPoxpEZ3IkAUthcrmaA==",
-      "requires": {
-        "@ckeditor/ckeditor5-engine": "^15.0.0"
-      }
-    },
     "@ckeditor/ckeditor5-react": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-react/-/ckeditor5-react-2.1.0.tgz",
       "integrity": "sha512-rlHjRKhwP9tNK0Yj2UJShL14mRfxLPgJ+Pv6zTv/Mvmd4wrwGnJf+5ybOAGK92S02hP1cXH+9km+PRO1b4V+ng==",
       "requires": {
         "prop-types": "^15.6.1"
-      }
-    },
-    "@ckeditor/ckeditor5-utils": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-15.0.0.tgz",
-      "integrity": "sha512-eAUYjFusNuj2N8NqGbquMOnSv4wjcO2TuipCP1Rao/FHWX6h+PWBhxnD3J9igRQRvLePYbtQAUAvLeD846JA0A==",
-      "requires": {
-        "ckeditor5": "^15.0.0",
-        "lodash-es": "^4.17.10"
       }
     },
     "@cnakazawa/watch": {
@@ -2482,12 +2456,39 @@
         "styled-components": "^4.1.3"
       }
     },
-    "@renku/renku-ui-ckeditor5-build": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@renku/renku-ui-ckeditor5-build/-/renku-ui-ckeditor5-build-0.0.2.tgz",
-      "integrity": "sha512-AFOOo31ebRQhA4mXgT/RylOUbfRfn9IPjpkZ5Q1HvvJTdLqkh5b2AJIRrowDtFvjuDx76J/J/UJmpRTQywcWTw==",
+    "@renku/ckeditor5-build-renku": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@renku/ckeditor5-build-renku/-/ckeditor5-build-renku-0.0.1.tgz",
+      "integrity": "sha512-YafT2Lu3RgmI1cnYtYopYA1SElb6k4JhQTXAaIuSPaST48MApUoHbvHFTKWW8ZMb0AY/FI6mGKH5Taidy69RKQ==",
       "requires": {
-        "@ckeditor/ckeditor5-markdown-gfm": "^15.0.0"
+        "@renku/ckeditor5-markdown-gfm": "^19.0.1"
+      }
+    },
+    "@renku/ckeditor5-markdown-gfm": {
+      "version": "19.0.1",
+      "resolved": "https://registry.npmjs.org/@renku/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-19.0.1.tgz",
+      "integrity": "sha512-iRbG1NIEPlocAT78EzB4yARLgZK0oLqdOli48GufOqkUs7jKB0O/wnKi+64aNf9Vu7NU+ssf3mb3Op7vS4f/Sg==",
+      "requires": {
+        "@ckeditor/ckeditor5-engine": "^19.0.0"
+      },
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": {
+          "version": "19.0.0",
+          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-19.0.0.tgz",
+          "integrity": "sha512-Ahgr/NKJOIwNZZ2rZZTQUO5iJkgytossmK7CrRUeyGiEol/9GmyTOXtrmqItITebZV5wMe+UVM8bR6HJD/4TJw==",
+          "requires": {
+            "@ckeditor/ckeditor5-utils": "^19.0.0",
+            "lodash-es": "^4.17.10"
+          }
+        },
+        "@ckeditor/ckeditor5-utils": {
+          "version": "19.0.0",
+          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-19.0.0.tgz",
+          "integrity": "sha512-6/oTD1qi/VCj99+3rmagH0sctQcbyCU3hZ4L1xcR3+xJMAkavSLJ4vbcBrmtZDcgyW74XDnVJ84CKf9WJ4WoUw==",
+          "requires": {
+            "lodash-es": "^4.17.10"
+          }
+        }
       }
     },
     "@sentry/browser": {
@@ -4061,7 +4062,7 @@
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-plugin-syntax-object-rest-spread": {
@@ -4705,7 +4706,7 @@
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "requires": {
         "camelcase": "^2.0.0",
@@ -4861,11 +4862,6 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
-    },
-    "ckeditor5": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-15.0.0.tgz",
-      "integrity": "sha512-LVrey6xTa+Sm2CvYaicPbW51/fV19fd9EFkhERSvskTSyKelvzLwBlug0PYHS8JFnrdBWjQf5bbdggzFZyVt2w=="
     },
     "class-utils": {
       "version": "0.3.6",
@@ -12438,7 +12434,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -12865,7 +12861,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "requires": {
         "camelcase-keys": "^2.0.0",
@@ -13311,7 +13307,7 @@
       "dependencies": {
         "semver": {
           "version": "5.3.0",
-          "resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
         }
       }
@@ -14059,12 +14055,12 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "requires": {
         "lcid": "^1.0.0"
@@ -14072,7 +14068,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "osenv": {
@@ -14335,7 +14331,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
@@ -14410,7 +14406,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
     },
     "pinkie": {
@@ -17321,7 +17317,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
         "ret": "~0.1.10"
@@ -17460,7 +17456,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.4.4",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "requires": {
             "amdefine": ">=0.0.4"
@@ -18683,7 +18679,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
@@ -18709,7 +18705,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -20762,7 +20758,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.11.2",
     "@fortawesome/react-fontawesome": "^0.1.7",
     "@nteract/notebook-render": "^5.0.4-alpha.0",
-    "@renku/renku-ui-ckeditor5-build": "0.0.2",
+    "@renku/ckeditor5-build-renku": "0.0.1",
     "@sentry/browser": "^5.12.1",
     "ajv": "^6.10.2",
     "apollo-boost": "^0.4.4",

--- a/src/dataset/Dataset.present.js
+++ b/src/dataset/Dataset.present.js
@@ -19,8 +19,7 @@
 import React, { useState, useEffect } from "react";
 import { Row, Col, Card, CardHeader, CardBody, Table, Alert, Button } from "reactstrap";
 import { Link } from "react-router-dom";
-import { Loader, FileExplorer } from "../utils/UIComponents";
-import DOMPurify from "dompurify";
+import { Loader, FileExplorer, RenkuMarkdown } from "../utils/UIComponents";
 import { API_ERRORS } from "../api-client";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faExternalLinkAlt, faPen, faPlus } from "@fortawesome/free-solid-svg-icons";
@@ -217,8 +216,9 @@ export default function DatasetView(props) {
         </small>
         : null
     }
-    <p style={{ paddingTop: "12px" }} dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(dataset.description) }}>
-    </p>
+    <div style={{ paddingTop: "12px" }}>
+      <RenkuMarkdown markdownText={dataset.description} />
+    </div>
     {
       props.insideProject || dataset.sameAs.includes("doi.org") ?
         <LinkToExternal link={dataset.url} label="Source" />

--- a/src/dataset/list/DatasetList.present.js
+++ b/src/dataset/list/DatasetList.present.js
@@ -21,7 +21,7 @@ import { Link, Route, Switch } from "react-router-dom";
 import { Row, Col, Alert, Card, CardBody, Badge } from "reactstrap";
 import { Button, Form, FormText, Input, Label, InputGroup, UncontrolledCollapse } from "reactstrap";
 import { InputGroupButtonDropdown, DropdownToggle, DropdownMenu, DropdownItem } from "reactstrap";
-import { Loader, Pagination, MarkdownTextExtract } from "../../utils/UIComponents";
+import { Loader, Pagination, MarkdownTextExcerpt } from "../../utils/UIComponents";
 import { faCheck, faSortAmountUp, faSortAmountDown } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
@@ -53,7 +53,7 @@ class DatasetListRow extends Component {
         {
           dataset.description !== undefined && dataset.description !== null ?
             <div className="datasetDescriptionText font-weight-normal">
-              <MarkdownTextExtract markdownText={dataset.description} charsLimit={500} />
+              <MarkdownTextExcerpt markdownText={dataset.description} charsLimit={500} />
             </div>
             : null
         }

--- a/src/dataset/list/DatasetList.present.js
+++ b/src/dataset/list/DatasetList.present.js
@@ -21,18 +21,13 @@ import { Link, Route, Switch } from "react-router-dom";
 import { Row, Col, Alert, Card, CardBody, Badge } from "reactstrap";
 import { Button, Form, FormText, Input, Label, InputGroup, UncontrolledCollapse } from "reactstrap";
 import { InputGroupButtonDropdown, DropdownToggle, DropdownMenu, DropdownItem } from "reactstrap";
-import { Loader, Pagination } from "../../utils/UIComponents";
+import { Loader, Pagination, MarkdownTextExtract } from "../../utils/UIComponents";
 import { faCheck, faSortAmountUp, faSortAmountDown } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 
 class DatasetListRow extends Component {
 
-  HTMLtoText = (textContent) => {
-    var temp = document.createElement("div");
-    temp.innerHTML = textContent;
-    return temp.textContent || temp.innerText || "";
-  }
 
   render() {
     const datasetsUrl = this.props.datasetsUrl;
@@ -57,12 +52,9 @@ class DatasetListRow extends Component {
         }
         {
           dataset.description !== undefined && dataset.description !== null ?
-            <p className="datasetDescriptionText font-weight-normal">
-              {dataset.description.length > 500 ?
-                this.HTMLtoText(dataset.description).substr(0, 500) + "..." :
-                this.HTMLtoText(dataset.description)
-              }
-            </p>
+            <div className="datasetDescriptionText font-weight-normal">
+              <MarkdownTextExtract markdownText={dataset.description} charsLimit={500} />
+            </div>
             : null
         }
         {

--- a/src/model/RenkuModels.js
+++ b/src/model/RenkuModels.js
@@ -283,8 +283,9 @@ const datasetFormSchema = new Schema({
     name: "description",
     label: "Description",
     edit: false,
-    type: FormGenerator.FieldTypes.TEXT_AREA,
-    help: "Basic HTML styling tags are allowed in this field.",
+    type: FormGenerator.FieldTypes.TEXT_EDITOR,
+    outputType: "markdown",
+    help: "Basic markdown styling tags are allowed in this field.",
     validators: [{
       id: "name-length",
       //  isValidFun: expression => FormGenerator.Validators.isNotEmpty(expression, 3),
@@ -324,7 +325,7 @@ const issueFormSchema = new Schema({
     initial: "",
     name: "textarea",
     label: "Description",
-    type: FormGenerator.FieldTypes.TEXT_AREA, //to change to TEXT_EDITOR
+    type: FormGenerator.FieldTypes.TEXT_EDITOR,
     outputType: "markdown",
     placeholder: "A brief name to identify the issue",
     help: "A description of the issue helps users understand it and is highly recommended.",

--- a/src/project/datasets/DatasetsListView.js
+++ b/src/project/datasets/DatasetsListView.js
@@ -3,7 +3,7 @@ import { NavLink, Link } from "react-router-dom";
 import { Row, Col, ListGroup, ListGroupItem } from "reactstrap";
 import { ACCESS_LEVELS } from "../../api-client";
 import "../filestreeview/treeviewstyle.css";
-import { Loader } from "../../utils/UIComponents";
+import { Loader, MarkdownTextExtract } from "../../utils/UIComponents";
 
 function DatasetListRow(props) {
   const dataset = props.dataset;
@@ -11,12 +11,6 @@ function DatasetListRow(props) {
     key={dataset.identifier}
     to={`${props.datasetsUrl}/${encodeURIComponent(dataset.identifier)}/`}
   > {dataset.name} </NavLink>;
-
-  const HTMLtoText = (textContent) => {
-    var temp = document.createElement("div");
-    temp.innerHTML = textContent;
-    return temp.textContent || temp.innerText || "";
-  };
 
   const projectsCountLabel = dataset.isPartOf.length > 1
     ? `In ${dataset.isPartOf.length} projects`
@@ -41,12 +35,9 @@ function DatasetListRow(props) {
             }
             {
               dataset.description !== undefined && dataset.description !== null ?
-                <p className="datasetDescriptionText font-weight-normal">
-                  {dataset.description.length > 500 ?
-                    HTMLtoText(dataset.description).substr(0, 500) + "..." :
-                    HTMLtoText(dataset.description)
-                  }
-                </p>
+                <div className="datasetDescriptionText font-weight-normal">
+                  <MarkdownTextExtract markdownText={dataset.description} charsLimit={500} />
+                </div>
                 : null
             }
           </div>

--- a/src/project/datasets/DatasetsListView.js
+++ b/src/project/datasets/DatasetsListView.js
@@ -3,7 +3,7 @@ import { NavLink, Link } from "react-router-dom";
 import { Row, Col, ListGroup, ListGroupItem } from "reactstrap";
 import { ACCESS_LEVELS } from "../../api-client";
 import "../filestreeview/treeviewstyle.css";
-import { Loader, MarkdownTextExtract } from "../../utils/UIComponents";
+import { Loader, MarkdownTextExcerpt } from "../../utils/UIComponents";
 
 function DatasetListRow(props) {
   const dataset = props.dataset;
@@ -36,7 +36,7 @@ function DatasetListRow(props) {
             {
               dataset.description !== undefined && dataset.description !== null ?
                 <div className="datasetDescriptionText font-weight-normal">
-                  <MarkdownTextExtract markdownText={dataset.description} charsLimit={500} />
+                  <MarkdownTextExcerpt markdownText={dataset.description} charsLimit={500} />
                 </div>
                 : null
             }

--- a/src/utils/UIComponents.js
+++ b/src/utils/UIComponents.js
@@ -439,6 +439,22 @@ class RenkuMarkdown extends Component {
 }
 
 /**
+ * This function converts markdown to text, is ment to be used when an extract of
+ * a description in markdown wants to be displayed.
+ *  @param {string} markdownText is the markdown text that wants to be displayed
+ *  @param {integer} charsLimit is the number of characters that will be displayed
+ */
+class MarkdownTextExtract extends Component {
+  render() {
+    const temp = document.createElement("div");
+    temp.innerHTML = sanitizedHTMLFromMarkdown(this.props.markdownText, false);
+    const innerText = temp.textContent || temp.innerText || "";
+    return this.props.charsLimit !== undefined && innerText.length > this.props.charsLimit ?
+      innerText.substr(0, this.props.charsLimit) + "..." : innerText;
+  }
+}
+
+/**
  * Jupyter icon
  *
  * @param {boolean} [greyscale] - show the grayscale version of the logo
@@ -719,4 +735,4 @@ export { UserAvatar, TimeCaption, FieldGroup, RenkuNavLink, Pagination, RenkuMar
 export { ExternalLink, ExternalDocsLink, ExternalIconLink, IconLink, RefreshButton };
 export { Loader, InfoAlert, SuccessAlert, WarnAlert, ErrorAlert, JupyterIcon };
 export { Clipboard, ThrottledTooltip, TooltipToggleButton, ProjectAvatar };
-export { ButtonWithMenu, FileExplorer, getFilesTree };
+export { ButtonWithMenu, FileExplorer, getFilesTree, MarkdownTextExtract };

--- a/src/utils/UIComponents.js
+++ b/src/utils/UIComponents.js
@@ -439,12 +439,12 @@ class RenkuMarkdown extends Component {
 }
 
 /**
- * This function converts markdown to text, is ment to be used when an extract of
- * a description in markdown wants to be displayed.
+ * This component converts markdown to text. It is meant to be used when an extract of
+ * a description in markdown should be be displayed.
  *  @param {string} markdownText is the markdown text that wants to be displayed
  *  @param {integer} charsLimit is the number of characters that will be displayed
  */
-class MarkdownTextExtract extends Component {
+class MarkdownTextExcerpt extends Component {
   render() {
     const temp = document.createElement("div");
     temp.innerHTML = sanitizedHTMLFromMarkdown(this.props.markdownText, false);
@@ -735,4 +735,4 @@ export { UserAvatar, TimeCaption, FieldGroup, RenkuNavLink, Pagination, RenkuMar
 export { ExternalLink, ExternalDocsLink, ExternalIconLink, IconLink, RefreshButton };
 export { Loader, InfoAlert, SuccessAlert, WarnAlert, ErrorAlert, JupyterIcon };
 export { Clipboard, ThrottledTooltip, TooltipToggleButton, ProjectAvatar };
-export { ButtonWithMenu, FileExplorer, getFilesTree, MarkdownTextExtract };
+export { ButtonWithMenu, FileExplorer, getFilesTree, MarkdownTextExcerpt };

--- a/src/utils/UIComponents.js
+++ b/src/utils/UIComponents.js
@@ -425,14 +425,20 @@ class ErrorAlert extends Component {
   }
 }
 
+/**
+ * Safely render markdown.
+ * @param {string} markdownText the markdown text to display
+ * @param {boolean} singleLine if true, render the output as a single line without line breaks
+ * @param {object} style any styles to apply
+ */
 class RenkuMarkdown extends Component {
   render() {
-    const { singleLine } = this.props;
+    const { singleLine, style } = this.props;
     let className = "text-break";
     if (singleLine)
       className += " children-no-spacing";
 
-    return <div className={className}
+    return <div className={className} style={style}
       dangerouslySetInnerHTML={{ __html: sanitizedHTMLFromMarkdown(this.props.markdownText, singleLine) }}>
     </div>;
   }
@@ -441,17 +447,18 @@ class RenkuMarkdown extends Component {
 /**
  * This component converts markdown to text. It is meant to be used when an extract of
  * a description in markdown should be be displayed.
- *  @param {string} markdownText is the markdown text that wants to be displayed
- *  @param {integer} charsLimit is the number of characters that will be displayed
+ * @param {string} markdownText is the markdown text that wants to be displayed
+ * @param {integer} charsLimit is the number of characters that will be displayed
  */
-class MarkdownTextExcerpt extends Component {
-  render() {
-    const temp = document.createElement("div");
-    temp.innerHTML = sanitizedHTMLFromMarkdown(this.props.markdownText, false);
-    const innerText = temp.textContent || temp.innerText || "";
-    return this.props.charsLimit !== undefined && innerText.length > this.props.charsLimit ?
-      innerText.substr(0, this.props.charsLimit) + "..." : innerText;
-  }
+function MarkdownTextExcerpt(props) {
+  // Alternative implementation to strip styling.
+  // const temp = document.createElement("div");
+  // temp.innerHTML = sanitizedHTMLFromMarkdown(this.props.markdownText, false);
+  // const innerText = temp.textContent || temp.innerText || "";
+  // return this.props.charsLimit !== undefined && innerText.length > this.props.charsLimit ?
+  //   innerText.substr(0, this.props.charsLimit) + "..." : innerText;
+  const style = { maxWidth: `${props.charsLimit}ch` };
+  return <RenkuMarkdown markdownText={props.markdownText} singleLine={false} style={style} />;
 }
 
 /**

--- a/src/utils/formgenerator/fields/CKEditorTextArea.js
+++ b/src/utils/formgenerator/fields/CKEditorTextArea.js
@@ -28,7 +28,7 @@ import ValidationAlert from "./ValidationAlert";
 import HelpText from "./HelpText";
 import { FormGroup, Label } from "reactstrap";
 import CKEditor from "@ckeditor/ckeditor5-react";
-import { RenkuMarkdownEditor, ClassicEditor } from "@renku/renku-ui-ckeditor5-build";
+import RenkuCKEditor from "@renku/ckeditor5-build-renku";
 import { CustomInput, Input } from "reactstrap";
 
 
@@ -53,7 +53,7 @@ function CktextareaInput({ name, label, type, value, alert, setInputs, help, out
         codeview === false ?
           <CKEditor
             id={name}
-            editor={outputType === "markdown" ? RenkuMarkdownEditor : ClassicEditor}
+            editor={outputType === "markdown" ? RenkuCKEditor.RenkuMarkdownEditor : RenkuCKEditor.RenkuHTMLEditor}
             type={type}
             data={value || ""}
             disabled={disabled}


### PR DESCRIPTION
This is the first step into integrating CKEditor inside renku.

For this: 
- I created a new build of the editor for renku  https://github.com/SwissDataScienceCenter/ckeditor5-build-renku 
- I forked the ckeditor5 entire project (https://github.com/SwissDataScienceCenter/ckeditor5) (this is what they call ckeditor5 frameworK) since i was having some problems with some components.
  - Inside this project i modified and published individually inside npm:
    - https://www.npmjs.com/package/@renku/ckeditor5-code-block
    - https://www.npmjs.com/package/@renku/ckeditor5-markdown-gfm
    - https://www.npmjs.com/package/@renku/ckeditor5-table

  Since i was having some problems with integrating this and markdown inside the editor. I hope 
  they fix this bugs and we can just delete this packages and use the CKEditor packages instead.

- I modified the issues form, so now the ckeditor is usable
- I modified the datasets form and also components using html, now all is markdown, since you can render html inside markdown there shouldn't be any problems with this, and in my opinion is better to have all be markdown.

HEADS UP!!! this is a first version and lots of things changed and are changing inside the ckeditor5, i couldn't make some things work 100%, i.e: tables (i couldn't manage to enable alignment inside columns), they still don't support task lists inside markdown and also i couldn't make the editor support different code languages, so for now all is the same language. I am sure you will find new errors. In my opinion this is ready or almost ready to be merged, but in case we find some error we can't live with i will make my best to fix it.

testing available in https://virginia.dev.renku.ch  (inside new dataset and also inside new issue)
docker image: virfried/renku-ui:0.10.1-2fbff7c