### PR TITLE
feat: improve project search and project list layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -211,3 +211,11 @@ body {
   margin-bottom: 0;
   word-break: normal;
 }
+
+.mw-0 {
+  min-width: 0;
+}
+
+.limit-width {
+  max-width: 1140px;
+}

--- a/src/landing/Landing.present.js
+++ b/src/landing/Landing.present.js
@@ -38,7 +38,8 @@ import { ProjectListRow } from "../project";
 function truncatedProjectListRows(projects, projectsUrl, moreUrl) {
   const maxProjectsRows = 5;
   const projectSlice = projects.slice(0, maxProjectsRows);
-  const rows = projectSlice.map(p => <ProjectListRow key={p.id} projectsUrl={projectsUrl} {...p} />);
+  const rows = projectSlice.map(p =>
+    <ProjectListRow key={p.id} projectsUrl={projectsUrl} compact={true} {...p} />);
   const more = (projects.length > maxProjectsRows) ? <Link key="more" to={moreUrl}>more...</Link> : null;
   return [
     <Row key="projects"><Col style={{ overflowX: "auto" }}>{rows}</Col></Row>,
@@ -258,7 +259,7 @@ class LoggedInHome extends Component {
       </Row>,
       <Row key="spacer"><Col md={12}>&nbsp;</Col></Row>,
       <Row key="content">
-        <Col xs={{ order: 2 }} md={{ size: 4, order: 1 }}>
+        <Col xs={{ order: 2 }} md={{ size: 6, order: 1 }}>
           <Row>
             <Col>
               <YourProjects urlMap={urlMap} loading={neverLoaded || projects.fetching} projects={projects.member} />

--- a/src/landing/NavBar.js
+++ b/src/landing/NavBar.js
@@ -204,11 +204,10 @@ class LoggedInNavBar extends Component {
     if (null != nextRoute) this.props.history.push(nextRoute);
   }
   render() {
-    // TODO If there is is an active project, show it in the navbar
     return (
       <header>
         <nav className="navbar navbar-expand-sm navbar-light bg-light justify-content-between">
-          <span className="navbar-brand">
+          <span className="navbar-brand mr-2">
             <Link to="/"><img src={logo} alt="Renku" height="24" /></Link>
           </span>
           <button className="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
@@ -216,21 +215,23 @@ class LoggedInNavBar extends Component {
             <span className="navbar-toggler-icon"></span>
           </button>
 
-          <div className="collapse navbar-collapse" id="navbarSupportedContent">
+          <div className="collapse navbar-collapse flex-wrap" id="navbarSupportedContent">
             <QuickNav client={this.props.client} model={this.props.model} />
 
-            <ul className="navbar-nav mr-auto">
-              <RenkuNavLink to="/projects" title="Projects" />
-              <RenkuNavLink to="/datasets" title="Datasets" />
-              <RenkuNavLink to="/environments" title="Environments" />
-            </ul>
+            <div className="d-flex flex-grow-1">
+              <ul className="navbar-nav mr-auto">
+                <RenkuNavLink to="/projects" title="Projects" />
+                <RenkuNavLink to="/datasets" title="Datasets" />
+                <RenkuNavLink to="/environments" title="Environments" />
+              </ul>
+              <ul className="navbar-nav">
+                <RenkuToolbarItemPlus currentPath={this.props.location.pathname} />
+                <RenkuToolbarGitLabMenu user={this.props.user} />
+                <RenkuToolbarHelpMenu />
+                <RenkuToolbarItemUser {...this.props} />
+              </ul>
+            </div>
 
-            <ul className="navbar-nav">
-              <RenkuToolbarItemPlus currentPath={this.props.location.pathname}/>
-              <RenkuToolbarGitLabMenu user={this.props.user} />
-              <RenkuToolbarHelpMenu />
-              <RenkuToolbarItemUser {...this.props} />
-            </ul>
           </div>
         </nav>
       </header>
@@ -251,7 +252,7 @@ class AnonymousNavBar extends Component {
     return (
       <header>
         <nav className="navbar navbar-expand-sm navbar-light bg-light justify-content-between">
-          <span className="navbar-brand">
+          <span className="navbar-brand mr-2">
             <Link to="/"><img src={logo} alt="Renku" height="24" /></Link>
           </span>
           <button className="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
@@ -259,18 +260,20 @@ class AnonymousNavBar extends Component {
             <span className="navbar-toggler-icon"></span>
           </button>
 
-          <div className="collapse navbar-collapse" id="navbarSupportedContent">
+          <div className="collapse navbar-collapse flex-wrap" id="navbarSupportedContent">
             <QuickNav client={this.props.client} model={this.props.model} />
 
-            <ul className="navbar-nav mr-auto">
-              <RenkuNavLink to="/projects" title="Projects" />
-              <RenkuNavLink to="/datasets" title="Datasets" />
-              <RenkuNavLink to="/environments" title="Environments" />
-            </ul>
-            <ul className="navbar-nav">
-              <RenkuToolbarHelpMenu />
-              <RenkuToolbarItemUser {...this.props} />
-            </ul>
+            <div className="d-flex flex-grow-1">
+              <ul className="navbar-nav mr-auto">
+                <RenkuNavLink to="/projects" title="Projects" />
+                <RenkuNavLink to="/datasets" title="Datasets" />
+                <RenkuNavLink to="/environments" title="Environments" />
+              </ul>
+              <ul className="navbar-nav">
+                <RenkuToolbarHelpMenu />
+                <RenkuToolbarItemUser {...this.props} />
+              </ul>
+            </div>
           </div>
         </nav>
       </header>

--- a/src/project/list/ProjectList.container.js
+++ b/src/project/list/ProjectList.container.js
@@ -46,7 +46,7 @@ const urlMap = {
   projectsSearchUrl: "/projects/all",
   projectNewUrl: "/project_new",
   starred: "/projects/starred",
-  yourProjects: "/projects/your_projects"
+  yourProjects: "/projects"
 };
 
 class List extends Component {
@@ -254,6 +254,10 @@ class AvailableUserList extends Component {
 
   onSearchSubmit(e) {
     e.preventDefault();
+    const query = this.model.get("query");
+    if (query && query.length && query.length < 3)
+      return;
+
     this.model.resetBeforeNewSearch();
     this.pushNewSearchToHistory();
   }

--- a/src/project/list/ProjectList.present.js
+++ b/src/project/list/ProjectList.present.js
@@ -171,11 +171,13 @@ class ProjectNavTabs extends Component {
           {
             (this.props.loggedIn) ?
               [
-                <div key="top-space">&nbsp;</div>,
                 <Nav key="nav" pills className={"nav-pills-underline"}>
                   <NavItem>
-                    <RenkuNavLink to={this.props.urlMap.projectsUrl}
-                      alternate={this.props.urlMap.yourProjects} title="Your Projects" />
+                    <RenkuNavLink
+                      to={this.props.urlMap.projectsUrl}
+                      alternate={this.props.urlMap.yourProjects}
+                      noSubpath={true}
+                      title="Your Projects" />
                   </NavItem>
                   <NavItem>
                     <RenkuNavLink exact={false} to={this.props.urlMap.starred} title="Starred Projects" />
@@ -184,9 +186,9 @@ class ProjectNavTabs extends Component {
                     <RenkuNavLink exact={false} to={this.props.urlMap.projectsSearchUrl} title="All Projects" />
                   </NavItem>
                 </Nav>,
-                <div key="bottom-space">&nbsp;</div>]
-              :
-              <span></span>
+                <div key="bottom-space">&nbsp;</div>
+              ] :
+              null
           }
         </Col>
       </Row>
@@ -366,16 +368,17 @@ class ProjectList extends Component {
     const urlMap = this.props.urlMap;
     let emptyListText = "You are logged in, but you have not yet starred any projects. Starring a ";
     emptyListText += "project declares your interest in it. ";
+    const newProjectButton = hasUser ?
+      <Link className="btn btn-primary mt-auto mb-auto" role="button" to={urlMap.projectNewUrl}>
+        New Project
+      </Link> :
+      null;
 
     return [
       <Row key="header">
-        <Col md={3} lg={2}><h1>Projects</h1></Col>
-        <Col md={2}>
-          {
-            (hasUser) ?
-              <Link className="btn btn-primary" role="button" to={urlMap.projectNewUrl}>New Project</Link> :
-              <span></span>
-          }
+        <Col className="d-flex mb-2">
+          <h1 className="mr-5">Projects</h1>
+          {newProjectButton}
         </Col>
       </Row>,
       <ProjectNavTabs loggedIn={hasUser} key="navbar" urlMap={urlMap} />,

--- a/src/project/list/ProjectList.present.js
+++ b/src/project/list/ProjectList.present.js
@@ -32,29 +32,44 @@ import "../Project.css";
 
 class ProjectListRow extends Component {
   render() {
-    const MAX_DESCRIPTION_LENGTH = 250;
-    const projectsUrl = this.props.projectsUrl;
-    const title =
+    const { projectsUrl, description, compact } = this.props;
+    const title = (
       <Link to={`${projectsUrl}/${this.props.path_with_namespace}`}>
         {this.props.path_with_namespace || "no title"}
-      </Link>;
-    let description = (this.props.description !== "" && this.props.description !== null) ?
-      this.props.description :
-      "No description available";
-    if (description.length > MAX_DESCRIPTION_LENGTH)
-      description = description.slice(0, MAX_DESCRIPTION_LENGTH) + "...";
+      </Link>
+    );
+
+    let directionModifier = "", marginModfier = "";
+    if (!compact) {
+      directionModifier = " flex-sm-row";
+      marginModfier = " ml-sm-auto";
+    }
 
     return (
-      <div className="d-flex project-list-row mb-3">
-        <div className="mr-2">
-          <ProjectAvatar owner={this.props.owner} avatar_url={this.props.avatar_url} namespace={this.props.namespace}
-            getAvatarFromNamespace={this.props.getAvatarFromNamespace} />
+      <div className="d-flex limit-width pt-2 pb-2 border-top">
+        <div className="d-flex flex-column mt-auto mb-auto">
+          <ProjectAvatar
+            owner={this.props.owner}
+            avatar_url={this.props.avatar_url}
+            namespace={this.props.namespace}
+            getAvatarFromNamespace={this.props.getAvatarFromNamespace}
+          />
         </div>
-        <div>
-          <p className="mb-1">
-            <b>{title}</b>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<ProjectTagList taglist={this.props.tag_list} />
-          </p>
-          <span>{description} <TimeCaption caption="Updated" time={this.props.last_activity_at} /></span>
+        <div className={"d-flex flex-fill flex-column ml-2 mw-0" + directionModifier}>
+          <div className="d-flex flex-column text-truncate">
+            <p className="mt-auto mb-auto text-truncate">
+              <b>{title}</b>
+              <span className="ml-2">
+                <ProjectTagList taglist={this.props.tag_list} />
+              </span>
+            </p>
+            {description ? <p className="mt-auto mb-auto text-truncate">{description}</p> : null}
+          </div>
+          <div className={"d-flex flex-shrink-0" + marginModfier}>
+            <p className="mt-auto mb-auto">
+              <TimeCaption caption="Updated" time={this.props.last_activity_at} />
+            </p>
+          </div>
         </div>
       </div>
     );
@@ -337,7 +352,7 @@ class ProjectsSearch extends Component {
       </Row>,
       forbidden ?
         null :
-        (<Pagination key="pagination" {...this.props} />)
+        (<div key="pagination" className="mt-3"><Pagination {...this.props} /></div>)
     ];
   }
 }

--- a/src/project/list/ProjectList.present.js
+++ b/src/project/list/ProjectList.present.js
@@ -18,14 +18,15 @@
 
 import React, { Component } from "react";
 import { Link, Route, Switch } from "react-router-dom";
-import { Row, Col, Alert } from "reactstrap";
-import { Button, Form, InputGroup, FormText, Input, Label, ButtonGroup } from "reactstrap";
-import { Nav, NavItem, InputGroupButtonDropdown, DropdownToggle, DropdownMenu, DropdownItem } from "reactstrap";
+import {
+  Row, Col, Alert, UncontrolledTooltip, Button, Form, InputGroup, FormText, Input, Label, ButtonGroup,
+  Nav, NavItem, InputGroupButtonDropdown, DropdownToggle, DropdownMenu, DropdownItem
+} from "reactstrap";
+import { faCheck, faSortAmountDown, faSortAmountUp } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 import { ProjectAvatar, Loader, Pagination, TimeCaption, RenkuNavLink } from "../../utils/UIComponents";
 import { ProjectTagList } from "../shared";
-import { faCheck, faSortAmountDown, faSortAmountUp } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 import "../Project.css";
 
@@ -61,83 +62,103 @@ class ProjectListRow extends Component {
 }
 
 class ProjectSearchForm extends Component {
-
   render() {
-    return [<Form key="form" onSubmit={this.props.handlers.onSearchSubmit} inline>
-      <InputGroup>
-        <Input name="searchQuery" id="searchQuery" placeholder={this.props.searchText} style={{ minWidth: "300px" }}
-          value={this.props.searchQuery} onChange={this.props.handlers.onSearchQueryChange}
-          className="border-primary" />
-        <Label for="searchQuery" hidden>Query</Label>
-        {
-          this.props.urlMap.projectsSearchUrl === this.props.currentTab || this.props.hasUser === false ?
-            <InputGroupButtonDropdown addonType="append"
-              toggle={this.props.handlers.onSearchInDropdownToogle} isOpen={this.props.searchInDropdownOpen} >
-              <DropdownToggle outline caret color="primary" >
-                Filter by: {this.props.searchInLabel}
-              </DropdownToggle>
-              <DropdownMenu>
-                <DropdownItem value={this.props.searchInValuesMap.PROJECTNAME}
-                  onClick={this.props.handlers.changeSearchDropdownFilter}>
-                  {this.props.searchIn === this.props.searchInValuesMap.PROJECTNAME ?
-                    <FontAwesomeIcon icon={faCheck} /> : null} Project Name
-                </DropdownItem>
-                <DropdownItem key={this.props.searchInValuesMap.USERNAME}
-                  value={this.props.searchInValuesMap.USERNAME}
-                  onClick={this.props.handlers.changeSearchDropdownFilter}>
-                  {this.props.searchIn === this.props.searchInValuesMap.USERNAME ?
-                    <FontAwesomeIcon icon={faCheck} /> : null} User Name
-                </DropdownItem>
-                <DropdownItem key={this.props.searchInValuesMap.GROUPNAME}
-                  value={this.props.searchInValuesMap.GROUPNAME}
-                  onClick={this.props.handlers.changeSearchDropdownFilter}>
-                  {this.props.searchIn === this.props.searchInValuesMap.GROUPNAME ?
-                    <FontAwesomeIcon icon={faCheck} /> : null} Group Name
-                </DropdownItem>
-              </DropdownMenu>
-            </InputGroupButtonDropdown>
-            : null
-        }
-        <InputGroupButtonDropdown addonType="append"
-          toggle={this.props.handlers.onOrderByDropdownToogle} isOpen={this.props.orderByDropdownOpen} >
-          <Button outline color="primary" onClick={this.props.handlers.toogleSearchSorting}>
-            {this.props.orderSearchAsc ?
-              <FontAwesomeIcon icon={faSortAmountUp} /> :
-              <FontAwesomeIcon icon={faSortAmountDown} />}
-          </Button>
-          <DropdownToggle outline caret color="primary" >
-            Order by: {this.props.orderByLabel}
-          </DropdownToggle>
-          <DropdownMenu>
-            <DropdownItem value={this.props.orderByValuesMap.NAME}
-              onClick={this.props.handlers.changeSearchDropdownOrder}>
-              {this.props.orderBy === this.props.orderByValuesMap.NAME ?
-                <FontAwesomeIcon icon={faCheck} /> :
-                null} Name
-            </DropdownItem>
-            <DropdownItem value={this.props.orderByValuesMap.CREATIONDATE}
-              onClick={this.props.handlers.changeSearchDropdownOrder}>
-              {this.props.orderBy === this.props.orderByValuesMap.CREATIONDATE ?
-                <FontAwesomeIcon icon={faCheck} /> :
-                null} Creation Date
-            </DropdownItem>
-            <DropdownItem value={this.props.orderByValuesMap.UPDATEDDATE}
-              onClick={this.props.handlers.changeSearchDropdownOrder}>
-              {this.props.orderBy === this.props.orderByValuesMap.UPDATEDDATE ?
-                <FontAwesomeIcon icon={faCheck} /> :
-                null} Updated Date
-            </DropdownItem>
-          </DropdownMenu>
-        </InputGroupButtonDropdown>
-      </InputGroup>
-      &nbsp;
-      <Button color="primary" onClick={this.props.handlers.onSearchSubmit}>
-        Filter
-      </Button>
-    </Form>,
-    this.props.searchIn === this.props.searchInValuesMap.PROJECTNAME ?
-      <FormText key="help" color="muted">Leave emtpy to browse all projects.</FormText>
-      : null
+    const { searchQuery, forbidden } = this.props;
+    const noSearch = (searchQuery && searchQuery.length && searchQuery.length < 3) ?
+      true :
+      false;
+    let tooltip = null;
+    if (forbidden || noSearch) {
+      let tip;
+      if (forbidden)
+        tip = "Anynomous user can't filter by User";
+      else
+        tip = "Please enter at least 3 characters to filter";
+      tooltip = (
+        <UncontrolledTooltip key="tooltip" placement="top" target="searchButton">
+          {tip}
+        </UncontrolledTooltip>
+      );
+    }
+
+    return [
+      <Form key="form" onSubmit={this.props.handlers.onSearchSubmit} inline>
+        <InputGroup>
+          <Input name="searchQuery" id="searchQuery" placeholder={this.props.searchText} style={{ minWidth: "300px" }}
+            value={searchQuery} onChange={this.props.handlers.onSearchQueryChange}
+            className="border-primary" />
+          <Label for="searchQuery" hidden>Query</Label>
+          {
+            this.props.urlMap.projectsSearchUrl === this.props.currentTab || this.props.hasUser === false ?
+              <InputGroupButtonDropdown addonType="append"
+                toggle={this.props.handlers.onSearchInDropdownToogle} isOpen={this.props.searchInDropdownOpen} >
+                <DropdownToggle outline caret color="primary" >
+                  Filter by: {this.props.searchInLabel}
+                </DropdownToggle>
+                <DropdownMenu>
+                  <DropdownItem value={this.props.searchInValuesMap.PROJECTNAME}
+                    onClick={this.props.handlers.changeSearchDropdownFilter}>
+                    {this.props.searchIn === this.props.searchInValuesMap.PROJECTNAME ?
+                      <FontAwesomeIcon icon={faCheck} /> : null} Project Name
+                  </DropdownItem>
+                  <DropdownItem key={this.props.searchInValuesMap.USERNAME}
+                    value={this.props.searchInValuesMap.USERNAME}
+                    onClick={this.props.handlers.changeSearchDropdownFilter}>
+                    {this.props.searchIn === this.props.searchInValuesMap.USERNAME ?
+                      <FontAwesomeIcon icon={faCheck} /> : null} User Name
+                  </DropdownItem>
+                  <DropdownItem key={this.props.searchInValuesMap.GROUPNAME}
+                    value={this.props.searchInValuesMap.GROUPNAME}
+                    onClick={this.props.handlers.changeSearchDropdownFilter}>
+                    {this.props.searchIn === this.props.searchInValuesMap.GROUPNAME ?
+                      <FontAwesomeIcon icon={faCheck} /> : null} Group Name
+                  </DropdownItem>
+                </DropdownMenu>
+              </InputGroupButtonDropdown>
+              : null
+          }
+          <InputGroupButtonDropdown addonType="append"
+            toggle={this.props.handlers.onOrderByDropdownToogle} isOpen={this.props.orderByDropdownOpen} >
+            <Button outline color="primary" onClick={this.props.handlers.toogleSearchSorting}>
+              {this.props.orderSearchAsc ?
+                <FontAwesomeIcon icon={faSortAmountUp} /> :
+                <FontAwesomeIcon icon={faSortAmountDown} />}
+            </Button>
+            <DropdownToggle outline caret color="primary" >
+              Order by: {this.props.orderByLabel}
+            </DropdownToggle>
+            <DropdownMenu>
+              <DropdownItem value={this.props.orderByValuesMap.NAME}
+                onClick={this.props.handlers.changeSearchDropdownOrder}>
+                {this.props.orderBy === this.props.orderByValuesMap.NAME ?
+                  <FontAwesomeIcon icon={faCheck} /> :
+                  null} Name
+              </DropdownItem>
+              <DropdownItem value={this.props.orderByValuesMap.CREATIONDATE}
+                onClick={this.props.handlers.changeSearchDropdownOrder}>
+                {this.props.orderBy === this.props.orderByValuesMap.CREATIONDATE ?
+                  <FontAwesomeIcon icon={faCheck} /> :
+                  null} Creation Date
+              </DropdownItem>
+              <DropdownItem value={this.props.orderByValuesMap.UPDATEDDATE}
+                onClick={this.props.handlers.changeSearchDropdownOrder}>
+                {this.props.orderBy === this.props.orderByValuesMap.UPDATEDDATE ?
+                  <FontAwesomeIcon icon={faCheck} /> :
+                  null} Updated Date
+              </DropdownItem>
+            </DropdownMenu>
+          </InputGroupButtonDropdown>
+        </InputGroup>
+        &nbsp;
+        <Button disabled={noSearch || forbidden} color="primary" id="searchButton"
+          onClick={this.props.handlers.onSearchSubmit}>
+          Search
+        </Button>
+        {tooltip}
+      </Form>,
+      <FormText key="help" color="muted">
+        Leave emtpy to browse all projects or enter at least 3 characters to filter.
+      </FormText>
     ];
   }
 }
@@ -193,9 +214,11 @@ class DisplayEmptyProjects extends Component {
 
 class ProjectsRows extends Component {
   render() {
-    if (this.props.forbidden) return <Col>You need to be logged in to search projects per user name.</Col>;
+    if (this.props.forbidden)
+      return (<Col>Only logged users con search by User.</Col>);
 
-    if (this.props.loading) return <Col md={{ size: 2, offset: 3 }}><Loader /></Col>;
+    if (this.props.loading)
+      return (<Col><Loader /></Col>);
 
     if (this.props.page.emptyResponseMessage) {
       return <DisplayEmptyProjects
@@ -205,13 +228,16 @@ class ProjectsRows extends Component {
     }
 
     const projects = this.props.page.projects || [];
+    if (projects.length === 0)
+      return (<Col>We couldn&apos;t find any project with the search criteria.</Col>);
+
     const rows = projects.map((p) =>
       <ProjectListRow
         key={p.id}
         projectsUrl={this.props.urlMap.projectsUrl}
         {...p}
         getAvatarFromNamespace={this.props.getAvatarFromNamespace} />);
-    return <Col md={8}>{rows}</Col>;
+    return (<Col>{rows}</Col>);
   }
 }
 
@@ -274,12 +300,11 @@ class ProjectsSearch extends Component {
             handlers={this.props.handlers}
             currentTab={this.props.currentTab}
             urlMap={this.props.urlMap}
-            hasUser={hasUser} />
+            hasUser={hasUser}
+            forbidden={forbidden} />
         </Col>
       </Row>,
-      <Row key="spacer2">
-        <Col md={8}>&nbsp;</Col>
-      </Row>,
+      <Row key="spacer2"><Col>&nbsp;</Col></Row>,
       this.props.searchIn === this.props.searchInValuesMap.USERNAME ||
       this.props.searchIn === this.props.searchInValuesMap.GROUPNAME ?
         <Row key="users">
@@ -292,9 +317,12 @@ class ProjectsSearch extends Component {
             loading={loading}
             forbidden={forbidden}
           />
-        </Row> :
+        </Row>
+        :
         null,
-      <Row key="spacer3"><Col md={8}>&nbsp;</Col></Row>,
+      this.props.usersOrGroupsList && this.props.usersOrGroupsList.length ?
+        <Row key="spacer3"><Col>&nbsp;</Col></Row> :
+        null,
       <Row key="projects">
         <ProjectsRows
           page={this.props.page}
@@ -305,7 +333,9 @@ class ProjectsSearch extends Component {
           getAvatarFromNamespace={this.props.handlers.getAvatarFromNamespace}
         />
       </Row>,
-      <Pagination key="pagination" {...this.props} />
+      forbidden ?
+        null :
+        (<Pagination key="pagination" {...this.props} />)
     ];
   }
 }

--- a/src/project/list/ProjectList.state.js
+++ b/src/project/list/ProjectList.state.js
@@ -158,11 +158,6 @@ class ProjectListModel extends StateModel {
   }
 
   searchProjectsByUsernameOrGroup(searchIn, queryParams, search, selectedUserOrGroupId) {
-    if (search.length < 3) {
-      this.setUsersOrGroupsList([]);
-      this.set("loading", false);
-      return [];
-    }
     return this.client.searchUsersOrGroups({ search }, searchIn)
       .then(response => {
         this.setUsersOrGroupsList(response);
@@ -211,15 +206,10 @@ class ProjectListModel extends StateModel {
       }
     }
 
-    switch (searchIn) {
-      case searchInValuesMap.PROJECTNAME :
-        return this.searchProjects({ search: query, ...queryParams });
-      case searchInValuesMap.USERNAME :
-        return this.searchProjectsByUsernameOrGroup( searchIn, queryParams, query, selectedUserOrGroupId );
-      case searchInValuesMap.GROUPNAME :
-        return this.searchProjectsByUsernameOrGroup( searchIn, queryParams, query, selectedUserOrGroupId );
-      default : return [];
-    }
+    // use searchProject when there is no filter (browse all projects)
+    if (searchIn === searchInValuesMap.PROJECTNAME || !query)
+      return this.searchProjects({ search: query, ...queryParams });
+    return this.searchProjectsByUsernameOrGroup( searchIn, queryParams, query, selectedUserOrGroupId );
   }
 }
 export default ProjectListModel;

--- a/src/utils/UIComponents.js
+++ b/src/utils/UIComponents.js
@@ -142,17 +142,17 @@ class RenkuNavLink extends Component {
   }
 
   testActive(match, location) {
+    const alt = this.props.alternate;
     if (this.props.matchpath === true) {
-      const alt = this.props.alternate;
       let haveMatch = (match != null || location.pathname.startsWith(this.props.to));
       if (alt == null) return haveMatch;
       return haveMatch || location.pathname.startsWith(alt);
     }
-    const alt = this.props.alternate;
     let haveMatch = match != null;
     if (alt == null) return haveMatch;
+    if (this.props.noSubpath)
+      return haveMatch || location.pathname.endsWith(alt);
     return haveMatch || location.pathname.startsWith(alt);
-
   }
 
   render() {

--- a/src/utils/quicknav/QuickNav.present.js
+++ b/src/utils/quicknav/QuickNav.present.js
@@ -19,8 +19,10 @@
 import React, { Component } from "react";
 import { Link } from "react-router-dom";
 import Autosuggest from "react-autosuggest";
+import { InputGroup, InputGroupAddon, Button } from "reactstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSearch } from "@fortawesome/free-solid-svg-icons";
+
 import "./QuickNav.style.css";
 
 class QuickNavPresent extends Component {
@@ -61,28 +63,27 @@ class QuickNavPresent extends Component {
       onChange: this.props.callbacks.onChange
     };
 
-    return <form className="form-inline my-2 my-lg-0" onSubmit={this.props.callbacks.onSubmit}>
-      <div className="input-group">
-        <Autosuggest
-          suggestions={this.props.suggestions}
-          getSuggestionValue={this.props.callbacks.getSuggestionValue}
-          onSuggestionsFetchRequested={this.props.callbacks.onSuggestionsFetchRequested}
-          onSuggestionsClearRequested={this.props.callbacks.onSuggestionsClearRequested}
-          onSuggestionSelected={this.props.callbacks.onSuggestionSelected}
-          multiSection={true}
-          renderSectionTitle={this.onSectionTitle}
-          getSectionSuggestions={(section) => section.suggestions}
-          inputProps={inputProps}
-          theme={theme}
-          renderSuggestion={this.onRenderSuggestion} />
-        <span className="input-group-append">
-          <button className="btn btn-outline-primary my-2 my-sm-0" type="submit">
-            <FontAwesomeIcon icon={faSearch} />
-          </button>
-        </span>
-      </div>
-    </form>;
-
+    return (
+      <form className="form-inline m-1" onSubmit={this.props.callbacks.onSubmit}>
+        <InputGroup className="flex-nowrap">
+          <Autosuggest
+            suggestions={this.props.suggestions}
+            getSuggestionValue={this.props.callbacks.getSuggestionValue}
+            onSuggestionsFetchRequested={this.props.callbacks.onSuggestionsFetchRequested}
+            onSuggestionsClearRequested={this.props.callbacks.onSuggestionsClearRequested}
+            onSuggestionSelected={this.props.callbacks.onSuggestionSelected}
+            multiSection={true}
+            renderSectionTitle={this.onSectionTitle}
+            getSectionSuggestions={(section) => section.suggestions}
+            inputProps={inputProps}
+            theme={theme}
+            renderSuggestion={this.onRenderSuggestion} />
+          <InputGroupAddon addonType="append">
+            <Button color="outline-primary"><FontAwesomeIcon icon={faSearch} /></Button>
+          </InputGroupAddon>
+        </InputGroup>
+      </form>
+    );
   }
 }
 


### PR DESCRIPTION
In #703, we suggest to slightly modify the project list layout, hiding the description when not available.

This PR introduces that change and it fixes a number of other issues related to project list and project search. The idea is to keep the layout consistent at different window sizes while adapting to the content (e.g. missing description, date positioning, ... -- see the screen below or the preview).

Preview: https://lorenzotest.dev.renku.ch/projects

Please feel free to suggest any further improvement.
The final result is closer to the current GitLab project list layout: https://dev.renku.ch/gitlab/

![Screenshot_20200608_091701](https://user-images.githubusercontent.com/43481553/84002962-93874f00-a969-11ea-865a-e5ed24d139fd.png)

![Screenshot_20200608_091732](https://user-images.githubusercontent.com/43481553/84002981-9aae5d00-a969-11ea-8765-047bf467007c.png)

![Screenshot_20200608_092950](https://user-images.githubusercontent.com/43481553/84003655-a64e5380-a96a-11ea-8026-2c587c51fa1a.png)
