### PR TITLE
fix: dataset name replaced by title where needed

### DIFF
--- a/src/dataset/Dataset.present.js
+++ b/src/dataset/Dataset.present.js
@@ -177,7 +177,7 @@ export default function DatasetView(props) {
             : null
         }
         <h4 key="datasetTitle">
-          {dataset.name}
+          {dataset.title || dataset.name}
           { dataset.url && props.insideProject ?
             <a href={dataset.url} target="_blank" rel="noreferrer noopener">
               <Button size="sm" color="link" style={{ color: "rgba(0, 0, 0, 0.5)" }}>

--- a/src/dataset/list/DatasetList.present.js
+++ b/src/dataset/list/DatasetList.present.js
@@ -41,7 +41,7 @@ class DatasetListRow extends Component {
           <Badge color="success" className="font-weight-light">{projectsCountLabel}</Badge>
         </div>
         <Link to={`${datasetsUrl}/${encodeURIComponent(dataset.identifier)}`}>
-          {dataset.name || "no title"}
+          {dataset.title || dataset.name}
         </Link>
         {
           dataset.published !== undefined && dataset.published.creator !== undefined ?

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -1139,7 +1139,7 @@ class ProjectViewDatasetsOverview extends Component {
     let datasets = this.props.datasets.map((dataset) =>
       <OverviewDatasetRow
         key={dataset.identifier}
-        name={dataset.name}
+        name={dataset.title || dataset.name}
         fullDatasetUrl={`${this.props.datasetsUrl}/${encodeURIComponent(dataset.identifier)}`}
       />
     );

--- a/src/project/datasets/DatasetsListView.js
+++ b/src/project/datasets/DatasetsListView.js
@@ -10,7 +10,7 @@ function DatasetListRow(props) {
   const title = <NavLink
     key={dataset.identifier}
     to={`${props.datasetsUrl}/${encodeURIComponent(dataset.identifier)}/`}
-  > {dataset.name} </NavLink>;
+  > {dataset.title || dataset.name}</NavLink>;
 
   const projectsCountLabel = dataset.isPartOf.length > 1
     ? `In ${dataset.isPartOf.length} projects`
@@ -76,11 +76,15 @@ export default function DatasetsListView(props) {
   });
 
   return [<Row key="header" className="pb-3">
-    <Col md={3} lg={2}><h2 className="ml-3">Datasets</h2></Col>
-    <Col md={3}>
-      <AddDatasetButton
-        visibility={props.visibility}
-        newDatasetUrl={props.newDatasetUrl}/>
+    <Col md={12}>
+      <h2 className="ml-3">
+        <span style={{ verticalAlign: "middle" }}>Datasets</span>
+        <span className="pl-3" style={{ display: "inline-flex" }}>
+          <AddDatasetButton
+            visibility={props.visibility}
+            newDatasetUrl={props.newDatasetUrl} />
+        </span>
+      </h2>
     </Col>
   </Row>, <Row key="datasetslist">
     <Col xs={12}>


### PR DESCRIPTION
Name was replaced by title for dataset display purposes...

Before:
![image](https://user-images.githubusercontent.com/42647877/90394218-8c2fa080-e092-11ea-8dea-f292c39c4bbc.png)

After:
![image](https://user-images.githubusercontent.com/42647877/90393992-188d9380-e092-11ea-88c6-6639eb38b290.png)

Right now the difference is only visible with datasets that have name and title that are not the same (like the flights dataset or zenodo imported datasets)

If you want to see the "before" you might have to deploy the renku-graph version: 1.5.0

Closes #1009 