### PR TITLE
fix: go to source and source button only displayed when inside project

### DIFF
--- a/src/dataset/Dataset.present.js
+++ b/src/dataset/Dataset.present.js
@@ -178,7 +178,7 @@ export default function DatasetView(props) {
         }
         <h4 key="datasetTitle">
           {dataset.name}
-          { dataset.url && (props.insideProject || dataset.sameAs.includes("doi.org")) ?
+          { dataset.url && props.insideProject ?
             <a href={dataset.url} target="_blank" rel="noreferrer noopener">
               <Button size="sm" color="link" style={{ color: "rgba(0, 0, 0, 0.5)" }}>
                 <FontAwesomeIcon icon={faExternalLinkAlt} color="dark" /> Go to source
@@ -220,7 +220,7 @@ export default function DatasetView(props) {
       <RenkuMarkdown markdownText={dataset.description} />
     </div>
     {
-      props.insideProject || dataset.sameAs.includes("doi.org") ?
+      dataset.url && props.insideProject ?
         <LinkToExternal link={dataset.url} label="Source" />
         : null
     }


### PR DESCRIPTION
Go to source button and source link are redirecting the user to the current location when the dataset is seen from outside a project:
![image](https://user-images.githubusercontent.com/42647877/89305937-88058b00-d66f-11ea-9fc1-99c9ac4c98c4.png)

With this change the buttons are not displayed in case the user is not inside a project.

Closes #729 