### PR TITLE
fix(editor): when the editor is in code mode on edit is now disabled

### DIFF
--- a/src/utils/formgenerator/fields/CKEditorTextArea.js
+++ b/src/utils/formgenerator/fields/CKEditorTextArea.js
@@ -74,6 +74,7 @@ function CktextareaInput({ name, label, type, value, alert, setInputs, help, out
             id={name + "text-area"}
             name={name}
             type="textarea"
+            disabled={disabled}
             value={value || ""}
             onChange={setInputs}
             rows={value ? value.split("\n").length + 1 : 2}


### PR DESCRIPTION
Closes #953

To test this:
- go to dev
- pick a dataset to modify
- change the editor to "code view"
- you will be able to modify (but not to save) the dataset description
- do this again on this branch and you will not be able to do this