### PR TITLE
fix(environments): avoid project options to disappear once deselected

### DIFF
--- a/src/notebooks/Notebooks.container.js
+++ b/src/notebooks/Notebooks.container.js
@@ -247,8 +247,10 @@ class StartNotebookServer extends Component {
 
   async refreshCommits() {
     if (this._isMounted) {
-      if (!this.projectModel.get("commits.fetching"))
-        await this.projectCoordinator.fetchCommits();
+      if (!this.projectModel.get("commits.fetching")) {
+        const branch = this.model.get("filters.branch");
+        await this.projectCoordinator.fetchCommits({ branch: branch.name });
+      }
       this.selectCommitWhenReady();
     }
   }

--- a/src/notebooks/Notebooks.present.js
+++ b/src/notebooks/Notebooks.present.js
@@ -1140,6 +1140,7 @@ class StartNotebookServerOptions extends Component {
     const renderedServerOptions = sortedOptionKeys
       .filter(key => key !== "commitId")
       .map(key => {
+        // when the project has a default option, ensure it's added to the global options
         const options = Object.keys(projectOptions).indexOf(key) >= 0 &&
           globalOptions[key].options.indexOf(projectOptions[key]) === -1 ?
           [...globalOptions[key].options, projectOptions[key]] :

--- a/src/notebooks/Notebooks.present.js
+++ b/src/notebooks/Notebooks.present.js
@@ -1140,7 +1140,17 @@ class StartNotebookServerOptions extends Component {
     const renderedServerOptions = sortedOptionKeys
       .filter(key => key !== "commitId")
       .map(key => {
-        const serverOption = { ...globalOptions[key], selected: selectedOptions[key] };
+        const options = Object.keys(projectOptions).indexOf(key) >= 0 &&
+          globalOptions[key].options.indexOf(projectOptions[key]) === -1 ?
+          [...globalOptions[key].options, projectOptions[key]] :
+          globalOptions[key].options;
+
+        const serverOption = {
+          ...globalOptions[key],
+          options: options,
+          selected: selectedOptions[key]
+        };
+
         const onChange = (event, value) => {
           this.props.handlers.setServerOption(key, event, value);
         };


### PR DESCRIPTION
Custom project options selected by default don't disappear anymore when another option is selected.
The problem happened only if the pinned option at the project level was of type `enum` and it was not available per default on that renkulab deployment.

This also fixes a bug introduced in a recent refractory that prevented fetching commits for specific branches.

Preview: ~https://lorenzotest.dev.renku.ch/~

***HOW TO TEST***
Pick a project with custom options, try to select different options and verify none of them disappear.
E.G. on the following project, select the branch `tree` and compare
https://lorenzotest.dev.renku.ch/projects/lorenzo.cavazzi.tech/flights-tutorial/environments/new
https://dev.renku.ch/projects/lorenzo.cavazzi.tech/flights-tutorial/environments/new

fix #935 