### PR TITLE
feat(markdown): code is highlighted a bit more

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -184,3 +184,30 @@ body {
     opacity: 1;
   }
 }
+
+.renku-markdown code {
+  padding: .2em .4em;
+  font-size: 85%;
+  background-color: rgba(0, 0, 0, 0.04);
+  border-radius: 3px;
+}
+
+.renku-markdown pre {
+  word-wrap: normal;
+  padding: 16px;
+  overflow: auto;
+  line-height: 1.4;
+  background-color: rgba(0, 0, 0, 0.04);
+}
+
+.renku-markdown pre>code {
+  padding: 0;
+  font-size: 100%;
+  white-space: pre;
+  background: transparent;
+}
+
+.renku-markdown .highlight pre {
+  margin-bottom: 0;
+  word-break: normal;
+}

--- a/src/utils/UIComponents.js
+++ b/src/utils/UIComponents.js
@@ -434,7 +434,7 @@ class ErrorAlert extends Component {
 class RenkuMarkdown extends Component {
   render() {
     const { singleLine, style } = this.props;
-    let className = "text-break";
+    let className = "text-break renku-markdown";
     if (singleLine)
       className += " children-no-spacing";
 


### PR DESCRIPTION
Right now code gets a bit "lost" inside markdown....
![image](https://user-images.githubusercontent.com/42647877/82021433-17139000-968b-11ea-8fe5-17376426bbc5.png)

I think we should highlight it a bit better.. 
![image](https://user-images.githubusercontent.com/42647877/82021345-f4817700-968a-11ea-9e58-bc8692694c8b.png)

This is just a proposal, we could also do it a bit darker with lighter words or something similar.

We could also think about going all the way and using something like this https://github.com/sindresorhus/github-markdown-css 
(This makes all our markdown look like the gitlab one) ---> NOT SURE THIS IS WHAT WE WANT