### PR TITLE
Get all code resources from webpack

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -13,7 +13,7 @@
     <link rel="apple-touch-icon" sizes="180x180" href="%PUBLIC_URL%/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="%PUBLIC_URL%/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="%PUBLIC_URL%/favicon-16x16.png">
-    <link rel="mask-icon" href="%PUBLIC_URL%/safari-pinned-tab.svg" color="#5bbad5">    
+    <link rel="mask-icon" href="%PUBLIC_URL%/safari-pinned-tab.svg" color="#5bbad5">
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
@@ -40,9 +40,5 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-    <!-- TODO Get these from webpack -->
-    <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.3/umd/popper.min.js" integrity="sha384-vFJXuSJphROIrBnz7yo7oB41mKfc8JzQZiCq4NCceLEaO4IHwicKwpJf9c9IpFgh" crossorigin="anonymous"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.2/js/bootstrap.min.js" integrity="sha384-alpBpkh1PFOepccYVYDB4do5UnbKysX5WZXm3XxPqe5iKTfUKjNkCk9SaVuEZflJ" crossorigin="anonymous"></script>
   </body>
 </html>

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,8 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { connect } from "react-redux";
 import * as Sentry from "@sentry/browser";
+import "bootstrap";
+import "jquery";
 // Use our version of bootstrap, not the one in import 'bootstrap/dist/css/bootstrap.css';
 import "./styles/index.css";
 import "./index.css";


### PR DESCRIPTION
All code resources are retrieved from the renkulab server.

Before, `jquery`, `popper`, and `bootstrap` were retrieved from the web.

Compare before change:
<img width="1374" alt="image" src="https://user-images.githubusercontent.com/1196411/92933200-3efede80-f446-11ea-80a5-871e2e5cff97.png">

With after:

Compare (new):
<img width="1374" alt="image" src="https://user-images.githubusercontent.com/1196411/92933155-2d1d3b80-f446-11ea-870a-ffd91a37dd3a.png">

Now, only the Source Code Pro font is retrieved from the web, but if this is missing, it shouldn't cause a major problem for the UI, since it will default to another monospaced font.

The new version can be tested on https://sekhar.dev.renku.ch/

Fix #1027