### PR TITLE
fix: when user clicks on dataset tabs they see an initial search

### DIFF
--- a/src/dataset/list/DatasetList.state.js
+++ b/src/dataset/list/DatasetList.state.js
@@ -131,7 +131,7 @@ class DatasetListModel extends StateModel {
     if (this.get("loading")) return;
     this.set("loading", true);
     const searchParams = {
-      query: this.get("query"),
+      query: this.get("query") === "" ? "*" : this.get("query"),
       sort: this.getSorting(),
       per_page: this.get("perPage"),
       page: this.get("currentPage"),


### PR DESCRIPTION
This works in a similar way as projects, when user goes to the "Datasets" tab on top they see an initial search...

![image](https://user-images.githubusercontent.com/42647877/89308034-14b14880-d672-11ea-86fe-af0a338651e7.png)

Closes #826 
