### PR TITLE
ci: fix test-chart action precedence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
   test-chart:
     needs: test
     runs-on: ubuntu-latest
-    if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
+    if: "startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1


### PR DESCRIPTION
The helm chart should be linted only for master/tagged version, not on the PRs.
This fixes a wrong precedence in the ci action preventing them from publishing the chart