### PR TITLE
feat(dataset): description display has ben shortened

### DIFF
--- a/client/src/project/Project.css
+++ b/client/src/project/Project.css
@@ -32,33 +32,10 @@ Button.alert-link {
   font-size: 14px;
   margin-block-start: 0.5em;
   margin-block-end: 0.5em;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
+  overflow: hidden; 
   -webkit-box-orient: vertical;
 }
 
-
-.list-group-item:hover .datasetDescriptionText{
-  -webkit-line-clamp: 8;
-}
-
-
-.list-group-item:hover .datasetDescriptionText::after{
-  background: unset;
-}
-
-.datasetDescriptionText:after{
-  content: "";
-  text-align: right;
-  position: absolute;
-  bottom: 0;
-  right: 0;
-  width: 100%;
-  height: 2em;
-  background: linear-gradient(to bottom, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 75%);
-}
 
 .datasetAuthors{
   display: block;

--- a/client/src/project/Project.css
+++ b/client/src/project/Project.css
@@ -32,6 +32,40 @@ Button.alert-link {
   font-size: 14px;
   margin-block-start: 0.5em;
   margin-block-end: 0.5em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+}
+
+
+.list-group-item:hover .datasetDescriptionText{
+  -webkit-line-clamp: 8;
+}
+
+
+.list-group-item:hover .datasetDescriptionText::after{
+  background: unset;
+}
+
+.datasetDescriptionText:after{
+  content: "";
+  text-align: right;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 100%;
+  height: 2em;
+  background: linear-gradient(to bottom, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 75%);
+}
+
+.datasetAuthors{
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  width: 98%;
+  text-overflow: ellipsis;
 }
 
 .margin-no-triangle{

--- a/client/src/project/datasets/DatasetsListView.js
+++ b/client/src/project/datasets/DatasetsListView.js
@@ -13,7 +13,7 @@ function DatasetListRow(props) {
     to={`${props.datasetsUrl}/${encodeURIComponent(dataset.name)}/`}
   > {dataset.title || dataset.name}</NavLink>;
 
-  return <ListGroupItem action style={{ border: "none" }}>
+  return <ListGroupItem className="pb-0" action style={{ border: "none" }}>
     <Row>
       <Col xs={8} md={8} className="pb-0">
         <div className="d-flex project-list-row">
@@ -27,7 +27,7 @@ function DatasetListRow(props) {
         </div>
         {
           dataset.creators !== undefined ?
-            <small style={{ display: "block" }} className="font-weight-light">
+            <small style={{ display: "block" }} className="font-weight-light issue-text-crop">
               {dataset.creators.map((creator) => creator.name).join("; ")}
             </small>
             : null

--- a/client/src/project/datasets/DatasetsListView.js
+++ b/client/src/project/datasets/DatasetsListView.js
@@ -27,8 +27,9 @@ function DatasetListRow(props) {
         </div>
         {
           dataset.creators !== undefined ?
-            <small style={{ display: "block" }} className="font-weight-light issue-text-crop">
-              {dataset.creators.map((creator) => creator.name).join("; ")}
+            <small style={{ display: "block" }} className="font-weight-light">
+              {dataset.creators.slice(0, 3).map((creator) => creator.name).join(", ")}
+              {dataset.creators.length > 3 ? ", et al." : null}
             </small>
             : null
         }
@@ -52,7 +53,7 @@ function DatasetListRow(props) {
         dataset.description !== undefined && dataset.description !== null ?
           <Col md={12}>
             <div className="datasetDescriptionText font-weight-light">
-              <MarkdownTextExcerpt markdownText={dataset.description} charsLimit={200} />
+              <MarkdownTextExcerpt markdownText={dataset.description} heightLimit={7} />
             </div></Col>
           : null
       }

--- a/client/src/project/datasets/DatasetsListView.js
+++ b/client/src/project/datasets/DatasetsListView.js
@@ -15,7 +15,7 @@ function DatasetListRow(props) {
 
   return <ListGroupItem action style={{ border: "none" }}>
     <Row>
-      <Col xs={8} md={8}>
+      <Col xs={8} md={8} className="pb-0">
         <div className="d-flex project-list-row">
           <div className="issue-text-crop">
             <b>
@@ -23,22 +23,15 @@ function DatasetListRow(props) {
                 {title}
               </span>
             </b><br />
-            {
-              dataset.creators !== undefined ?
-                <small style={{ display: "block" }} className="font-weight-light">
-                  {dataset.creators.map((creator) => creator.name).join("; ")}
-                </small>
-                : null
-            }
-            {
-              dataset.description !== undefined && dataset.description !== null ?
-                <div className="datasetDescriptionText font-weight-normal">
-                  <MarkdownTextExcerpt markdownText={dataset.description} charsLimit={500} />
-                </div>
-                : null
-            }
           </div>
         </div>
+        {
+          dataset.creators !== undefined ?
+            <small style={{ display: "block" }} className="font-weight-light">
+              {dataset.creators.map((creator) => creator.name).join("; ")}
+            </small>
+            : null
+        }
       </Col>
       <Col xs={4} md={4} className="float-right" style={{ textAlign: "end" }}>
         <small>
@@ -55,6 +48,14 @@ function DatasetListRow(props) {
             : null
         }
       </Col>
+      {
+        dataset.description !== undefined && dataset.description !== null ?
+          <Col md={12}>
+            <div className="datasetDescriptionText font-weight-light">
+              <MarkdownTextExcerpt markdownText={dataset.description} charsLimit={200} />
+            </div></Col>
+          : null
+      }
     </Row>
   </ListGroupItem>;
 }

--- a/client/src/utils/UIComponents.js
+++ b/client/src/utils/UIComponents.js
@@ -470,7 +470,9 @@ function MarkdownTextExcerpt(props) {
   // const innerText = temp.textContent || temp.innerText || "";
   // return this.props.charsLimit !== undefined && innerText.length > this.props.charsLimit ?
   //   innerText.substr(0, this.props.charsLimit) + "..." : innerText;
-  const style = { maxWidth: `${props.charsLimit}ch` };
+  const style = props.heightLimit ?
+    { maxHeight: `${props.heightLimit}ch` }
+    : { maxWidth: `${props.charsLimit}ch` };
   return <RenkuMarkdown markdownText={props.markdownText} singleLine={false} style={style} />;
 }
 


### PR DESCRIPTION
The description is now cropped... This is just a proposal, when the user hovers over the description he can see a bit more, we can do changes to this by just cropping and not showing more.

We could also crop the creator's list, in most cases is not too long but in other it could be.

![image](https://user-images.githubusercontent.com/42647877/99255515-52e30a00-2814-11eb-99cf-416da882ee8a.png)


TEST: https://virginiatest.dev.renku.ch/projects/virginiafriedrich/project-11/datasets
https://virginiatest.dev.renku.ch/projects/virginiafriedrich/markdown-images/datasets

