### PR TITLE
fix(datasets): when dataset takes too long we display an ok button instead of cancel and add dataset

### DIFF
--- a/src/dataset/addtoproject/DatasetAdd.present.js
+++ b/src/dataset/addtoproject/DatasetAdd.present.js
@@ -42,12 +42,13 @@ function DatasetAdd(props) {
         <Row className="mb-3">
           <Col>
             <FormPanel
-              btnName={"Add dataset"}
-              submitCallback={props.submitCallback}
+              btnName={"Add Dataset"}
+              submitCallback={!props.takingTooLong ? props.submitCallback : undefined}
               model={props.addDatasetToProjectSchema}
               serverErrors={props.serverErrors}
               submitLoader={{ value: props.submitLoader, text: props.submitLoaderText }}
-              onCancel={props.closeModal} />
+              onCancel={props.closeModal}
+              cancelBtnName={!props.takingTooLong ? "Cancel" : "OK"} />
           </Col>
         </Row>
       </ModalBody>

--- a/src/utils/formgenerator/FormPanel.js
+++ b/src/utils/formgenerator/FormPanel.js
@@ -35,7 +35,8 @@ import FileuploaderInput from "./fields/FileUploaderInput";
 import { Loader } from "../../utils/UIComponents";
 import "./FormGenerator.css";
 
-function FormPanel({ title, btnName, submitCallback, model, serverErrors, submitLoader, onCancel, edit }) {
+function FormPanel(
+  { title, btnName, submitCallback, model, serverErrors, submitLoader, onCancel, edit, cancelBtnName }) {
   const modelValues = Object.values(model);
   const [inputs, setInputs, setSubmit] = useForm(modelValues, submitCallback);
   const Components = {
@@ -69,13 +70,19 @@ function FormPanel({ title, btnName, submitCallback, model, serverErrors, submit
             </FormText>
             : null
           }
-          <Button type="submit" disabled={submitLoader.value} className="float-right mt-1" color="primary">
-            {btnName}
-          </Button>
+          {
+            submitCallback !== undefined ?
+              <Button type="submit" disabled={submitLoader.value} className="float-right mt-1" color="primary">
+                {btnName}
+              </Button>
+              : null
+          }
           {
             onCancel !== undefined ?
               <Button disabled={submitLoader.value} className="float-right mt-1 mr-1"
-                color="secondary" onClick={onCancel}>Cancel</Button>
+                color="secondary" onClick={onCancel}>
+                {cancelBtnName ? cancelBtnName : "Cancel"}
+              </Button>
               : null
           }
         </div>


### PR DESCRIPTION
When adding a dataset takes too long we display display OK button when import fails (This button will close the modal) instead of "Add Dataset" and "Cancel" this should be less confusing for the user. 

![image](https://user-images.githubusercontent.com/42647877/82207437-1fc5c980-990a-11ea-9fef-7648fd5f5444.png)

To test this pull the branch and inside /dataset/addtoproject/datasetadd.container change line 125 

from:
`if ((cont > 30 && job.state !== "IN_PROGRESS") || (cont > 50 && job.state === "IN_PROGRESS")) {`

to:
`if ((cont > 1 && job.state !== "IN_PROGRESS") || (cont > 1 && job.state === "IN_PROGRESS")) {`

this will make the wait too short so the dataset add should display an error message and the new button.