### PR TITLE
refactor: dataset info partially retrieved from the core service

### DIFF
--- a/src/api-client/dataset.js
+++ b/src/api-client/dataset.js
@@ -73,8 +73,15 @@ export default function addDatasetMethods(client) {
     });
   };
 
-  //we should use this instead of clone, this checks if the project was cloned already...
-  client.getProjectIdFromSvc = (projectUrl) => {
+  /**
+   * This method checks weather the dataset is or not in the cache.
+   * In case the project is already there it returns the id of the project in the cache.
+   * If the project is not there, it clones the project and returns the id of the project in the cache.
+   *
+   * projectUrl is the http project in gitlab
+   * example: https://dev.renku.ch/gitlab/virginiafriedrich/project-11.git
+  */
+  client.getProjectIdFromCoreService = (projectUrl) => {
     let headers = client.getBasicHeaders();
     headers.append("Content-Type", "application/json");
     headers.append("X-Requested-With", "XMLHttpRequest");
@@ -117,7 +124,7 @@ export default function addDatasetMethods(client) {
 
     let project_id;
 
-    return client.getProjectIdFromSvc(projectUrl)
+    return client.getProjectIdFromCoreService(projectUrl)
       .then(response => {
 
         if (response.data !== undefined && response.data.error !== undefined)
@@ -159,7 +166,7 @@ export default function addDatasetMethods(client) {
 
     let project_id;
 
-    return client.getProjectIdFromSvc(projectUrl)
+    return client.getProjectIdFromCoreService(projectUrl)
       .then(response => {
 
         if (response.data !== undefined && response.data.error !== undefined)
@@ -179,7 +186,7 @@ export default function addDatasetMethods(client) {
       });
   };
 
-  client.listProjectDatasetsFromCore = (git_url) => {
+  client.listProjectDatasetsFromCoreService = (git_url) => {
     let headers = client.getBasicHeaders();
     headers.append("Content-Type", "application/json");
     headers.append("X-Requested-With", "XMLHttpRequest");
@@ -193,7 +200,7 @@ export default function addDatasetMethods(client) {
       }));
   };
 
-  client.fetchDatasetFilesFromCore = (name, git_url) => {
+  client.fetchDatasetFilesFromCoreService = (name, git_url) => {
     let headers = client.getBasicHeaders();
     headers.append("Content-Type", "application/json");
     headers.append("X-Requested-With", "XMLHttpRequest");

--- a/src/api-client/project.js
+++ b/src/api-client/project.js
@@ -388,8 +388,7 @@ function addProjectMethods(client) {
     const headers = client.getBasicHeaders();
     const datasetPromise = client.clientFetch(datasetLink, { method: "GET", headers });
     return Promise.resolve(datasetPromise)
-      .then(dataset => dataset.data)
-      .catch((error) => "error");
+      .then(dataset => dataset.data);
   };
 
   client.getProjectDatasetsFromKG = (projectPath) => {

--- a/src/dataset/Dataset.container.js
+++ b/src/dataset/Dataset.container.js
@@ -21,19 +21,10 @@ import DatasetView from "./Dataset.present";
 import { API_ERRORS } from "../api-client";
 import { Loader } from "../utils/UIComponents";
 
-//We are not getting the folder structure from the core service at the moment
-//I decided to do this fix so when the length of the files in core and kg is the same
-//We return the files from the kg so we can display the folder structure
-//If the length is not the same we return the files from the core service
-//this will be displayed as a list of files instead of a folder structure :(
 function fixFetchedFiles(core_files, kg_files) {
   if (core_files) {
     if (core_files.error) return core_files;
-    if (kg_files) {
-      if (kg_files.length === core_files.length)
-        return kg_files;
-      return core_files;
-    } return core_files;
+    return core_files;
   }
   return kg_files;
 }
@@ -78,7 +69,7 @@ export default function ShowDataset(props) {
   useEffect(()=>{
     let unmounted = false;
     if (props.insideProject && datasetFiles === undefined && dataset.name) {
-      props.client.fetchDatasetFilesFromCore(dataset.name, props.httpProjectUrl)
+      props.client.fetchDatasetFilesFromCoreService(dataset.name, props.httpProjectUrl)
         .then(response =>{
           if (!unmounted && datasetFiles === undefined) {
             if (response.data.result) {

--- a/src/dataset/Dataset.container.js
+++ b/src/dataset/Dataset.container.js
@@ -108,8 +108,10 @@ export default function ShowDataset(props) {
         }).catch(error => {
           if (fetchError === undefined) {
             if (!unmounted && error.case === API_ERRORS.notFoundError) {
-              setFetchError("Error 404: The dataset that was selected does not exist or" +
-                " could not be accessed. If you just created or imported the dataset try reloading the page.");
+              setFetchError(props.insideProject ? "Error 404: The dataset that was selected does not exist or" +
+                " could not be accessed. If you just created or imported the dataset try reloading the page."
+                : "Error 404: The dataset that was selected does not exist or" +
+                " could not be accessed.");
             }
             else if (!unmounted && error.case === API_ERRORS.internalServerError) {
               setFetchError("Error 500: The dataset that was selected couldn't be fetched.");
@@ -145,5 +147,6 @@ export default function ShowDataset(props) {
     projectId={props.projectId}
     projectPathWithNamespace={props.projectPathWithNamespace}
     dataset={dataset}
+    fetchError={fetchError}
   />;
 }

--- a/src/dataset/Dataset.container.js
+++ b/src/dataset/Dataset.container.js
@@ -48,9 +48,16 @@ function mapDataset(dataset_core, dataset_kg, core_files) {
       dataset.url = dataset_kg.url;
       dataset.sameAs = dataset_kg.sameAs;
       dataset.isPartOf = dataset_kg.isPartOf;
+      dataset.insideKg = true;
+    }
+    else {
+      dataset.insideKg = false;
     }
     return dataset;
   }
+  //while things are loading dataset_kg could be undefined
+  if (dataset_kg)
+    dataset_kg.insideKg = true;
   return dataset_kg;
 }
 
@@ -121,10 +128,7 @@ export default function ShowDataset(props) {
     return <Loader />;
 
   return <DatasetView
-    fetchGraphStatus={props.fetchGraphStatus}
     maintainer={props.maintainer}
-    createGraphWebhook={props.createGraphWebhook}
-    forked={props.forked}
     insideProject={props.insideProject}
     identifier={props.identifier}
     progress={props.progress}

--- a/src/dataset/Dataset.container.js
+++ b/src/dataset/Dataset.container.js
@@ -89,7 +89,8 @@ export default function ShowDataset(props) {
 
   useEffect(() => {
     let unmounted = false;
-    if (datasetKg === undefined && ((props.insideProject && dataset.identifier) || (props.identifier !== undefined))) {
+    if (datasetKg === undefined && ((props.insideProject && dataset.identifier && props.graphStatus)
+    || (props.identifier !== undefined))) {
       const id = props.insideProject ? dataset.identifier : props.identifier;
       props.client
         .fetchDatasetFromKG(props.client.baseUrl.replace("api", "knowledge-graph/datasets/") + id)
@@ -114,7 +115,7 @@ export default function ShowDataset(props) {
       unmounted = true;
     };
   }, [props.insideProject, props.datasets_kg, props.datasetId, props.identifier,
-    props.client, datasetKg, fetchError, dataset]);
+    props.client, datasetKg, fetchError, dataset, props.graphStatus]);
 
   if (props.insideProject && datasetFiles === undefined)
     return <Loader />;

--- a/src/dataset/Dataset.present.js
+++ b/src/dataset/Dataset.present.js
@@ -130,7 +130,7 @@ export default function DatasetView(props) {
         {
           dataset.published !== undefined && dataset.published.datePublished !== undefined ?
             <small style={{ display: "block", paddingBottom: "8px" }} className="font-weight-light font-italic">
-              Uploaded on {Time.getReadableDate(dataset.published.datePublished)}.
+              Uploaded on {Time.getReadableDate(dataset.published.datePublished.replace(/ /g, "T"))}.
             </small>
             : null
         }

--- a/src/dataset/Dataset.present.js
+++ b/src/dataset/Dataset.present.js
@@ -124,15 +124,17 @@ export default function DatasetView(props) {
     );
   }
 
+  const datasetPublished = dataset.published !== undefined && dataset.published.datePublished
+    !== undefined && dataset.published.datePublished !== null;
+
   return <Col>
     <Row>
       <Col md={8} sm={12}>
-        {
-          dataset.published !== undefined && dataset.published.datePublished !== undefined ?
-            <small style={{ display: "block", paddingBottom: "8px" }} className="font-weight-light font-italic">
-              Uploaded on {Time.getReadableDate(dataset.published.datePublished.replace(/ /g, "T"))}.
-            </small>
-            : null
+        { datasetPublished ?
+          <small style={{ display: "block", paddingBottom: "8px" }} className="font-weight-light font-italic">
+            Uploaded on {Time.getReadableDate(dataset.published.datePublished.replace(/ /g, "T"))}.
+          </small>
+          : null
         }
         <h4 key="datasetTitle">
           {dataset.title || dataset.name}
@@ -148,7 +150,7 @@ export default function DatasetView(props) {
       </Col>
       <Col md={4} sm={12}>
         { props.logged ?
-          <Button disabled={dataset.url === undefined}
+          <Button disabled={dataset.insideKg === false}
             className="float-right mb-1" size="sm" color="primary" onClick={() => setAddDatasetModalOpen(true)}>
             <FontAwesomeIcon icon={faPlus} color="dark" /> Add to project
           </Button>
@@ -211,7 +213,7 @@ export default function DatasetView(props) {
       projectsUrl={props.projectsUrl}
     />
     {
-      dataset.url === undefined ?
+      dataset.insideKg === false ?
         <Alert color="primary">
           <strong>This dataset is not in the Knowledge Graph;</strong> this means that some
           operations on it are not possible.<br /><br />

--- a/src/dataset/Dataset.present.js
+++ b/src/dataset/Dataset.present.js
@@ -108,11 +108,12 @@ function LinkToExternal(props) {
 export default function DatasetView(props) {
 
   const [addDatasetModalOpen, setAddDatasetModalOpen] = useState(false);
+  const dataset = props.dataset;
 
-  if (props.fetchError !== null && props.dataset === undefined)
+  if (props.fetchError !== null && dataset === undefined)
     return <Alert color="danger">{props.fetchError}</Alert>;
-  if (props.dataset === undefined) return <Loader />;
-  if (props.dataset === null) {
+  if (dataset === undefined) return <Loader />;
+  if (dataset === null) {
     return (
       <Alert color="danger">
         The dataset that was selected does not exist or could notbe accessed.<br /> <br />
@@ -127,16 +128,16 @@ export default function DatasetView(props) {
     <Row>
       <Col md={8} sm={12}>
         {
-          props.dataset.published !== undefined && props.dataset.published.datePublished !== undefined ?
+          dataset.published !== undefined && dataset.published.datePublished !== undefined ?
             <small style={{ display: "block", paddingBottom: "8px" }} className="font-weight-light font-italic">
-              Uploaded on {Time.getReadableDate(props.dataset.published.datePublished)}.
+              Uploaded on {Time.getReadableDate(dataset.published.datePublished)}.
             </small>
             : null
         }
         <h4 key="datasetTitle">
-          {props.dataset.title || props.dataset.name}
-          {props.dataset.url && props.insideProject ?
-            <a href={props.dataset.url} target="_blank" rel="noreferrer noopener">
+          {dataset.title || dataset.name}
+          {dataset.url && props.insideProject ?
+            <a href={dataset.url} target="_blank" rel="noreferrer noopener">
               <Button size="sm" color="link" style={{ color: "rgba(0, 0, 0, 0.5)" }}>
                 <FontAwesomeIcon icon={faExternalLinkAlt} color="dark" /> Go to source
               </Button>
@@ -147,13 +148,13 @@ export default function DatasetView(props) {
       </Col>
       <Col md={4} sm={12}>
         { props.logged ?
-          <Button disabled={props.dataset.url === undefined}
+          <Button disabled={dataset.url === undefined}
             className="float-right mb-1" size="sm" color="primary" onClick={() => setAddDatasetModalOpen(true)}>
             <FontAwesomeIcon icon={faPlus} color="dark" /> Add to project
           </Button>
           : null}
         { props.insideProject && props.maintainer ?
-          <Link className="float-right mr-1 mb-1" to={{ pathname: "modify", state: { dataset: props.dataset } }} >
+          <Link className="float-right mr-1 mb-1" to={{ pathname: "modify", state: { dataset: dataset } }} >
             <Button size="sm" color="primary" >
               <FontAwesomeIcon icon={faPen} color="dark" /> Modify
             </Button>
@@ -162,10 +163,10 @@ export default function DatasetView(props) {
         }
       </Col>
     </Row>
-    { props.dataset.published !== undefined && props.dataset.published.creator !== undefined ?
+    { dataset.published !== undefined && dataset.published.creator !== undefined ?
       <small style={{ display: "block" }} className="font-weight-light">
         {
-          props.dataset.published.creator
+          dataset.published.creator
             .map((creator) => creator.name + (creator.affiliation ? ` (${creator.affiliation})` : ""))
             .join("; ")
         }
@@ -179,51 +180,51 @@ export default function DatasetView(props) {
             projectPathWithNamespace={props.projectPathWithNamespace}
             filePath={""}
             fixRelativePaths={true}
-            markdownText={props.dataset.description}
+            markdownText={dataset.description}
             client={props.client}
             projectId={props.projectId}
           />
           :
-          <RenkuMarkdown markdownText={props.dataset.description} />
+          <RenkuMarkdown markdownText={dataset.description} />
       }
     </div>
     {
-      props.dataset.url && props.insideProject ?
-        <LinkToExternal link={props.dataset.url} label="Source" />
+      dataset.url && props.insideProject ?
+        <LinkToExternal link={dataset.url} label="Source" />
         : null
     }
     {
-      props.dataset.sameAs && props.dataset.sameAs.includes("doi.org") ?
-        <LinkToExternal link={props.dataset.sameAs} label="DOI" />
+      dataset.sameAs && dataset.sameAs.includes("doi.org") ?
+        <LinkToExternal link={dataset.sameAs} label="DOI" />
         : null
     }
     <DisplayFiles
       projectsUrl={props.projectsUrl}
       fileContentUrl={props.fileContentUrl}
       lineagesUrl={props.lineagesUrl}
-      files={props.dataset.hasPart}
+      files={dataset.hasPart}
       insideProject={props.insideProject}
     />
     <br />
     <DisplayProjects
-      projects={props.dataset.isPartOf}
+      projects={dataset.isPartOf}
       projectsUrl={props.projectsUrl}
     />
     {
-      props.dataset.url === undefined ?
+      dataset.url === undefined ?
         <Alert color="primary">
-          <strong>This dataset is not in the Knowledge Graph</strong>,
-          this means that only basic operations can be performed in it.<br /><br />
-          If the dataset was created recently and the project has the Knowledge Graph features activated,
-          you need to wait until the dataset is added to the Knowledge Graph otherwise you need to activate the
-          Knowlede Graph features to be able to use the full set of dataset features.
+          <strong>This dataset is not in the Knowledge Graph;</strong> this means that some
+          operations on it are not possible.<br /><br />
+          If the dataset was created recently, and the Knowledge Graph integration for the project is active,
+          the dataset should be added to the Knowledge Graph soon. Otherwise, you need to
+          activate the Knowlede Graph to be able to use the full set of dataset features.
         </Alert>
         : null
     }
     {
       props.logged ?
         <AddDataset
-          dataset={props.dataset}
+          dataset={dataset}
           modalOpen={addDatasetModalOpen}
           setModalOpen={setAddDatasetModalOpen}
           projectsCoordinator={new ProjectsCoordinator(props.client, props.model.subModel("projects"))}

--- a/src/dataset/Dataset.present.js
+++ b/src/dataset/Dataset.present.js
@@ -35,7 +35,7 @@ function DisplayFiles(props) {
         <span className="caption align-baseline">Dataset files</span>
       </CardHeader>
       <CardBody>
-        Error fetching dataset files: {props.files.error.reason}
+        <strong>Error fetching dataset files:</strong> {props.files.error.reason}
       </CardBody>
     </Card>;
   }
@@ -166,7 +166,7 @@ export default function DatasetView(props) {
       <small style={{ display: "block" }} className="font-weight-light">
         {
           props.dataset.published.creator
-            .map((creator) => creator.name + (creator.affiliation ? `(${creator.affiliation})` : ""))
+            .map((creator) => creator.name + (creator.affiliation ? ` (${creator.affiliation})` : ""))
             .join("; ")
         }
       </small>

--- a/src/file/KnowledgeGraphStatus.container.js
+++ b/src/file/KnowledgeGraphStatus.container.js
@@ -109,7 +109,6 @@ class KnowledgeGraphStatus extends Component {
 
   render() {
     return <KnowledgeGraphStatusPresent
-      insideDatasets={this.props.insideDatasets}
       progress={this.props.progress}
       webhookJustCreated={this.state.webhookJustCreated}
       maintainer={this.props.maintainer}

--- a/src/file/KnowledgeGraphStatus.present.js
+++ b/src/file/KnowledgeGraphStatus.present.js
@@ -78,10 +78,6 @@ function KnowledgeGraphStatus(props) {
     return (
       <div>
         <Alert color="primary">
-          { props.insideDatasets ?
-            <p><strong>Knowledge Graph integration is needed to be able to see the datasets.</strong></p>
-            : null
-          }
           Please wait, Knowledge Graph integration recently triggered.
           {forkedInfo}
         </Alert>
@@ -93,10 +89,6 @@ function KnowledgeGraphStatus(props) {
     return (
       <div>
         <Alert color="primary">
-          { props.insideDatasets ?
-            <p><strong>Knowledge Graph integration is needed to be able to see the datasets.</strong></p>
-            : null
-          }
           <p>Knowledge Graph is building... {parseInt(progress)}%</p>
           <Progress value={progress} />
         </Alert>

--- a/src/file/KnowledgeGraphStatus.present.js
+++ b/src/file/KnowledgeGraphStatus.present.js
@@ -28,7 +28,7 @@ function KnowledgeGraphStatus(props) {
   const { error, progress, webhookJustCreated } = props;
   if (error != null) {
     return <Alert color="warning">
-      Knowledge Graph integration must be activated to view the lineage and the datasets, but&nbsp;
+      Knowledge Graph integration must be activated to view the lineage, but&nbsp;
       there is a problem with the knowledge graph integration for this project. To resolve this problem,
       you should contact the development team on&nbsp;
       <a href="https://gitter.im/SwissDataScienceCenter/renku"
@@ -57,7 +57,7 @@ function KnowledgeGraphStatus(props) {
 
     return (
       <Alert color="warning">
-        Knowledge Graph integration must be activated to view the lineage and the datasets.&nbsp;
+        Knowledge Graph integration must be activated to view the lineage.&nbsp;
         {action}
       </Alert>
     );

--- a/src/file/KnowledgeGraphStatus.present.js
+++ b/src/file/KnowledgeGraphStatus.present.js
@@ -69,7 +69,7 @@ function KnowledgeGraphStatus(props) {
       forkedInfo = (
         <div>
           <br />
-          <FontAwesomeIcon icon={faInfoCircle} /> <span className="font-italic">If you recenty forked
+          <FontAwesomeIcon icon={faInfoCircle} /> <span className="font-italic">If you recently forked
             this project, the graph integration will not finish until you create at least one commit.
           </span>
         </div>

--- a/src/project/Project.js
+++ b/src/project/Project.js
@@ -452,7 +452,7 @@ class View extends Component {
         insideProject={true}
         datasets={datasets}
         datasetId={p.match.params.datasetId}
-        projectPath={projectPathWithNamespace}
+        projectPathWithNamespace={projectPathWithNamespace}
         lineagesUrl={subUrls.lineagesUrl}
         fileContentUrl={subUrls.fileContentUrl}
         projectsUrl={subUrls.projectsUrl}
@@ -460,7 +460,6 @@ class View extends Component {
         logged={this.props.user.logged}
         model={this.props.model}
         projectId={projectId}
-        projectPathWithNamespace={this.projectState.get("core.path_with_namespace")}
         httpProjectUrl={httpProjectUrl}
       />,
 

--- a/src/project/Project.js
+++ b/src/project/Project.js
@@ -372,6 +372,7 @@ class View extends Component {
     const filesTree = this.projectState.get("filesTree");
     const datasets = this.projectState.get("core.datasets");
     const graphProgress = this.projectState.get("webhook.progress");
+    const graphStatus = this.projectState.get("webhook.status");
     const maintainer = this.projectState.get("visibility.accessLevel") >= ACCESS_LEVELS.MAINTAINER ?
       true :
       false;
@@ -461,6 +462,7 @@ class View extends Component {
         model={this.props.model}
         projectId={projectId}
         httpProjectUrl={httpProjectUrl}
+        graphStatus={graphStatus}
       />,
 
       newDataset: (p) => <NewDataset

--- a/src/project/Project.js
+++ b/src/project/Project.js
@@ -371,7 +371,6 @@ class View extends Component {
     const updateProjectView = this.forceUpdate.bind(this);
     const filesTree = this.projectState.get("filesTree");
     const datasets = this.projectState.get("core.datasets");
-    const datasets_kg = this.projectState.get("core.datasets_kg");
     const graphProgress = this.projectState.get("webhook.progress");
     const maintainer = this.projectState.get("visibility.accessLevel") >= ACCESS_LEVELS.MAINTAINER ?
       true :
@@ -452,7 +451,6 @@ class View extends Component {
         maintainer={maintainer}
         insideProject={true}
         datasets={datasets}
-        datasets_kg={datasets_kg}
         datasetId={p.match.params.datasetId}
         projectPath={projectPathWithNamespace}
         lineagesUrl={subUrls.lineagesUrl}

--- a/src/project/Project.js
+++ b/src/project/Project.js
@@ -231,8 +231,8 @@ class View extends Component {
   async setProjectOpenFolder(filepath) {
     this.projectState.setProjectOpenFolder(this.props.client, filepath);
   }
-  async fetchProjectDatasets() {
-    return this.projectState.fetchProjectDatasets(this.props.client);
+  async fetchProjectDatasets(forceReFetch) {
+    return this.projectState.fetchProjectDatasets(this.props.client, forceReFetch);
   }
   async fetchProjectDatasetsFromKg() {
     return this.projectState.fetchProjectDatasetsFromKg(this.props.client);
@@ -598,9 +598,9 @@ class View extends Component {
       this.fetchProjectFilesTree();
       //this.fetchModifiedFiles();
     },
-    fetchDatasets: () => {
+    fetchDatasets: (forceReFetch = true) => {
       this.fetchProjectDatasetsFromKg();
-      this.fetchProjectDatasets();
+      this.fetchProjectDatasets(forceReFetch);
     },
     setOpenFolder: (filePath) => {
       this.setProjectOpenFolder(filePath);

--- a/src/project/Project.js
+++ b/src/project/Project.js
@@ -234,6 +234,9 @@ class View extends Component {
   async fetchProjectDatasets() {
     return this.projectState.fetchProjectDatasets(this.props.client);
   }
+  async fetchProjectDatasetsFromKg() {
+    return this.projectState.fetchProjectDatasetsFromKg(this.props.client);
+  }
   async fetchGraphStatus() { return this.projectState.fetchGraphStatus(this.props.client); }
 
   async fetchMigrationCheck() { this.projectState.fetchMigrationCheck(this.props.client); }
@@ -368,6 +371,7 @@ class View extends Component {
     const updateProjectView = this.forceUpdate.bind(this);
     const filesTree = this.projectState.get("filesTree");
     const datasets = this.projectState.get("core.datasets");
+    const datasets_kg = this.projectState.get("core.datasets_kg");
     const graphProgress = this.projectState.get("webhook.progress");
     const maintainer = this.projectState.get("visibility.accessLevel") >= ACCESS_LEVELS.MAINTAINER ?
       true :
@@ -445,20 +449,21 @@ class View extends Component {
 
       datasetView: (p) => <ShowDataset
         key="datasetpreview" {...subProps}
-        progress={graphProgress}
         maintainer={maintainer}
-        forked={forked}
         insideProject={true}
         datasets={datasets}
+        datasets_kg={datasets_kg}
+        datasetId={p.match.params.datasetId}
+        projectPath={projectPathWithNamespace}
         lineagesUrl={subUrls.lineagesUrl}
         fileContentUrl={subUrls.fileContentUrl}
         projectsUrl={subUrls.projectsUrl}
-        selectedDataset={p.match.params.datasetId}
         history={this.props.history}
         logged={this.props.user.logged}
         model={this.props.model}
         projectId={projectId}
         projectPathWithNamespace={this.projectState.get("core.path_with_namespace")}
+        httpProjectUrl={httpProjectUrl}
       />,
 
       newDataset: (p) => <NewDataset
@@ -469,7 +474,6 @@ class View extends Component {
         forked={forked}
         insideProject={true}
         datasets={datasets}
-        reFetchProject={this.fetchAll.bind(this)}
         lineagesUrl={subUrls.lineagesUrl}
         fileContentUrl={subUrls.fileContentUrl}
         projectsUrl={subUrls.projectsUrl}
@@ -477,6 +481,8 @@ class View extends Component {
         client={this.props.client}
         history={this.props.history}
         httpProjectUrl={httpProjectUrl}
+        fetchDatasets={this.eventHandlers.fetchDatasets}
+        overviewCommitsUrl={subUrls.overviewCommitsUrl}
       />,
 
       editDataset: (p) => <EditDataset
@@ -487,7 +493,6 @@ class View extends Component {
         forked={forked}
         insideProject={true}
         datasets={datasets}
-        reFetchProject={this.fetchAll.bind(this)}
         lineagesUrl={subUrls.lineagesUrl}
         fileContentUrl={subUrls.fileContentUrl}
         projectsUrl={subUrls.projectsUrl}
@@ -497,6 +502,8 @@ class View extends Component {
         datasetId={p.match.params.datasetId}
         dataset={p.location.state ? p.location.state.dataset : null}
         httpProjectUrl={httpProjectUrl}
+        fetchDatasets={this.eventHandlers.fetchDatasets}
+        overviewCommitsUrl={subUrls.overviewCommitsUrl}
       />,
 
       importDataset: (p) => <ImportDataset
@@ -507,7 +514,6 @@ class View extends Component {
         forked={forked}
         insideProject={true}
         datasets={datasets}
-        reFetchProject={this.fetchAll.bind(this)}
         lineagesUrl={subUrls.lineagesUrl}
         fileContentUrl={subUrls.fileContentUrl}
         projectsUrl={subUrls.projectsUrl}
@@ -515,6 +521,8 @@ class View extends Component {
         client={this.props.client}
         history={this.props.history}
         httpProjectUrl={httpProjectUrl}
+        fetchDatasets={this.eventHandlers.fetchDatasets}
+        overviewCommitsUrl={subUrls.overviewCommitsUrl}
       />,
 
       fork: () => <Fork
@@ -527,9 +535,8 @@ class View extends Component {
         client={this.props.client}
         user={this.props.user} />,
 
-      kgStatusView: (insideDatasets) =>
+      kgStatusView: () =>
         <KnowledgeGraphStatus
-          insideDatasets={insideDatasets}
           fetchGraphStatus={this.eventHandlers.fetchGraphStatus}
           createGraphWebhook={this.eventHandlers.createGraphWebhook}
           maintainer={maintainer}
@@ -593,6 +600,7 @@ class View extends Component {
       //this.fetchModifiedFiles();
     },
     fetchDatasets: () => {
+      this.fetchProjectDatasetsFromKg();
       this.fetchProjectDatasets();
     },
     setOpenFolder: (filePath) => {

--- a/src/project/Project.js
+++ b/src/project/Project.js
@@ -372,7 +372,8 @@ class View extends Component {
     const filesTree = this.projectState.get("filesTree");
     const datasets = this.projectState.get("core.datasets");
     const graphProgress = this.projectState.get("webhook.progress");
-    const graphStatus = this.projectState.get("webhook.status");
+    const webhookStatus = this.projectState.get("webhook");
+    const graphStatus = webhookStatus.status || (webhookStatus.created && webhookStatus.stop);
     const maintainer = this.projectState.get("visibility.accessLevel") >= ACCESS_LEVELS.MAINTAINER ?
       true :
       false;
@@ -611,6 +612,8 @@ class View extends Component {
     },
     onCloseGraphWebhook: () => {
       this.stopCheckingWebhook();
+      this.fetchProjectDatasetsFromKg();
+      this.fetchProjectDatasets(true);
     },
     fetchGraphStatus: () => {
       return this.fetchGraphStatus();

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -1164,13 +1164,15 @@ class ProjectViewDatasetsOverview extends Component {
   }
 
   render() {
-    if (this.props.datasets === undefined)
-      return <p>Loading datasets...</p>;
+    const datasetsList = this.props.core.datasets;
 
-    if (this.props.datasets.length === 0)
+    if (datasetsList === undefined || datasetsList === SpecialPropVal.UPDATING)
+      return <Loader />;
+
+    if (datasetsList.length === 0)
       return <p>No datasets to display.</p>;
 
-    let datasets = this.props.datasets.map((dataset) =>
+    let datasets = datasetsList.map((dataset) =>
       <OverviewDatasetRow
         key={dataset.name}
         name={dataset.title || dataset.name}

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -928,13 +928,12 @@ function ProjectViewDatasets(props) {
       <Button color="warning" onClick={() => props.history.push(props.overviewVersionUrl)} >More Info</Button>
     </Alert> : null;
 
-  useEffect(() => {
+  useEffect(()=>{
     const loading = props.core.datasets === SpecialPropVal.UPDATING;
     if (loading) return;
-    if (props.core.datasets === undefined)
-      props.fetchDatasets();
-  }
-  , [props.core.datasets, props.fetchDatasets, props]);
+    props.fetchDatasets();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const loading = props.core.datasets === SpecialPropVal.UPDATING || props.core.datasets === undefined;
   if (loading)
@@ -1173,9 +1172,9 @@ class ProjectViewDatasetsOverview extends Component {
 
     let datasets = this.props.datasets.map((dataset) =>
       <OverviewDatasetRow
-        key={dataset.identifier}
+        key={dataset.name}
         name={dataset.title || dataset.name}
-        fullDatasetUrl={`${this.props.datasetsUrl}/${encodeURIComponent(dataset.identifier)}`}
+        fullDatasetUrl={`${this.props.datasetsUrl}/${encodeURIComponent(dataset.name)}`}
       />
     );
 

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -931,7 +931,7 @@ function ProjectViewDatasets(props) {
   useEffect(()=>{
     const loading = props.core.datasets === SpecialPropVal.UPDATING;
     if (loading) return;
-    props.fetchDatasets();
+    props.fetchDatasets(false);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -1160,7 +1160,7 @@ class OverviewDatasetRow extends Component {
 class ProjectViewDatasetsOverview extends Component {
 
   componentDidMount() {
-    this.props.fetchDatasets();
+    this.props.fetchDatasets(false);
   }
 
   render() {

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -940,6 +940,19 @@ function ProjectViewDatasets(props) {
   if (loading)
     return <Loader />;
 
+  //When the core service can return stuff for anounymous users this should be removed
+  if (!props.user.logged) {
+    const postLoginUrl = props.location.pathname;
+    const to = { "pathname": "/login", "state": { previous: postLoginUrl } };
+
+    return <Col sm={12} md={12} lg={8}>
+      <Alert color="primary">You are logged out, please&nbsp;
+        <Link className="btn btn-primary btn-sm" to={to} previous={postLoginUrl}>
+          Log in
+        </Link> to see datasets for this project.</Alert>
+    </Col>;
+  }
+
   if (props.core.datasets.error) {
     return <Col sm={12} md={12} lg={8}>
       <Alert color="danger">

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -849,6 +849,7 @@ class ProjectDatasetsNav extends Component {
       datasetsUrl={this.props.datasetsUrl}
       newDatasetUrl={this.props.newDatasetUrl}
       visibility={this.props.visibility}
+      graphStatus={this.props.webhook.status || (this.props.webhook.created && this.props.webhook.stop)}
     />;
   }
 }

--- a/src/project/Project.state.js
+++ b/src/project/Project.state.js
@@ -268,7 +268,7 @@ class ProjectModel extends StateModel {
       })
       .catch(err => {
         const datasets = [];
-        const updatedState = { datasets_kg: datasets, transient: { requests: { datasets_kg: false } } };
+        const updatedState = { datasets_kg: { $set: datasets }, transient: { requests: { datasets_kg: false } } };
         this.set("core.datasets_kg", datasets);
         this.setObject(updatedState);
       });
@@ -278,7 +278,7 @@ class ProjectModel extends StateModel {
   fetchProjectDatasets(client) {
     if (this.get("core.datasets") === SpecialPropVal.UPDATING) return;
     this.setUpdating({ core: { datasets: true } });
-    return client.listProjectDatasetsFromCore(this.get("system.http_url"))
+    return client.listProjectDatasetsFromCoreService(this.get("system.http_url"))
       .then(response => {
         let responseDs = response.data.error ? response.data : response.data.result.datasets;
         const updatedState = { datasets: responseDs, transient: { requests: { datasets: false } } };

--- a/src/project/Project.state.js
+++ b/src/project/Project.state.js
@@ -256,38 +256,40 @@ class ProjectModel extends StateModel {
     this.set("filesTree", filesTree);
   }
 
-  fetchProjectDatasets(client) { //from KG
-    if (this.get("core.datasets") === SpecialPropVal.UPDATING) return;
-    this.setUpdating({ core: { datasets: true } });
-    return client.getProjectDatasetsFromKG(this.get("core.path_with_namespace"))
+  fetchProjectDatasetsFromKg(client) { //from KG
+    if (this.get("core.datasets_kg") === SpecialPropVal.UPDATING) return;
+    this.setUpdating({ core: { datasets_kg: true } });
+    return client.getProjectDatasetsFromKG_short(this.get("core.path_with_namespace"))
       .then(datasets => {
-        const updatedState = { datasets: datasets, transient: { requests: { datasets: false } } };
-        this.set("core.datasets", datasets);
+        const updatedState = { datasets_kg: datasets, transient: { requests: { datasets_kg: false } } };
+        this.set("core.datasets_kg", datasets);
         this.setObject(updatedState);
         return datasets;
       })
       .catch(err => {
         const datasets = [];
-        const updatedState = { datasets: datasets, transient: { requests: { datasets: false } } };
-        this.set("core.datasets", datasets);
+        const updatedState = { datasets_kg: datasets, transient: { requests: { datasets_kg: false } } };
+        this.set("core.datasets_kg", datasets);
         this.setObject(updatedState);
       });
   }
 
-  fetchProjectDatasetsFromMetadata(client) {
-    if (this.get("transient.requests.datasets") === SpecialPropVal.UPDATING) return;
-    this.setUpdating({ transient: { requests: { datasets: true } } });
 
-    return client.getProjectDatasets(this.get("core.id"))
-      .then(datasets => {
-        datasets = datasets.map(dataset => {
-          dataset.identifier = dataset.identifier.split("-").join("");
-          return dataset;
-        } );
-        const updatedState = { datasets: datasets, transient: { requests: { datasets: false } } };
-        this.set("core.datasets", datasets);
+  fetchProjectDatasets(client) {
+    if (this.get("core.datasets") === SpecialPropVal.UPDATING) return;
+    this.setUpdating({ core: { datasets: true } });
+    return client.listProjectDatasetsFromCore(this.get("system.http_url"))
+      .then(response => {
+        let responseDs = response.data.error ? response.data : response.data.result.datasets;
+        const updatedState = { datasets: responseDs, transient: { requests: { datasets: false } } };
+        this.set("core.datasets", responseDs);
         this.setObject(updatedState);
-        return datasets;
+        return responseDs;
+      })
+      .catch(err => {
+        const updatedState = { datasets: { error: err }, transient: { requests: { datasets: false } } };
+        this.set("core.datasets", { error: err });
+        this.setObject(updatedState);
       });
   }
 

--- a/src/project/Project.state.js
+++ b/src/project/Project.state.js
@@ -261,7 +261,7 @@ class ProjectModel extends StateModel {
     this.setUpdating({ core: { datasets_kg: true } });
     return client.getProjectDatasetsFromKG_short(this.get("core.path_with_namespace"))
       .then(datasets => {
-        const updatedState = { datasets_kg: datasets, transient: { requests: { datasets_kg: false } } };
+        const updatedState = { datasets_kg: { $set: datasets }, transient: { requests: { datasets_kg: false } } };
         this.set("core.datasets_kg", datasets);
         this.setObject(updatedState);
         return datasets;

--- a/src/project/Project.state.js
+++ b/src/project/Project.state.js
@@ -273,8 +273,10 @@ class ProjectModel extends StateModel {
   }
 
 
-  fetchProjectDatasets(client) {
-    if (this.get("core.datasets") === SpecialPropVal.UPDATING) return;
+  fetchProjectDatasets(client, forceReFetch = true) {
+    let datasets = this.get("core.datasets");
+    if (datasets === SpecialPropVal.UPDATING) return;
+    if (datasets && datasets.error === undefined && !forceReFetch) return datasets;
     this.setUpdating({ core: { datasets: true } });
     return client.listProjectDatasetsFromCoreService(this.get("system.http_url"))
       .then(response => {

--- a/src/project/Project.state.js
+++ b/src/project/Project.state.js
@@ -262,15 +262,13 @@ class ProjectModel extends StateModel {
     return client.getProjectDatasetsFromKG_short(this.get("core.path_with_namespace"))
       .then(datasets => {
         const updatedState = { datasets_kg: { $set: datasets }, transient: { requests: { datasets_kg: false } } };
-        this.set("core.datasets_kg", datasets);
-        this.setObject(updatedState);
+        this.setObject({ core: updatedState });
         return datasets;
       })
       .catch(err => {
         const datasets = [];
         const updatedState = { datasets_kg: { $set: datasets }, transient: { requests: { datasets_kg: false } } };
-        this.set("core.datasets_kg", datasets);
-        this.setObject(updatedState);
+        this.setObject({ core: updatedState });
       });
   }
 
@@ -281,15 +279,13 @@ class ProjectModel extends StateModel {
     return client.listProjectDatasetsFromCoreService(this.get("system.http_url"))
       .then(response => {
         let responseDs = response.data.error ? response.data : response.data.result.datasets;
-        const updatedState = { datasets: responseDs, transient: { requests: { datasets: false } } };
-        this.set("core.datasets", responseDs);
-        this.setObject(updatedState);
+        const updatedState = { datasets: { $set: responseDs }, transient: { requests: { datasets: false } } };
+        this.setObject({ core: updatedState });
         return responseDs;
       })
       .catch(err => {
-        const updatedState = { datasets: { error: err }, transient: { requests: { datasets: false } } };
-        this.set("core.datasets", { error: err });
-        this.setObject(updatedState);
+        const updatedState = { datasets: { $set: { error: err } }, transient: { requests: { datasets: false } } };
+        this.setObject({ core: updatedState });
       });
   }
 

--- a/src/project/datasets/DatasetsListView.js
+++ b/src/project/datasets/DatasetsListView.js
@@ -4,6 +4,7 @@ import { Row, Col, ListGroup, ListGroupItem } from "reactstrap";
 import { ACCESS_LEVELS } from "../../api-client";
 import "../filestreeview/treeviewstyle.css";
 import { Loader, MarkdownTextExcerpt } from "../../utils/UIComponents";
+import { SpecialPropVal } from "../../model";
 
 function DatasetListRow(props) {
   const dataset = props.dataset;
@@ -70,6 +71,9 @@ function AddDatasetButton(props) {
 export default function DatasetsListView(props) {
 
   const datasets = useMemo(()=>props.datasets, [props.datasets]);
+
+  if (props.datasets_kg === SpecialPropVal.UPDATING)
+    return <Loader />;
 
   return [<Row key="header" className="pb-3">
     <Col md={12}>

--- a/src/project/datasets/DatasetsListView.js
+++ b/src/project/datasets/DatasetsListView.js
@@ -14,7 +14,7 @@ function DatasetListRow(props) {
 
   return <ListGroupItem action style={{ border: "none" }}>
     <Row>
-      <Col md={9}>
+      <Col xs={8} md={8}>
         <div className="d-flex project-list-row">
           <div className="issue-text-crop">
             <b>
@@ -39,7 +39,7 @@ function DatasetListRow(props) {
           </div>
         </div>
       </Col>
-      <Col sm={3} md={3} className="float-right" style={{ textAlign: "end" }}>
+      <Col xs={4} md={4} className="float-right" style={{ textAlign: "end" }}>
         <small>
           {props.dataset_kg ?
             <strong>In the Knowledge Graph</strong>

--- a/src/project/datasets/DatasetsListView.js
+++ b/src/project/datasets/DatasetsListView.js
@@ -47,9 +47,9 @@ function DatasetListRow(props) {
         </small>
         <br />
         {
-          dataset.created_at !== undefined ?
+          dataset.created_at !== undefined && dataset.created_at !== null ?
             <small className="font-italic">
-              {"Published: " + new Date(dataset.created_at).toLocaleDateString()}
+              {"Published: " + new Date(dataset.created_at.replace(/ /g, "T")).toLocaleDateString()}
             </small>
             : null
         }

--- a/src/project/datasets/DatasetsListView.js
+++ b/src/project/datasets/DatasetsListView.js
@@ -42,7 +42,7 @@ function DatasetListRow(props) {
       </Col>
       <Col xs={4} md={4} className="float-right" style={{ textAlign: "end" }}>
         <small>
-          {props.dataset_kg ?
+          {props.dataset_kg !== undefined && props.graphStatus === true ?
             <strong>In the Knowledge Graph</strong>
             : <strong>Not in the Knowledge Graph</strong>}
         </small>
@@ -97,6 +97,7 @@ export default function DatasetsListView(props) {
                 dataset={dataset}
                 dataset_kg={props.datasets_kg
                   ? props.datasets_kg.find(dataset_kg => dataset_kg.name === dataset.name) : undefined}
+                graphStatus={props.graphStatus}
                 datasetsUrl={props.datasetsUrl} />
             )
             : <Loader />

--- a/src/project/datasets/edit/DatasetEdit.container.js
+++ b/src/project/datasets/edit/DatasetEdit.container.js
@@ -86,6 +86,7 @@ function EditDataset(props) {
 
   const redirectAfterSuccess = (interval, datasetName) => {
     setSubmitLoader(false);
+    props.fetchDatasets(true);
     datasetFormSchema.name.value = datasetFormSchema.name.initial;
     datasetFormSchema.description.value = datasetFormSchema.description.initial;
     datasetFormSchema.files.value = datasetFormSchema.files.initial;

--- a/src/project/datasets/edit/DatasetEdit.present.js
+++ b/src/project/datasets/edit/DatasetEdit.present.js
@@ -44,9 +44,9 @@ function DatasetEdit(props) {
       {props.jobsStats.tooLong ?
         <div>
           This operation is taking too long and it will continue being processed in the background.<br/>
-          Please check the dataset in a while to make sure that the changes are there. <br/>
+          Please check the datasets list later to make sure that the new dataset is available. <br />
           You can also check the <Link to={props.overviewCommitsUrl}>commits list
-          </Link> in the project and see if the new change was pushed.
+          </Link> in the project to see if commits for the new dataset appear there.
           <br />
           <br />
         </div>

--- a/src/project/datasets/edit/DatasetEdit.present.js
+++ b/src/project/datasets/edit/DatasetEdit.present.js
@@ -26,6 +26,7 @@
 
 import React from "react";
 import { Col, Alert, Button } from "reactstrap";
+import { Link } from "react-router-dom";
 import { FormPanel } from "../../../utils/formgenerator";
 import { ACCESS_LEVELS } from "../../../api-client";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -35,15 +36,6 @@ function DatasetEdit(props) {
 
   const getServerWarnings = () => {
 
-    const tooLongText = "The Knowledge Graph has not finished updating.  The new files" +
-    " will not be visible until this is complete, but you can continue to work freely within RenkuLab.";
-    if (props.jobsStats.failed.length === 0 && props.jobsStats.inProgress.length === 0 && props.jobsStats.tooLong) {
-      return <div>
-        {tooLongText}
-        <br/><br/>
-        You can keep on working while this operation is running.
-      </div>;
-    }
     const failed = props.jobsStats.failed
       .map(job => <div key={"warn-" + job.file_url} className="pl-2">- {job.file_url}<br /></div>);
     const progress = props.jobsStats.inProgress
@@ -51,7 +43,10 @@ function DatasetEdit(props) {
     return <div>
       {props.jobsStats.tooLong ?
         <div>
-          {tooLongText}
+          This operation is taking too long and it will continue being processed in the background.<br/>
+          Please check the dataset in a while to make sure that the changes are there. <br/>
+          You can also check the <Link to={props.overviewCommitsUrl}>commits list
+          </Link> in the project and see if the new change was pushed.
           <br />
           <br />
         </div>
@@ -71,8 +66,6 @@ function DatasetEdit(props) {
         </div>
         : null}
       <br /><br />
-      <strong>If more files where added they should be in the dataset, it could take some time until
-        they are visible since the Knowledge Graph could still be processing the operation.</strong>
     </div>;
   };
 

--- a/src/project/datasets/import/DatasetImport.container.js
+++ b/src/project/datasets/import/DatasetImport.container.js
@@ -40,7 +40,7 @@ function ImportDataset(props) {
 
   const redirectUser = () => {
     setSubmitLoader(false);
-    props.fetchDatasets();
+    props.fetchDatasets(true);
     props.history.push({
       //we should do the redirect to the new dataset
       //but for this we need the dataset name in the response of the dataset.import operation :(
@@ -50,28 +50,30 @@ function ImportDataset(props) {
   };
 
   function handleJobResponse(job, monitorJob, cont) {
-    switch (job.state) {
-      case "ENQUEUED":
-        setSubmitLoaderText(ImportStateMessage.ENQUEUED);
-        break;
-      case "IN_PROGRESS":
-        setSubmitLoaderText(ImportStateMessage.IN_PROGRESS);
-        break;
-      case "COMPLETED":
-        setSubmitLoaderText(ImportStateMessage.COMPLETED);
-        clearInterval(monitorJob);
-        redirectUser();
-        break;
-      case "FAILED":
-        setSubmitLoader(false);
-        setServerErrors(ImportStateMessage.FAILED + job.extras.error);
-        clearInterval(monitorJob);
-        break;
-      default:
-        setSubmitLoader(false);
-        setServerErrors(ImportStateMessage.FAILED_NO_INFO);
-        clearInterval(monitorJob);
-        break;
+    if (job !== null && job !== undefined) {
+      switch (job.state) {
+        case "ENQUEUED":
+          setSubmitLoaderText(ImportStateMessage.ENQUEUED);
+          break;
+        case "IN_PROGRESS":
+          setSubmitLoaderText(ImportStateMessage.IN_PROGRESS);
+          break;
+        case "COMPLETED":
+          setSubmitLoaderText(ImportStateMessage.COMPLETED);
+          clearInterval(monitorJob);
+          redirectUser();
+          break;
+        case "FAILED":
+          setSubmitLoader(false);
+          setServerErrors(ImportStateMessage.FAILED + job.extras.error);
+          clearInterval(monitorJob);
+          break;
+        default:
+          setSubmitLoader(false);
+          setServerErrors(ImportStateMessage.FAILED_NO_INFO);
+          clearInterval(monitorJob);
+          break;
+      }
     }
     if (cont === 100) {
       setSubmitLoader(false);

--- a/src/project/datasets/import/DatasetImport.container.js
+++ b/src/project/datasets/import/DatasetImport.container.js
@@ -38,31 +38,18 @@ function ImportDataset(props) {
     props.history.push({ pathname: `/projects/${props.projectPathWithNamespace}/datasets` });
   };
 
-  const redirectUserAndClearInterval = (datasets, oldDatasetsList, waitForDatasetInKG) => {
-    let new_dataset = datasets.filter(ds =>
-      oldDatasetsList.find(ods => ds.identifier === ods.identifier) === undefined);
-    if (new_dataset.length > 0) {
-      setSubmitLoader(false);
-      clearInterval(waitForDatasetInKG);
-      props.history.push({
-        pathname: `/projects/${props.projectPathWithNamespace}/datasets/${new_dataset[0].identifier}/`,
-        state: { datasets: datasets }
-      })
-      ;
-    }
+  const redirectUser = () => {
+    setSubmitLoader(false);
+    props.fetchDatasets();
+    props.history.push({
+      //we should do the redirect to the new dataset
+      //but for this we need the dataset name in the response of the dataset.import operation :(
+      pathname: `/projects/${props.projectPathWithNamespace}/datasets`
+    })
+    ;
   };
 
-  const findDatasetInKgAnRedirect = (oldDatasetsList) => {
-    let waitForDatasetInKG = setInterval(() => {
-      props.client.getProjectDatasetsFromKG_short(props.projectPathWithNamespace)
-        .then(datasets => {
-          if (datasets.length !== oldDatasetsList.length)
-            redirectUserAndClearInterval(datasets, oldDatasetsList, waitForDatasetInKG);
-        });
-    }, 6000);
-  };
-
-  function handleJobResponse(job, monitorJob, cont, oldDatasetsList) {
+  function handleJobResponse(job, monitorJob, cont) {
     switch (job.state) {
       case "ENQUEUED":
         setSubmitLoaderText(ImportStateMessage.ENQUEUED);
@@ -73,7 +60,7 @@ function ImportDataset(props) {
       case "COMPLETED":
         setSubmitLoaderText(ImportStateMessage.COMPLETED);
         clearInterval(monitorJob);
-        findDatasetInKgAnRedirect(oldDatasetsList);
+        redirectUser();
         break;
       case "FAILED":
         setSubmitLoader(false);
@@ -93,40 +80,32 @@ function ImportDataset(props) {
     }
   }
 
-  const monitorJobStatusAndHandleResponse = (job_id, oldDatasetsList) => {
+  const monitorJobStatusAndHandleResponse = (job_id) => {
     let cont = 0;
     let monitorJob = setInterval(() => {
       props.client.getJobStatus(job_id)
         .then(job => {
           cont++;
           if (job !== undefined || cont === 50)
-            handleJobResponse(job, monitorJob, cont, oldDatasetsList);
+            handleJobResponse(job, monitorJob, cont);
         });
     }, 10000);
   };
-
 
   const submitCallback = e => {
     setServerErrors(undefined);
     setSubmitLoader(true);
     const dataset = {};
-    let oldDatasetsList = [];
     dataset.uri = datasetImportFormSchema.uri.value;
-    props.client.getProjectDatasetsFromKG_short(props.projectPathWithNamespace)
-      .then(result => {
-        oldDatasetsList = result;
-        props.client.datasetImport(props.httpProjectUrl, dataset.uri)
-          .then(response => {
-            if (response.data.error !== undefined) {
-              setSubmitLoader(false);
-              setServerErrors(response.data.error.reason);
-            }
-            else {
-              monitorJobStatusAndHandleResponse(
-                response.data.result.job_id,
-                oldDatasetsList);
-            }
-          });
+    props.client.datasetImport(props.httpProjectUrl, dataset.uri)
+      .then(response => {
+        if (response.data.error !== undefined) {
+          setSubmitLoader(false);
+          setServerErrors(response.data.error.reason);
+        }
+        else {
+          monitorJobStatusAndHandleResponse(response.data.result.job_id);
+        }
       });
   };
 

--- a/src/project/datasets/new/DatasetNew.container.js
+++ b/src/project/datasets/new/DatasetNew.container.js
@@ -83,7 +83,7 @@ function NewDataset(props) {
   const redirectAfterSuccess = (interval, datasetId) => {
     setSubmitLoader(false);
     if (interval !== undefined) clearInterval(interval);
-    props.fetchDatasets();
+    props.fetchDatasets(true);
     props.history.push({
       pathname: `/projects/${props.projectPathWithNamespace}/datasets/${datasetId}/`
     });

--- a/src/project/datasets/new/DatasetNew.container.js
+++ b/src/project/datasets/new/DatasetNew.container.js
@@ -80,21 +80,10 @@ function NewDataset(props) {
       });
   };
 
-  const monitorFilesInKgAndRedirect = (dataset, interval, datasetId) => {
-    props.client.fetchDatasetFromKG(props.client.baseUrl.replace(
-      "api", "knowledge-graph/datasets/") + datasetId)
-      .then(response => {
-        return response.hasPart.length >= dataset.files.length;
-      }).then( filesInKg => {
-        if (filesInKg)
-          redirectAfterSuccess(interval, datasetId);
-
-      });
-  };
-
   const redirectAfterSuccess = (interval, datasetId) => {
     setSubmitLoader(false);
     if (interval !== undefined) clearInterval(interval);
+    props.fetchDatasets();
     props.history.push({
       pathname: `/projects/${props.projectPathWithNamespace}/datasets/${datasetId}/`
     });
@@ -123,7 +112,6 @@ function NewDataset(props) {
           setServerErrors(response.data.error.reason);
         }
         else {
-          let datasetInKg = false;
           let filesURLJobsArray = [];
 
           if (response.data.result.files) {
@@ -136,48 +124,29 @@ function NewDataset(props) {
 
           let cont = 0;
           const INTERVAL = 6000;
-          let datasetId;
 
-          let monitorKGandJobs = setInterval(() => {
-            if (!datasetInKg) {
-              props.client.getProjectDatasetsFromKG_short(props.projectPathWithNamespace)
-                .then(datasets => {
-                // eslint-disable-next-line
-                  let new_dataset = datasets.find( ds => ds.name === response.data.result.name);
-                  if (new_dataset !== undefined) {
-                    datasetInKg = true;
-                    datasetId = new_dataset.identifier;
-                  }
-
-                  if (cont >= 20) {
-                    checkJobsAndSetWarnings([], true);
-                    clearInterval(monitorKGandJobs);
-                  }
-                });
+          let monitorJobs = setInterval(() => {
+            if (filesURLJobsArray.length === 0) {
+              redirectAfterSuccess(monitorJobs, dataset.name);
             }
             else {
-              if (filesURLJobsArray.length === 0) {
-                monitorFilesInKgAndRedirect(dataset, monitorKGandJobs, datasetId);
-              }
-              else {
-                monitorURLJobsStatuses(filesURLJobsArray).then(jobsStats => {
-                  if (jobsStats.finished) {
-                    if (jobsStats.failed.length === 0) {
-                      monitorFilesInKgAndRedirect(dataset, monitorKGandJobs, datasetId);
-                    }
-                    else {
-                    //some or all failed, but all finished
-                      checkJobsAndSetWarnings(filesURLJobsArray, false);
-                      clearInterval(monitorKGandJobs);
-                    }
+              monitorURLJobsStatuses(filesURLJobsArray).then(jobsStats => {
+                if (jobsStats.finished) {
+                  if (jobsStats.failed.length === 0) {
+                    redirectAfterSuccess(monitorJobs, dataset.name);
                   }
-                });
-              }
+                  else {
+                    //some or all failed, but all finished
+                    checkJobsAndSetWarnings(filesURLJobsArray, false);
+                    clearInterval(monitorJobs);
+                  }
+                }
+              });
+            }
 
-              if (cont >= 20) {
-                checkJobsAndSetWarnings(filesURLJobsArray, true);
-                clearInterval(monitorKGandJobs);
-              }
+            if (cont >= 20) {
+              checkJobsAndSetWarnings(filesURLJobsArray, true);
+              clearInterval(monitorJobs);
             }
             cont++;
           }, INTERVAL);
@@ -202,6 +171,7 @@ function NewDataset(props) {
     onCancel={onCancel}
     warningOn={warningOn}
     jobsStats={jobsStats}
+    overviewCommitsUrl={props.overviewCommitsUrl}
   />;
 }
 

--- a/src/project/datasets/new/DatasetNew.present.js
+++ b/src/project/datasets/new/DatasetNew.present.js
@@ -44,9 +44,9 @@ function DatasetNew(props) {
       {props.jobsStats.tooLong ?
         <div>
           This operation is taking too long and it will continue being processed in the background.<br />
-          Please check the datasets list in a while to make sure that the changes are there. <br />
+          Please check the datasets list later to make sure that the changes are visible in the dataset. <br />
           You can also check the <Link to={props.overviewCommitsUrl}>commits list
-          </Link> in the project and see if the new change was pushed.
+          </Link> in the project to see if commits for the new dataset appear there.
           <br/><br/>
         </div>
         : null

--- a/src/project/datasets/new/DatasetNew.present.js
+++ b/src/project/datasets/new/DatasetNew.present.js
@@ -26,6 +26,7 @@
 
 import React from "react";
 import { Col, Alert, Button } from "reactstrap";
+import { Link } from "react-router-dom";
 import { FormPanel } from "../../../utils/formgenerator";
 import { ACCESS_LEVELS } from "../../../api-client";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -35,15 +36,6 @@ import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
 function DatasetNew(props) {
 
   const getServerWarnings = () => {
-    const tooLongText = "The Knowledge Graph has not finished updating.  The new dataset/files" +
-    " will not be visible until this is complete, but you can continue to work freely within RenkuLab.";
-    if (props.jobsStats.failed.length === 0 && props.jobsStats.inProgress.length === 0 && props.jobsStats.tooLong) {
-      return <div>
-        {tooLongText}
-        <br/>
-        You can keep on working while this operation is running.
-      </div>;
-    }
     const failed = props.jobsStats.failed
       .map(job => <div key={"warn-" + job.file_url} className="pl-2">- {job.file_url}<br /></div>);
     const progress = props.jobsStats.inProgress
@@ -51,7 +43,10 @@ function DatasetNew(props) {
     return <div>
       {props.jobsStats.tooLong ?
         <div>
-          {tooLongText}
+          This operation is taking too long and it will continue being processed in the background.<br />
+          Please check the datasets list in a while to make sure that the changes are there. <br />
+          You can also check the <Link to={props.overviewCommitsUrl}>commits list
+          </Link> in the project and see if the new change was pushed.
           <br/><br/>
         </div>
         : null
@@ -70,8 +65,6 @@ function DatasetNew(props) {
         </div>
         : null}
       <br /><br />
-      <strong>The dataset has been created, but some files are still being processed.
-        They will become visible when processing completes.</strong>
     </div>;
   };
 
@@ -97,7 +90,8 @@ function DatasetNew(props) {
     disableAll={props.warningOn.current === true}
     cancelBtnName={props.warningOn.current ? "Go to list" : "Cancel"}
     submitLoader={{ value: props.submitLoader, text: "Creating dataset, please wait..." }}
-    onCancel={props.onCancel} />;
+    onCancel={props.onCancel}
+  />;
 
 
 }


### PR DESCRIPTION
Dataset info for projects is partially retrieved from the core service.

--> Dataset List is almost the same, I only took out the number of projects a dataset is in and replaced it for information about whether the dataset is or not in the KG:
![image](https://user-images.githubusercontent.com/42647877/92418374-8136d000-f167-11ea-8012-b81895ce7206.png)

--> Dataset list for projects that are not in the KG is now visible:
![image](https://user-images.githubusercontent.com/42647877/92418410-a4617f80-f167-11ea-852e-d0d8544a77f1.png)

--> Inside datasets that are not in the KG: (this can be because the entire project doesn't have the kg activated or because the kg is building)
![image](https://user-images.githubusercontent.com/42647877/92418430-b6432280-f167-11ea-9480-75f5be03c5af.png) 

--> Datasets that are not in the KG have the "add to project" button disabled.

There are no major changes that are visible in dataset preview, add and edit. This operations run much faster because they don't wait for the KG. Messages about KG errors were removed. 

When the planets are aligned all works much smoother, I have experienced some problems with the core but I think this is because things are running in production. Sam also mentioned some problems with the KG.
 
This is ready to be tested.

Preview: will be available soon, i built an image but there is something wrong with it.

To test in your own env you need to use virfried/renku-core:0.11.1-2b4d54e4 in the core service... This is a build from https://github.com/SwissDataScienceCenter/renku-python/pull/1508

Closes #997 