### PR TITLE
fix: update project topics correctly

### DIFF
--- a/src/api-client/project.js
+++ b/src/api-client/project.js
@@ -387,12 +387,12 @@ function addProjectMethods(client) {
       });
   };
 
-  client.setTags = (projectId, name, tags) => {
-    return client.putProjectField(projectId, name, "tag_list", tags);
+  client.setTags = (projectId, tags) => {
+    return client.putProjectField(projectId, "tag_list", tags);
   };
 
-  client.setDescription = (projectId, name, description) => {
-    return client.putProjectField(projectId, name, "description", description);
+  client.setDescription = (projectId, description) => {
+    return client.putProjectField(projectId, "description", description);
   };
 
   client.starProject = (projectId, starred) => {
@@ -407,8 +407,8 @@ function addProjectMethods(client) {
 
   };
 
-  client.putProjectField = (projectId, name, field_name, field_value) => {
-    const putData = { id: projectId, name, [field_name]: field_value };
+  client.putProjectField = (projectId, field_name, field_value) => {
+    const putData = { id: projectId, [field_name]: field_value };
     const headers = client.getBasicHeaders();
     headers.append("Content-Type", "application/json");
 

--- a/src/project/Project.state.js
+++ b/src/project/Project.state.js
@@ -112,7 +112,10 @@ class ProjectModel extends StateModel {
       .then(d => {
         const updatedState = {
           core: { ...d.metadata.core, available: true },
-          system: d.metadata.system,
+          system: {
+            ...d.metadata.system,
+            tag_list: { $set: d.metadata.system.tag_list } // fix empty tag_list not updating
+          },
           visibility: d.metadata.visibility,
           statistics: d.metadata.statistics
         };
@@ -299,13 +302,13 @@ class ProjectModel extends StateModel {
 
   setTags(client, tags) {
     this.setUpdating({ system: { tag_list: [true] } });
-    client.setTags(this.get("core.id"), this.get("core.title"), tags)
+    client.setTags(this.get("core.id"), tags)
       .then(() => { this.fetchProject(client, this.get("core.id")); });
   }
 
   setDescription(client, description) {
     this.setUpdating({ core: { description: true } });
-    client.setDescription(this.get("core.id"), this.get("core.title"), description).then(() => {
+    client.setDescription(this.get("core.id"), description).then(() => {
       this.fetchProject(client, this.get("core.id"));
     });
   }


### PR DESCRIPTION
Every time we update the topics or the description in the setting page of a project, the name is also provided to the API so that it's updated with the current value.
This makes the update fail when the user has the permissions to update one of the fields but not the project name (see the example in #951).

This PR removes that unnecessary name update and fixes the `is_updating` label that appears on the tags list when removing the last tag (probably introduced during a recent re-factory)

fix #951