### PR TITLE
Notebook launch errors

### DIFF
--- a/src/notebooks/Notebooks.present.js
+++ b/src/notebooks/Notebooks.present.js
@@ -1204,7 +1204,7 @@ class StartNotebookServerOptions extends Component {
 
     return renderedServerOptions.length ?
       renderedServerOptions.concat(globalWarning) :
-      <label>Notebook options not avilable</label>;
+      <label>Notebook options not available</label>;
   }
 }
 
@@ -1300,12 +1300,25 @@ class ServerOptionLaunch extends Component {
 
   render() {
     const { warnings } = this.props.options;
+    const launchError = this.props.launchError;
     const globalNotification = (warnings.length < 1) ?
       null :
       <Warning key="globalNotification">
         The environment cannot be configured exactly as requested for this project.
         You can still start one, but some things may not work correctly.
       </Warning>;
+    const launchErrorAlert = (launchError != null) ?
+      <Fragment key="launch-error">
+        <br />
+        <InfoAlert timeout={0}>
+          <FontAwesomeIcon icon={faInfoCircle} /> {" "}
+          The attempt to start an environment failed. This could be an intermittent issue, so you should {" "}
+          try a second time, and the environment will hopefully start. If the problem persists, you can {" "}
+          <Link to="/help">contact us for assistance</Link>.
+        </InfoAlert>
+      </Fragment> :
+      null;
+
     return [
       <Button key="button" color="primary" onClick={this.checkServer}>
         Start environment
@@ -1316,7 +1329,8 @@ class ServerOptionLaunch extends Component {
         currentBranch={this.state.current}
         {...this.props}
       />,
-      globalNotification
+      globalNotification,
+      launchErrorAlert
     ];
   }
 }


### PR DESCRIPTION
# Description

This should better handle the case that sometimes happens where a user tries to start a notebook and is shown an endless spinning wheel.

The source of the problem is a 500 response from the notebook server when the UI asks to start a notebook.

# Behavior

If the server returns an error on notebook launch, it is retried. If the second attempt also fails, an info message is shown:

<img width="769" alt="image" src="https://user-images.githubusercontent.com/1196411/91168766-75aec800-e6d6-11ea-8979-07ad58c4a8da.png">


## Testing

This is hard to test because it does not happen very frequently. To simulate, you can change the implementation of the function in notebook-servers.js:75 to:
```
  client.startNotebook = async (namespacePath, projectPath, branchName, commitId, options) => {
    const headers = client.getBasicHeaders();
    headers.append("Content-Type", "application/json");
    const url = `${client.baseUrl}/notebooks/servers`;
    const parameters = {
      namespace: decodeURIComponent(namespacePath),
      project: projectPath,
      commit_sha: commitId,
      branch: branchName,
      ...options
    };

    return new Promise((resolve, reject) => {
      setTimeout(() => {
        reject(new Error("testing"));
      }, 3000)
    });

    // return client.clientFetch(url, {
    //   method: "POST",
    //   headers,
    //   body: JSON.stringify(parameters)
    // }).then((resp) => {
    //   return resp.data;
    // });
  };
```