### PR TITLE
feat: handle paging responses from apis

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -39,6 +39,7 @@
     "space-unary-ops": ["warn", {"words": true, "nonwords": false}],
     "keyword-spacing": ["warn", { "before": true }],
     "no-multiple-empty-lines": ["warn", { "max": 2, "maxEOF": 1 }],
+    "no-unsafe-finally": "off",
     "react/jsx-curly-spacing": ["warn", "never"],
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn"

--- a/src/api-client/index.js
+++ b/src/api-client/index.js
@@ -89,6 +89,7 @@ class APIClient {
 
   /**
    * A fetch method which is attached to an API client instance so that it can contain a user token.
+   * Optional arguments default values are set from FETCH_DEFAULT.
    *
    * @param {string} url - Target API url
    * @param {object} [options] - Fetch options, like method, headers, body, ... Default only include basic headers.
@@ -145,13 +146,15 @@ class APIClient {
 
   /**
    * Create an iterable object to manage pagination. At each iteration, another page is fetched.
-   * You can use the for await syntax to fetch all the avilable pages
-   * E.G. for await (const partialData of clientIterableFetch(url)) { console.log(partialData) }
+   * You can use the for await syntax to fetch all the avilable pages (see exmaple).
+   * Optional arguments default values are set from FETCH_DEFAULT
    *
    * @param {string} url - API url
    * @param {object} [parameters] - Optional parameters object to be provided to clientFetch.
-   * @param {number} [parameters.maxIterations] - maximum iterations before throwing an error.
-   *   Default is 10. Set 0 for unlimited.
+   * @param {number} [parameters.maxIterations] - Maximum iterations before throwing an error. Used to prevent
+   *   long/endless loops that would trigger the gateway rate limit. Set 0 for unlimited.
+   * @example "for await" syntax that consumes the async iterator
+   * for await (const partialData of clientIterableFetch("myApiUrl")) { console.log(partialData) }
    */
   async* clientIterableFetch(url, {
     options = FETCH_DEFAULT.options,

--- a/src/api-client/index.js
+++ b/src/api-client/index.js
@@ -51,7 +51,8 @@ const FETCH_DEFAULT = {
   returnType: RETURN_TYPES.json,
   alertOnErr: false,
   reLogin: true,
-  anonymousLogin: false
+  anonymousLogin: false,
+  maxIterations: 10
 };
 
 class APIClient {
@@ -86,9 +87,18 @@ class APIClient {
     addMigrationMethods(this);
   }
 
-  // A fetch method which is attached to a API client instance so that it can
-  // contain a user token.
-  clientFetch(
+  /**
+   * A fetch method which is attached to an API client instance so that it can contain a user token.
+   *
+   * @param {string} url - Target API url
+   * @param {object} [options] - Fetch options, like method, headers, body, ... Default only include basic headers.
+   * @param {string} [returnType] - Expected content type. Allowed values are "json" (default), "text" and "full".
+   * @param {bool} [alertOnErr] - whether to trigger a default error on fetch errors. Default is false
+   * @param {bool} [reLogin] - whether to trigger a re-login on 401 error. Default is true
+   * @param {bool} [anonymousLogin] - whether to trigger an anonymous login to work with anonymous credentials.
+   *   Default is false
+   */
+  async clientFetch(
     url,
     options = FETCH_DEFAULT.options,
     returnType = FETCH_DEFAULT.returnType,
@@ -120,7 +130,7 @@ class APIClient {
             return response.json().then(data => {
               return {
                 data,
-                pagination: processPaginationHeaders(this, response.headers)
+                pagination: processPaginationHeaders(response.headers)
               };
             });
           case RETURN_TYPES.text:
@@ -131,6 +141,45 @@ class APIClient {
             return response;
         }
       });
+  }
+
+  /**
+   * Create an iterable object to manage pagination. At each iteration, another page is fetched.
+   * You can use the for await syntax to fetch all the avilable pages
+   * E.G. for await (const partialData of clientIterableFetch(url)) { console.log(partialData) }
+   *
+   * @param {string} url - API url
+   * @param {object} [parameters] - Optional parameters object to be provided to clientFetch.
+   * @param {number} [parameters.maxIterations] - maximum iterations before throwing an error.
+   *   Default is 10. Set 0 for unlimited.
+   */
+  async* clientIterableFetch(url, {
+    options = FETCH_DEFAULT.options,
+    returnType = FETCH_DEFAULT.returnType,
+    alertOnErr = FETCH_DEFAULT.alertOnErr,
+    reLogin = FETCH_DEFAULT.reLogin,
+    anonymousLogin = FETCH_DEFAULT.anonymousLogin,
+    maxIterations = FETCH_DEFAULT.maxIterations
+  } = {}) {
+    let iterations = 1, page = 1;
+    do {
+      // throw an error if the number of iterations is more than the maximum
+      if (maxIterations && iterations > maxIterations)
+        throw new Error(`Cannot iterate more than ${maxIterations} times.`);
+
+      // set target page and fetch
+      if (options.queryParams)
+        options.queryParams.page = page;
+      else
+        options.queryParams = { page: page };
+      const response = await this.clientFetch(url, options, returnType, alertOnErr, reLogin, anonymousLogin);
+      if (!response.pagination)
+        throw new Error("Invoked API doesn't return structured data, making pagination unusable.");
+      page = response.pagination.nextPage;
+      response.pagination.progress = response.pagination.currentPage / response.pagination.totalPages;
+      iterations++;
+      yield response;
+    } while (page);
   }
 
   graphqlFetch(query, variables) {

--- a/src/api-client/pagination.js
+++ b/src/api-client/pagination.js
@@ -44,7 +44,7 @@ const NUMERICAL_PAGINATION_HEADERS = {
 // information. The idea that methods performing the the request to
 // to fetch the next page has been dropped because we prefer to
 // keep the state of the corresponding components serializable.
-function processPaginationHeaders(client, headers) {
+function processPaginationHeaders(headers) {
   let paginationDetail = {};
 
   // Parse the link header if it exists

--- a/src/api-client/repository.js
+++ b/src/api-client/repository.js
@@ -186,7 +186,7 @@ function addRepositoryMethods(client) {
       });
   };
 
-  // ? Unfotunately, the API doesn't offer a way to query only for unmerged branches
+  // ? Unfortunately, the API doesn't offer a way to query only for unmerged branches
   // ? REF: https://docs.gitlab.com/ee/api/branches.html
   client.getBranches = async (projectId, per_page = 100) => {
     const url = `${client.baseUrl}/projects/${projectId}/repository/branches`;

--- a/src/api-client/repository.js
+++ b/src/api-client/repository.js
@@ -32,30 +32,29 @@ function addRepositoryMethods(client) {
     });
   };
 
-
-  client.getCommits = (projectId, ref = "master", max = 100) => {
+  client.getCommits = async (projectId, ref = "master", per_page = 100) => {
+    const url = `${client.baseUrl}/projects/${projectId}/repository/commits`;
     let headers = client.getBasicHeaders();
     headers.append("Content-Type", "application/json");
+    const queryParams = { ref_name: ref, per_page };
+    const options = { method: "GET", headers, queryParams };
+    const commitsIterator = client.clientIterableFetch(url, { options });
 
-    const queryParams = {
-      ref_name: ref,
-      per_page: max
-    };
-    return client.clientFetch(`${client.baseUrl}/projects/${projectId}/repository/commits`, {
-      method: "GET",
-      headers: headers,
-      queryParams
-    })
-      .then(resp => {
-        if (resp.data.length > 0)
-          return resp;
-
-
-        throw API_ERRORS.notFoundError;
-
-      });
+    let commits = [], pagination = {}, error = false;
+    try {
+      for await (const commitsPage of commitsIterator) {
+        commits = [...commits, ...commitsPage.data];
+        pagination = { ...commitsPage.pagination, done: false };
+      }
+      pagination.done = true;
+    }
+    catch (exception) {
+      error = exception;
+    }
+    finally {
+      return { data: commits, pagination, error };
+    }
   };
-
 
   client.getProjectReadme = (projectId) => {
     return client.getRepositoryFile(projectId, "README.md", "master", "raw")
@@ -63,7 +62,6 @@ function addRepositoryMethods(client) {
         return { text: text || "Could not find a README.md file. Why don't you add one to the repository?" };
       });
   };
-
 
   client.getRepositoryFileMeta = (projectId, path, ref = "master") => {
     let headers = client.getBasicHeaders();
@@ -188,17 +186,30 @@ function addRepositoryMethods(client) {
       });
   };
 
-  // TODO: Unfotunately, the API doesn't offer a way to query only for unmerged branches -
-  // TODO: add this capability to the gateway.
-  // TODO: Page through results in gateway, for the moment assuming a max of 100 branches seems ok.
-  client.getBranches = (projectId) => {
-    let headers = client.getBasicHeaders();
+  // ? Unfotunately, the API doesn't offer a way to query only for unmerged branches
+  // ? REF: https://docs.gitlab.com/ee/api/branches.html
+  client.getBranches = async (projectId, per_page = 100) => {
     const url = `${client.baseUrl}/projects/${projectId}/repository/branches`;
-    return client.clientFetch(url, {
-      method: "GET",
-      headers,
-      queryParams: { per_page: 100 }
-    });
+    let headers = client.getBasicHeaders();
+    headers.append("Content-Type", "application/json");
+    const queryParams = { per_page };
+    const options = { method: "GET", headers, queryParams };
+    const branchesIterator = client.clientIterableFetch(url, { options });
+
+    let branches = [], pagination = {}, error = false;
+    try {
+      for await (const branchesPage of branchesIterator) {
+        branches = [...branches, ...branchesPage.data];
+        pagination = { ...branchesPage.pagination, done: false };
+      }
+      pagination.done = true;
+    }
+    catch (exception) {
+      error = exception;
+    }
+    finally {
+      return { data: branches, pagination, error };
+    }
   };
 
 }

--- a/src/api-client/utils.js
+++ b/src/api-client/utils.js
@@ -21,7 +21,7 @@ import { APIError, API_ERRORS, throwAPIErrors } from "./errors";
 const RETURN_TYPES = {
   json: "json",
   text: "text",
-  full: "fullResponseObject"
+  full: "full"
 };
 
 // Wrapper around fetch which will throw exceptions on all non 20x responses.

--- a/src/model/RenkuModels.js
+++ b/src/model/RenkuModels.js
@@ -267,9 +267,9 @@ const projectGlobalSchema = new Schema({
   commits: {
     schema: {
       list: { initial: [], mandatory: true },
-
       fetched: { initial: null },
       fetching: { initial: false },
+      error: { initial: null }
     }
   },
   filters: {
@@ -300,7 +300,7 @@ const notebooksSchema = new Schema({
       options: { initial: {} },
 
       includeMergedBranches: { initial: false },
-      displayedCommits: { initial: 10 },
+      displayedCommits: { initial: 25 },
     }
   },
   options: {

--- a/src/notebooks/Notebooks.present.js
+++ b/src/notebooks/Notebooks.present.js
@@ -1049,10 +1049,10 @@ class StartNotebookCommitsOptions extends Component {
         <PopoverBody>
           <FormGroup>
             <Label>Number of commits to display</Label>
-            <Input type="number" min={0} max={1000} step={1}
+            <Input type="number" min={0} max={100} step={1}
               onChange={(event) => { this.props.handlers.setDisplayedCommits(event.target.value); }}
               value={this.props.filters.displayedCommits} />
-            <FormText>1-1000, 0 for unlimited</FormText>
+            <FormText>1-100, 0 for unlimited</FormText>
           </FormGroup>
         </PopoverBody>
       </UncontrolledPopover>

--- a/src/notebooks/Notebooks.present.js
+++ b/src/notebooks/Notebooks.present.js
@@ -1049,10 +1049,10 @@ class StartNotebookCommitsOptions extends Component {
         <PopoverBody>
           <FormGroup>
             <Label>Number of commits to display</Label>
-            <Input type="number" min={0} max={100} step={1}
+            <Input type="number" min={0} max={1000} step={1}
               onChange={(event) => { this.props.handlers.setDisplayedCommits(event.target.value); }}
               value={this.props.filters.displayedCommits} />
-            <FormText>1-100, 0 for unlimited</FormText>
+            <FormText>1-1000, 0 for unlimited</FormText>
           </FormGroup>
         </PopoverBody>
       </UncontrolledPopover>

--- a/src/project/Project.test.js
+++ b/src/project/Project.test.js
@@ -87,7 +87,10 @@ describe("test ProjectCoordinator related components", () => {
 
     ReactDOM.render(
       <MemoryRouter>
-        <ProjectViewCommitsConnected projectCoordinator={projectCoordinator} />
+        <ProjectViewCommitsConnected
+          history={fakeHistory}
+          location={fakeHistory.location}
+          projectCoordinator={projectCoordinator} />
       </MemoryRouter>
       , div);
   });

--- a/src/utils/UIComponents.js
+++ b/src/utils/UIComponents.js
@@ -179,16 +179,17 @@ class Pagination extends Component {
 
     // We do not display the pagination footer when there are no pages or only one page
     if (this.props.totalItems == null
-        || this.props.totalItems < 1
-        || this.props.totalItems <= this.props.perPage)
+      || this.props.totalItems < 1
+      || this.props.totalItems <= this.props.perPage)
       return null;
 
-
+    const className = `pagination ${this.props.className ? this.props.className : null}`;
     return <ReactPagination
       activePage={this.props.currentPage}
       itemsCountPerPage={this.props.perPage}
       totalItemsCount={this.props.totalItems}
       onChange={this.props.onPageChange}
+      innerClass={className}
 
       // Some defaults for the styling
       prevPageText={"Previous"}
@@ -196,7 +197,8 @@ class Pagination extends Component {
       itemClass={"page-item"}
       linkClass={"page-link"}
       activeClass={"page-item active"}
-      hideFirstLastPages={true}
+      hideFirstLastPages={false}
+      hideDisabled={true}
     />;
   }
 }


### PR DESCRIPTION
This went a bit further than expected, introducing a couple of related (minor) changes.

* Introduces a method to fetch from API returning paginated data.
* Handles up to 1000 branches and commits (the limit is in place to prevent endless fetching loops that will fail anyway due to the gateway rate limit).
* Updates visualization where needed (project pages "overview --> commits" and "environments --> new")
* Minor changes to the Pagination component.

fix #1037, accidentally fix #764

P.S. All my namespaces are currently full so no preview available. You can run it on telepresence or contact me and I'll create a temporary preview.