### PR TITLE
Integrate statuspage.io in the UI

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -30,6 +30,7 @@ echo " PRIVACY_ENABLED=${PRIVACY_ENABLED}"
 echo " PRIVACY_BANNER_CONTENT=${PRIVACY_BANNER_CONTENT}"
 echo " PRIVACY_BANNER_LAYOUT=${PRIVACY_BANNER_LAYOUT}"
 echo " TEMPLATES=${TEMPLATES}"
+echo " STATUSPAGE_ID=${STATUSPAGE_ID}"
 echo "==================================================="
 
 echo "Privacy file contains the following markdown (first 5 lines):"
@@ -49,7 +50,8 @@ tee > "${NGINX_PATH}/config.json" << EOF
   "PRIVACY_ENABLED": "${PRIVACY_ENABLED}",
   "PRIVACY_BANNER_CONTENT": "${PRIVACY_BANNER_CONTENT}",
   "PRIVACY_BANNER_LAYOUT": ${PRIVACY_BANNER_LAYOUT},
-  "TEMPLATES": ${TEMPLATES}
+  "TEMPLATES": ${TEMPLATES},
+  "STATUSPAGE_ID": "${STATUSPAGE_ID}"
 }
 EOF
 echo "config.json created in ${NGINX_PATH}"
@@ -58,7 +60,7 @@ FILE=/config-privacy/statement.md
 if [ -f "$FILE" ]; then
   more /config-privacy/statement.md | base64 | tr -d \\n > "${NGINX_PATH}/privacy-statement.md"
   echo "privacy-statement.md created in ${NGINX_PATH}"
-else 
+else
   echo "privacy-statement.md created in ${NGINX_PATH}"
 fi
 

--- a/helm-chart/renku-ui/templates/deployment.yaml
+++ b/helm-chart/renku-ui/templates/deployment.yaml
@@ -48,6 +48,10 @@ spec:
               value: {{ .Values.gatewayUrl | default (printf "%s://%s/api" (include "ui.protocol" .) .Values.global.renku.domain) | quote }}
             - name: WELCOME_PAGE
               value: {{ .Values.welcomePage.text | b64enc | quote }}
+            {{- if .Values.statuspage }}
+            - name: STATUSPAGE_ID
+              value: {{ .Values.statuspage.id | quote }}
+            {{- end }}
               {{- if .Values.sentry.enabled }}
             - name: SENTRY_URL
               value: {{ .Values.sentry.url | quote }}

--- a/helm-chart/renku-ui/values.yaml
+++ b/helm-chart/renku-ui/values.yaml
@@ -95,3 +95,6 @@ privacy:
       contentClasses: text-white small
       buttonClasses: btn btn-sm btn-light mr-2
       buttonWrapperClasses: mt-2
+## If you maintain a statuspage.io page for the status of your RenkuLab instance, put the id for it here.
+statuspage:
+  id:

--- a/run-telepresence.sh
+++ b/run-telepresence.sh
@@ -38,6 +38,8 @@ else
   echo "Warning! your OS has not been tested yet"
 fi
 
+if [ -z "$STATUSPAGE_ID" ]; then STATUSPAGE_ID="r3j2c84ftq49"; else echo "STATUSPAGE_ID is set to '$STATUSPAGE_ID'"; fi
+
 if [[ $CURRENT_CONTEXT == 'minikube' ]]
 then
   echo "Exchanging k8s deployments using the following context: ${CURRENT_CONTEXT}"
@@ -93,7 +95,8 @@ tee > ./public/config.json << EOF
   "SENTRY_NAMESPACE": "${SENTRY_NAMESPACE}",
   "ANONYMOUS_SESSIONS": "true",
   "PRIVACY_ENABLED": "false",
-  "TEMPLATES": ${TEMPLATES}
+  "TEMPLATES": ${TEMPLATES},
+  "STATUSPAGE_ID": "${STATUSPAGE_ID}"
 }
 EOF
 

