### PR TITLE
fix: jsonify structured error messages when fecthing custom templates

### DIFF
--- a/src/project/new/ProjectNew.present.js
+++ b/src/project/new/ProjectNew.present.js
@@ -623,12 +623,16 @@ class Create extends Component {
         content = <pre className="text-wrap">{error}</pre>;
       }
       else {
-        Object.keys(error).map(v => {
+        const errors = Object.keys(error).map(v => {
           const text = typeof error[v] == "string" ?
             `${v}: ${error[v]}` :
             `Error message: ${JSON.stringify(error[v])}`;
-          content = (<pre key={v} className="text-wrap">{text}</pre>);
+          return (<pre key={v} className="text-wrap">{text}</pre>);
         });
+        if (errors.length === 1)
+          content = (errors[0]);
+        else
+          content = error[0];
       }
       const fatal = templates.all && templates.all.length ? false : true;
       const description = fatal ?

--- a/src/project/new/ProjectNew.present.js
+++ b/src/project/new/ProjectNew.present.js
@@ -618,9 +618,18 @@ class Create extends Component {
       templates.errors[0] :
       null;
     if (error) {
-      let content = typeof error == "string" ?
-        (<pre className="text-wrap">{error}</pre>) :
-        Object.keys(error).map(v => (<pre key={v} className="text-wrap">{v}: {error[v]}</pre>));
+      let content;
+      if (typeof error == "string") {
+        content = <pre className="text-wrap">{error}</pre>;
+      }
+      else {
+        Object.keys(error).map(v => {
+          const text = typeof error[v] == "string" ?
+            `${v}: ${error[v]}` :
+            `Error message: ${JSON.stringify(error[v])}`;
+          content = (<pre key={v} className="text-wrap">{text}</pre>);
+        });
+      }
       const fatal = templates.all && templates.all.length ? false : true;
       const description = fatal ?
         (<p>Unable to fetch templates.</p>) :
@@ -631,8 +640,7 @@ class Create extends Component {
           If the error persists, you may want to use a RenkuLab template instead.
         </span>) :
         (<span>
-          You
-          can try refreshing the page. If the error persists, you should contact the development team on&nbsp;
+          You can try refreshing the page. If the error persists, you should contact the development team on&nbsp;
           <a href="https://gitter.im/SwissDataScienceCenter/renku"
             target="_blank" rel="noreferrer noopener">Gitter</a> or&nbsp;
           <a href="https://github.com/SwissDataScienceCenter/renku"


### PR DESCRIPTION
The error message we get when trying to fetch custom templates can be structured. Invoking `JSON.stringify` when that happens is the easiest solution to prevent the UI from crashing.

In the specific case mentioned in the reference issue, I *think* the message is changed in the core service and it becomes more cryptic compared to the original git command error.
If it turns out that users get confused, we could either try to intercept and parse specific errors in the UI or change the message we emit from the core service.

Preview: https://lorenzotest.dev.renku.ch/projects/new

![Screenshot_20201014_165457](https://user-images.githubusercontent.com/43481553/96008160-8f030380-0e3f-11eb-82c8-8fa1d498084e.png)

fix #1056 