### PR TITLE
feat: client side notification system (core)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6654,6 +6654,11 @@
         "cssom": "0.3.x"
       }
     },
+    "csstype": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.3.tgz",
+      "integrity": "sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag=="
+    },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -17212,6 +17217,51 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
           "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
+        }
+      }
+    },
+    "react-toastify": {
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-6.0.8.tgz",
+      "integrity": "sha512-NSqCNwv+C4IfR+c92PFZiNyeBwOJvigrP2bcRi2f6Hg3WqcHhEHOknbSQOs9QDFuqUjmK3SOrdvScQ3z63ifXg==",
+      "requires": {
+        "classnames": "^2.2.6",
+        "prop-types": "^15.7.2",
+        "react-transition-group": "^4.4.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.11.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+          "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "dom-helpers": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.0.tgz",
+          "integrity": "sha512-Ru5o9+V8CpunKnz5LGgWXkmrH/20cGKwcHwS4m73zIvs54CN9epEmT/HLqFJW3kXpakAFkEdzgy1hzlJe3E4OQ==",
+          "requires": {
+            "@babel/runtime": "^7.8.7",
+            "csstype": "^3.0.2"
+          }
+        },
+        "react-transition-group": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",
+          "integrity": "sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==",
+          "requires": {
+            "@babel/runtime": "^7.5.5",
+            "dom-helpers": "^5.0.1",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "react-motion": "^0.5.2",
     "react-redux": "^5.0.6",
     "react-router-dom": "^5.1.2",
+    "react-toastify": "^6.0.8",
     "reactstrap": "^8.1.1",
     "redux": "^4.0.4",
     "redux-thunk": "^2.2.0",

--- a/src/App.js
+++ b/src/App.js
@@ -23,9 +23,9 @@
  *  Coordinator for the application.
  */
 
-import React, { Component } from "react";
+import React, { Component, Fragment } from "react";
 import { Jumbotron } from "reactstrap";
-import { BrowserRouter as Router, Route, Switch, Redirect } from "react-router-dom";
+import { Route, Switch, Redirect } from "react-router-dom";
 import { ToastContainer } from "react-toastify";
 
 import Project from "./project/Project";
@@ -61,106 +61,104 @@ class App extends Component {
     const blockAnonymous = !user.logged && !this.props.params["ANONYMOUS_SESSIONS"];
 
     // setup notification system
-    const notifications = new NotificationsManager(this.props.model, this.props.client);
+    const notifications = new NotificationsManager(this.props.model, this.props.client, this.props.location);
 
     return (
-      <Router>
-        <div>
-          <Route render={props =>
-            <RenkuNavBar {...props} {...this.props} notifications={notifications} />
-          } />
-          <main role="main" className="container-fluid">
-            <div key="gap">&nbsp;</div>
-            <Switch>
-              {/* Route forces trailing slashes on routes ending with a numerical id */}
-              <Route exact path="/login" render={
-                p => <Login key="login" {...p} {...this.props} />} />
-              <Route exact strict path="/*(\d+)" render={props => <Redirect to={`${props.location.pathname}/`} />} />
-              <Route exact path="/" render={
-                p => <Landing.Home
-                  key="landing" welcomePage={this.props.params["WELCOME_PAGE"]}
-                  user={this.props.user}
-                  client={this.props.client}
-                  model={this.props.model}
-                  statuspageId={this.props.statuspageId}
-                  {...p} />} />
-              <Route path="/help" render={
-                p => <Help key="help" {...p} statuspageId={this.props.statuspageId} {...this.props} />} />
-              <Route exact path={["/projects", "/projects/starred", "/projects/all"]} render={
-                p => <Project.List
-                  key="projects"
-                  user={this.props.user}
-                  client={this.props.client}
-                  statusSummary={this.props.statusSummary}
-                  {...p}
-                />}
-              />
-              <Route exact path="/projects/new" render={
-                p => <Project.New
-                  key="newProject"
-                  client={this.props.client}
-                  model={this.props.model}
-                  user={this.props.user}
-                  templates={this.props.params["TEMPLATES"]}
-                  {...p}
-                />}
-              />
-              <Route path="/projects/:subUrl+" render={
-                p => <Project.View
-                  key={`${p.match.params.projectNamespace}/${p.match.params.projectName}`}
-                  projectPathWithNamespace={`${p.match.params.projectNamespace}/${p.match.params.projectName}`}
-                  client={this.props.client}
-                  params={this.props.params}
-                  model={this.props.model}
-                  user={this.props.user}
-                  blockAnonymous={blockAnonymous}
-                  notifications={notifications}
-                  {...p}
-                />}
-              />
-              <Route exact path="/environments" render={
-                p => <Notebooks
-                  key="environments"
-                  standalone={true}
-                  client={this.props.client}
-                  model={this.props.model}
-                  blockAnonymous={blockAnonymous}
-                  {...p}
-                />}
-              />
-              <Route path="/datasets/:identifier" render={
-                p => <ShowDataset
-                  key="datasetpreview" {...p}
-                  insideProject={false}
-                  identifier={`${p.match.params.identifier}`}
-                  client={this.props.client}
-                  projectsUrl="/projects"
-                  selectedDataset={p.match.params.datasetId}
-                  logged={this.props.user.logged}
-                  model={this.props.model}
-                />}
-              />
-              <Route path="/datasets" render={
-                p => <DatasetList key="datasets"
-                  client={this.props.client}
-                  model={this.props.model}
-                  {...p}
-                />}
-              />
-              <Route path="/privacy" render={
-                p => <Privacy key="privacy"
-                  params={this.props.params}
-                  {...p}
-                />}
-              />
-              <Route path="*" render={p => <NotFound {...p} />} />
-            </Switch>
-          </main>
-          <Route render={props => <FooterNavbar {...props} params={this.props.params} />} />
-          <Route render={props => <Cookie {...props} params={this.props.params} />} />
-          <ToastContainer />
-        </div>
-      </Router>
+      <Fragment>
+        <Route render={props =>
+          <RenkuNavBar {...props} {...this.props} notifications={notifications} />
+        } />
+        <main role="main" className="container-fluid">
+          <div key="gap">&nbsp;</div>
+          <Switch>
+            {/* Route forces trailing slashes on routes ending with a numerical id */}
+            <Route exact path="/login" render={
+              p => <Login key="login" {...p} {...this.props} />} />
+            <Route exact strict path="/*(\d+)" render={props => <Redirect to={`${props.location.pathname}/`} />} />
+            <Route exact path="/" render={
+              p => <Landing.Home
+                key="landing" welcomePage={this.props.params["WELCOME_PAGE"]}
+                user={this.props.user}
+                client={this.props.client}
+                model={this.props.model}
+                statuspageId={this.props.statuspageId}
+                {...p} />} />
+            <Route path="/help" render={
+              p => <Help key="help" {...p} statuspageId={this.props.statuspageId} {...this.props} />} />
+            <Route exact path={["/projects", "/projects/starred", "/projects/all"]} render={
+              p => <Project.List
+                key="projects"
+                user={this.props.user}
+                client={this.props.client}
+                statusSummary={this.props.statusSummary}
+                {...p}
+              />}
+            />
+            <Route exact path="/projects/new" render={
+              p => <Project.New
+                key="newProject"
+                client={this.props.client}
+                model={this.props.model}
+                user={this.props.user}
+                templates={this.props.params["TEMPLATES"]}
+                {...p}
+              />}
+            />
+            <Route path="/projects/:subUrl+" render={
+              p => <Project.View
+                key={`${p.match.params.projectNamespace}/${p.match.params.projectName}`}
+                projectPathWithNamespace={`${p.match.params.projectNamespace}/${p.match.params.projectName}`}
+                client={this.props.client}
+                params={this.props.params}
+                model={this.props.model}
+                user={this.props.user}
+                blockAnonymous={blockAnonymous}
+                notifications={notifications}
+                {...p}
+              />}
+            />
+            <Route exact path="/environments" render={
+              p => <Notebooks
+                key="environments"
+                standalone={true}
+                client={this.props.client}
+                model={this.props.model}
+                blockAnonymous={blockAnonymous}
+                {...p}
+              />}
+            />
+            <Route path="/datasets/:identifier" render={
+              p => <ShowDataset
+                key="datasetpreview" {...p}
+                insideProject={false}
+                identifier={`${p.match.params.identifier}`}
+                client={this.props.client}
+                projectsUrl="/projects"
+                selectedDataset={p.match.params.datasetId}
+                logged={this.props.user.logged}
+                model={this.props.model}
+              />}
+            />
+            <Route path="/datasets" render={
+              p => <DatasetList key="datasets"
+                client={this.props.client}
+                model={this.props.model}
+                {...p}
+              />}
+            />
+            <Route path="/privacy" render={
+              p => <Privacy key="privacy"
+                params={this.props.params}
+                {...p}
+              />}
+            />
+            <Route path="*" render={p => <NotFound {...p} />} />
+          </Switch>
+        </main>
+        <Route render={props => <FooterNavbar {...props} params={this.props.params} />} />
+        <Route render={props => <Cookie {...props} params={this.props.params} />} />
+        <ToastContainer />
+      </Fragment>
     );
 
   }

--- a/src/App.js
+++ b/src/App.js
@@ -38,7 +38,7 @@ import NotFound from "./not-found";
 import ShowDataset from "./dataset/Dataset.container";
 import { Loader } from "./utils/UIComponents";
 import { Cookie, Privacy } from "./privacy";
-import { NotificationsManager } from "./notifications";
+import { NotificationsManager, NotificationsPage } from "./notifications";
 
 import "./App.css";
 import "react-toastify/dist/ReactToastify.css";
@@ -149,6 +149,14 @@ class App extends Component {
             <Route path="/privacy" render={
               p => <Privacy key="privacy"
                 params={this.props.params}
+                {...p}
+              />}
+            />
+            <Route path="/notifications" render={
+              p => <NotificationsPage key="notifications"
+                client={this.props.client}
+                model={this.props.model}
+                notifications={notifications}
                 {...p}
               />}
             />

--- a/src/App.js
+++ b/src/App.js
@@ -26,6 +26,7 @@
 import React, { Component } from "react";
 import { Jumbotron } from "reactstrap";
 import { BrowserRouter as Router, Route, Switch, Redirect } from "react-router-dom";
+import { ToastContainer } from "react-toastify";
 
 import Project from "./project/Project";
 import DatasetList from "./dataset/list/DatasetList.container";
@@ -37,12 +38,15 @@ import NotFound from "./not-found";
 import ShowDataset from "./dataset/Dataset.container";
 import { Loader } from "./utils/UIComponents";
 import { Cookie, Privacy } from "./privacy";
+import { Notifications } from "./notifications";
 
 import "./App.css";
+import "react-toastify/dist/ReactToastify.css";
 
 
 class App extends Component {
   render() {
+    // Avoid rendering the application while authenticating the user
     const { user } = this.props;
     if (!user.fetched && user.fetching) {
       return (
@@ -56,11 +60,14 @@ class App extends Component {
     // check anonymous sessions settings
     const blockAnonymous = !user.logged && !this.props.params["ANONYMOUS_SESSIONS"];
 
+    // setup notification system
+    const notifications = Notifications({ client: this.props.client, model: this.props.model });
+
     return (
       <Router>
         <div>
           <Route render={props =>
-            <RenkuNavBar {...props} {...this.props} />
+            <RenkuNavBar {...props} {...this.props} notifications={notifications} />
           } />
           <main role="main" className="container-fluid">
             <div key="gap">&nbsp;</div>
@@ -107,6 +114,7 @@ class App extends Component {
                   model={this.props.model}
                   user={this.props.user}
                   blockAnonymous={blockAnonymous}
+                  notifications={notifications}
                   {...p}
                 />}
               />
@@ -150,6 +158,7 @@ class App extends Component {
           </main>
           <Route render={props => <FooterNavbar {...props} params={this.props.params} />} />
           <Route render={props => <Cookie {...props} params={this.props.params} />} />
+          <ToastContainer />
         </div>
       </Router>
     );

--- a/src/App.js
+++ b/src/App.js
@@ -38,7 +38,7 @@ import NotFound from "./not-found";
 import ShowDataset from "./dataset/Dataset.container";
 import { Loader } from "./utils/UIComponents";
 import { Cookie, Privacy } from "./privacy";
-import { Notifications } from "./notifications";
+import { NotificationsManager } from "./notifications";
 
 import "./App.css";
 import "react-toastify/dist/ReactToastify.css";
@@ -61,7 +61,7 @@ class App extends Component {
     const blockAnonymous = !user.logged && !this.props.params["ANONYMOUS_SESSIONS"];
 
     // setup notification system
-    const notifications = Notifications({ client: this.props.client, model: this.props.model });
+    const notifications = new NotificationsManager(this.props.model, this.props.client);
 
     return (
       <Router>

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,23 +1,23 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import App from "./App";
+import { BrowserRouter as Router } from "react-router-dom";
 
+import App from "./App";
 import { testClient as client } from "./api-client";
 import { StateModel, globalSchema } from "./model";
 import { generateFakeUser } from "./user/User.test";
 
 describe("rendering", () => {
   const model = new StateModel(globalSchema);
+  const params = { WELCOME_PAGE: "Some text", STATUSPAGE_ID: "5bcn9bqff4qt" };
 
   it("renders anonymous user without crashing", () => {
     const div = document.createElement("div");
     const user = generateFakeUser(true);
     ReactDOM.render(
-      <App
-        client={client}
-        model={model}
-        user={user}
-        params={{ WELCOME_PAGE: "Some text", STATUSPAGE_ID: "5bcn9bqff4qt" }} />
+      <Router>
+        <App client={client} model={model} user={user} params={params} />
+      </Router>
       , div);
   });
 
@@ -25,11 +25,9 @@ describe("rendering", () => {
     const div = document.createElement("div");
     const user = generateFakeUser();
     ReactDOM.render(
-      <App
-        client={client}
-        model={model}
-        user={user}
-        params={{ WELCOME_PAGE: "Some text", STATUSPAGE_ID: "5bcn9bqff4qt" }} />
+      <Router>
+        <App client={client} model={model} user={user} params={params} />
+      </Router>
       , div);
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import { connect } from "react-redux";
+import { BrowserRouter as Router, Route } from "react-router-dom";
 import * as Sentry from "@sentry/browser";
 import "bootstrap";
 import "jquery";
@@ -84,8 +85,12 @@ Promise.all([configFetch, privacyFetch]).then(valuesRead => {
 
     const VisibleApp = connect(mapStateToProps)(App);
     ReactDOM.render(
-      <VisibleApp client={client} params={params} store={model.reduxStore} model={model}
-        statuspageId={statuspageId} />,
+      <Router>
+        <Route render={props =>
+          <VisibleApp client={client} params={params} store={model.reduxStore} model={model}
+            statuspageId={statuspageId} location={props.location} />
+        } />
+      </Router>,
       document.getElementById("root")
     );
   });

--- a/src/landing/NavBar.js
+++ b/src/landing/NavBar.js
@@ -25,7 +25,7 @@
 
 import React, { Component } from "react";
 import { Link } from "react-router-dom";
-import { DropdownItem, Navbar, Nav } from "reactstrap";
+import { UncontrolledDropdown, DropdownItem, Navbar, Nav } from "reactstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPlus } from "@fortawesome/free-solid-svg-icons";
 import { faQuestionCircle } from "@fortawesome/free-regular-svg-icons";
@@ -35,6 +35,7 @@ import logo from "./logo.svg";
 import { ExternalDocsLink, ExternalLink, Loader, RenkuNavLink, UserAvatar } from "../utils/UIComponents";
 import { getActiveProjectPathWithNamespace, gitLabUrlFromProfileUrl } from "../utils/HelperFunctions";
 import QuickNav from "../utils/quicknav";
+import { NotificationsMenu } from "../notifications";
 
 import "./NavBar.css";
 
@@ -168,6 +169,16 @@ function RenkuToolbarGitLabMenu(props) {
   </li>;
 }
 
+function RenkuToolbarNotifications(props) {
+  if (!props.notifications)
+    return null;
+
+  return (
+    <UncontrolledDropdown>
+      <NotificationsMenu {...props} />
+    </UncontrolledDropdown>
+  );
+}
 
 class LoggedInNavBar extends Component {
 
@@ -222,6 +233,7 @@ class LoggedInNavBar extends Component {
                 <RenkuToolbarItemPlus currentPath={this.props.location.pathname} />
                 <RenkuToolbarGitLabMenu user={this.props.user} />
                 <RenkuToolbarHelpMenu />
+                <RenkuToolbarNotifications {...this.props} />
                 <RenkuToolbarItemUser {...this.props} />
               </ul>
             </div>

--- a/src/model/GlobalSchema.js
+++ b/src/model/GlobalSchema.js
@@ -26,7 +26,7 @@
 import { Schema, PropertyName as Prop } from "./index";
 import {
   notebooksSchema, userSchema, projectsSchema, projectGlobalSchema, newProjectSchema,
-  statuspageSchema
+  statuspageSchema, notificationsSchema
 } from "./RenkuModels";
 
 const globalSchema = new Schema({
@@ -35,7 +35,8 @@ const globalSchema = new Schema({
   projects: { [Prop.SCHEMA]: projectsSchema },
   project: { [Prop.SCHEMA]: projectGlobalSchema },
   newProject: { [Prop.SCHEMA]: newProjectSchema },
-  statuspage: { [Prop.SCHEMA]: statuspageSchema }
+  statuspage: { [Prop.SCHEMA]: statuspageSchema },
+  notifications: { [Prop.SCHEMA]: notificationsSchema }
 });
 
 export { globalSchema };

--- a/src/model/RenkuModels.js
+++ b/src/model/RenkuModels.js
@@ -469,9 +469,20 @@ const statuspageSchema = new Schema({
   error: { initial: null }
 });
 
+const notificationsSchema = new Schema({
+  unread: { [Prop.INITIAL]: 0, [Prop.MANDATORY]: true },
+  all: { [Prop.INITIAL]: [], [Prop.MANDATORY]: true },
+  toast: {
+    [Prop.SCHEMA]: new Schema({
+      enabled: { [Prop.INITIAL]: true, [Prop.MANDATORY]: true },
+      timeout: { [Prop.INITIAL]: 5000, [Prop.MANDATORY]: true },
+      position: { [Prop.INITIAL]: "top-right", [Prop.MANDATORY]: true },
+    })
+  }
+});
 
 export {
   userSchema, metaSchema, newProjectSchema, projectSchema, forkProjectSchema, notebooksSchema,
   projectsSchema, datasetFormSchema, issueFormSchema, datasetImportFormSchema, projectGlobalSchema,
-  addDatasetToProjectSchema, statuspageSchema
+  addDatasetToProjectSchema, statuspageSchema, notificationsSchema
 };

--- a/src/notebooks/Notebooks.container.js
+++ b/src/notebooks/Notebooks.container.js
@@ -19,10 +19,10 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
 
-import { NotebooksCoordinator } from "./Notebooks.state";
-import { StartNotebookServer as StartNotebookServerPresent, NotebooksDisabled } from "./Notebooks.present";
-import { Notebooks as NotebooksPresent } from "./Notebooks.present";
-import { CheckNotebookIcon } from "./Notebooks.present";
+import { NotebooksCoordinator, ExpectedAnnotations } from "./Notebooks.state";
+import {
+  StartNotebookServer as StartNotebookServerPresent, NotebooksDisabled, Notebooks as NotebooksPresent, CheckNotebookIcon
+} from "./Notebooks.present";
 import { StatusHelper } from "../model/Model";
 import { ProjectCoordinator } from "../project";
 
@@ -75,6 +75,7 @@ class Notebooks extends Component {
     this.coordinator.stopNotebookPolling();
   }
 
+  // TODO: add info notification here
   stopNotebook(serverName, force) {
     this.coordinator.stopNotebook(serverName, force);
   }
@@ -135,6 +136,7 @@ class Notebooks extends Component {
  * @param {string} scope.project - path of the reference project
  * @param {string} externalUrl - GitLabl repository url
  * @param {boolean} blockAnonymous - When true, block non logged in users
+ * @param {Object} notifications - Notifications object
  * @param {Object} [location] - react location object. Use location.state.successUrl to inidcate the
  *     redirect url to be used when a notebook is succesfully started
  * @param {Object} [history] - mandatory if successUrl is provided
@@ -149,6 +151,7 @@ class StartNotebookServer extends Component {
     // TODO: this should go away when moving all project content to projectCoordinator
     this.projectModel = props.model.subModel("project");
     this.projectCoordinator = new ProjectCoordinator(props.client, props.model.subModel("project"));
+    this.notifications = props.notifications;
     // temporarily reset data since notebooks model was not designed to be static
     this.coordinator.reset();
 
@@ -328,9 +331,26 @@ class StartNotebookServer extends Component {
   internalStartServer() {
     // The core internal logic extracted here for re-use
     const { location, history } = this.props;
-    return this.coordinator.startServer().then(() => {
+    return this.coordinator.startServer().then((data) => {
       this.setState({ "starting": false });
-      if (history && location && location.state && location.state.successUrl)
+      const resources = Object.keys(data.resources).map(res => `${res}: ${data.resources[res]}`);
+      const projectData = Object.keys(data.annotations)
+        .filter(elem => elem.startsWith(ExpectedAnnotations.domain))
+        .map(elem => `${elem.substring(ExpectedAnnotations.domain.length + 1)}: ${data.annotations[elem]}`);
+      const fullDescription = `Interactive environment will start soon.
+      Reference URL: ${data.url}
+      Source project: ${projectData.join("\n")}
+      List of resources: ${resources.join("\n")}
+      `;
+      this.notifications.addSuccess(
+        this.notifications.Topics.ENVIRONMENT_START,
+        "The interactive environment is starting",
+        data.url, "Open environment",
+        fullDescription
+      );
+      if (!history || !location)
+        return;
+      if (location.state && location.state.successUrl && history.location.pathname === location.pathname)
         history.push(location.state.successUrl);
     });
   }
@@ -343,9 +363,15 @@ class StartNotebookServer extends Component {
       // Some failures just go away. Try again to see if it works the second time.
       setTimeout(() => {
         this.internalStartServer().catch((error) => {
-          // TODO: #991
-          // eslint-disable-next-line no-console
-          console.log(["Could not start server", error]);
+          const fullError = `An error occurred when trying to start a new Interactive environment.
+          Error message: "${error.message}",
+          Stack trace: ${error.stack}
+          `;
+          this.notifications.addWarning(
+            this.notifications.Topics.ENVIRONMENT_START,
+            "Unable to start the interactive environment. Error message: " + error.message,
+            this.props.location.pathname, "Try again",
+            fullError);
           this.setState({ "starting": false, launchError: error.message });
         });
       }, 3000);

--- a/src/notebooks/Notebooks.container.js
+++ b/src/notebooks/Notebooks.container.js
@@ -346,6 +346,7 @@ class StartNotebookServer extends Component {
         this.notifications.Topics.ENVIRONMENT_START,
         "The interactive environment is starting",
         data.url, "Open environment",
+        [location.state.successUrl, "/environments"],
         fullDescription
       );
       if (!history || !location)

--- a/src/notifications/Notifications.container.js
+++ b/src/notifications/Notifications.container.js
@@ -1,0 +1,127 @@
+/*!
+ * Copyright 2020 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  Notifications.container.js
+ *  Container components for notifications
+ */
+
+import React, { Component } from "react";
+import { toast } from "react-toastify";
+import { connect } from "react-redux";
+
+import { NotificationsCoordinator, Notifications as NotificationsInfo } from "./Notifications.state";
+import { Notification, CloseToast, NotificationsMenu as NotificationsMenuPresent } from "./Notifications.present";
+
+
+/**
+ * Notifications component
+ *
+ * @param {object} client
+ * @param {object} model
+ */
+const Notifications = (props) => {
+  const model = props.model.subModel("notifications");
+  const coordinator = new NotificationsCoordinator(props.client, model);
+  const { Levels, Topics } = NotificationsInfo;
+
+  // get toast settings -- can't be static anymore once users will be able to change settings from the UI
+  const settings = coordinator.getToastSettings();
+
+  /**
+   * Add a notification to the list
+   *
+   * @param {string} level - notification level as in NotificationsInfo.Levels
+   * @param {string} topic - general topic as in NotificationsInfo.Topics
+   * @param {string} desc - short description/information.
+   * @param {string} [link] - source page or target page relevant for a follow up.
+   * @param {string} [linkText] - text to show on the link.
+   * @param {string} [longDesc] - detailed description of what happened.
+   */
+  const add = (level, topic, desc, link, linkText, longDesc) => {
+    const notification = coordinator.addNotification(level, topic, desc, link, linkText, longDesc);
+    if (settings.enabled && level !== Levels.INFO) {
+      const markRead = () => { coordinator.markRead(notification.id); };
+      let options = {
+        closeOnClick: false,
+        toastId: `toast-${notification.id}`,
+        className: level.toLowerCase(),
+        position: settings.position,
+        autoClose: settings.timeout ? settings.timeout : false,
+        closeButton: <CloseToast markRead={markRead} />
+      };
+      const toastPresent = (<Notification notification={notification} settings={settings} markRead={markRead} />);
+      toast(toastPresent, options );
+    }
+  };
+
+  const addInfo = (topic, desc, link, linkText, longDesc) => {
+    return add(Levels.INFO, topic, desc, link, linkText, longDesc);
+  };
+  const addSuccess = (topic, desc, link, linkText, longDesc) => {
+    return add(Levels.SUCCESS, topic, desc, link, linkText, longDesc);
+  };
+  const addWarning = (topic, desc, link, linkText, longDesc) => {
+    return add(Levels.WARNING, topic, desc, link, linkText, longDesc);
+  };
+  const addError = (topic, desc, link, linkText, longDesc) => {
+    return add(Levels.ERROR, topic, desc, link, linkText, longDesc);
+  };
+
+  return { Levels, Topics, add, addInfo, addSuccess, addWarning, addError };
+};
+
+/**
+ * NotificationsMenu component
+ *
+ * @param {object} xxx
+ */
+class NotificationsMenu extends Component {
+  constructor(props) {
+    super(props);
+    this.model = props.model.subModel("notifications");
+    this.coordinator = new NotificationsCoordinator(props.client, this.model);
+
+    this.handlers = {
+      markRead: this.markRead.bind(this),
+    };
+  }
+
+  markRead(id) {
+    this.coordinator.markRead(id);
+  }
+
+  mapStateToProps(state, ownProps) {
+    return {
+      handlers: this.handlers,
+      notifications: state.notifications.all,
+      unread: state.notifications.unread
+    };
+  }
+
+  render() {
+    const VisibleNotificationsMenu = connect(this.mapStateToProps.bind(this))(NotificationsMenuPresent);
+    return (<VisibleNotificationsMenu
+      store={this.model.reduxStore}
+      levels={this.props.notifications.Levels} />);
+  }
+}
+
+export { Notifications, NotificationsMenu };

--- a/src/notifications/Notifications.container.js
+++ b/src/notifications/Notifications.container.js
@@ -101,7 +101,74 @@ class NotificationsMenu extends Component {
 
     this.handlers = {
       markRead: this.markRead.bind(this),
+      addMultipleNotifications: this.addMultipleNotifications.bind(this), // ! TEMP - only for testing
+      addRandomNotification: this.addRandomNotification.bind(this), // ! TEMP - only for testing
     };
+  }
+
+  // ! TEMP - only for testing
+  addMultipleNotifications() {
+    const { notifications } = this.props;
+    notifications.addWarning(
+      notifications.Topics.DATASET_CREATE,
+      "Warning test with external link",
+      "https://getbootstrap.com",
+      "External link");
+    notifications.addSuccess(
+      notifications.Topics.ENVIRONMENT_START,
+      "Environment xyz has started, you can now access it.",
+      "/environments",
+      "Environments list");
+    notifications.addInfo(
+      "Fake topic Info",
+      "I'm an info, I shouldn't appear",
+      "/",
+      "Home");
+    notifications.addError(
+      notifications.Topics.ENVIRONMENT_START,
+      "Test - environment couldn't start",
+      "/environments",
+      "Environments list");
+  }
+  // ! TEMP - only for testing
+  addRandomNotification() {
+    const { notifications } = this.props;
+    const rdn = Math.random();
+    let level, topic, desc, link, linkText;
+    if (rdn < 0.3) {
+      level = notifications.Levels.INFO;
+      topic = "Random info";
+      desc = "Randomly generated info notification";
+    }
+    else if (rdn < 0.6) {
+      level = notifications.Levels.SUCCESS;
+      topic = "Random success";
+      desc = "Randomly generated success notification";
+      if (rdn < 0.5) {
+        link = "/";
+        linkText = "Check home";
+      }
+      else {
+        link = "https://getbootstrap.com";
+        linkText = "External link";
+      }
+    }
+    else if (rdn < 0.8) {
+      level = notifications.Levels.WARNING;
+      topic = "Random warning";
+      desc = "Randomly generated success warning";
+      link = "/environments";
+      linkText = "Environments list";
+    }
+    else {
+      level = notifications.Levels.ERROR;
+      topic = "Random error";
+      desc = "Randomly generated success error";
+      link = "https://github.com/fkhadra/react-toastify";
+      linkText = "Toastify library";
+    }
+
+    notifications.add(level, topic, desc, link, linkText);
   }
 
   markRead(id) {

--- a/src/notifications/Notifications.container.js
+++ b/src/notifications/Notifications.container.js
@@ -32,10 +32,10 @@ import { Notification, CloseToast, NotificationsMenu as NotificationsMenuPresent
 
 
 /**
- * Notifications component
+ * Notifications object - it's not a React component.
  *
- * @param {object} client
- * @param {object} model
+ * @param {Object} client - api-client used to query the gateway
+ * @param {Object} model - global model for the ui
  */
 const Notifications = (props) => {
   const model = props.model.subModel("notifications");
@@ -91,7 +91,9 @@ const Notifications = (props) => {
 /**
  * NotificationsMenu component
  *
- * @param {object} xxx
+ * @param {Object} client - api-client used to query the gateway
+ * @param {Object} model - global model for the ui
+ * @param {Object} notifications - global notifications object
  */
 class NotificationsMenu extends Component {
   constructor(props) {

--- a/src/notifications/Notifications.css
+++ b/src/notifications/Notifications.css
@@ -58,16 +58,47 @@
 }
 
 .notification-list-container {
-  padding: 4px;
+  padding: 0;
 }
 
-.notification-list-container .notification-list-item {
-  margin-bottom: 8px !important;
-}
-.notification-list-container .notification-list-item:last-of-type {
-  margin-bottom: 0 !important;
+.notification-list-item {
+  font-size: 80%;
+  padding: 8px;
+  position: relative;
+  
 }
 
-.notification-list-container .font16 {
-  font-size: 16px;
+.notification-list-item:not(:last-of-type) {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.15);
+}
+.notification-list-item:first-of-type {
+  padding-top: 0;
+}
+.notification-list-item:last-of-type {
+  padding-bottom: 0;
+}
+
+.notification-list-item .close-icon {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+}
+
+.notification-list-item p {
+  margin-bottom: 4px;
+}
+
+.notification-list-item h5 {
+  margin-bottom: 4px;
+  font-size: 120%;
+}
+
+.notification-list-item.success svg.svg-inline--fa {
+  color: #28a745
+}
+.notification-list-item.warning svg.svg-inline--fa {
+  color: #ffc107
+}
+.notification-list-item.error svg.svg-inline--fa {
+  color: #dc3545
 }

--- a/src/notifications/Notifications.css
+++ b/src/notifications/Notifications.css
@@ -50,15 +50,34 @@
 }
 
 
-/* Menu components */
+/* Notification components */
 
 .notification-badge {
   font-size: 10px;
   position: absolute;
 }
 
+.notification.info svg.svg-inline--fa {
+  color: #5561A6
+}
+.notification.success svg.svg-inline--fa {
+  color: #28a745
+}
+.notification.warning svg.svg-inline--fa {
+  color: #ffc107
+}
+.notification.error svg.svg-inline--fa {
+  color: #dc3545
+}
+
+.notification-menu > a {
+  text-decoration: none;
+}
+
 .notification-list-container {
   padding: 0;
+  margin-top: -8px;
+  margin-bottom: -8px;
 }
 
 .notification-list-item {
@@ -70,12 +89,6 @@
 
 .notification-list-item:not(:last-of-type) {
   border-bottom: 1px solid rgba(0, 0, 0, 0.15);
-}
-.notification-list-item:first-of-type {
-  padding-top: 0;
-}
-.notification-list-item:last-of-type {
-  padding-bottom: 0;
 }
 
 .notification-list-item .close-icon {
@@ -93,12 +106,34 @@
   font-size: 120%;
 }
 
-.notification-list-item.success svg.svg-inline--fa {
-  color: #28a745
+.notification-page-item {
+  margin: 12px 0;
+  border-top: 1px solid #dee2e6;
 }
-.notification-list-item.warning svg.svg-inline--fa {
-  color: #ffc107
+
+.notification-page-item > div.notification {
+  margin: 12px 0;
 }
-.notification-list-item.error svg.svg-inline--fa {
-  color: #dc3545
+
+.notification-page-item > .notification p {
+  margin-bottom: 6px;
+}
+
+.notification-page-item > .notification h4 .time-caption {
+  font-size: 70%;
+}
+
+.notification-page-item > .notification.unread {
+  border-left: 5px solid #5561A6;
+  padding-left: 6px;
+}
+
+.notification-page-item > .notification.unread.success {
+  border-color: #28a745;
+}
+.notification-page-item > .notification.unread.warning {
+  border-color: #ffc107;
+}
+.notification-page-item > .notification.unread.error {
+  border-color: #dc3545;
 }

--- a/src/notifications/Notifications.css
+++ b/src/notifications/Notifications.css
@@ -1,0 +1,73 @@
+/* Prevent overwriting defaults: https://fkhadra.github.io/react-toastify/how-to-style */
+.Toastify__toast {
+  font-family: inherit !important;
+  cursor: inherit !important;
+}
+
+.Toastify__toast--default {
+  color: inherit !important;
+}
+
+.Toastify__toast-container {
+  color: inherit !important;
+}
+
+
+/* Customization */
+
+.Toastify__toast {
+  opacity: 0.90;
+}
+
+.Toastify__toast.success {
+  border: 1px solid #28a745 /* #5561A6 */
+}
+.Toastify__toast.success .Toastify__progress-bar {
+  background: #28a745;
+}
+.Toastify__toast.success svg.svg-inline--fa {
+  color: #28a745
+}
+
+.Toastify__toast.warning {
+  border: 1px solid #ffc107
+}
+.Toastify__toast.warning .Toastify__progress-bar {
+  background: #ffc107;
+}
+.Toastify__toast.warning svg.svg-inline--fa {
+  color: #ffc107
+}
+
+.Toastify__toast.error {
+  border: 1px solid #dc3545
+}
+.Toastify__toast.error .Toastify__progress-bar {
+  background: #dc3545;
+}
+.Toastify__toast.error svg.svg-inline--fa {
+  color: #dc3545
+}
+
+
+/* Menu components */
+
+.notification-badge {
+  font-size: 10px;
+  position: absolute;
+}
+
+.notification-list-container {
+  padding: 4px;
+}
+
+.notification-list-container .notification-list-item {
+  margin-bottom: 8px !important;
+}
+.notification-list-container .notification-list-item:last-of-type {
+  margin-bottom: 0 !important;
+}
+
+.notification-list-container .font16 {
+  font-size: 16px;
+}

--- a/src/notifications/Notifications.present.js
+++ b/src/notifications/Notifications.present.js
@@ -146,7 +146,21 @@ class NotificationsMenuList extends Component {
       <Fragment>
         <DropdownItem>Show all notifications</DropdownItem>
         <DropdownItem divider />
+        <NotificationsMenuTesting {...this.props} />
         <div className="notification-list-container">{renderNotifications}</div>
+      </Fragment>
+    );
+  }
+}
+
+class NotificationsMenuTesting extends Component {
+  render() {
+    return (
+      <Fragment>
+        {/* TEST ONLY */}
+        <DropdownItem onClick={() => this.props.handlers.addMultipleNotifications()}>TEST - add multiple</DropdownItem>
+        <DropdownItem onClick={() => this.props.handlers.addRandomNotification()}>TEST - add random</DropdownItem>
+        <DropdownItem divider />
       </Fragment>
     );
   }

--- a/src/notifications/Notifications.present.js
+++ b/src/notifications/Notifications.present.js
@@ -1,0 +1,156 @@
+/*!
+ * Copyright 2020 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  Notifications.present.js
+ *  Presentational components for notifications
+ */
+
+import React, { Component, Fragment } from "react";
+import { Link } from "react-router-dom";
+import { Badge, DropdownMenu, DropdownToggle, DropdownItem } from "reactstrap";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faLink, faInfoCircle, faExclamationTriangle, faInbox, faTimes } from "@fortawesome/free-solid-svg-icons";
+
+import { NotificationsInfo } from ".";
+import { ExternalLink } from "../utils/UIComponents";
+
+import "./Notifications.css";
+
+
+/**
+ * Close button for the toast notification.
+ * REF: https://fkhadra.github.io/react-toastify/use-a-custom-close-button-or-remove-it/
+ *
+ * @param {function} markRead - function to mark the notification as read
+ * @param {function} [closeToast] - function to close the toast notification
+ */
+class CloseToast extends Component {
+  close() {
+    this.props.markRead();
+    if (this.props.closeToast)
+      this.props.closeToast();
+  }
+
+  render() {
+    const addedClasses = this.props.addClasses ? ` ${this.props.addClasses}` : null;
+    const className = `Toastify__close-button Toastify__close-button--default${addedClasses}`;
+
+    return (
+      <button className={className} aria-label="close"
+        onClick={() => { this.close(); }}>
+        <FontAwesomeIcon icon={faTimes} />
+      </button>
+    );
+  }
+}
+
+
+class Notification extends Component {
+  render() {
+    const { notification, settings } = this.props;
+    if (!settings.enabled)
+      return null;
+
+    let link = null;
+    if (notification.link) {
+      const target = notification.link.startsWith("http") ?
+        (<ExternalLink url={notification.link} title={notification.linkText} role="link" showLinkIcon={true}
+          onClick={() => this.props.markRead()} />) :
+        (<Link onClick={() => this.props.markRead()} to={notification.link}>
+          <FontAwesomeIcon icon={faLink} /> {notification.linkText}
+        </Link>);
+      link = (<p className="mb-1">{target}</p>);
+    }
+
+    const icon = notification.level === NotificationsInfo.Levels.SUCCESS ?
+      (<FontAwesomeIcon icon={faInfoCircle} />) :
+      (<FontAwesomeIcon icon={faExclamationTriangle} />);
+
+    return (
+      <div className="small">
+        {this.props.renderCloseButton ? this.props.renderCloseButton : null}
+        <div>
+          <h6>{icon} {notification.topic}</h6>
+        </div>
+        <p className="mb-1">{notification.desc}</p>
+        {link}
+      </div>
+    );
+  }
+}
+
+class NotificationsMenu extends Component {
+  render() {
+    const badge = this.props.unread ?
+      (<Badge color="danger" className="notification-badge">{this.props.unread}</Badge>) :
+      null;
+    return (
+      <Fragment>
+        <DropdownToggle className="nav-link" nav caret>
+          <FontAwesomeIcon icon={faInbox} id="notificationsBarIcon" />
+          {badge}
+        </DropdownToggle>
+        {/* //TODO: adjust the size, maybe with modifiers. REF: https://reactstrap.github.io/components/dropdowns/ */}
+        <DropdownMenu right key="notifications-bar" aria-labelledby="gitLab-menu">
+          <NotificationsMenuList {...this.props} />
+        </DropdownMenu>
+      </Fragment>
+    );
+  }
+}
+
+class NotificationsMenuList extends Component {
+  // TODO: create a different Notification elelemnt? OR just add the timestamp?
+  render() {
+    const settings = { enabled: true };
+    const notifications = this.props.notifications.filter(notification =>
+      notification.level !== this.props.levels.INFO &&
+      !notification.read);
+    let renderNotifications = notifications.map(notification => {
+      const className = "notification-list-item Toastify__toast Toastify__toast--default " +
+        notification.level.toLowerCase();
+      const markRead = () => { this.props.handlers.markRead(notification.id); };
+      const closeButton = (
+        <CloseToast settings={settings} notification={notification} addClasses="float-right font16"
+          markRead={() => markRead()} />
+      );
+      return (
+        <div key={notification.id} className={className}>
+          <Notification settings={settings} notification={notification}
+            renderCloseButton={closeButton} markRead={() => markRead()} />
+        </div>
+      );
+    });
+    if (!renderNotifications.length)
+      renderNotifications = (<DropdownItem className="font-italic">Nothing new</DropdownItem>);
+
+    return (
+      <Fragment>
+        <DropdownItem>Show all notifications</DropdownItem>
+        <DropdownItem divider />
+        <div className="notification-list-container">{renderNotifications}</div>
+      </Fragment>
+    );
+  }
+}
+
+
+export { NotificationsMenu, Notification, CloseToast };

--- a/src/notifications/Notifications.state.js
+++ b/src/notifications/Notifications.state.js
@@ -23,7 +23,7 @@
  *  Notifications controller code.
  */
 
-const Notifications = {
+const NotificationsInfo = {
   Levels: {
     INFO: "info",
     SUCCESS: "success",
@@ -66,11 +66,11 @@ class NotificationsCoordinator {
       link,
       linkText,
       longDesc,
-      read: level === Notifications.Levels.INFO ? true : false
+      read: level === NotificationsInfo.Levels.INFO ? true : false
     };
     const notifications = this.model.get("");
     let updateObject = { all: { $set: [...notifications.all, notification] } };
-    if (level !== Notifications.Levels.INFO)
+    if (level !== NotificationsInfo.Levels.INFO)
       updateObject.unread = notifications.unread + 1;
     this.model.setObject(updateObject);
     return notification;
@@ -95,4 +95,4 @@ class NotificationsCoordinator {
   }
 }
 
-export { Notifications, NotificationsCoordinator };
+export { NotificationsInfo, NotificationsCoordinator };

--- a/src/notifications/Notifications.state.js
+++ b/src/notifications/Notifications.state.js
@@ -100,6 +100,24 @@ class NotificationsCoordinator {
       });
     }
   }
+
+  markAllRead() {
+    const notifications = this.model.get("");
+    let changed = false;
+    const updateAll = notifications.all.map((elem) => {
+      if (!elem.read) {
+        changed = true;
+        elem.read = true;
+      }
+      return elem;
+    });
+    if (changed) {
+      this.model.setObject({
+        all: { $set: updateAll },
+        unread: 0
+      });
+    }
+  }
 }
 
 export { NotificationsInfo, NotificationsCoordinator };

--- a/src/notifications/Notifications.state.js
+++ b/src/notifications/Notifications.state.js
@@ -1,0 +1,98 @@
+/*!
+ * Copyright 2020 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  Notifications.state.js
+ *  Notifications controller code.
+ */
+
+const Notifications = {
+  Levels: {
+    INFO: "info",
+    SUCCESS: "success",
+    WARNING: "warning",
+    ERROR: "error",
+  },
+  Topics: {
+    DATASET_CREATE: "Dataset creation",
+    ENVIRONMENT_START: "Interactive environment",
+  },
+};
+
+class NotificationsCoordinator {
+  constructor(client, model) {
+    this.client = client;
+    this.model = model;
+  }
+
+  getToastSettings() {
+    return this.model.get("toast");
+  }
+
+  /**
+   * Add a notification to the list
+   *
+   * @param {string} level - notification level as in Notifications.Levels
+   * @param {string} topic - general topic as in Notifications.Topics.key
+   * @param {string} desc - short description/information.
+   * @param {string} [link] - source page or target page relevant for a follow up.
+   * @param {string} [linkText] - text to show on the link.
+   * @param {string} [longDesc] - detailed description of what happened.
+   */
+  addNotification(level, topic, desc, link, linkText, longDesc) {
+    const notification = {
+      id: Math.random().toString(36).substring(2),
+      timestamp: new Date(),
+      level,
+      topic,
+      desc,
+      link,
+      linkText,
+      longDesc,
+      read: level === Notifications.Levels.INFO ? true : false
+    };
+    const notifications = this.model.get("");
+    let updateObject = { all: { $set: [...notifications.all, notification] } };
+    if (level !== Notifications.Levels.INFO)
+      updateObject.unread = notifications.unread + 1;
+    this.model.setObject(updateObject);
+    return notification;
+  }
+
+  markRead(id) {
+    const notifications = this.model.get("");
+    let changed = false;
+    const updateAll = notifications.all.map((elem) => {
+      if (elem.id === id && !elem.read) {
+        changed = true;
+        elem.read = true;
+      }
+      return elem;
+    });
+    if (changed) {
+      this.model.setObject({
+        all: { $set: updateAll },
+        unread: notifications.unread - 1
+      });
+    }
+  }
+}
+
+export { Notifications, NotificationsCoordinator };

--- a/src/notifications/Notifications.state.js
+++ b/src/notifications/Notifications.state.js
@@ -54,9 +54,15 @@ class NotificationsCoordinator {
    * @param {string} desc - short description/information.
    * @param {string} [link] - source page or target page relevant for a follow up.
    * @param {string} [linkText] - text to show on the link.
+   * @param {string || string[]} [awareLocations] - location or list of locations where the user
+   *  would know about the notification, thus marking it as read
    * @param {string} [longDesc] - detailed description of what happened.
+   * @param {string} [forceRead] - mark the notification as read
    */
-  addNotification(level, topic, desc, link, linkText, longDesc) {
+  addNotification(level, topic, desc, link, linkText, awareLocations, longDesc, forceRead) {
+    const read = forceRead || level === NotificationsInfo.Levels.INFO ?
+      true :
+      false;
     const notification = {
       id: Math.random().toString(36).substring(2),
       timestamp: new Date(),
@@ -65,12 +71,13 @@ class NotificationsCoordinator {
       desc,
       link,
       linkText,
+      awareLocations,
       longDesc,
-      read: level === NotificationsInfo.Levels.INFO ? true : false
+      read
     };
     const notifications = this.model.get("");
     let updateObject = { all: { $set: [...notifications.all, notification] } };
-    if (level !== NotificationsInfo.Levels.INFO)
+    if (!read)
       updateObject.unread = notifications.unread + 1;
     this.model.setObject(updateObject);
     return notification;

--- a/src/notifications/Notifications.test.js
+++ b/src/notifications/Notifications.test.js
@@ -27,7 +27,7 @@ import React from "react";
 import ReactDOM, { unmountComponentAtNode } from "react-dom";
 import { MemoryRouter } from "react-router-dom";
 
-import { Notifications, NotificationsMenu, NotificationsInfo } from "./index";
+import { NotificationsManager, NotificationsMenu, NotificationsInfo } from "./index";
 // ? Testing presentational component here because they are normally only rendered in response of toastify events
 import { Notification, CloseToast } from "./Notifications.present";
 import { StateModel, globalSchema } from "../model";
@@ -69,7 +69,7 @@ describe("setup and use notification system", () => {
   const model = new StateModel(globalSchema);
   let notifications;
   it("create notification object", () => {
-    notifications = Notifications({ client, model });
+    notifications = new NotificationsManager(model, client);
     expect(Object.keys(notifications)).toContain("Topics");
     expect(Object.keys(notifications.Topics)).toContain("DATASET_CREATE");
     expect(notifications.Topics.DATASET_CREATE).toBe("Dataset creation");
@@ -116,7 +116,7 @@ describe("setup and use notification system", () => {
 describe("rendering", () => {
   const model = new StateModel(globalSchema);
   const props = { client, model };
-  const notifications = Notifications(props);
+  const notifications = new NotificationsManager(model, client);
   addMultipleNotifications(notifications, 1);
   const notification = model.get("notifications.all")[0];
   const settings = model.get("notifications.toast");

--- a/src/notifications/Notifications.test.js
+++ b/src/notifications/Notifications.test.js
@@ -27,12 +27,13 @@ import React from "react";
 import ReactDOM, { unmountComponentAtNode } from "react-dom";
 import { MemoryRouter } from "react-router-dom";
 
-import { NotificationsManager, NotificationsMenu, NotificationsInfo } from "./index";
-// ? Testing presentational component here because they are normally only rendered in response of toastify events
-import { Notification, CloseToast } from "./Notifications.present";
+import { NotificationsManager, NotificationsMenu, NotificationsInfo, Notification } from "./index";
+import { CloseToast } from "./Notifications.present";
 import { StateModel, globalSchema } from "../model";
 import { testClient as client } from "../api-client";
 
+
+const fakeLocation = { pathname: "" };
 
 // random notifications generator
 // ! TODO: check why test throw the following warning
@@ -69,7 +70,7 @@ describe("setup and use notification system", () => {
   const model = new StateModel(globalSchema);
   let notifications;
   it("create notification object", () => {
-    notifications = new NotificationsManager(model, client);
+    notifications = new NotificationsManager(model, client, fakeLocation);
     expect(Object.keys(notifications)).toContain("Topics");
     expect(Object.keys(notifications.Topics)).toContain("DATASET_CREATE");
     expect(notifications.Topics.DATASET_CREATE).toBe("Dataset creation");
@@ -87,6 +88,7 @@ describe("setup and use notification system", () => {
       "Warning test with external link",
       "https://getbootstrap.com",
       "External link",
+      [],
       "Long description here");
     expect(model.get("notifications.all")).toHaveLength(1);
     const firstNotification = model.get("notifications.all")[0];
@@ -116,7 +118,7 @@ describe("setup and use notification system", () => {
 describe("rendering", () => {
   const model = new StateModel(globalSchema);
   const props = { client, model };
-  const notifications = new NotificationsManager(model, client);
+  const notifications = new NotificationsManager(model, client, fakeLocation);
   addMultipleNotifications(notifications, 1);
   const notification = model.get("notifications.all")[0];
   const settings = model.get("notifications.toast");
@@ -140,17 +142,16 @@ describe("rendering", () => {
       </MemoryRouter>, div);
   });
 
-  it("renders presentational component Notification", () => {
+  it("renders Notification", () => {
     ReactDOM.render(
       <MemoryRouter>
-        <Notification settings={settings} notification={notification} />
+        <Notification type="dropdown" notification={notification} markRead={() => null} />
       </MemoryRouter>, div);
-  });
 
-  it("renders presentational component CloseToast", () => {
+    const closeToast = (<CloseToast settings={settings} markRead={() => true} />);
     ReactDOM.render(
       <MemoryRouter>
-        <CloseToast settings={settings} markRead={() => true} />
+        <Notification type="toast" notification={notification} markRead={() => null} closeToast={closeToast} />
       </MemoryRouter>, div);
   });
 });

--- a/src/notifications/Notifications.test.js
+++ b/src/notifications/Notifications.test.js
@@ -27,7 +27,9 @@ import React from "react";
 import ReactDOM, { unmountComponentAtNode } from "react-dom";
 import { MemoryRouter } from "react-router-dom";
 
-import { NotificationsManager, NotificationsMenu, NotificationsInfo, Notification } from "./index";
+import {
+  NotificationsManager, NotificationsMenu, NotificationsInfo, NotificationsPage, Notification
+} from "./index";
 import { CloseToast } from "./Notifications.present";
 import { StateModel, globalSchema } from "../model";
 import { testClient as client } from "../api-client";
@@ -135,6 +137,13 @@ describe("rendering", () => {
     div = null;
   });
 
+  it("renders NotificationsPage", () => {
+    ReactDOM.render(
+      <MemoryRouter>
+        <NotificationsPage {...props} notifications={notifications} />
+      </MemoryRouter>, div);
+  });
+
   it("renders NotificationsMenu", () => {
     ReactDOM.render(
       <MemoryRouter>
@@ -148,10 +157,20 @@ describe("rendering", () => {
         <Notification type="dropdown" notification={notification} markRead={() => null} />
       </MemoryRouter>, div);
 
+    ReactDOM.render(
+      <MemoryRouter>
+        <Notification type="complete" notification={notification} markRead={() => null} />
+      </MemoryRouter>, div);
+
     const closeToast = (<CloseToast settings={settings} markRead={() => true} />);
     ReactDOM.render(
       <MemoryRouter>
         <Notification type="toast" notification={notification} markRead={() => null} closeToast={closeToast} />
+      </MemoryRouter>, div);
+
+    ReactDOM.render(
+      <MemoryRouter>
+        <Notification type="custom" present={(<div><span>empty</span></div>)} />
       </MemoryRouter>, div);
   });
 });

--- a/src/notifications/Notifications.test.js
+++ b/src/notifications/Notifications.test.js
@@ -1,0 +1,156 @@
+/*!
+ * Copyright 2020 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  Notifications.test.js
+ *  Tests for notifications
+ */
+
+import React from "react";
+import ReactDOM, { unmountComponentAtNode } from "react-dom";
+import { MemoryRouter } from "react-router-dom";
+
+import { Notifications, NotificationsMenu, NotificationsInfo } from "./index";
+// ? Testing presentational component here because they are normally only rendered in response of toastify events
+import { Notification, CloseToast } from "./Notifications.present";
+import { StateModel, globalSchema } from "../model";
+import { testClient as client } from "../api-client";
+
+
+// random notifications generator
+// ! TODO: check why test throw the following warning
+// ! Warning: `Reference` should not be used outside of a `Manager` component
+function addMultipleNotifications(notifications, quantity = 1) {
+  for (let num = 0; num < quantity; num++) {
+    const rnd = Math.random();
+    if (rnd <= 0.33) {
+      notifications.addSuccess(
+        notifications.Topics.ENVIRONMENT_START,
+        "Environment xyz has started, you can now access it.",
+        "/environments",
+        "Environments list");
+    }
+    else if (rnd >= 0.67) {
+      notifications.addInfo(
+        "Fake topic Info",
+        "I'm an info, I shouldn't appear",
+        "/",
+        "Home");
+    }
+    else {
+      notifications.addError(
+        notifications.Topics.ENVIRONMENT_START,
+        "Test - environment couldn't start",
+        "/environments",
+        "Environments list");
+    }
+  }
+}
+
+// tests
+describe("setup and use notification system", () => {
+  const model = new StateModel(globalSchema);
+  let notifications;
+  it("create notification object", () => {
+    notifications = Notifications({ client, model });
+    expect(Object.keys(notifications)).toContain("Topics");
+    expect(Object.keys(notifications.Topics)).toContain("DATASET_CREATE");
+    expect(notifications.Topics.DATASET_CREATE).toBe("Dataset creation");
+    expect(Object.keys(notifications.Topics).length).toBeGreaterThanOrEqual(2);
+    expect(Object.keys(notifications)).toContain("Levels");
+    expect(Object.keys(notifications.Levels)).toContain("INFO");
+    expect(notifications.Levels.INFO).toBe("INFO".toLowerCase());
+    expect(Object.keys(notifications.Levels)).toHaveLength(4);
+  });
+
+  it("add notifications", () => {
+    expect(model.get("notifications.all")).toHaveLength(0);
+    notifications.addWarning(
+      notifications.Topics.DATASET_CREATE,
+      "Warning test with external link",
+      "https://getbootstrap.com",
+      "External link",
+      "Long description here");
+    expect(model.get("notifications.all")).toHaveLength(1);
+    const firstNotification = model.get("notifications.all")[0];
+    expect(firstNotification.level).toBe(notifications.Levels.WARNING);
+    expect(firstNotification.topic).toBe(notifications.Topics.DATASET_CREATE);
+    expect(firstNotification.desc).toBe("Warning test with external link");
+    expect(firstNotification.link).toBe("https://getbootstrap.com");
+    expect(firstNotification.linkText).toBe("External link");
+    expect(firstNotification.longDesc).toBe("Long description here");
+    expect(firstNotification.read).toBeFalsy();
+    addMultipleNotifications(notifications, 3);
+    expect(model.get("notifications.all")).toHaveLength(4);
+  });
+
+  it("NotificationsInfo object is included in the notification obejct", () => {
+    const keys = Object.keys(NotificationsInfo).sort();
+    const subNotification = Object.keys(notifications).sort().reduce((subNotifications, key) => {
+      if (keys.includes(key))
+        subNotifications[key] = notifications[key];
+      return subNotifications;
+    }, {});
+    expect(JSON.stringify(NotificationsInfo)).toBe(JSON.stringify(subNotification));
+  });
+});
+
+
+describe("rendering", () => {
+  const model = new StateModel(globalSchema);
+  const props = { client, model };
+  const notifications = Notifications(props);
+  addMultipleNotifications(notifications, 1);
+  const notification = model.get("notifications.all")[0];
+  const settings = model.get("notifications.toast");
+
+  // setup a DOM element as a render target and cleanup on exit
+  let div;
+  beforeEach(() => {
+    div = document.createElement("div");
+    document.body.appendChild(div);
+  });
+  afterEach(() => {
+    unmountComponentAtNode(div);
+    div.remove();
+    div = null;
+  });
+
+  it("renders NotificationsMenu", () => {
+    ReactDOM.render(
+      <MemoryRouter>
+        <NotificationsMenu {...props} notifications={notifications} />
+      </MemoryRouter>, div);
+  });
+
+  it("renders presentational component Notification", () => {
+    ReactDOM.render(
+      <MemoryRouter>
+        <Notification settings={settings} notification={notification} />
+      </MemoryRouter>, div);
+  });
+
+  it("renders presentational component CloseToast", () => {
+    ReactDOM.render(
+      <MemoryRouter>
+        <CloseToast settings={settings} markRead={() => true} />
+      </MemoryRouter>, div);
+  });
+});

--- a/src/notifications/index.js
+++ b/src/notifications/index.js
@@ -23,7 +23,7 @@
  *  Components for the notification page
  */
 
-import { NotificationsManager, NotificationsMenu } from "./Notifications.container";
+import { NotificationsManager, NotificationsMenu, Notification } from "./Notifications.container";
 import { NotificationsInfo } from "./Notifications.state";
 
-export { NotificationsManager, NotificationsMenu, NotificationsInfo };
+export { NotificationsManager, NotificationsMenu, NotificationsInfo, Notification };

--- a/src/notifications/index.js
+++ b/src/notifications/index.js
@@ -23,7 +23,7 @@
  *  Components for the notification page
  */
 
-import { NotificationsManager, NotificationsMenu, Notification } from "./Notifications.container";
+import { NotificationsManager, NotificationsMenu, NotificationsPage, Notification } from "./Notifications.container";
 import { NotificationsInfo } from "./Notifications.state";
 
-export { NotificationsManager, NotificationsMenu, NotificationsInfo, Notification };
+export { NotificationsManager, NotificationsMenu, NotificationsInfo, NotificationsPage, Notification };

--- a/src/notifications/index.js
+++ b/src/notifications/index.js
@@ -23,7 +23,7 @@
  *  Components for the notification page
  */
 
-import { Notifications, NotificationsMenu } from "./Notifications.container";
-import { Notifications as NotificationsInfo } from "./Notifications.state";
+import { NotificationsManager, NotificationsMenu } from "./Notifications.container";
+import { NotificationsInfo } from "./Notifications.state";
 
-export { Notifications, NotificationsMenu, NotificationsInfo };
+export { NotificationsManager, NotificationsMenu, NotificationsInfo };

--- a/src/notifications/index.js
+++ b/src/notifications/index.js
@@ -1,0 +1,29 @@
+/*!
+ * Copyright 2020 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  notifications
+ *  Components for the notification page
+ */
+
+import { Notifications, NotificationsMenu } from "./Notifications.container";
+import { Notifications as NotificationsInfo } from "./Notifications.state";
+
+export { Notifications, NotificationsMenu, NotificationsInfo };

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -1261,7 +1261,7 @@ class ProjectStartNotebookServer extends Component {
   render() {
     const {
       client, model, user, visibility, toggleForkModal, externalUrl, system, location,
-      fetchBranches, notebookServersUrl, history, blockAnonymous
+      fetchBranches, notebookServersUrl, history, blockAnonymous, notifications
     } = this.props;
     const warning = notebookWarning(
       user.logged, visibility.accessLevel, toggleForkModal, location.pathname, externalUrl
@@ -1286,6 +1286,7 @@ class ProjectStartNotebookServer extends Component {
         externalUrl={externalUrl}
         successUrl={notebookServersUrl}
         blockAnonymous={blockAnonymous}
+        notifications={notifications}
         scope={{ namespace: this.props.core.namespace_path, project: this.props.core.project_path }}
       />
     );

--- a/src/utils/UIComponents.js
+++ b/src/utils/UIComponents.js
@@ -215,6 +215,8 @@ function ExternalLinkButton(props) {
   let otherProps = {};
   if (props.id)
     otherProps.id = props.id;
+  if (props.onClick)
+    otherProps.onClick = props.onClick;
 
   return (
     <a role="button" target="_blank" rel="noreferrer noopener"
@@ -237,6 +239,8 @@ function ExternalLinkText(props) {
   let otherProps = {};
   if (props.id)
     otherProps.id = props.id;
+  if (props.onClick)
+    otherProps.onClick = props.onClick;
 
   return (
     <a target="_blank" rel="noreferrer noopener"
@@ -257,18 +261,16 @@ function ExternalLinkText(props) {
  * @param {string} [title] - The text to show for the link
  * @param {string} [role] - "link" or "text" to be shown as a link, null for a button
  * @param {string?} [className] - [Optional] Any classes to add, e.g., 'nav-link' or 'dropdown-item'
- * @param {boolean} [showExternalLinkIcon] - Show the icon to indicate an external link if true (default false)
+ * @param {boolean} [showLinkIcon] - Show the icon to indicate an external link if true (default false)
  * @param {string} [id] - main element's id
  */
 function ExternalLink(props) {
   const role = props.role;
-  const showLinkIcon = (props.showExternalLinkIcon === true) ? true : false;
-  const displayTitle = (showLinkIcon) ?
-    <span>
-      <FontAwesomeIcon icon={faExternalLinkAlt} color="dark" /> {props.title}
-    </span> :
+  const displayTitle = (props.showLinkIcon) ?
+    (<span><FontAwesomeIcon icon={faExternalLinkAlt} color="dark" /> {props.title}</span>) :
     props.title;
-  const myProps = { title: displayTitle, ...props };
+  const myProps = { ...props, title: displayTitle };
+
   if (role === "link" || role === "text")
     return ExternalLinkText(myProps);
   return ExternalLinkButton(myProps);
@@ -281,7 +283,7 @@ function ExternalLink(props) {
  * @param {string} [url] - The URL to link to
  * @param {string} [title] - The text to show for the link
  * @param {string?} [className] - [Optional] Any classes to add, e.g., 'nav-link' or 'dropdown-item'
- * @param {boolean} [showExternalLinkIcon] - Show the icon to indicate an external link if true (default false)
+ * @param {boolean} [showLinkIcon] - Show the icon to indicate an external link if true (default false)
  */
 function ExternalDocsLink(props) {
   const role = "link";


### PR DESCRIPTION
Client-side notification system with toast notifications and dropdown menu in the top navbar.
Currently, only a couple of notebooks action trigger notifications.

For convenience, on the test deploment it's possible to create fake notifications from the notifications menu

Preview: https://lorenzotest.dev.renku.ch/

![Screenshot_20200915_124252](https://user-images.githubusercontent.com/43481553/93204693-cc984200-f756-11ea-9047-10d178ea87a2.png)
