### PR TITLE
feat: remove superfluous server setup documentation

### DIFF
--- a/src/help/Help.container.js
+++ b/src/help/Help.container.js
@@ -34,7 +34,6 @@ function urlMap(baseUrl) {
     getting: `${baseUrl}/getting`,
     documentation: `${baseUrl}/docs`,
     features: `${baseUrl}/features`,
-    setup: `${baseUrl}/setup`,
     status: `${baseUrl}/status`,
   };
 }

--- a/src/help/Help.present.js
+++ b/src/help/Help.present.js
@@ -52,9 +52,6 @@ class HelpNav extends Component {
         <NavItem>
           <RenkuNavLink to={this.props.url.features} title="Features" />
         </NavItem>
-        <NavItem>
-          <RenkuNavLink to={this.props.url.setup} title="Set Up / Admin" />
-        </NavItem>
         { statusLink }
       </Nav>
     );
@@ -210,31 +207,6 @@ class HelpFeatures extends Component {
   }
 }
 
-class HelpSetup extends Component {
-  render() {
-    return (
-      <div>
-        <h2>Running the platform</h2>
-        <p>
-          It is easy to deploy the Renku platform on{" "}
-          <a href="https://github.com/kubernetes/minikube" target="_blank" rel="noreferrer noopener">
-            minikube
-          </a>
-          . You can find the instructions on our{" "}
-          <a
-            href="https://renku.readthedocs.io/en/latest/developer/setup.html"
-            target="_blank"
-            rel="noreferrer noopener"
-          >
-            documentation
-          </a>
-          .
-        </p>
-      </div>
-    );
-  }
-}
-
 class HelpContent extends Component {
   render() {
     return [
@@ -259,7 +231,6 @@ class HelpContent extends Component {
         key="features"
         render={props => <HelpFeatures key="features" {...this.props} />}
       />,
-      <Route path={this.props.url.setup} key="setup" render={props => <HelpSetup key="setup" {...this.props} />} />,
       <Route
         path={this.props.url.status} key="status"
         render={props => <StatuspageDisplay key="status" statuspageId={this.props.statuspageId}


### PR DESCRIPTION
The server setup documentation isn't very helpful for the normal RenkuLab user. We can remove it.

The help page now looks like this:

<img width="1237" alt="image" src="https://user-images.githubusercontent.com/1196411/91167837-e523b800-e6d4-11ea-8f86-7dc54e7ab2cd.png">
