### PR TITLE
feat: unify kg integration and renku version warning

### DIFF
--- a/src/model/RenkuModels.js
+++ b/src/model/RenkuModels.js
@@ -168,7 +168,8 @@ const projectSchema = new Schema({
       project_supported: { initial: null },
       migrating: { initial: false },
       migration_status: { initial: null },
-      check_error: { initial: undefined }
+      migration_error: { initial: null },
+      check_error: { initial: null }
     }
   }
 });

--- a/src/project/Project.js
+++ b/src/project/Project.js
@@ -51,7 +51,7 @@ const subRoutes = {
   stats: "overview/stats",
   overviewDatasets: "overview/datasets",
   overviewCommits: "overview/commits",
-  overviewVersion: "overview/version",
+  overviewStatus: "overview/status",
   datasets: "datasets",
   datasetsAdd: "datasets/new",
   dataset: "datasets/:datasetId",
@@ -324,7 +324,7 @@ class View extends Component {
       statsUrl: `${baseUrl}/overview/stats`,
       overviewDatasetsUrl: `${baseUrl}/overview/datasets`,
       overviewCommitsUrl: `${baseUrl}/overview/commits`,
-      overviewVersionUrl: `${baseUrl}/overview/version`,
+      overviewStatusUrl: `${baseUrl}/overview/status`,
       datasetsUrl: `${datasetsUrl}`,
       newDatasetUrl: `${datasetsUrl}/new`,
       datasetUrl: `${datasetsUrl}/:datasetId`,
@@ -613,11 +613,6 @@ class View extends Component {
     createGraphWebhook: (e) => {
       e.preventDefault();
       return this.createGraphWebhook();
-    },
-    onCloseGraphWebhook: () => {
-      this.stopCheckingWebhook();
-      this.fetchProjectDatasetsFromKg();
-      this.fetchProjectDatasets(true);
     },
     fetchGraphStatus: () => {
       return this.fetchGraphStatus();

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -95,22 +95,45 @@ class ProjectVisibilityLabel extends Component {
   }
 }
 
-class ProjectMigrationIcon extends Component {
+/**
+ * Shows a warning icon when Renku version is outdated or Knowledge Graph integration is not active.
+ *
+ * @param {Object} webhook - project.webhook store object
+ * @param {bool} migration_required - whether it's necessary to migrate the project or not
+ * @param {Object} history - react history object
+ * @param {string} overviewStatusUrl - overview status url
+ */
+class ProjectStatusIcon extends Component {
   render() {
-    const migration_required = this.props.migration_required;
+    const { webhook, migration_required, overviewStatusUrl, history } = this.props;
+    const kgDown =
+      webhook === false ||
+      (webhook.status === false && webhook.created !== true) ||
+      webhookError(webhook.status);
 
-    if (migration_required) {
-      return <span className="warningLabel">
+    if (!migration_required && !kgDown)
+      return null;
+
+    const versionInfo = migration_required ?
+      "Current Renku version is outdated. " :
+      null;
+    const kgInfo = kgDown ?
+      "Knowledge Graph integration not active. " :
+      null;
+
+    return (
+      <span className="warningLabel">
         <FontAwesomeIcon
           icon={faExclamationTriangle}
-          onClick={()=>this.props.history.push(this.props.overviewStatusUrl)}
+          onClick={() => history.push(overviewStatusUrl)}
           id="warningStatusLink" />
         <UncontrolledTooltip placement="top" target="warningStatusLink">
-          This project&apos;s <b>renku</b> version needs to be updated. Click here to see details.
+          {versionInfo}
+          {kgInfo}
+          Click to see details.
         </UncontrolledTooltip>
-      </span>;
-    }
-    return null;
+      </span>
+    );
   }
 }
 
@@ -181,7 +204,7 @@ class KnowledgeGraphIntegration extends Component {
 
     return (
       <Alert color="success">
-        Knowledge Graph integration is active.
+        <FontAwesomeIcon icon={faCheck} /> Knowledge Graph integration is active.
       </Alert>
     );
   }
@@ -193,7 +216,7 @@ class KnowledgeGraphWarning extends Component {
     if (webhook === true) {
       return (
         <Alert color="success">
-          Integration with the Knowledge Graph was successful.
+          <FontAwesomeIcon icon={faCheck} /> Integration with the Knowledge Graph was successful.
         </Alert>
       );
     }
@@ -323,8 +346,9 @@ class ProjectViewHeaderOverview extends Component {
         <Row>
           <Col xs={12} md>
             <h3>
-              <ProjectMigrationIcon
+              <ProjectStatusIcon
                 history={this.props.history}
+                webhook={this.props.webhook}
                 overviewStatusUrl={this.props.overviewStatusUrl}
                 migration_required={this.props.migration.migration_required}
               />{core.title} <ProjectVisibilityLabel visibilityLevel={this.props.visibility.level} />

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -29,7 +29,8 @@ import React, { Component, Fragment, useState, useEffect } from "react";
 import { Link, Route, Switch } from "react-router-dom";
 import {
   Container, Row, Col, Alert, DropdownItem, Table, Nav, NavItem, Button, ButtonGroup, Badge, Spinner,
-  Card, CardBody, CardHeader, Form, FormGroup, FormText, Label, Input, UncontrolledTooltip, ListGroupItem
+  Card, CardBody, CardHeader, Form, FormGroup, FormText, Label, Input, UncontrolledTooltip, ListGroupItem,
+  UncontrolledCollapse
 } from "reactstrap";
 import qs from "query-string";
 
@@ -44,7 +45,7 @@ import { faGitlab } from "@fortawesome/free-brands-svg-icons";
 
 import {
   Clipboard, ExternalLink, Loader, RenkuNavLink, TimeCaption, RefreshButton, Pagination,
-  ButtonWithMenu, InfoAlert, SuccessAlert, WarnAlert, ErrorAlert, GoBackButton, RenkuMarkdown
+  ButtonWithMenu, InfoAlert, SuccessAlert, WarnAlert, ErrorAlert, GoBackButton, RenkuMarkdown,
 } from "../utils/UIComponents";
 import { SpecialPropVal } from "../model/Model";
 import { ProjectTags, ProjectTagList } from "./shared";
@@ -102,9 +103,9 @@ class ProjectMigrationIcon extends Component {
       return <span className="warningLabel">
         <FontAwesomeIcon
           icon={faExclamationTriangle}
-          onClick={()=>this.props.history.push(this.props.overviewVersionUrl)}
-          id="warningVersionLink" />
-        <UncontrolledTooltip placement="top" target="warningVersionLink">
+          onClick={()=>this.props.history.push(this.props.overviewStatusUrl)}
+          id="warningStatusLink" />
+        <UncontrolledTooltip placement="top" target="warningStatusLink">
           This project&apos;s <b>renku</b> version needs to be updated. Click here to see details.
         </UncontrolledTooltip>
       </span>;
@@ -138,34 +139,51 @@ class MergeRequestSuggestions extends Component {
 }
 
 /**
- * If appropriate, show a warning banner that the project has not been integration with the knowledge graph.
+ * Knowledge Graph integration banner.
+ *
+ * @param {Object} webhook - project.webhook store object
+ * @param {Object} visibility - project visibility data
+ * @param {function} createGraphWebhook - function to trigger webhook creation
  */
-class KnowledgeGraphIntegrationWarningBanner extends Component {
+class KnowledgeGraphIntegration extends Component {
   render() {
-    if (this.props.webhook.stop) return null;
+    const { webhook, visibility, createGraphWebhook } = this.props;
+    if (webhook.stop)
+      return null;
 
-    const status = this.props.webhook.status;
-    if (status === false) {
-      const isPrivate = this.props.visibility && this.props.visibility.level === "private" ? true : false;
+    if (webhook.possible === null || webhook.status === SpecialPropVal.UPDATING)
+      return (<Loader />);
+
+    if (webhook.status === false) {
+      const isPrivate = visibility && visibility.level === "private" ?
+        true :
+        false;
       return (
-        <KnowledgeGraphWarning
-          close={this.props.onCloseGraphWebhook}
-          webhook={this.props.webhook.created}
-          create={this.props.createGraphWebhook}
-          isPrivate={isPrivate} />
+        <KnowledgeGraphWarning webhook={webhook.created} create={createGraphWebhook} isPrivate={isPrivate} />
       );
     }
-    // I would keep this error for safety, even if this error *should* not happen
-    const error = webhookError(status);
+
+    const error = webhookError(webhook.status);
     if (error) {
+      const errorDetails = webhook.status.message ?
+        (<Fragment>
+          <p className="mb-2">Error details:</p>
+          <pre>{webhook.status.message}</pre>
+        </Fragment>) :
+        null;
       return (
-        <WarnAlert dismissCallback={this.props.onCloseGraphWebhook}>
-          An error prevented checking integration of the project with the Knowledge Graph. Error: &quot;
-          <span className="font-italic">{status.message}</span>&quot;
-        </WarnAlert>
+        <Alert color="danger">
+          <p className="mb-2">An error prevented checking integration of the project with the Knowledge Graph.</p>
+          {errorDetails}
+        </Alert>
       );
     }
-    return null;
+
+    return (
+      <Alert color="success">
+        Knowledge Graph integration is active.
+      </Alert>
+    );
   }
 }
 
@@ -174,19 +192,22 @@ class KnowledgeGraphWarning extends Component {
     const webhook = this.props.webhook;
     if (webhook === true) {
       return (
-        <SuccessAlert dismissCallback={this.props.close}>
+        <Alert color="success">
           Integration with the Knowledge Graph was successful.
-        </SuccessAlert>
+        </Alert>
       );
     }
     else if (webhook === false || webhook === SpecialPropVal.UPDATING) {
       const updating = webhook === SpecialPropVal.UPDATING ? true : false;
       return (
-        <WarnAlert dismissCallback={this.props.close}>
-          Knowledge Graph integration has not been turned on. &nbsp;
-          <KnowledgeGraphPrivateWarning {...this.props} />
-          <KnowledgeGraphLink color="warning" {...this.props} updating={updating} />
-        </WarnAlert>
+        <Alert color="warning">
+          <p>
+            <FontAwesomeIcon icon={faExclamationTriangle} />&nbsp;
+            Knowledge Graph integration has not been turned on.
+          </p>
+          <KnowledgeGraphPrivateInfo {...this.props} />
+          <KnowledgeGraphButton color="warning" {...this.props} updating={updating} />
+        </Alert>
       );
     }
 
@@ -194,23 +215,21 @@ class KnowledgeGraphWarning extends Component {
       `The project was not integrated with the Knowledge Graph. Error: "${webhook.message}".` :
       "An unknown error prevented integration of the project with the Knowledge Graph.";
     return (
-      <ErrorAlert dismissCallback={this.props.close}>
+      <Alert color="danger">
         <p>{error}</p>
-        <KnowledgeGraphLink color="danger" {...this.props} />
-      </ErrorAlert>
+        <KnowledgeGraphButton color="danger" {...this.props} />
+      </Alert>
     );
-
   }
 }
 
-class KnowledgeGraphPrivateWarning extends Component {
+class KnowledgeGraphPrivateInfo extends Component {
   render() {
     if (!this.props.isPrivate) return null;
     return (
-      <p className="font-italic">
-        {/* <span className="font-weight-bold">WARNING! </span> */}
-        <FontAwesomeIcon icon={faExclamationTriangle} /> This is a private project. Though contents remain private,
-        the Knowledge Graph may make some metadata public; only activate if that is acceptable.
+      <p className="font-italic small">
+        This is a private project. Though contents remain private,
+        the Knowledge Graph may make some metadata public. Only activate if that is acceptable.
         <br />
         <a href="https://renku.readthedocs.io/en/latest/user/knowledge-graph.html"
           target="_blank" rel="noopener noreferrer">
@@ -221,15 +240,15 @@ class KnowledgeGraphPrivateWarning extends Component {
   }
 }
 
-class KnowledgeGraphLink extends Component {
+class KnowledgeGraphButton extends Component {
   render() {
     if (this.props.updating) {
       return (
-        <span>Activating... <Loader size="12" inline="true" /></span>
+        <Button color={this.props.color} disabled={true}>Activating... <Loader size="12" inline="true" /></Button>
       );
     }
     return (
-      <Button color={this.props.color} onClick={this.props.create}>Activate Knowledge Graph</Button>
+      <Button color={this.props.color} onClick={this.props.create}>Activate</Button>
     );
   }
 }
@@ -303,11 +322,13 @@ class ProjectViewHeaderOverview extends Component {
       <Container fluid>
         <Row>
           <Col xs={12} md>
-            <h3><ProjectMigrationIcon
-              history={this.props.history}
-              overviewVersionUrl={this.props.overviewVersionUrl}
-              migration_required={this.props.migration.migration_required}
-            />{core.title} <ProjectVisibilityLabel visibilityLevel={this.props.visibility.level} /></h3>
+            <h3>
+              <ProjectMigrationIcon
+                history={this.props.history}
+                overviewStatusUrl={this.props.overviewStatusUrl}
+                migration_required={this.props.migration.migration_required}
+              />{core.title} <ProjectVisibilityLabel visibilityLevel={this.props.visibility.level} />
+            </h3>
             <p>
               <span>{this.props.core.path_with_namespace}{forkedFrom}</span> <br />
             </p>
@@ -342,7 +363,6 @@ class ProjectViewHeaderOverview extends Component {
             </div>
           </Col>
         </Row>
-        <KnowledgeGraphIntegrationWarningBanner {...this.props} />
         {this.props.fork(this.props)}
       </Container>
     );
@@ -512,124 +532,141 @@ class ProjectViewStats extends Component {
 
 class ProjectViewVersion extends Component {
   render() {
-    const loading = isRequestPending(this.props, "readme");
-    const migration_required = this.props.migration.migration_required;
-    const project_supported = this.props.migration.project_supported;
-    const migration_status = this.props.migration.migration_status;
-    const check_error = this.props.migration.check_error;
-    const migration_error = this.props.migration.migration_error;
+    const {
+      migration_required, project_supported, migration_status, check_error, migration_error
+    } = this.props.migration;
+    const loading = isRequestPending(this.props, "readme") || migration_required === null;
     const maintainer = this.props.visibility.accessLevel >= ACCESS_LEVELS.MAINTAINER;
 
-    if (loading || (migration_required === null && migration_error === null))
-      return <Loader />;
-
-    return <Card key="storage-stats" className="border-0">
-      <CardHeader>Renku Version</CardHeader>
-      <CardBody>
-        <Col md={10} sm={12}>
-          <Row>
-            <Col>
-              { migration_required ?
-                <Alert color="warning">
-                  <FontAwesomeIcon icon={faExclamationTriangle} /> A new
-                  version of <strong>renku</strong> is availabe.
-                  <br /><br />
-                  This project is currently using an older version of renku.
-                  A migration is necessary to make changes to datasets and is recommended for all projects.
-                  <br /><br />
-                  {
-                    migration_status === MigrationStatus.ERROR ?
-                      <div>
-                        There was an error while trying to upgrade your project. Please try again,
-                        if the problem persists you should contact the development team on&nbsp;
-                        <a href="https://gitter.im/SwissDataScienceCenter/renku"
-                          target="_blank" rel="noreferrer noopener">Gitter</a> or create an issue in&nbsp;
-                        <a href="https://github.com/SwissDataScienceCenter/renku/issues"
-                          target="_blank" rel="noreferrer noopener">GitHub</a>.
-                        <br /><br />
-                        <strong>Error: </strong>{migration_error}
-                      </div>
-                      : null
+    let body = null;
+    if (loading) {
+      body = (<Loader />);
+    }
+    else {
+      // print the error if any
+      if (check_error || migration_status === MigrationStatus.ERROR) {
+        const error = check_error ?
+          check_error :
+          migration_status;
+        body = (
+          <Alert color="danger">
+            <p>
+              Error while { check_error ? "checking" : "updating" } the version. Please reload the page to try again.
+              If the problem persistsy you should contact the development team on&nbsp;
+              <a href="https://gitter.im/SwissDataScienceCenter/renku"
+                target="_blank" rel="noreferrer noopener">Gitter</a> or create an issue in&nbsp;
+              <a href="https://github.com/SwissDataScienceCenter/renku/issues"
+                target="_blank" rel="noreferrer noopener">GitHub</a>.
+            </p>
+            <div><strong>Error Message</strong><pre>{error}</pre></div>
+          </Alert>
+        );
+      }
+      // migration required
+      else if (migration_required) {
+        let updateSection = null;
+        const updateInstruction = (
+          <Fragment>
+            You can launch
+            an <Link to={this.props.launchNotebookUrl}>interactive environment</Link> and follow the
+            {/* eslint-disable-next-line max-len */}
+            &nbsp;<a href="https://renku.readthedocs.io/en/latest/user/upgrading_renku.html#upgrading-your-image-to-use-the-latest-renku-cli-version">
+              instructions for upgrading</a>.
+            When finished, you will need to run <code>renku migrate</code>.
+          </Fragment>
+        );
+        if (maintainer) {
+          if (project_supported) {
+            updateSection = (
+              <Fragment>
+                <Button
+                  color="warning"
+                  disabled={migration_status === MigrationStatus.MIGRATING}
+                  onClick={this.props.onMigrateProject}
+                >
+                  {migration_status === MigrationStatus.MIGRATING ?
+                    <span><Spinner size="sm" /> Updating...</span> : "Update"
                   }
-                  {
-                    project_supported ?
-                      maintainer ?
-                        <div>
-                          <Col align="right">
-                            <Button
-                              color="warning"
-                              disabled={migration_status === MigrationStatus.MIGRATING}
-                              onClick={this.props.onMigrateProject}>
-                              {migration_status === MigrationStatus.MIGRATING ?
-                                <span>
-                                  <Spinner size="sm" /> Updating...
-                                </span>
-                                :
-                                "Update"
-                              }
-                            </Button>
-                          </Col>
-                          <br /><br />
-                          Or, if you prefer, you can update the project manually by launching&nbsp;
-                          an <Link to={this.props.launchNotebookUrl}>interactive environment</Link> and follow the
-                          {/* eslint-disable-next-line max-len */}
-                          <a href="https://renku.readthedocs.io/en/latest/user/upgrading_renku.html#upgrading-your-image-to-use-the-latest-renku-cli-version">
-                              &nbsp;instructions for upgrading</a>.
-                          When finished, you will need to run <i>renku migrate</i>.&nbsp;
-                          If you encounter any problems or have any questions,&nbsp;
-                          please contact the development team on&nbsp;
-                          <a href="https://gitter.im/SwissDataScienceCenter/renku"
-                            target="_blank" rel="noreferrer noopener">Gitter</a> or create an issue in&nbsp;
-                          <a href="https://github.com/SwissDataScienceCenter/renku/issues"
-                            target="_blank" rel="noreferrer noopener">GitHub</a>.
+                </Button>
+                <Button color="link" id="btn_instructions"><i>Do you prefer manual instructions?</i></Button>
+                <UncontrolledCollapse toggler="#btn_instructions">
+                  <br />
+                  <p>{updateInstruction}</p>
+                </UncontrolledCollapse>
+              </Fragment>
+            );
+          }
+          else {
+            updateSection = (
+              <p>
+                <strong>Updating this project automatically is not possible.</strong>
+                <br /> {updateInstruction}
+              </p>
+            );
+          }
+        }
+        else {
+          updateSection = (
+            <p>
+              <strong>You do not have the required permissions to upgrade this project.</strong>
+              &nbsp;You can <ExternalLink role="text" size="sm"
+                title="ask a project maintainer" url={`${this.props.externalUrl}/project_members`} /> to
+              do that for you.
+            </p>
+          );
+        }
+        body = (
+          <Alert color="warning">
+            <p>
+              <FontAwesomeIcon icon={faExclamationTriangle} /> A new version of <strong>renku</strong> is available.
+              The project needs to be migrated to keep working.
+            </p>
+            {updateSection}
+          </Alert>
+        );
+      }
+      // migration not needed
+      else {
+        body = (<Alert color="success"><FontAwesomeIcon icon={faCheck} /> The current version is up to date.</Alert>);
+      }
+    }
 
-                        </div>
-                        : <strong>You do not have sufficient rights to upgrade this project, but
-                          a project maintainer can do this. <ExternalLink role="text" size="sm"
-                          title="Contact a maintainer" url={`${this.props.externalUrl}/project_members`} />
-                          .</strong>
-                      : <span>
-                        <strong>This project&apos;s renku version cannot be upgraded automatically</strong>.
-                        <br/><br/>
-                        You can launch an <Link to={this.props.launchNotebookUrl}>
-                          interactive environment</Link> and follow the&nbsp;
-                        {/* eslint-disable-next-line max-len */}
-                        <a href="https://renku.readthedocs.io/en/latest/user/upgrading_renku.html#upgrading-your-image-to-use-the-latest-renku-cli-version">
-                          &nbsp;instructions for upgrading</a>.&nbsp;
-                        When finished, you will need to run <i>renku migrate</i>.&nbsp;
-                        If you encounter any problems or have any questions,&nbsp;
-                        please contact the development team on&nbsp;
-                        <a href="https://gitter.im/SwissDataScienceCenter/renku"
-                          target="_blank" rel="noreferrer noopener">Gitter</a> or create an issue in&nbsp;
-                        <a href="https://github.com/SwissDataScienceCenter/renku/issues"
-                          target="_blank" rel="noreferrer noopener">GitHub</a>.
-                      </span>
-                  }
-                </Alert>
-                :
-                check_error !== undefined ?
-                  <Alert color="danger">
-                    There was an error while performing the migration check, please reload the page and try again.
-                    If the problem persists you should contact the development team on&nbsp;
-                    <a href="https://gitter.im/SwissDataScienceCenter/renku"
-                      target="_blank" rel="noreferrer noopener">Gitter</a> or create an issue in&nbsp;
-                    <a href="https://github.com/SwissDataScienceCenter/renku/issues"
-                      target="_blank" rel="noreferrer noopener">GitHub</a>.
-                    <br></br>
-                    <br></br>
-                    <strong>Error Message: </strong> {check_error}
-                  </Alert>
-                  : migration_required === false ?
-                    <Alert color="success">
-                      <FontAwesomeIcon icon={faCheck} /> The current renku version is compatible with RenkuLab.
-                    </Alert>
-                    : <Loader />
-              }
-            </Col>
-          </Row>
-        </Col>
-      </CardBody>
-    </Card>;
+    return (
+      <Card className="border-0">
+        <CardHeader>Renku Version</CardHeader>
+        <CardBody>
+          <Row><Col>{body}</Col></Row>
+        </CardBody>
+      </Card>
+    );
+  }
+}
+
+class ProjectViewKG extends Component {
+  render() {
+    const loading = false;
+
+    let body = null;
+    if (loading) {
+      body = (<Loader />);
+    }
+    else {
+      body = (
+        <KnowledgeGraphIntegration
+          webhook={this.props.webhook}
+          visibility={this.props.visibility}
+          createGraphWebhook={this.props.createGraphWebhook} />
+      );
+    }
+
+    return (
+      <Card className="border-0">
+        <CardHeader>Knowledge Graph integration</CardHeader>
+        <CardBody>
+          <Row><Col>{body}</Col></Row>
+        </CardBody>
+      </Card>
+    );
   }
 }
 
@@ -655,7 +692,7 @@ class ProjectViewOverviewNav extends Component {
           <RenkuNavLink to={`${this.props.overviewCommitsUrl}`} title="Commits" />
         </NavItem>
         <NavItem>
-          <RenkuNavLink to={`${this.props.overviewVersionUrl}`} title="Version" />
+          <RenkuNavLink to={`${this.props.overviewStatusUrl}`} title="Status" />
         </NavItem>
       </Nav>);
   }
@@ -715,8 +752,11 @@ class ProjectViewOverview extends Component {
                 );
               }}
             />
-            <Route exact path={this.props.overviewVersionUrl} render={props =>
-              <ProjectViewVersion {...this.props} />}
+            <Route exact path={this.props.overviewStatusUrl} render={props =>
+              <Fragment>
+                <ProjectViewVersion {...this.props} />
+                <ProjectViewKG {...this.props} />
+              </Fragment>}
             />
           </Switch>
         </Col>
@@ -926,7 +966,7 @@ function ProjectViewDatasets(props) {
       <FontAwesomeIcon icon={faExclamationTriangle} /> <strong>A new version of renku is available.</strong>
       <br />
       An upgrade is necessary to allow modification of datasets and is recommended for all projects.&nbsp;
-      <Button color="warning" onClick={() => props.history.push(props.overviewVersionUrl)} >More Info</Button>
+      <Button color="warning" onClick={() => props.history.push(props.overviewStatusUrl)} >More Info</Button>
     </Alert> : null;
 
   useEffect(()=>{

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -45,7 +45,7 @@ import { faGitlab } from "@fortawesome/free-brands-svg-icons";
 
 import {
   Clipboard, ExternalLink, Loader, RenkuNavLink, TimeCaption, RefreshButton, Pagination,
-  ButtonWithMenu, InfoAlert, SuccessAlert, WarnAlert, ErrorAlert, GoBackButton, RenkuMarkdown,
+  ButtonWithMenu, InfoAlert, GoBackButton, RenkuMarkdown,
 } from "../utils/UIComponents";
 import { SpecialPropVal } from "../model/Model";
 import { ProjectTags, ProjectTagList } from "./shared";
@@ -556,9 +556,7 @@ class ProjectViewStats extends Component {
 
 class ProjectViewVersion extends Component {
   render() {
-    const {
-      migration_required, project_supported, migration_status, check_error, migration_error
-    } = this.props.migration;
+    const { migration_required, project_supported, migration_status, check_error } = this.props.migration;
     const loading = isRequestPending(this.props, "readme") || migration_required === null;
     const maintainer = this.props.visibility.accessLevel >= ACCESS_LEVELS.MAINTAINER;
 

--- a/src/project/Project.present.js
+++ b/src/project/Project.present.js
@@ -574,7 +574,7 @@ class ProjectViewVersion extends Component {
           <Alert color="danger">
             <p>
               Error while { check_error ? "checking" : "updating" } the version. Please reload the page to try again.
-              If the problem persistsy you should contact the development team on&nbsp;
+              If the problem persists you should contact the development team on&nbsp;
               <a href="https://gitter.im/SwissDataScienceCenter/renku"
                 target="_blank" rel="noreferrer noopener">Gitter</a> or create an issue in&nbsp;
               <a href="https://github.com/SwissDataScienceCenter/renku/issues"

--- a/src/project/Project.state.js
+++ b/src/project/Project.state.js
@@ -83,7 +83,7 @@ class ProjectModel extends StateModel {
             else {
               this.fetchMigrationCheck(client);
               this.set("migration.migration_status", MigrationStatus.FINISHED);
-              this.set("migration.migration_error", undefined);
+              this.set("migration.migration_error", null);
             }
           });
       });


### PR DESCRIPTION
This PR address most of the points from #1051. Speficially, these are the implemented changes:
* Create a new `status` tab on the project overview page
* Move the Knowledge Graph integration and Renku version information to the new page, adapting the layout to be consistent
* Remove Webhook banner from the project title/header
* Add Knowledge Graph integration info to project warning icon

I'll create a follow-up issue for further reworking the webhook-relate parts once the ui-backend will be in place --> #1080 

***Preview***: https://lorenzotest.dev.renku.ch/

![Screenshot_20201016_171956](https://user-images.githubusercontent.com/43481553/96278079-58f78800-0fd5-11eb-8fc8-fe104cd01de3.png)