--- a/src/App.js
+++ b/src/App.js
@@ -75,14 +75,16 @@ class App extends Component {
                   user={this.props.user}
                   client={this.props.client}
                   model={this.props.model}
+                  statuspageId={this.props.statuspageId}
                   {...p} />} />
               <Route path="/help" render={
-                p => <Help key="help" {...p} {...this.props} />} />
+                p => <Help key="help" {...p} statuspageId={this.props.statuspageId} {...this.props} />} />
               <Route exact path={["/projects", "/projects/starred", "/projects/all"]} render={
                 p => <Project.List
                   key="projects"
                   user={this.props.user}
                   client={this.props.client}
+                  statusSummary={this.props.statusSummary}
                   {...p}
                 />}
               />

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -17,7 +17,7 @@ describe("rendering", () => {
         client={client}
         model={model}
         user={user}
-        params={{ WELCOME_PAGE: "Some text" }} />
+        params={{ WELCOME_PAGE: "Some text", STATUSPAGE_ID: "5bcn9bqff4qt" }} />
       , div);
   });
 
@@ -29,7 +29,7 @@ describe("rendering", () => {
         client={client}
         model={model}
         user={user}
-        params={{ WELCOME_PAGE: "Some text" }} />
+        params={{ WELCOME_PAGE: "Some text", STATUSPAGE_ID: "5bcn9bqff4qt" }} />
       , div);
   });
 });

--- a/src/help/Help.container.js
+++ b/src/help/Help.container.js
@@ -24,27 +24,24 @@
  */
 
 
-import React, { Component } from "react";
+import React from "react";
 
 import { Help as HelpPresent } from "./Help.present";
 
