### PR TITLE
Add button to clone renku project

### DIFF
--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -1327,7 +1327,7 @@ function RepositoryUrlRow(props) {
     <tr>
       <th scope="row">{props.urlType}</th>
       <td>{props.url}</td>
-      <td><Clipboard clipboardText={props.url} /></td>
+      <td style={{ width: 1 }}><Clipboard clipboardText={props.url} /></td>
     </tr>
   );
 }
@@ -1355,7 +1355,7 @@ function CommandRow(props) {
       <td>
         <code>{props.command}</code>
       </td>
-      <td><Clipboard clipboardText={props.command} /></td>
+      <td style={{ width: 1 }}><Clipboard clipboardText={props.command} /></td>
     </tr>
   );
 }

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -1378,10 +1378,10 @@ class RepositoryClone extends Component {
           </tbody>
         </Table>
         <small className="font-italic">
-          <FontAwesomeIcon icon={faExclamationTriangle} /> If you clone the project using Git instead
-          or Renku, remember to run <code>renku githooks install</code> once before you run any other
-          renku command.
+          <FontAwesomeIcon icon={faExclamationTriangle} /> If you clone the project using <b>Git</b> instead
+          of Renku, remember to run the following once before you run any other renku command:
         </small>
+        <small><blockquote className="ml-5"><code>renku githooks install</code></blockquote></small>
       </Fragment>
     );
   }

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -1334,15 +1334,56 @@ function RepositoryUrlRow(props) {
 
 class RepositoryUrls extends Component {
   render() {
-    return [
-      <strong key="header">Repository URL</strong>,
-      <Table key="table" size="sm">
-        <tbody>
-          <RepositoryUrlRow urlType="SSH" url={this.props.system.ssh_url} />
-          <RepositoryUrlRow urlType="HTTP" url={this.props.system.http_url} />
-        </tbody>
-      </Table>
-    ];
+    return (
+      <Fragment>
+        <Label className="font-weight-bold">Repository URL</Label>
+        <Table size="sm">
+          <tbody>
+            <RepositoryUrlRow urlType="SSH" url={this.props.system.ssh_url} />
+            <RepositoryUrlRow urlType="HTTP" url={this.props.system.http_url} />
+          </tbody>
+        </Table>
+      </Fragment>
+    );
+  }
+}
+
+function CommandRow(props) {
+  return (
+    <tr>
+      <th scope="row">{props.application}</th>
+      <td>
+        <code>{props.command}</code>
+      </td>
+      <td><Clipboard clipboardText={props.command} /></td>
+    </tr>
+  );
+}
+
+
+class RepositoryClone extends Component {
+  render() {
+    const { externalUrl } = this.props;
+    const projectPath = this.props.core.project_path;
+    const renkuClone = `renku clone ${externalUrl}.git`;
+    const gitClone = `git clone ${externalUrl}.git && cd ${projectPath} && git lfs install --local --force`;
+
+    return (
+      <Fragment>
+        <Label className="font-weight-bold">Clone commands</Label>
+        <Table size="sm" className="mb-0">
+          <tbody>
+            <CommandRow application="Renku" command={renkuClone} />
+            <CommandRow application="Git" command={gitClone} />
+          </tbody>
+        </Table>
+        <small className="font-italic">
+          <FontAwesomeIcon icon={faExclamationTriangle} /> If you clone the project using Git instead
+          or Renku, remember to run <code>renku githooks install</code> once before you run any other
+          renku command.
+        </small>
+      </Fragment>
+    );
   }
 }
 
@@ -1386,14 +1427,17 @@ class ProjectSettings extends Component {
   render() {
     return <Col key="settings" xs={12}>
       <Row>
-        <Col xs={12} md={10} lg={6}>
+        <Col xs={12} lg={6}>
           <ProjectTags
             tag_list={this.props.system.tag_list}
             onProjectTagsChange={this.props.onProjectTagsChange}
             settingsReadOnly={this.props.settingsReadOnly} />
           <ProjectDescription {...this.props} />
         </Col>
-        <Col xs={12} md={10} lg={6}><RepositoryUrls {...this.props} /></Col>
+        <Col xs={12} lg={6}>
+          <RepositoryUrls {...this.props} />
+          <RepositoryClone {...this.props} />
+        </Col>
       </Row>
     </Col>;
   }

--- a/src/utils/UIComponents.js
+++ b/src/utils/UIComponents.js
@@ -26,7 +26,7 @@
 
 import _ from "lodash/util";
 import human from "human-time";
-import React, { Component, Fragment, useState, useEffect } from "react";
+import React, { Component, Fragment, useState, useEffect, useRef } from "react";
 import { Link, NavLink as RRNavLink } from "react-router-dom";
 import ReactPagination from "react-js-pagination";
 import ReactClipboard from "react-clipboard.js";
@@ -572,10 +572,17 @@ function Clipboard(props) {
   const [copied, setCopied] = useState(false);
   const timeoutDur = 3000;
 
+  // keep track of mounted state
+  const isMounted = useRef(true);
+  useEffect(() => {
+    isMounted.current = true;
+    return () => { isMounted.current = false; };
+  }, []);
+
   return (
-    <ReactClipboard component="a" data-clipboard-text={props.clipboardText}
-      onSuccess={()=> { setCopied(true); setTimeout(() => setCopied(false), timeoutDur); }}>
-      {
+    <ReactClipboard component="a" data-clipboard-text={props.clipboardText} onSuccess={
+      () => { setCopied(true); setTimeout(() => { if (isMounted.current) setCopied(false); }, timeoutDur); }
+    }> {
         (copied) ?
           <FontAwesomeIcon icon={faCheck} color="green" /> :
           <FontAwesomeIcon icon={faCopy} />


### PR DESCRIPTION
Adds a button with the commands to clone the project locally, similar to what we find in both the GitLab and GitHub interfaces.

![Screenshot_20200928_205620](https://user-images.githubusercontent.com/43481553/94474035-54f1fa80-01cd-11eb-82c3-e2876be73262.png)

Preview: https://lorenzotest.dev.renku.ch/

fix #929