### PR TITLE
fix(datasets): if a dataset fails we display non-failed datasets

### DIFF
--- a/src/api-client/project.js
+++ b/src/api-client/project.js
@@ -468,7 +468,9 @@ function addProjectMethods(client) {
   client.fetchDatasetFromKG = (datasetLink) => {
     const headers = client.getBasicHeaders();
     const datasetPromise = client.clientFetch(datasetLink, { method: "GET", headers });
-    return Promise.resolve(datasetPromise).then(dataset => dataset.data);
+    return Promise.resolve(datasetPromise)
+      .then(dataset => dataset.data)
+      .catch((error) => "error");
   };
 
   client.getProjectDatasetsFromKG = (projectPath) => {
@@ -480,7 +482,10 @@ function addProjectMethods(client) {
     }).then(resp => {
       let fullDatasets = resp.map(dataset =>
         client.fetchDatasetFromKG(dataset._links[0].href));
-      return Promise.all(fullDatasets);
+      return Promise.all(fullDatasets).then(datasets => {
+        //in case one of the dataset fetch fails we return the ones that didn't fail
+        return datasets.filter(dataset => dataset !== "error");
+      });
     });
   };
 

--- a/src/project/datasets/import/DatasetImport.container.js
+++ b/src/project/datasets/import/DatasetImport.container.js
@@ -54,7 +54,7 @@ function ImportDataset(props) {
 
   const findDatasetInKgAnRedirect = (oldDatasetsList) => {
     let waitForDatasetInKG = setInterval(() => {
-      props.client.getProjectDatasetsFromKG(props.projectPathWithNamespace)
+      props.client.getProjectDatasetsFromKG_short(props.projectPathWithNamespace)
         .then(datasets => {
           if (datasets.length !== oldDatasetsList.length)
             redirectUserAndClearInterval(datasets, oldDatasetsList, waitForDatasetInKG);
@@ -112,7 +112,7 @@ function ImportDataset(props) {
     const dataset = {};
     let oldDatasetsList = [];
     dataset.uri = datasetImportFormSchema.uri.value;
-    props.client.getProjectDatasetsFromKG(props.projectPathWithNamespace)
+    props.client.getProjectDatasetsFromKG_short(props.projectPathWithNamespace)
       .then(result => {
         oldDatasetsList = result;
         props.client.datasetImport(props.httpProjectUrl, dataset.uri)

--- a/src/project/datasets/new/DatasetNew.container.js
+++ b/src/project/datasets/new/DatasetNew.container.js
@@ -56,7 +56,7 @@ function NewDataset(props) {
         }
         else {
           let waitForDatasetInKG = setInterval(() => {
-            props.client.getProjectDatasetsFromKG(props.projectPathWithNamespace)
+            props.client.getProjectDatasetsFromKG_short(props.projectPathWithNamespace)
               .then(datasets => {
                 // eslint-disable-next-line
                 let new_dataset = datasets.find( ds => ds.name === dataset.data.result.short_name);


### PR DESCRIPTION
Closes #924 

In case a dataset fetch fails all dataset fetch was failing.

This was causing a "no dataset inside this project" message.

Now in case a dataset can't be fetched we display all the datasets that where fetched with no problem.

I also replaced some calls to get dataset for simplified ones when we don't need to get all the dataset info (i.e redirect after dataset add). 