### PR TITLE
perf: query 100 projects instead of 20

### DIFF
--- a/src/api-client/project.js
+++ b/src/api-client/project.js
@@ -108,7 +108,7 @@ function addProjectMethods(client) {
   };
 
   client.getAllProjects = (extraParams = [],
-    { recursive = false, per_page = 20, page = 1, previousResults = [] } = {}
+    { recursive = false, per_page = 100, page = 1, previousResults = [] } = {}
   ) => {
     let headers = client.getBasicHeaders();
 

--- a/src/project/shared/Projects.state.js
+++ b/src/project/shared/Projects.state.js
@@ -54,7 +54,7 @@ class ProjectsCoordinator {
     if (this.model.get("featured.fetching")) return;
     // set status to fetching and invoke both APIs
     this.model.set("featured.fetching", true);
-    const promiseStarred = this.client.getProjects({ starred: true, order_by: "last_activity_at" })
+    const promiseStarred = this.client.getProjects({ starred: true, order_by: "last_activity_at", per_page: 100 })
       .then((projectResponse) => {
         const projects = projectResponse.data.map((project) => this._starredProjectMetadata(project));
         return projects;
@@ -62,7 +62,7 @@ class ProjectsCoordinator {
       .catch((error) => {
         this.model.set("starredProjects", []);
       });
-    const promiseMember = this.client.getAllProjects({ membership: true, order_by: "last_activity_at" })
+    const promiseMember = this.client.getAllProjects({ membership: true, order_by: "last_activity_at", per_page: 100 })
       .then((projectResponse) => {
         const projects = projectResponse.map((project) => this._starredProjectMetadata(project));
         return projects;


### PR DESCRIPTION
We should query for 100 projects per page instead of 20 to prevent unnecessary multiple queries.

![Screenshot_20200720_113154](https://user-images.githubusercontent.com/43481553/87923636-15e15380-ca7e-11ea-8942-0f86e381122f.png)

Not a big change tbf, but I noticed that the current limit per page is pretty low and we end up making way more queries than necessary.