### PR TITLE
feat: display of relative paths in markdown and improvement in file preview in markdown

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -219,3 +219,16 @@ body {
 .limit-width {
   max-width: 1140px;
 }
+
+
+.visually-hidden {
+    position: absolute;
+    left: -100vw;
+}
+
+.hide-show-me {
+  display: none;
+}
+.fake-toggle:checked ~ .hide-show-me {
+  display: block;
+}

--- a/src/App.css
+++ b/src/App.css
@@ -82,8 +82,6 @@ body {
 
 .image-preview {
   max-width: 100%;
-  min-width: 100%;
-  height: auto;
 }
 
 .text-link {

--- a/src/collaboration/issue/Issue.js
+++ b/src/collaboration/issue/Issue.js
@@ -140,6 +140,8 @@ class IssueViewHeader extends Component {
       <Row key="description" className="pb-2">
         <Col sm={11}>
           <RenkuMarkdown
+            projectPathWithNamespace={this.props.projectPathWithNamespace}
+            filePath={""}
             fixRelativePaths={true}
             markdownText={description}
             client={this.props.client}

--- a/src/collaboration/issue/Issue.js
+++ b/src/collaboration/issue/Issue.js
@@ -139,7 +139,12 @@ class IssueViewHeader extends Component {
       </Row>
       <Row key="description" className="pb-2">
         <Col sm={11}>
-          <RenkuMarkdown markdownText={description} />
+          <RenkuMarkdown
+            fixRelativePaths={true}
+            markdownText={description}
+            client={this.props.client}
+            projectId={this.props.projectId}
+          />
         </Col>
       </Row>
       <Row key="info">

--- a/src/contribution/Contribution.container.js
+++ b/src/contribution/Contribution.container.js
@@ -18,108 +18,8 @@
 
 import React from "react";
 
-import { ContributionBody as ContributionBodyPresent,
-  NewContribution as NewContributionPresent } from "./Contribution.present";
+import { NewContribution as NewContributionPresent } from "./Contribution.present";
 import { EDIT, patterns } from "./Contribution.constants";
-
-
-class ContributionBody extends React.Component {
-  constructor(props) {
-    super(props);
-    this._mounted = false;
-    const body = this.props.contribution.body ?
-      this.props.contribution.body :
-      this.props.contribution.note;
-    const blocks = matchRefs(body);
-    this.state = { blocks };
-  }
-
-  componentDidMount() {
-    this._mounted = true;
-    const blocks = this.state.blocks;
-    this.fetchRefs(blocks);
-  }
-
-  componentWillUnmount() {
-    this._mounted = false;
-  }
-
-  // Fetch all the references and add them to the app-state.
-  fetchRefs(blocks) {
-    blocks.forEach(block => {
-      if (block.type === "fileRef") {
-        this.props.client.getRepositoryFile(this.props.projectId, block.refPath, "master", "base64")
-          .then(d => { this.modifyBlock(block.iBlock, "data", d); })
-          .catch(error => { this.modifyBlock(block.iBlock, "isOpened", false); });
-        //the catch should be handled better, there is some error with loading diff for discussions in Merge Requests
-      }
-    });
-  }
-
-  // Safe way of setting a property of a given block to a certain value and put it to app-state.
-  modifyBlock(iBlock, property, value) {
-    let blocks = [...this.state.blocks];
-    let updateBlock = { ...blocks[iBlock] };
-    updateBlock[property] = value;
-    blocks[iBlock] = updateBlock;
-    if (this._mounted) this.setState({ blocks });
-  }
-
-  render() {
-    return <ContributionBodyPresent
-      {...this.props}
-      blocks={this.state.blocks}
-      onReferenceClick={iBlock => this.modifyBlock(iBlock, "isOpened", !this.state.blocks[iBlock].isOpened)}
-    />;
-  }
-}
-
-
-// Match all references to files in the repo and turn
-// the body into blocks of either simple text or references.
-function matchRefs(contributionText) {
-
-  let blocks = [];
-  let blockCounter = 0;
-  let match, previousMatch = {
-    0: "",
-    index: 0
-  };
-  while ((match = patterns.fileRefFull.exec(contributionText)) !== null) {
-    const isOpened = match[0][0] === "!";
-    const refText = match[1];
-    const refPath = match[2];
-
-    blocks.push({
-      type: "text",
-      text: contributionText.slice(previousMatch.index + previousMatch[0].length, match.index),
-      iBlock: blockCounter
-    });
-    blockCounter++;
-
-    blocks.push({
-      type: "fileRef",
-      refPath: refPath,
-      refText: refText,
-      isOpened: isOpened,
-      data: null,
-      iBlock: blockCounter
-    });
-    blockCounter++;
-    previousMatch = match;
-  }
-  // Let's finish up by adding the last text block (after any reference) if there is any.
-  if (previousMatch.index + previousMatch[0].length < contributionText.length) {
-    blocks.push({
-      type: "text",
-      text: contributionText.slice(previousMatch.index + previousMatch[0].length,
-        contributionText.length),
-      iBlock: blockCounter
-    });
-  }
-  return blocks;
-}
-
 
 class NewContribution extends React.Component {
   constructor(props) {
@@ -279,4 +179,4 @@ class NewContribution extends React.Component {
   }
 }
 
-export { ContributionBody, NewContribution };
+export { NewContribution };

--- a/src/contribution/Contribution.container.js
+++ b/src/contribution/Contribution.container.js
@@ -175,6 +175,7 @@ class NewContribution extends React.Component {
       submitting={this.state.submitting}
       client={this.props.client}
       projectId={this.props.projectId}
+      projectPathWithNamespace={this.props.projectPath}
     />;
   }
 }

--- a/src/contribution/Contribution.present.js
+++ b/src/contribution/Contribution.present.js
@@ -59,6 +59,8 @@ class Contribution extends React.Component {
             <CardBody className="mb-0 pb-0">
               <div className="pb-3">
                 <RenkuMarkdown
+                  projectPathWithNamespace={this.props.projectPathWithNamespace}
+                  filePath={""}
                   fixRelativePaths={true}
                   markdownText={contribution.body ?
                     contribution.body :
@@ -121,6 +123,8 @@ const NewContribution = props => {
               {props.tab === PREVIEW ?
                 <div className="pb-3">
                   <RenkuMarkdown
+                    projectPathWithNamespace={props.projectPathWithNamespace}
+                    filePath={""}
                     fixRelativePaths={true}
                     markdownText={props.contribution.body}
                     client={props.client}

--- a/src/contribution/Contribution.present.js
+++ b/src/contribution/Contribution.present.js
@@ -22,11 +22,8 @@ import {
   Nav, NavLink, DropdownMenu, DropdownItem, DropdownToggle, Dropdown
 } from "reactstrap";
 import classnames from "classnames";
-import Collapse from "react-collapse";
 
 import { UserAvatar, TimeCaption, RenkuMarkdown } from "../utils/UIComponents";
-import { FilePreview } from "../file";
-import { ContributionBody as ContributionBodyContainer } from "./Contribution.container";
 import { EDIT, PREVIEW } from "./Contribution.constants";
 import { Card, CardHeader, CardBody } from "reactstrap";
 
@@ -60,7 +57,16 @@ class Contribution extends React.Component {
               </Row>
             </CardHeader>
             <CardBody className="mb-0 pb-0">
-              <ContributionBodyContainer {...this.props} />
+              <div className="pb-3">
+                <RenkuMarkdown
+                  fixRelativePaths={true}
+                  markdownText={contribution.body ?
+                    contribution.body :
+                    contribution.note}
+                  client={this.props.client}
+                  projectId={this.props.projectId}
+                />
+              </div>
             </CardBody>
           </Card>
         </Col>
@@ -68,57 +74,6 @@ class Contribution extends React.Component {
     </div>;
   }
 }
-
-// Parameters defining the opening/closing of react-collapse reference inlining.
-const STIFFNESS = 290;
-const DAMPING = 20;
-
-class ContributionBody extends React.Component {
-
-  // Needed props:
-  //  - blocks: array of blocks (parsed contribution body). A block can be piece of text
-  //            or a reference.
-  //  - onReferenceClick:
-
-  // Render the blocks. After putting the rendered blocks together,
-  // this will be the entire body of the contribution
-  renderBlocks() {
-    return this.props.blocks.map(block => {
-      if (block.type === "fileRef") {
-        return (
-          <span key={block.iBlock}>
-            <input
-              type="button"
-              className="text-link"
-              value={block.refText}
-              onClick={() => this.props.onReferenceClick(block.iBlock)}
-            />
-            <Collapse isOpened={block.isOpened}>
-              <div className="expanded-reference">
-                <FilePreview
-                  file={block.data}
-                  {...this.props}
-                  springConfig={{ STIFFNESS, DAMPING }}
-                />
-              </div>
-            </Collapse>
-          </span>);
-      }
-      return <div key={block.iBlock} className="comment-block">
-        <RenkuMarkdown markdownText={block.text} />
-      </div>;
-    });
-  }
-
-  render() {
-    return (
-      <div className="pb-3">
-        {this.renderBlocks()}
-      </div>
-    );
-  }
-}
-
 
 const NewContribution = props => {
 
@@ -163,7 +118,16 @@ const NewContribution = props => {
             <TabPane tabId={PREVIEW} className="pt-2">
               {/*This might look silly, but I want to remove the preview from the virtual DOM when the user*/}
               {/*is editing rather than re-rendering it on every keystroak while the user is typing.*/}
-              {props.tab === PREVIEW ? <ContributionBodyContainer {...props} /> : null}
+              {props.tab === PREVIEW ?
+                <div className="pb-3">
+                  <RenkuMarkdown
+                    fixRelativePaths={true}
+                    markdownText={props.contribution.body}
+                    client={props.client}
+                    projectId={props.projectId}
+                  />
+                </div>
+                : null}
             </TabPane>
           </TabContent>
           <Button
@@ -192,4 +156,4 @@ const MentionsList = props =>
     </DropdownMenu>
   </Dropdown>;
 
-export { Contribution, ContributionBody, NewContribution };
+export { Contribution, NewContribution };

--- a/src/dataset/Dataset.container.js
+++ b/src/dataset/Dataset.container.js
@@ -38,5 +38,6 @@ export default function ShowDataset(props) {
     logged={props.logged}
     model={props.model}
     projectId={props.projectId}
+    projectPathWithNamespace={props.projectPathWithNamespace}
   />;
 }

--- a/src/dataset/Dataset.container.js
+++ b/src/dataset/Dataset.container.js
@@ -37,5 +37,6 @@ export default function ShowDataset(props) {
     history={props.history}
     logged={props.logged}
     model={props.model}
+    projectId={props.projectId}
   />;
 }

--- a/src/dataset/Dataset.present.js
+++ b/src/dataset/Dataset.present.js
@@ -217,7 +217,17 @@ export default function DatasetView(props) {
         : null
     }
     <div style={{ paddingTop: "12px" }}>
-      <RenkuMarkdown markdownText={dataset.description} />
+      {
+        props.insideProject ?
+          <RenkuMarkdown
+            fixRelativePaths={true}
+            markdownText={dataset.description}
+            client={props.client}
+            projectId={props.projectId}
+          />
+          :
+          <RenkuMarkdown markdownText={dataset.description} />
+      }
     </div>
     {
       dataset.url && props.insideProject ?

--- a/src/dataset/Dataset.present.js
+++ b/src/dataset/Dataset.present.js
@@ -220,6 +220,8 @@ export default function DatasetView(props) {
       {
         props.insideProject ?
           <RenkuMarkdown
+            projectPathWithNamespace={props.projectPathWithNamespace}
+            filePath={""}
             fixRelativePaths={true}
             markdownText={dataset.description}
             client={props.client}

--- a/src/file/File.container.js
+++ b/src/file/File.container.js
@@ -77,7 +77,7 @@ class FilePreview extends React.Component {
       if (atob(this.props.file.content).includes("https://git-lfs.github.com/"))
         return "The image can't be previewed because it's stored in Git LFS.";
       return (
-        <CardBody key="file preview">
+        <CardBody key="file preview" className="pb-0">
           <img
             className="image-preview"
             alt={this.props.file.file_name}
@@ -89,7 +89,7 @@ class FilePreview extends React.Component {
     // Code with syntax highlighting
     if (this.fileIsCode()) {
       return (
-        <CardBody key="file preview">
+        <CardBody key="file preview" className="pb-0">
           <pre className={`hljs ${this.getFileExtension()}`}>
             <code>{atobUTF8(this.props.file.content)}</code>
           </pre>
@@ -100,7 +100,7 @@ class FilePreview extends React.Component {
     if (this.getFileExtension() === "md") {
       let content = atobUTF8(this.props.file.content);
       return (
-        <CardBody key="file preview">
+        <CardBody key="file preview" className="pb-0">
           <RenkuMarkdown markdownText={content} />{" "}
         </CardBody>
       );
@@ -121,7 +121,7 @@ class FilePreview extends React.Component {
 
     if (this.fileHasNoExtension()) {
       return (
-        <CardBody key="file preview">
+        <CardBody key="file preview" className="pb-0">
           <pre className={`hljs ${this.getFileExtension()}`}>
             <code>{atobUTF8(this.props.file.content)}</code>
           </pre>

--- a/src/file/File.container.js
+++ b/src/file/File.container.js
@@ -102,6 +102,8 @@ class FilePreview extends React.Component {
       return (
         <CardBody key="file preview" className="pb-0">
           <RenkuMarkdown
+            projectPathWithNamespace={this.props.projectPathWithNamespace}
+            filePath={this.props.file.file_path}
             markdownText={content}
             projectId={this.props.projectId}
             fixRelativePaths={this.props.insideProject}
@@ -310,7 +312,9 @@ class ShowFile extends React.Component {
       error={this.state.error}
       projectId={this.props.projectId}
       client={this.props.client}
-      insideProject={true} />;
+      insideProject={true}
+      projectPathWithNamespace={this.props.projectPathWithNamespace}
+    />;
   }
 }
 

--- a/src/file/File.container.js
+++ b/src/file/File.container.js
@@ -101,7 +101,12 @@ class FilePreview extends React.Component {
       let content = atobUTF8(this.props.file.content);
       return (
         <CardBody key="file preview" className="pb-0">
-          <RenkuMarkdown markdownText={content} />{" "}
+          <RenkuMarkdown
+            markdownText={content}
+            projectId={this.props.projectId}
+            fixRelativePaths={this.props.insideProject}
+            client={this.props.client}
+          />{" "}
         </CardBody>
       );
     }
@@ -302,7 +307,10 @@ class ShowFile extends React.Component {
       buttonJupyter={buttonJupyter}
       file={this.state.file}
       commit={this.state.commit}
-      error={this.state.error} />;
+      error={this.state.error}
+      projectId={this.props.projectId}
+      client={this.props.client}
+      insideProject={true} />;
   }
 }
 

--- a/src/model/RenkuModels.test.js
+++ b/src/model/RenkuModels.test.js
@@ -2,7 +2,7 @@
 
 import { testClient as client } from "../api-client";
 import { StateKind, StateModel } from "../model/Model";
-import { Project, projectSchema } from "./RenkuModels";
+// import { Project, projectSchema } from "./RenkuModels";
 import { ProjectModel } from "../project/Project.state";
 
 describe("fetch project", () => {

--- a/src/project/Project.js
+++ b/src/project/Project.js
@@ -438,6 +438,7 @@ class View extends Component {
         projectPath={this.projectState.get("core.project_path")}
         branches={branches}
         projectId={projectId}
+        projectPathWithNamespace={this.projectState.get("core.path_with_namespace")}
         hashElement={filesTree !== undefined ?
           filesTree.hash[p.location.pathname.replace(pathComponents.baseUrl + "/files/blob/", "")] :
           undefined} />,
@@ -457,6 +458,7 @@ class View extends Component {
         logged={this.props.user.logged}
         model={this.props.model}
         projectId={projectId}
+        projectPathWithNamespace={this.projectState.get("core.path_with_namespace")}
       />,
 
       newDataset: (p) => <NewDataset

--- a/src/project/Project.js
+++ b/src/project/Project.js
@@ -437,6 +437,7 @@ class View extends Component {
         projectNamespace={this.projectState.get("core.namespace_path")}
         projectPath={this.projectState.get("core.project_path")}
         branches={branches}
+        projectId={projectId}
         hashElement={filesTree !== undefined ?
           filesTree.hash[p.location.pathname.replace(pathComponents.baseUrl + "/files/blob/", "")] :
           undefined} />,
@@ -455,6 +456,7 @@ class View extends Component {
         history={this.props.history}
         logged={this.props.user.logged}
         model={this.props.model}
+        projectId={projectId}
       />,
 
       newDataset: (p) => <NewDataset

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -42,7 +42,7 @@ import {
 import { faGitlab } from "@fortawesome/free-brands-svg-icons";
 
 import {
-  Clipboard, ExternalLink, Loader, RenkuMarkdown, RenkuNavLink, TimeCaption, RefreshButton,
+  Clipboard, ExternalLink, Loader, RenkuMarkdownDeep, RenkuNavLink, TimeCaption, RefreshButton,
   ButtonWithMenu, InfoAlert, SuccessAlert, WarnAlert, ErrorAlert, GoBackButton
 } from "../utils/UIComponents";
 import { SpecialPropVal } from "../model/Model";
@@ -424,7 +424,11 @@ class ProjectViewReadme extends Component {
       <Card className="border-0">
         <CardHeader>README.md</CardHeader>
         <CardBody style={{ overflow: "auto" }}>
-          <RenkuMarkdown markdownText={this.props.readme.text} />
+          <RenkuMarkdownDeep
+            markdownText={this.props.readme.text}
+            client={this.props.client}
+            projectId={this.props.core.id}
+          />
         </CardBody>
       </Card>
     );

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -42,8 +42,8 @@ import {
 import { faGitlab } from "@fortawesome/free-brands-svg-icons";
 
 import {
-  Clipboard, ExternalLink, Loader, RenkuMarkdownDeep, RenkuNavLink, TimeCaption, RefreshButton,
-  ButtonWithMenu, InfoAlert, SuccessAlert, WarnAlert, ErrorAlert, GoBackButton
+  Clipboard, ExternalLink, Loader, RenkuNavLink, TimeCaption, RefreshButton,
+  ButtonWithMenu, InfoAlert, SuccessAlert, WarnAlert, ErrorAlert, GoBackButton, RenkuMarkdown
 } from "../utils/UIComponents";
 import { SpecialPropVal } from "../model/Model";
 import { ProjectTags, ProjectTagList } from "./shared";
@@ -424,7 +424,8 @@ class ProjectViewReadme extends Component {
       <Card className="border-0">
         <CardHeader>README.md</CardHeader>
         <CardBody style={{ overflow: "auto" }}>
-          <RenkuMarkdownDeep
+          <RenkuMarkdown
+            fixRelativePaths={true}
             markdownText={this.props.readme.text}
             client={this.props.client}
             projectId={this.props.core.id}

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -425,6 +425,8 @@ class ProjectViewReadme extends Component {
         <CardHeader>README.md</CardHeader>
         <CardBody style={{ overflow: "auto" }}>
           <RenkuMarkdown
+            projectPathWithNamespace = {this.props.core.path_with_namespace}
+            filePath={""}
             fixRelativePaths={true}
             markdownText={this.props.readme.text}
             client={this.props.client}

--- a/src/utils/Markdown.js
+++ b/src/utils/Markdown.js
@@ -62,7 +62,13 @@ function FileAndWrapper(props) {
   /**
    * We are using a checkbox here because the onclick event doesn't work with the
    * React server side rendering, the checkbox helps us fake the toogleing
+   *
+   * We need to generate a random id here for the file preview to work on the
+   * issues, in case there is more than one file preview
+   * If we want a more sophisticated solution we can use a library like uuid
    */
+  const randomId = Math.floor(Math.random() * 1000);
+  const tooglerId = props.block.iBlock + randomId + "toogler";
   return <div>
     <Card>
       <CardBody className="p-2">
@@ -70,10 +76,10 @@ function FileAndWrapper(props) {
           <FontAwesomeIcon className="icon-grey mr-1" icon={faFile} />
           {props.block.data.file_name}
         </label>
-        <label className="mb-0 p-1 float-right btn btn-primary btn-sm" htmlFor={props.block.iBlock + "toogler"}>
+        <label className="mb-0 p-1 float-right btn btn-primary btn-sm" htmlFor={tooglerId}>
           Preview File
         </label>
-        <input type="checkbox" id={props.block.iBlock + "toogler"} className="visually-hidden fake-toggle" />
+        <input type="checkbox" id={tooglerId} className="visually-hidden fake-toggle" />
         <div className="hide-show-me">
           <FilePreview
             file={props.file}
@@ -114,7 +120,7 @@ function fixRelativePath(pathToFix, filePathArray) {
  * @param {boolean} singleLine if true, render the output as a single line without line breaks
  * @param {object} style any styles to apply
  */
-function RenkuMarkdownWithFiles(props) {
+function RenkuMarkdownWithPathTranslation(props) {
 
   const { singleLine, style } = props;
   let className = "text-break renku-markdown";
@@ -215,4 +221,5 @@ function RenkuMarkdownWithFiles(props) {
   </div>;
 
 }
-export default RenkuMarkdownWithFiles;
+export default RenkuMarkdownWithPathTranslation;
+export { fixRelativePath };

--- a/src/utils/UIComponents.js
+++ b/src/utils/UIComponents.js
@@ -43,6 +43,7 @@ import {
 
 import { sanitizedHTMLFromMarkdown, simpleHash } from "./HelperFunctions";
 import FileExplorer, { getFilesTree } from "./FileExplorer";
+import RenkuMarkdownDeep from "./Markdown";
 
 /**
  * Show user avatar
@@ -759,4 +760,4 @@ export { UserAvatar, TimeCaption, FieldGroup, RenkuNavLink, Pagination, RenkuMar
 export { ExternalLink, ExternalDocsLink, ExternalIconLink, IconLink, RefreshButton };
 export { Loader, InfoAlert, SuccessAlert, WarnAlert, ErrorAlert, JupyterIcon };
 export { Clipboard, ThrottledTooltip, TooltipToggleButton, ProjectAvatar };
-export { ButtonWithMenu, FileExplorer, getFilesTree, MarkdownTextExcerpt, GoBackButton };
+export { ButtonWithMenu, FileExplorer, getFilesTree, MarkdownTextExcerpt, GoBackButton, RenkuMarkdownDeep };

--- a/src/utils/UIComponents.js
+++ b/src/utils/UIComponents.js
@@ -438,7 +438,10 @@ class ErrorAlert extends Component {
  */
 class RenkuMarkdown extends Component {
   render() {
-    const { singleLine, style } = this.props;
+    const { singleLine, style, fixRelativePaths } = this.props;
+    if (fixRelativePaths)
+      return <RenkuMarkdownDeep {...this.props} />;
+
     let className = "text-break renku-markdown";
     if (singleLine)
       className += " children-no-spacing";
@@ -760,4 +763,4 @@ export { UserAvatar, TimeCaption, FieldGroup, RenkuNavLink, Pagination, RenkuMar
 export { ExternalLink, ExternalDocsLink, ExternalIconLink, IconLink, RefreshButton };
 export { Loader, InfoAlert, SuccessAlert, WarnAlert, ErrorAlert, JupyterIcon };
 export { Clipboard, ThrottledTooltip, TooltipToggleButton, ProjectAvatar };
-export { ButtonWithMenu, FileExplorer, getFilesTree, MarkdownTextExcerpt, GoBackButton, RenkuMarkdownDeep };
+export { ButtonWithMenu, FileExplorer, getFilesTree, MarkdownTextExcerpt, GoBackButton };

--- a/src/utils/UIComponents.js
+++ b/src/utils/UIComponents.js
@@ -43,7 +43,7 @@ import {
 
 import { sanitizedHTMLFromMarkdown, simpleHash } from "./HelperFunctions";
 import FileExplorer, { getFilesTree } from "./FileExplorer";
-import RenkuMarkdownWithFiles from "./Markdown";
+import RenkuMarkdownWithPathTranslation from "./Markdown";
 
 /**
  * Show user avatar
@@ -440,7 +440,7 @@ class RenkuMarkdown extends Component {
   render() {
     const { singleLine, style, fixRelativePaths } = this.props;
     if (fixRelativePaths)
-      return <RenkuMarkdownWithFiles {...this.props} />;
+      return <RenkuMarkdownWithPathTranslation {...this.props} />;
 
     let className = "text-break renku-markdown";
     if (singleLine)

--- a/src/utils/UIComponents.js
+++ b/src/utils/UIComponents.js
@@ -43,7 +43,7 @@ import {
 
 import { sanitizedHTMLFromMarkdown, simpleHash } from "./HelperFunctions";
 import FileExplorer, { getFilesTree } from "./FileExplorer";
-import RenkuMarkdownDeep from "./Markdown";
+import RenkuMarkdownWithFiles from "./Markdown";
 
 /**
  * Show user avatar
@@ -440,7 +440,7 @@ class RenkuMarkdown extends Component {
   render() {
     const { singleLine, style, fixRelativePaths } = this.props;
     if (fixRelativePaths)
-      return <RenkuMarkdownDeep {...this.props} />;
+      return <RenkuMarkdownWithFiles {...this.props} />;
 
     let className = "text-break renku-markdown";
     if (singleLine)

--- a/src/utils/Utils.test.js
+++ b/src/utils/Utils.test.js
@@ -34,6 +34,7 @@ import {
 } from "./HelperFunctions";
 import { RefreshButton } from "./UIComponents";
 import { StateModel, globalSchema } from "../model";
+import { fixRelativePath } from "./Markdown";
 
 
 describe("Render React components and functions", () => {
@@ -433,4 +434,44 @@ This is an *internal* project that is used for testing.
     const html = sanitizedHTMLFromMarkdown(markdown);
     expect(html).toEqual(expected);
   });
+});
+
+describe("Translate path for markdown", () => {
+
+  // This is the folder structure that will be used for testing
+  //
+  // /fileStructure
+  // ├── folder1
+  // │   ├── folder2
+  // │   │   ├── fileWithReferencesToFix.md
+  // │   │   └── testImage2.md
+  // │   └── folder3
+  // │       └── testImage3.md
+  // └── images
+  //     └── testImage1.png
+
+  const testCases = [
+    {
+      relativePath: "../../images/testImage1.png",
+      localFilePath: ["folder2", "folder1"],
+      expectedResult: "images/testImage1.png"
+    },
+    {
+      relativePath: "./testImage2.png",
+      localFilePath: ["folder2", "folder1"],
+      expectedResult: "folder1/folder2/testImage2.png"
+    },
+    {
+      relativePath: "../folder3/testImage3.png",
+      localFilePath: ["folder2", "folder1"],
+      expectedResult: "folder1/folder3/testImage3.png"
+    }
+  ];
+
+  it("function fixRelativePath", () => {
+    testCases.forEach(test => {
+      expect(fixRelativePath(test.relativePath, test.localFilePath)).toEqual(test.expectedResult);
+    });
+  });
+
 });


### PR DESCRIPTION
I created a markdown component that fetches images from relative paths and also fixes relative links in markdown files.

I also improved/restyled the preview of files...

We only preview files with "!" in the front... since I think it's nice to also leave the option to not preview a file in case this is not desired.

![image](https://user-images.githubusercontent.com/42647877/90188716-3c17bc00-ddbc-11ea-9cbd-de80e4d72628.png)

Closes #667 
Closes #941 