-class Help extends Component {
-  urlMap() {
-    const baseUrl = this.props.match.url;
-    return {
-      base: baseUrl,
-      getting: `${baseUrl}/getting`,
-      documentation: `${baseUrl}/docs`,
-      features: `${baseUrl}/features`,
-      setup: `${baseUrl}/setup`,
-    };
-  }
+function urlMap(baseUrl) {
+  return {
+    base: baseUrl,
+    getting: `${baseUrl}/getting`,
+    documentation: `${baseUrl}/docs`,
+    features: `${baseUrl}/features`,
+    setup: `${baseUrl}/setup`,
+    status: `${baseUrl}/status`,
+  };
+}
 
-  render() {
-    return (
-      <HelpPresent url={this.urlMap()} />
-    );
-  }
+function Help(props) {
+  return <HelpPresent url={urlMap(props.match.url)} statuspageId={props.statuspageId}
+    statuspageModel={props.model.subModel("statuspage")} />;
 }
 
 export { Help };

--- a/src/help/Help.present.js
+++ b/src/help/Help.present.js
@@ -25,15 +25,22 @@
 
 import React, { Component } from "react";
 import { Route } from "react-router-dom";
-import { ExternalDocsLink, ExternalIconLink, RenkuNavLink } from "../utils/UIComponents";
 
 import { Row, Col } from "reactstrap";
 import { Nav, NavItem } from "reactstrap";
 
 import { faDiscourse, faGithub, faGitter } from "@fortawesome/free-brands-svg-icons";
 
+import { ExternalDocsLink, ExternalIconLink, RenkuNavLink } from "../utils/UIComponents";
+import { StatuspageDisplay, isStatusConfigured } from "../statuspage";
+
 class HelpNav extends Component {
   render() {
+    const statusLink = isStatusConfigured(this.props.statuspageId) ?
+      <NavItem>
+        <RenkuNavLink to={this.props.url.status} title="Status" />
+      </NavItem> :
+      null;
     return (
       <Nav pills className={"nav-pills-underline"}>
         <NavItem>
@@ -48,6 +55,7 @@ class HelpNav extends Component {
         <NavItem>
           <RenkuNavLink to={this.props.url.setup} title="Set Up / Admin" />
         </NavItem>
+        { statusLink }
       </Nav>
     );
   }
@@ -251,7 +259,11 @@ class HelpContent extends Component {
         key="features"
         render={props => <HelpFeatures key="features" {...this.props} />}
       />,
-      <Route path={this.props.url.setup} key="setup" render={props => <HelpSetup key="setup" {...this.props} />} />
+      <Route path={this.props.url.setup} key="setup" render={props => <HelpSetup key="setup" {...this.props} />} />,
+      <Route
+        path={this.props.url.status} key="status"
+        render={props => <StatuspageDisplay key="status" statuspageId={this.props.statuspageId}
+          statuspageModel={this.props.statuspageModel} />} />
     ];
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -40,9 +40,9 @@ Promise.all([configFetch, privacyFetch]).then(valuesRead => {
       params["PRIVACY_STATEMENT"] = privacy;
 
     // show maintenance page when necessary
-    const maintenace = params["MAINTENANCE"];
-    if (maintenace) {
-      ReactDOM.render(<Maintenance info={maintenace} />, document.getElementById("root"));
+    const maintenance = params["MAINTENANCE"];
+    if (maintenance) {
+      ReactDOM.render(<Maintenance info={maintenance} />, document.getElementById("root"));
       return;
     }
 
@@ -77,9 +77,13 @@ Promise.all([configFetch, privacyFetch]).then(valuesRead => {
     function mapStateToProps(state, ownProps) {
       return { user: state.user, ...ownProps };
     }
+
+    const statuspageId = params["STATUSPAGE_ID"];
+
     const VisibleApp = connect(mapStateToProps)(App);
     ReactDOM.render(
-      <VisibleApp client={client} params={params} store={model.reduxStore} model={model} />,
+      <VisibleApp client={client} params={params} store={model.reduxStore} model={model}
+        statuspageId={statuspageId} />,
       document.getElementById("root")
     );
   });

--- a/src/landing/Landing.js
+++ b/src/landing/Landing.js
@@ -37,6 +37,7 @@ function urlMap() {
     projectNewUrl: "/projects/new",
     projectsSearchUrl: "/projects/all",
     projectsStarredUrl: "/projects/starred",
+    siteStatusUrl: "/help/status"
   };
 }
 
@@ -97,6 +98,8 @@ class HomeProjects extends Component {
           welcomePage={atob(this.props.welcomePage)}
           user={this.props.user}
           projects={this.props.projects}
+          statuspageId={this.props.statuspageId}
+          statuspageModel={this.props.model.subModel("statuspage")}
         />
       </Provider>
     ];

--- a/src/landing/Landing.present.js
+++ b/src/landing/Landing.present.js
@@ -34,6 +34,7 @@ import {
 
 import { RenkuMarkdown, Loader } from "../utils/UIComponents";
 import { ProjectListRow } from "../project";
+import { StatuspageBanner } from "../statuspage";
 
 function truncatedProjectListRows(projects, projectsUrl, moreUrl) {
   const maxProjectsRows = 5;
@@ -254,6 +255,8 @@ class LoggedInHome extends Component {
     return [
       <Row key="username">
         <Col>
+          <StatuspageBanner siteStatusUrl={urlMap.siteStatusUrl} statuspageId={this.props.statuspageId}
+            statuspageModel={this.props.statuspageModel} />
           <h1>{user.data.username} @ Renku</h1>
         </Col>
       </Row>,

--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -433,12 +433,12 @@ function updateObjectFromString(propAccessorString, value) {
 function updateObjectFromObject(obj, currentObject) {
   let updateObj = {};
   Object.keys(obj).forEach((prop) => {
-    if (obj[prop] instanceof Object && currentObject[prop])
+    if (obj[prop] instanceof Date)
+      updateObj[prop] = { $set: obj[prop] };
+    else if (obj[prop] instanceof Object && currentObject[prop])
       updateObj[prop] = updateObjectFromObject(obj[prop], currentObject[prop]);
-
     else if (prop[0] === "$" && prop.length && prop.length > 1)
       updateObj[prop] = obj[prop];
-
     else
       updateObj[prop] = { $set: obj[prop] };
 

--- a/src/model/RenkuModels.js
+++ b/src/model/RenkuModels.js
@@ -460,9 +460,18 @@ const addDatasetToProjectSchema = new Schema({
   }
 });
 
+/**
+ * Schema for information from statuspage.io. Used by the statuspage module.
+ */
+const statuspageSchema = new Schema({
+  retrieved_at: { initial: null },
+  statuspage: { initial: null },
+  error: { initial: null }
+});
+
 
 export {
   userSchema, metaSchema, newProjectSchema, projectSchema, forkProjectSchema, notebooksSchema,
   projectsSchema, datasetFormSchema, issueFormSchema, datasetImportFormSchema, projectGlobalSchema,
-  addDatasetToProjectSchema
+  addDatasetToProjectSchema, statuspageSchema
 };

--- a/src/statuspage/Statuspage.container.js
+++ b/src/statuspage/Statuspage.container.js
@@ -1,0 +1,111 @@
+/*!
+ * Copyright 2020 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  Statuspage.container
+ *  Components for the displaying information from statuspage.io
+ */
+
+import React, { useState, useEffect } from "react";
+
+import useInterval from "../utils/UseInterval";
+
+import { StatuspageDisplay as DisplayPresent, StatuspageBanner as BannerPresent } from "./Statuspage.present";
+import StatuspageAPI from "./StatuspageAPI";
+
+function isStatusConfigured(statuspageId) {
+  return statuspageId != null && statuspageId.length > 0;
+}
+
+
+const statusUpdateInterval = 1000 * 60 * 5; // Update every 5 minutes
+
+function useStatuspage(statuspageId, model) {
+  const [statusSummary, setStatusSummary] = useState({});
+  // Do an initial fetch
+  useEffect(() => {
+    const statusPage = new StatuspageAPI(statuspageId);
+    async function fetchIncidents() {
+      if (!isStatusConfigured(statuspageId)) {
+        setStatusSummary({ retrieved_at: new Date(), statuspage: null, error: null, not_configured: true });
+        return;
+      }
+      try {
+        const result = await statusPage.summary();
+        setStatusSummary({ retrieved_at: new Date(), statuspage: result, error: null });
+      }
+      catch (error) {
+        // we abort the fetch when the component is unmounted, so we can ignore this error
+        if (error.name !== "AbortError")
+          setStatusSummary({ error });
+      }
+    }
+    fetchIncidents();
+    // Abort the fetch on unmount, otherwise React complains
+    return () => { if (statusPage.controller != null) statusPage.controller.abort(); };
+  }, [statuspageId]);
+
+  // Start polling after the initial fetch returns
+  useInterval(() => {
+    async function fetchIncidents() {
+      const statusPage = new StatuspageAPI(statuspageId);
+      const result = await statusPage.summary();
+      setStatusSummary({ retrieved_at: new Date(), statuspage: result, error: null });
+    }
+    fetchIncidents();
+  }, (statusSummary.retrieved_at != null) ? statusUpdateInterval : null);
+
+  // Only status the status if there is something new there
+  if (statusSummary.retrieved_at != null) {
+    model.setObject(statusSummary);
+    return statusSummary;
+  }
+  return model.get();
+}
+
+/**
+ *
+ * @param {string} props.statuspageId The id for the statuspage
+ * @param {object} props.statuspageModel The model for the statuspage
+ */
+function StatuspageDisplay(props) {
+  const statuspageId = props.statuspageId;
+  const statusSummary = useStatuspage(statuspageId, props.statuspageModel);
+  if (statusSummary.not_configured) return null;
+
+  return <DisplayPresent statusSummary={statusSummary} />;
+}
+
+/**
+ *
+ * @param {string} props.statuspageId The id for the statuspage
+ * @param {string} props.siteStatusUrl The URL for the site status page
+ * @param {object} props.statuspageModel The model for the statuspage
+ */
+function StatuspageBanner(props) {
+  const statuspageId = props.statuspageId;
+  const statusSummary = useStatuspage(statuspageId, props.statuspageModel);
+  if (statusSummary.not_configured) return null;
+
+  return <BannerPresent statusSummary={statusSummary} siteStatusUrl={props.siteStatusUrl} />;
+}
+
+
+export { StatuspageDisplay, StatuspageBanner, isStatusConfigured };

--- a/src/statuspage/Statuspage.present.js
+++ b/src/statuspage/Statuspage.present.js
@@ -1,0 +1,275 @@
+/*!
+ * Copyright 2020 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  Statuspage.present
+ *  Components for the displaying information from statuspage.io
+ */
+
+import React, { Fragment } from "react";
+import { Link } from "react-router-dom";
+
+import human from "human-time";
+
+import { Row, Col } from "reactstrap";
+import { Alert, Badge, Table } from "reactstrap";
+
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCheckCircle, faExclamationCircle, faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
+import { faMinusCircle, faTimesCircle, faWrench } from "@fortawesome/free-solid-svg-icons";
+
+import { Loader, TimeCaption } from "../utils/UIComponents";
+import { Time } from "../utils/Time";
+
+function ComponentStatusIndicator(props) {
+  const status = props.status;
+  let indicator = null;
+  switch (status) {
+    case "operational":
+      indicator = {
+        color: "success",
+        icon: <FontAwesomeIcon icon={faCheckCircle} />
+      };
+      break;
+    case "degraded_performance":
+      indicator = {
+        color: "warning",
+        icon: <FontAwesomeIcon icon={faMinusCircle} />
+      };
+      break;
+    case "partial_outage":
+      indicator = {
+        color: "warning",
+        icon: <FontAwesomeIcon icon={faExclamationCircle} />
+      };
+      break;
+    case "major_outage":
+      indicator = {
+        color: "danger",
+        icon: <FontAwesomeIcon icon={faTimesCircle} />
+      };
+      break;
+    case "under_maintenance":
+      indicator = {
+        color: "info",
+        icon: <FontAwesomeIcon icon={faWrench} />
+      };
+      break;
+    default:
+      indicator = null;
+      break;
+  }
+
+  if (indicator == null) return <span></span>;
+  return <Badge color={indicator.color}>{indicator.icon}</Badge>;
+}
+
+/**
+ * The site status formatted for the details page.
+ */
+function SiteStatusDetails(props) {
+  const status = props.statuspage.status;
+  if (status.indicator === "none") {
+    return <div>
+      <span className="text-success" >
+        <FontAwesomeIcon icon={faCheckCircle} />
+      </span> { status.description }
+    </div>;
+  }
+  return <Alert color="warning"><FontAwesomeIcon icon={faExclamationTriangle} /> { status.description }</Alert>;
+}
+
+/**
+ * The site status formatted for the landing page.
+ */
+function SiteStatusLanding(props) {
+  const status = props.statuspage.status;
+  const siteStatusUrl = props.siteStatusUrl;
+  if (status.indicator === "none")
+    return null;
+  return <Alert color="warning">
+    <FontAwesomeIcon icon={faExclamationTriangle} /> RenkuLab is unstable: { status.description }. {" "}
+    See <b><Link to={siteStatusUrl}>RenkuLab Status</Link></b> for more details.
+  </Alert>;
+}
+
+/**
+ * Sort scheduled maintenances so the earliest is the first
+ * @param {array} maintenances
+ */
+function sortedMaintenances(maintenances) {
+  maintenances.sort((a, b) => a.scheduled_for < b.scheduled_for);
+  return maintenances;
+}
+
+function maintenanceTimeFragment(first) {
+  const scheduledDt = new Date(first.scheduled_for);
+  const displayTime = human(scheduledDt);
+  const maintenanceTimeFragment =
+    scheduledDt > new Date() ?
+      `Maintenance scheduled in ${displayTime}` :
+      `Maintenance started ${displayTime}`;
+  return maintenanceTimeFragment;
+}
+
+function MaintenanceSummaryDetails(props) {
+  const scheduled = sortedMaintenances(props.statuspage.scheduled_maintenances);
+  if (scheduled.length < 1)
+    return <span></span>;
+  const first = scheduled[0];
+  const mtf = maintenanceTimeFragment(first);
+  const summary =
+    `${mtf}. See below for information about the availability and limitations.`;
+  return <Alert color="warning"><FontAwesomeIcon icon={faWrench} /> { summary }</Alert>;
+}
+
+function MaintenanceSummaryLanding(props) {
+  const siteStatusUrl = props.siteStatusUrl;
+  const scheduled = sortedMaintenances(props.statuspage.scheduled_maintenances);
+  if (scheduled.length < 1)
+    return <span></span>;
+  const first = scheduled[0];
+  const mtf = maintenanceTimeFragment(first);
+  return <Alert color="warning"><FontAwesomeIcon icon={faWrench} /> { " "}
+    {mtf}. See <b><Link to={siteStatusUrl}>details</Link></b> { " "}
+    for information about the availability and limitations.
+  </Alert>;
+}
+
+function ComponentStatusRow(props) {
+  const status = props.component.status;
+  const statusText = status.split("_").join(" ");
+  return <tr>
+    <td><ComponentStatusIndicator status={status} /></td>
+    <td>
+      <span style={{ textTransform: "capitalize" }}>{statusText}</span>
+    </td>
+    <td>{props.component.name}</td>
+  </tr>;
+}
+
+
+function ComponentStatusDetails(props) {
+  const components = props.components;
+  return <Table>
+    <thead>
+      <tr><th width="10%"></th><th width="30%">Status</th><th>Component</th></tr>
+    </thead>
+    <tbody>
+      {
+        components.map(c => <ComponentStatusRow key={c.id} component={c} />)
+      }
+    </tbody>
+  </Table>;
+}
+
+function ScheduledMaintenanceIncident(props) {
+  const incident = props.incident;
+  return <Fragment>
+    <p>{incident.body} {" "}
+      <span className="time-caption" style={{ fontSize: "smaller" }}>Posted at {" "}
+        {Time.formatDateTime(Time.parseDate(incident.display_at))}
+      </span>
+    </p>
+  </Fragment>;
+}
+
+function ScheduledMaintenanceDetails(props) {
+  const maintenance = props.maintenance;
+  const maintenanceDuration = (new Date(maintenance.scheduled_until) - new Date(maintenance.scheduled_for)) / 1000;
+  // get the displayTime, but remove " ago" from it
+  const displayTime = human(maintenanceDuration).slice(0, -4);
+  const incidents = maintenance.incident_updates.map((u) => <ScheduledMaintenanceIncident key={u.id} incident={u} />);
+  return [
+    <h5 key="heading" className="border-bottom">{maintenance.name} {" "}
+      <span className="time-caption" style={{ fontSize: "smaller", fontWeight: "bold" }}>on {" "}
+        {Time.formatDateTime(Time.parseDate(maintenance.scheduled_for))} {" "}
+        for {displayTime}
+      </span>
+    </h5>,
+    ...incidents
+  ];
+}
+
+
+function ScheduledMaintenance(props) {
+  const maintenances = sortedMaintenances(props.maintenances);
+  if (maintenances.length < 1) {
+    return <p>
+      <span className="text-success" >
+        <FontAwesomeIcon icon={faCheckCircle} />
+      </span> No scheduled maintenance.</p>;
+  }
+  return maintenances.map(s => <ScheduledMaintenanceDetails key={s.id} maintenance={s} />);
+}
+
+/**
+ *
+ * @param {object} props.statusSummary The result from the StatuspageAPI.summary() call
+ */
+function StatuspageDisplay(props) {
+  const summary = props.statusSummary;
+  if (summary == null)
+    return <Loader />;
+  if (summary.error != null) {
+    return <Alert color="warning">Could not retrieve status information about this RenkuLab instance. {" "}
+      Please ask an administrator to check the statuspage.io configuration.</Alert>;
+  }
+  if (summary.statuspage == null)
+    return <Loader />;
+  return <Row>
+    <Col md={8}>
+      <h2>RenkuLab Status</h2>
+      <MaintenanceSummaryDetails statuspage={summary.statuspage} />
+      <SiteStatusDetails statuspage={summary.statuspage} />
+      <br />
+      <h4>Scheduled Maintenance Details</h4>
+      <ScheduledMaintenance maintenances={summary.statuspage.scheduled_maintenances} />
+      <br />
+      <h4>Component Details</h4>
+      <ComponentStatusDetails components={summary.statuspage.components} />
+      <br />
+      <p>
+        For further information, see <a href={summary.statuspage.page.url}>{summary.statuspage.page.url}</a>.<br />
+        <TimeCaption caption="Status retrieved" time={summary.retrieved_at} endPunctuation=";" />
+        {" "}<TimeCaption caption="last updated" time={summary.statuspage.page.updated_at} />
+      </p>
+    </Col>
+  </Row>;
+}
+
+/**
+ *
+ * @param {object} props.statusSummary The result from the StatuspageAPI.summary() call with timing information
+ * @param {string} props.siteStatusUrl The URL for the site status page
+ */
+function StatuspageBanner(props) {
+  const summary = props.statusSummary;
+  if (summary == null || summary.statuspage == null)
+    return null;
+  const statuspage = summary.statuspage;
+  return <Fragment>
+    <SiteStatusLanding statuspage={statuspage} siteStatusUrl={props.siteStatusUrl} />
+    <MaintenanceSummaryLanding statuspage={statuspage} siteStatusUrl={props.siteStatusUrl} />
+  </Fragment>;
+}
+
+
+export { StatuspageDisplay, StatuspageBanner };

--- a/src/statuspage/StatuspageAPI.js
+++ b/src/statuspage/StatuspageAPI.js
@@ -1,0 +1,56 @@
+/*!
+ * Copyright 2020 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  StatuspageAPI.js
+ */
+
+/**
+ *  Wrapper around statuspage.io
+ *
+ *  @param {string} pageId - the pageId for this application's status page
+ */
+class StatuspageAPI {
+
+  constructor(pageId) {
+    this.pageId = pageId;
+    this.controller = null;
+  }
+
+  async summary() {
+    const pageId = this.pageId;
+    this.controller = new AbortController();
+    const { signal } = this.controller;
+    let headers = new Headers({
+      "Accept": "application/json"
+    });
+
+    let queryParams = {
+      method: "GET",
+      headers: headers,
+      signal
+    };
+    return fetch(`https://${pageId}.statuspage.io/api/v2/summary.json`, queryParams).then(r => r.json());
+  }
+
+
+}
+
+export default StatuspageAPI;

--- a/src/statuspage/index.js
+++ b/src/statuspage/index.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019 - Swiss Data Science Center (SDSC)
+ * Copyright 2020 - Swiss Data Science Center (SDSC)
  * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
  * Eidgenössische Technische Hochschule Zürich (ETHZ).
  *
@@ -19,23 +19,11 @@
 /**
  *  renku-ui
  *
- *  model/GlobalSchema.js
- *  Schema for all Components.
+ *  statuspage
+ *  Components for the displaying information from statuspage.io
  */
 
-import { Schema, PropertyName as Prop } from "./index";
-import {
-  notebooksSchema, userSchema, projectsSchema, projectGlobalSchema, newProjectSchema,
-  statuspageSchema
-} from "./RenkuModels";
+import { StatuspageDisplay, StatuspageBanner, isStatusConfigured } from "./Statuspage.container";
+import StatuspageAPI from "./StatuspageAPI";
 
-const globalSchema = new Schema({
-  notebooks: { [Prop.SCHEMA]: notebooksSchema },
-  user: { [Prop.SCHEMA]: userSchema },
-  projects: { [Prop.SCHEMA]: projectsSchema },
-  project: { [Prop.SCHEMA]: projectGlobalSchema },
-  newProject: { [Prop.SCHEMA]: newProjectSchema },
-  statuspage: { [Prop.SCHEMA]: statuspageSchema }
-});
-
-export { globalSchema };
+export { StatuspageAPI, StatuspageBanner, StatuspageDisplay, isStatusConfigured };

--- a/src/utils/Time.js
+++ b/src/utils/Time.js
@@ -23,7 +23,8 @@
  *  Helper functions to handle date and time
  */
 
-// TODO: expand this with {timeFormat} from 'd3' to properly handle human readable dates according to localization
+import * as d3TimeFormat from "d3-time-format";
+
 
 class Time {
   static isDate(date) {
@@ -82,6 +83,25 @@ class Time {
     return date1.getUTCFullYear() === date2.getUTCFullYear() &&
       date1.getUTCMonth() === date2.getUTCMonth() &&
       date1.getUTCDate() === date2.getUTCDate();
+  }
+
+  /**
+   * Format a date/time string using either toLocale[Date,Time]String (default) or d3 format string.
+   *
+   * formatString should be a d3TimeFormat format string:
+   * @param {string} dt The date to format
+   * @param {object} options {localeTimeOptions: object, d3FormatString: string or null}.
+   *   The localeTimeOptions are passed to toLocaleTimeString. Defaults to
+   *     { hour: "2-digit", minute: "2-digit" }.
+   *   The d3FormatString should be of the form https://github.com/d3/d3-time-format.
+   *   If the d3FormatString is not null, it is used, otherwise, the locale formatting is used
+   */
+  static formatDateTime(dt,
+    { localeTimeOptions, d3FormatString } =
+    { localeTimeOptions: { hour: "2-digit", minute: "2-digit" }, d3FormatString: null } ) {
+    if (d3FormatString !== null)
+      return d3TimeFormat.timeFormat(d3FormatString)(dt);
+    return `${dt.toLocaleDateString()} ${dt.toLocaleTimeString([], localeTimeOptions)}`;
   }
 }
 

--- a/src/utils/UIComponents.js
+++ b/src/utils/UIComponents.js
@@ -126,10 +126,12 @@ class TimeCaption extends Component {
   // Take a time and caption and generate a span that shows it
   render() {
     const time = this.props.time;
-    const displayTime = human((new Date() - new Date(time)) / 1000);
+    const timeDiff = (new Date() - new Date(time)) / 1000;
+    const displayTime = timeDiff < 3 ? "just now" : human(timeDiff);
     const caption = (this.props.caption) ? this.props.caption : "Updated";
     const endCaption = (this.props.endCaption) ? " " + this.props.endCaption : "";
-    return <span className="time-caption">{caption} {displayTime}{endCaption}.</span>;
+    const endPunctuation = (this.props.endPunctuation) ? this.props.endPunctuation : ".";
+    return <span className="time-caption">{caption} {displayTime}{endCaption}{endPunctuation}</span>;
   }
 }
 

--- a/src/utils/UseInterval.js
+++ b/src/utils/UseInterval.js
@@ -1,0 +1,29 @@
+/**
+ * useInterval custom hook from Dan Abramov
+ *
+ * https://overreacted.io/making-setinterval-declarative-with-react-hooks/
+ */
+
+import { useEffect, useRef } from "react";
+
+function useInterval(callback, delay) {
+  const savedCallback = useRef();
+
+  // Remember the latest callback.
+  useEffect(() => {
+    savedCallback.current = callback;
+  }, [callback]);
+
+  // Set up the interval.
+  useEffect(() => {
+    function tick() {
+      savedCallback.current();
+    }
+    if (delay !== null) {
+      let id = setInterval(tick, delay);
+      return () => clearInterval(id);
+    }
+  }, [delay]);
+}
+
+export default useInterval;

--- a/src/utils/Utils.test.js
+++ b/src/utils/Utils.test.js
@@ -217,6 +217,19 @@ describe("Time class helper", () => {
     }
     expect(Time.toIsoTimezoneString(DatesTimezone.UTCZ_STRING)).toEqual(expectedString);
   });
+  it("function formatDateTime", () => {
+    let dt = Time.parseDate(Dates.ISO_READABLE_DATETIME);
+    expect(Time.formatDateTime(dt))
+      .not.toBeNull();
+    expect(Time.formatDateTime(dt, { d3FormatString: "%d %m %Y %H:%M:%S" }))
+      .toEqual("11 03 2019 09:34:51");
+    // Correct for the UTC offset, but this will not work for timezones with non-whole hour offsets
+    dt = Time.parseDate(Dates.UTCZ_STRING);
+    const offset = dt.getTimezoneOffset() / 60;
+    const hour = String(9 - offset).padStart(2, "0");
+    expect(Time.formatDateTime(dt, { d3FormatString: "%d %m %Y %H:%M:%S" }))
+      .toEqual(`11 03 2019 ${hour}:34:51`);
+  });
 });
 
 describe("Ini file parser", () => {


### PR DESCRIPTION
The is PR implements the design specified in #938.
The configuration for this feature is documented in https://github.com/SwissDataScienceCenter/renku/pull/1315.

The dev-values file template is updated in this PR: https://github.com/SwissDataScienceCenter/sdsc-dev-docs/pull/65

# Testing
- if the statuspage.id value is not configured, then you should not see the help/status page
- if the statuspage.id value is set to junk, then you should see a banner explaining that the statuspage is not correctly configured in the help/status page
- if you add a scheduled maintenance, you should a notification banner and details in the help/status page
- if a component is not stable, you should a notification banner and details in the help/status page

## Creating / setting a statuspage id

### Create a statuspage

You can create a free account at [statuspage.io](http://statuspage.io). 

### Setting the statuspage id

By default, no statuspage is configured. You can configure one by filling out the configuration.
```
ui:
  statuspage:
    id: [statuspage id]
```

The `run-telepresence.sh` script sets the statuspage to the dev statuspage id by default. You can override this by setting a STATUSPAGE_ID environment variable.

Finally, you can modify `src/index.js:81` and set the id explicitly. Just change this line to contain your statuspage id:
```const statuspageId = params["STATUSPAGE_ID"];```

The last option is nice for testing since you can change the statuspage id without having to redeploy.

# Screenshots

## Scheduled Maintenance

![image](https://user-images.githubusercontent.com/1196411/88563199-f9bb5480-d031-11ea-9bdf-0b25e66a5f71.png)

## Problems with Service (details)

![image](https://user-images.githubusercontent.com/1196411/88563394-3ab36900-d032-11ea-9506-9372b5222a4a.png)

## Problems with Service (landing page)
![image](https://user-images.githubusercontent.com/1196411/88659485-69cee680-d0d5-11ea-8f09-e5b0627966f3.png)

## Incorrectly configured statuspage

![image](https://user-images.githubusercontent.com/1196411/88792930-4fac0b80-d19c-11ea-9959-c6eefafe9b87.png)

Fix #938 