### PR TITLE
fix: dataset displays kg message correctly

### DIFF
--- a/src/project/Project.js
+++ b/src/project/Project.js
@@ -294,6 +294,12 @@ class View extends Component {
 
   }
 
+  isGraphReady() {
+    const webhookStatus = this.projectState.get("webhook");
+    return webhookStatus.status || (webhookStatus.created && webhookStatus.stop)
+      || webhookStatus.progress === GraphIndexingStatus.MAX_VALUE;
+  }
+
   getStarred() {
     const featured = this.props.model.get("projects.featured");
     // return false until data are available
@@ -372,8 +378,6 @@ class View extends Component {
     const filesTree = this.projectState.get("filesTree");
     const datasets = this.projectState.get("core.datasets");
     const graphProgress = this.projectState.get("webhook.progress");
-    const webhookStatus = this.projectState.get("webhook");
-    const graphStatus = webhookStatus.status || (webhookStatus.created && webhookStatus.stop);
     const maintainer = this.projectState.get("visibility.accessLevel") >= ACCESS_LEVELS.MAINTAINER ?
       true :
       false;
@@ -463,7 +467,7 @@ class View extends Component {
         model={this.props.model}
         projectId={projectId}
         httpProjectUrl={httpProjectUrl}
-        graphStatus={graphStatus}
+        graphStatus={this.isGraphReady()}
       />,
 
       newDataset: (p) => <NewDataset
@@ -635,6 +639,7 @@ class View extends Component {
     const externalUrl = this.projectState.get("core.external_url");
     const canCreateMR = state.visibility.accessLevel >= ACCESS_LEVELS.DEVELOPER;
     const forkModalOpen = this.projectState.get("transient.forkModalOpen");
+    const isGraphReady = this.isGraphReady();
 
     return {
       ...this.projectState.get(),
@@ -650,6 +655,7 @@ class View extends Component {
       suggestedMRBranches,
       externalUrl,
       canCreateMR,
+      isGraphReady
     };
   }
 

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -849,7 +849,7 @@ class ProjectDatasetsNav extends Component {
       datasetsUrl={this.props.datasetsUrl}
       newDatasetUrl={this.props.newDatasetUrl}
       visibility={this.props.visibility}
-      graphStatus={this.props.webhook.status || (this.props.webhook.created && this.props.webhook.stop)}
+      graphStatus={this.props.isGraphReady}
     />;
   }
 }
@@ -933,6 +933,7 @@ function ProjectViewDatasets(props) {
     const loading = props.core.datasets === SpecialPropVal.UPDATING;
     if (loading) return;
     props.fetchDatasets(false);
+    props.fetchGraphStatus();
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 


### PR DESCRIPTION
Datasets are now displaying the correct message.

They display: 
"in the knowledge graph" if they are in the knowledge graph and the project has the knowledge graph activated
"not in the knowledge graph" in case one of the previous conditions isn't reached

---> This bug was introduced because there was a missing check to see if a project had the kg activated or not, in some cases we where also not fetching this information.

Testing:
--> check datasets for a project that you don't have rights in. I.E: https://dev.renku.ch/projects/virginiafriedrich/more-dataset-testing/datasets this project has the kg activated and the kg finished building so the datasets should display "in the knowledge graph"
--> this is fixed here... https://virginiatest.dev.renku.ch/projects/virginiafriedrich/more-dataset-testing/datasets