### PR TITLE
fix: dataset redirects well and doesn't wait for the kg

### DIFF
--- a/client/src/dataset/Dataset.container.js
+++ b/client/src/dataset/Dataset.container.js
@@ -36,7 +36,7 @@ export default function ShowDataset(props) {
 
   useEffect(()=>{
     let unmounted = false;
-    if (props.insideProject && datasetFiles === undefined && dataset.name) {
+    if (props.insideProject && datasetFiles === undefined && dataset && dataset.name) {
       props.client.fetchDatasetFilesFromCoreService(dataset.name, props.httpProjectUrl)
         .then(response =>{
           if (!unmounted && datasetFiles === undefined) {

--- a/client/src/dataset/addtoproject/DatasetAdd.present.js
+++ b/client/src/dataset/addtoproject/DatasetAdd.present.js
@@ -42,7 +42,7 @@ function DatasetAdd(props) {
     modification of datasets and is recommended for all projects.
     <br />
     <Button color="warning" onClick={() =>
-      props.history.push(`/projects/${selectedProject.name}/overview/version`)}>More Info</Button>
+      props.history.push(`/projects/${selectedProject.name}/overview/status`)}>More Info</Button>
   </div> : undefined;
 
   return (

--- a/client/src/project/Project.present.js
+++ b/client/src/project/Project.present.js
@@ -994,7 +994,7 @@ function ProjectViewDatasets(props) {
   useEffect(()=>{
     const loading = props.core.datasets === SpecialPropVal.UPDATING;
     if (loading) return;
-    props.fetchDatasets(false);
+    props.fetchDatasets(props.location.state && props.location.state.reload);
     props.fetchGraphStatus();
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/client/src/utils/Dataset.js
+++ b/client/src/utils/Dataset.js
@@ -29,9 +29,7 @@ const ImportStateMessage = {
   COMPLETED: "Dataset was imported, you will be redirected soon...",
   FAILED: "Dataset import failed: ",
   FAILED_NO_INFO: "Dataset import failed, please try again.",
-  TOO_LONG: "Dataset import is taking too long, please check if the dataset was imported, and if it wasn't, try again.",
-  KG_TOO_LONG: "The knowledge graph update has not yet finished." +
-  " The dataset was imported and should be visible in a short time."
+  TOO_LONG: "Dataset import is taking too long, please check if the dataset was imported, and if it wasn't, try again."
 };
 
 export { ImportStateMessage };


### PR DESCRIPTION
The redirect after dataset add was broken... it was trying to redirect a user to /project/datasets/identifier (this was the identifier like c3177e09-0582-494d-8be3-a558ded9ea63) the projects now use the dataset-name. This pr redirects the user to the right place.

On top of that, it doesn't wait for the dataset to be in the KG to redirect since it's not needed anymore. 

To test: try to add a dataset to a project in dev using the "add to project" button
To see the fix: do the same in virginia.dev.renku.ch 

Closes #1075 
