### PR TITLE
fix: only merge server options for the default_url (#1025)

### DIFF
--- a/src/notebooks/Notebooks.present.js
+++ b/src/notebooks/Notebooks.present.js
@@ -1129,6 +1129,20 @@ class StartNotebookOptionsRunning extends Component {
   }
 }
 
+/**
+ * Combine the globalOptions and projectOptions to cover all valid options.
+ */
+function mergeEnumOptions(globalOptions, projectOptions, key) {
+  let options = globalOptions[key].options;
+  // defaultUrl can extend the existing options, but not the other ones
+  if (key === "defaultUrl"
+    && Object.keys(projectOptions).indexOf(key) >= 0
+    && globalOptions[key].options.indexOf(projectOptions[key]) === -1)
+    options = [...globalOptions[key].options, projectOptions[key]];
+
+  return options;
+}
+
 class StartNotebookServerOptions extends Component {
   render() {
     const globalOptions = this.props.options.global;
@@ -1158,10 +1172,7 @@ class StartNotebookServerOptions extends Component {
 
         switch (serverOption.type) {
           case "enum": {
-            const options = Object.keys(projectOptions).indexOf(key) >= 0 &&
-              globalOptions[key].options.indexOf(projectOptions[key]) === -1 ?
-              [...globalOptions[key].options, projectOptions[key]] :
-              globalOptions[key].options;
+            const options = mergeEnumOptions(globalOptions, projectOptions, key);
             serverOption["options"] = options;
             return <FormGroup key={key} className={serverOption.options.length === 1 ? "mb-0" : ""}>
               <Label>{serverOption.displayName}</Label>
@@ -1418,4 +1429,4 @@ class CheckNotebookIcon extends Component {
   }
 }
 
-export { NotebooksDisabled, Notebooks, StartNotebookServer, CheckNotebookIcon };
+export { NotebooksDisabled, Notebooks, StartNotebookServer, CheckNotebookIcon, mergeEnumOptions };


### PR DESCRIPTION
# Description

#950 introduced a change to prevent project options from disappearing, but this was applied to things like cpu_request and mem_request, which the user cannot actually control. With this change, only default_url can be extended by the project options in the `renku.ini` file, other options will be ignored and show a warning if the project default is not available in the server environment. 

![image](https://user-images.githubusercontent.com/1196411/93897158-0ab2da00-fcf2-11ea-9a27-de36fa7b11ec.png)

The fix is deployed to https://sekhar.dev.renku.ch, to test, try out this project: https://sekhar.dev.renku.ch/projects/cramakri/project-defaults-test/environments/new

Fix #1025.