### PR TITLE
fix: change name ordering with title ordering

### DIFF
--- a/src/dataset/list/DatasetList.container.js
+++ b/src/dataset/list/DatasetList.container.js
@@ -19,17 +19,11 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import DatasetList from "./DatasetList.present";
-import DatasetListModel from "./DatasetList.state";
+import DatasetListModel, { orderByValuesMap } from "./DatasetList.state";
 import qs from "query-string";
 
 const urlMap = {
   datasetsUrl: "/datasets",
-};
-
-const orderByValuesMap = {
-  NAME: "name",
-  DATE_PUBLISHED: "datePublished",
-  PROJECTSCOUNT: "projectsCount"
 };
 
 class List extends Component {
@@ -151,7 +145,7 @@ class List extends Component {
   getOrderByLabel() {
     switch (this.model.get("orderBy")) {
       case orderByValuesMap.NAME:
-        return "name";
+        return "title";
       case orderByValuesMap.DATE_PUBLISHED:
         return "date published";
       case orderByValuesMap.PROJECTSCOUNT:

--- a/src/dataset/list/DatasetList.present.js
+++ b/src/dataset/list/DatasetList.present.js
@@ -98,7 +98,7 @@ class DatasetSearchForm extends Component {
               <DropdownItem value={this.props.orderByValuesMap.NAME}
                 onClick={this.props.handlers.changeSearchDropdownOrder}>
                 {this.props.orderBy === this.props.orderByValuesMap.NAME ?
-                  <FontAwesomeIcon icon={faCheck} /> : null} Name
+                  <FontAwesomeIcon icon={faCheck} /> : null} Title
               </DropdownItem>
               <DropdownItem value={this.props.orderByValuesMap.DATE_PUBLISHED}
                 onClick={this.props.handlers.changeSearchDropdownOrder}>

--- a/src/dataset/list/DatasetList.state.js
+++ b/src/dataset/list/DatasetList.state.js
@@ -26,7 +26,7 @@
 import { Schema, StateKind, StateModel } from "../../model/Model";
 
 const orderByValuesMap = {
-  NAME: "name",
+  NAME: "title",
   DATE_PUBLISHED: "datePublished",
   PROJECTSCOUNT: "projectsCount"
 };
@@ -103,7 +103,7 @@ class DatasetListModel extends StateModel {
     const searchOrder = this.get("orderSearchAsc") === true ? "asc" : "desc";
     switch (this.get("orderBy")) {
       case orderByValuesMap.NAME:
-        return "name:" + searchOrder;
+        return "title:" + searchOrder;
       case orderByValuesMap.DATE_PUBLISHED:
         return "datePublished:" + searchOrder;
       case orderByValuesMap.PROJECTSCOUNT:
@@ -153,4 +153,5 @@ class DatasetListModel extends StateModel {
   }
 }
 
+export { orderByValuesMap };
 export default DatasetListModel;


### PR DESCRIPTION
The dataset search uses the property `title` instead of `name`.

![Screenshot_20200922_155217](https://user-images.githubusercontent.com/43481553/93891361-9ecd7300-fceb-11ea-8bf1-e86477193def.png)

I'm not totally sure if in the UI we want to use the word `title` or if this should stay behind the scene and we keep using `name` (I see `name` in other parts as well)

fix #1039