### PR TITLE
Stick file tree component and set max height

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -17323,6 +17323,15 @@
         }
       }
     },
+    "react-sticky": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/react-sticky/-/react-sticky-6.0.3.tgz",
+      "integrity": "sha512-LNH4UJlRatOqo29/VHxDZOf6fwbgfgcHO4mkEFvrie5FuaZCSTGtug5R8NGqJ0kSnX8gHw8qZN37FcvnFBJpTQ==",
+      "requires": {
+        "prop-types": "^15.5.8",
+        "raf": "^3.3.0"
+      }
+    },
     "react-syntax-highlighter": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-9.0.1.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -43,6 +43,7 @@
     "react-motion": "^0.5.2",
     "react-redux": "^5.0.6",
     "react-router-dom": "^5.1.2",
+    "react-sticky": "^6.0.3",
     "reactstrap": "^8.1.1",
     "redux": "^4.0.4",
     "redux-thunk": "^2.2.0",

--- a/client/src/project/Project.js
+++ b/client/src/project/Project.js
@@ -237,6 +237,7 @@ class View extends Component {
     return this.projectState.fetchProjectDatasetsFromKg(this.props.client);
   }
   async fetchGraphStatus() { return this.projectState.fetchGraphStatus(this.props.client); }
+  saveProjectLastNode(nodeData) { this.projectState.saveProjectLastNode(nodeData); }
 
   async fetchMigrationCheck() { this.projectState.fetchMigrationCheck(this.props.client); }
 
@@ -610,6 +611,9 @@ class View extends Component {
     },
     setOpenFolder: (filePath) => {
       this.setProjectOpenFolder(filePath);
+    },
+    setLastNode: (nodeData) => {
+      this.saveProjectLastNode(nodeData);
     },
     createGraphWebhook: (e) => {
       e.preventDefault();

--- a/client/src/project/Project.present.js
+++ b/client/src/project/Project.present.js
@@ -1191,7 +1191,6 @@ class ProjectMergeRequestList extends Component {
 }
 
 class ProjectViewFiles extends Component {
-  
   componentDidMount() {
     this.props.fetchFiles();
   }

--- a/client/src/project/Project.present.js
+++ b/client/src/project/Project.present.js
@@ -452,9 +452,11 @@ class ProjectFilesNav extends Component {
       lineageUrl={this.props.lineagesUrl}
       projectUrl={this.props.fileContentUrl}
       setOpenFolder={this.props.setOpenFolder}
+      setLastNode={this.props.setLastNode}
       hash={this.props.filesTree.hash}
       fileView={this.props.filesTreeView}
-      currentUrl={this.props.location.pathname} />;
+      currentUrl={this.props.location.pathname}
+      limitHeight={true} />;
   }
 }
 
@@ -1189,7 +1191,7 @@ class ProjectMergeRequestList extends Component {
 }
 
 class ProjectViewFiles extends Component {
-
+  
   componentDidMount() {
     this.props.fetchFiles();
   }

--- a/client/src/project/Project.state.js
+++ b/client/src/project/Project.state.js
@@ -178,6 +178,10 @@ class ProjectModel extends StateModel {
       });
   }
 
+  saveProjectLastNode(nodeData) {
+    this.set("filesTree.last", nodeData);
+  }
+
   initialFetchProjectFilesTree(client, openFilePath, openFolder ) {
     this.setUpdating({ transient: { requests: { filesTree: true } } });
     return client.getProjectFilesTree(this.get("core.id"), openFilePath)

--- a/client/src/project/filestreeview/treeviewstyle.css
+++ b/client/src/project/filestreeview/treeviewstyle.css
@@ -74,12 +74,10 @@
     color:white;
     border-radius: 0.25rem;
     text-overflow: ellipsis;
-    /* overflow: hidden;   */
     white-space: nowrap;
     font-size: 1rem;
     font-weight: 300;
     line-height: 1.5;
-    display: flex;
     padding: 0.75rem 1.25rem;
     margin-bottom: 10px;
 }
@@ -106,6 +104,10 @@
     flex-direction: column;
     font-size: 2rem;
     font-weight: 300;
+}
+
+.tree-content {
+    overflow-y: auto;
 }
 
 .lfs-badge{


### PR DESCRIPTION
Here is an alternative implementation of the file tree component with independent scroll from the main page (the other was #1070)

Following the reviews, I tried to

* remove any custom listener
* fix the visualization on Safari
* adjust the scroll

These required a few workarounds because the components in the project page are re-drawn every time the user clicks a file node on the tree. Changing this behavior would require a big re-design.
The only library I ended up using is [react-sticky](https://www.npmjs.com/package/react-sticky). I tried other solutions with [react-stickynode](https://www.npmjs.com/package/react-stickynode), [react-sizes](https://github.com/renatorib/react-sizes) and [react-measure](https://github.com/souporserious/react-measure), but the final result was either more verbose or more unstable.

PREVIEW: https://lorenzotest.dev.renku.ch/projects/lorenzo.cavazzi.tech/many_files/files

P.S.  The current solution has a few workarounds that I don't really like, but I have already spent a lot of time on this and I couldn't find a better solution. Any alternative implementation is very welcome.

fix #1021