### PR TITLE
fix: anonymous interactive environments

### DIFF
--- a/src/api-client/index.js
+++ b/src/api-client/index.js
@@ -115,6 +115,10 @@ class APIClient {
         }
       })
       .then(response => {
+        // This avoids showing errors for a second while doing the anonymous log-in.
+        // It should be solved in a more elegant way once we support interruptable fetch #776
+        if (!response && anonymousLogin)
+          return returnType === RETURN_TYPES.json ? { data: {} } : "";
         switch (returnType) {
           case RETURN_TYPES.json:
             return response.json().then(data => {

--- a/src/api-client/notebook-servers.js
+++ b/src/api-client/notebook-servers.js
@@ -56,14 +56,18 @@ function addNotebookServersMethods(client) {
       });
   };
 
-  client.getNotebookServerOptions = () => {
+  client.getNotebookServerOptions = (anonymous = false) => {
     const headers = client.getBasicHeaders();
     const url = `${client.baseUrl}/notebooks/server_options`;
 
-    return client.clientFetch(url, {
-      method: "GET",
-      headers
-    }).then((resp) => {
+    return client.clientFetch(
+      url,
+      { method: "GET", headers },
+      FETCH_DEFAULT.returnType,
+      FETCH_DEFAULT.alertOnErr,
+      FETCH_DEFAULT.reLogin,
+      anonymous
+    ).then((resp) => {
       let { data } = resp;
       Object.keys(data).forEach(key => {
         data[key].selected = data[key].default;

--- a/src/notebooks/Notebooks.state.js
+++ b/src/notebooks/Notebooks.state.js
@@ -324,12 +324,18 @@ class NotebooksCoordinator {
     if (Object.keys(oldData).length !== 0)
       return;
 
-    return this.client.getNotebookServerOptions().then((globalOptions) => {
-      this.model.set("options.global", globalOptions);
-      this.setDefaultOptions(globalOptions, null);
+    // get user status
+    const anonym = this.userModel.get("logged") ?
+      false :
+      true;
 
-      return globalOptions;
-    });
+    return this.client.getNotebookServerOptions(anonym)
+      .then((globalOptions) => {
+        this.model.set("options.global", globalOptions);
+        this.setDefaultOptions(globalOptions, null);
+
+        return globalOptions;
+      });
   }
 
   fetchProjectOptions() {


### PR DESCRIPTION
Fix an API call that mistakenly triggered the login workflow when trying to start an anonymous session. That happened only in specific situations.
This includes a minor workaround to prevent the UI from showing for a moment an error page when performing the "anonymous login".

Preview: https://lorenzotest.dev.renku.ch/

***How to test it***
The problem happens almost always if you
* Use a chrome-based browser
* Goes directly to the `/environments/new` page

A good test can be done by comparing the 2 following pages (advice: use chrome/chromium in a Private Window)
https://lorenzotest.dev.renku.ch/projects/renku-test/test-2020-09-24-13-27-17/environments/new
https://dev.renku.ch/projects/renku-test/test-2020-09-24-13-27-17/environments/new

fix #1030
