### PR TITLE
feat: show commit details on-request in environments pages

### DIFF
--- a/src/api-client/repository.js
+++ b/src/api-client/repository.js
@@ -98,7 +98,7 @@ function addRepositoryMethods(client) {
     );
   };
 
-  client.getRepositoryCommit = (projectId, commitSHA) => {
+  client.getRepositoryCommit = async (projectId, commitSHA) => {
     let headers = client.getBasicHeaders();
     return client.clientFetch(
       `${client.baseUrl}/projects/${projectId}/repository/commits/${commitSHA}`, {

--- a/src/model/RenkuModels.js
+++ b/src/model/RenkuModels.js
@@ -325,18 +325,16 @@ const notebooksSchema = new Schema({
       lastMainId: { initial: null },
     }
   },
-  data: {
-    schema: {
-      commits: { initial: [] }, // ! TODO: move to Project pages, shouldn't be here
-      fetched: { initial: null },
-      fetching: { initial: false },
-    }
-  },
   logs: {
     schema: {
       data: { initial: [] },
       fetched: { initial: null },
       fetching: { initial: false },
+    }
+  },
+  data: {
+    schema: {
+      commits: { initial: {} }, // use it as a dictionary where the key is the full commit sha
     }
   }
 });

--- a/src/notebooks/Notebooks.container.js
+++ b/src/notebooks/Notebooks.container.js
@@ -62,7 +62,8 @@ class Notebooks extends Component {
     this.handlers = {
       stopNotebook: this.stopNotebook.bind(this),
       fetchLogs: this.fetchLogs.bind(this),
-      toggleLogs: this.toggleLogs.bind(this)
+      toggleLogs: this.toggleLogs.bind(this),
+      fetchCommit: this.fetchCommit.bind(this)
     };
   }
 
@@ -83,6 +84,12 @@ class Notebooks extends Component {
     if (!serverName)
       return;
     return this.coordinator.fetchLogs(serverName, full);
+  }
+
+  async fetchCommit(serverName) {
+    if (!serverName)
+      return;
+    return this.coordinator.fetchCommit(serverName);
   }
 
   toggleLogs(serverName) {


### PR DESCRIPTION
There are a couple of issues requiring to show commit data in the environments list. The proposed solutions were slightly different from the implemented one, but it turns out that other ways would require to implement operations in the backend that are possibly (probably) resource/time intensive for a marginal benefit.

In this PR, commit details are fetched directly through the GitLab API only when required by the user. The implemented interaction requires clicking on an info icon in the "commit" column (mind that the click on the commit-sha already redirects the user).
If the interaction is confusing, we can change it (e.g. remove the icon and change the popover trigger to "on-hover")

![Screenshot_20200929_170347](https://user-images.githubusercontent.com/43481553/94579651-5b3db080-0279-11eb-9859-bb44872f8bf5.png)

I didn't make a preview because my test namespaces are already used, but this can be run through telepresence (no requirements on other components)

fix #853, #880