### PR TITLE
fix: properly handle missing description field in project page

### DIFF
--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -512,12 +512,15 @@ class ProjectViewOverview extends Component {
 
   render() {
     const { core, system, projectCoordinator } = this.props;
+    const description = core.description ?
+      (<Fragment><span className="lead">{core.description}</span><br /></Fragment>) :
+      null;
 
     return <Col key="overview">
       <Row>
         <Col xs={12} md={9}>
           <p>
-            <span className="lead">{core.description}</span> <br />
+            {description}
             <TimeCaption key="time-caption" time={core.last_activity_at} />
           </p>
         </Col>

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -1135,7 +1135,8 @@ class ProjectDescription extends Component {
   render() {
     const inputField = this.props.settingsReadOnly ?
       <Input id="projectDescription" readOnly value={this.state.value} /> :
-      <Input id="projectDescription" value={this.state.value} onChange={this.onValueChange} />;
+      <Input id="projectDescription" onChange={this.onValueChange}
+        value={this.state.value === null ? "" : this.state.value} />;
     let submit = (this.props.core.description !== this.state.value) ?
       <Button className="mb-3" color="primary">Update</Button> :
       <span></span>;


### PR DESCRIPTION
#961 got merged to handle projects without a `Description` field. This PR fixes a couple of minor leftovers:

1. Avoid React error on project's setting tab page
![Screenshot_20200709_153840](https://user-images.githubusercontent.com/43481553/87048289-d56f1380-c1fb-11ea-8dd7-0ae8dfbe71b0.png)

2. Avoid `<br />` element adding extra space on top of the project's overview page
![Screenshot_20200709_154029](https://user-images.githubusercontent.com/43481553/87048381-f0418800-c1fb-11ea-8bb0-60cd7056dfbf.png)
