### PR TITLE
build: update highlight library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10680,9 +10680,9 @@
       "dev": true
     },
     "highlight.js": {
-      "version": "9.12.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
-      "integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4="
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.2.1.tgz",
+      "integrity": "sha512-A+sckVPIb9zQTUydC9lpRX1qRFO/N0OKEh0NwIr65ckvWA/oMY8v9P3+kGRK3w2ULSh9E8v5MszXafodQ6039g=="
     },
     "history": {
       "version": "4.10.1",
@@ -13224,6 +13224,13 @@
       "requires": {
         "fault": "^1.0.2",
         "highlight.js": "~9.12.0"
+      },
+      "dependencies": {
+        "highlight.js": {
+          "version": "9.12.0",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
+          "integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4="
+        }
       }
     },
     "lru-cache": {
@@ -17198,6 +17205,13 @@
         "lowlight": "~1.9.1",
         "prismjs": "^1.8.4",
         "refractor": "^2.4.1"
+      },
+      "dependencies": {
+        "highlight.js": {
+          "version": "9.12.0",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
+          "integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4="
+        }
       }
     },
     "react-themeable": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "dompurify": "^2.0.7",
     "filesize": "^6.0.0",
     "graphql": "^14.5.8",
+    "highlight.js": "^10.2.1",
     "http-proxy": "^1.18.1",
     "human-time": "^0.0.2",
     "immutability-helper": "^3.0.1",

--- a/src/file/File.container.js
+++ b/src/file/File.container.js
@@ -29,9 +29,10 @@ import { CardBody } from "reactstrap";
 
 const IMAGE_EXTENSIONS = ["jpg", "jpeg", "png", "tiff", "pdf", "gif"];
 const CODE_EXTENSIONS = [
-  "py", "js", "json", "sh", "r", "txt", "yml", "csv", "parquet", "cwl", "job", "prn", "rout",
+  "py", "js", "json", "sh", "r", "yml", "csv", "parquet", "cwl", "job", "prn", "rout",
   "dcf", "rproj", "rst", "bat", "ini", "rmd", "jl", "toml"
 ];
+const TEXT_EXTENSIONS = ["txt"];
 
 // FIXME: Unify the file viewing for issues (embedded) and independent file viewing.
 // FIXME: Javascript highlighting is broken for large files.
@@ -46,10 +47,10 @@ class FilePreview extends React.Component {
     if (this.props.file.file_name.match(/\.(.*)/) === null)
       return null;
     return this.props.file.file_name.split(".").pop().toLowerCase();
-
   };
 
   fileIsCode = () => CODE_EXTENSIONS.indexOf(this.getFileExtension()) >= 0;
+  fileIsText = () => TEXT_EXTENSIONS.indexOf(this.getFileExtension()) >= 0;
   fileIsImage = () => IMAGE_EXTENSIONS.indexOf(this.getFileExtension()) >= 0;
   fileHasNoExtension = () => this.getFileExtension() === null;
 
@@ -83,6 +84,16 @@ class FilePreview extends React.Component {
             alt={this.props.file.file_name}
             src={"data:image;base64," + this.props.file.content}
           />
+        </CardBody>
+      );
+    }
+    // Free text
+    if (this.fileIsText()) {
+      return (
+        <CardBody key="file preview" className="pb-0">
+          <pre className="no-highlight">
+            <code>{atobUTF8(this.props.file.content)}</code>
+          </pre>
         </CardBody>
       );
     }


### PR DESCRIPTION
The highlight library we are using is outdated and the support for the R language has a few bugs.
This PR updates the library and adds it to the npm dependencies (previously, it was imported as a requirement for another dependency).

OLD (some comments not highlighted)
![Screenshot_20201014_091812](https://user-images.githubusercontent.com/43481553/95956360-77eff180-0dfe-11eb-82fe-9561ea6a819f.png)

NEW
![Screenshot_20201014_090740](https://user-images.githubusercontent.com/43481553/95956388-83dbb380-0dfe-11eb-9564-c04dee1fe8d7.png)
