### PR TITLE
feat: kg activation and kg in datasets improvements

### DIFF
--- a/client/src/dataset/Dataset.container.js
+++ b/client/src/dataset/Dataset.container.js
@@ -105,5 +105,7 @@ export default function ShowDataset(props) {
     projectPathWithNamespace={props.projectPathWithNamespace}
     dataset={dataset}
     fetchError={fetchError}
+    overviewStatusUrl={props.overviewStatusUrl}
+    projectInsideKg={props.projectInsideKg}
   />;
 }

--- a/client/src/dataset/Dataset.present.js
+++ b/client/src/dataset/Dataset.present.js
@@ -218,13 +218,20 @@ export default function DatasetView(props) {
       projectsUrl={props.projectsUrl}
     />
     {
-      dataset.insideKg === false ?
-        <Alert color="primary">
+      dataset.insideKg === false && props.projectInsideKg === true ?
+        <Alert color="warning">
           <strong>This dataset is not in the Knowledge Graph;</strong> this means that some
-          operations on it are not possible.<br /><br />
+          operations on it are not possible.
+          <br /><br />
           If the dataset was created recently, and the Knowledge Graph integration for the project is active,
-          the dataset should be added to the Knowledge Graph soon. Otherwise, you need to
-          activate the Knowlede Graph to be able to use the full set of dataset features.
+          the dataset should be added to the Knowledge Graph soon, you can&nbsp;
+          <Button size="sm" color="warning" onClick={() => window.location.reload()}>
+            refresh the page</Button> to see if the status changed.
+          <br /><br />
+          For more information about the Knowledge Graph status you can go to the&nbsp;
+          <Button size="sm" color="warning" onClick={() => props.history.push(props.overviewStatusUrl)}>
+            status page
+          </Button>.
         </Alert>
         : null
     }

--- a/client/src/file/KnowledgeGraphStatus.container.js
+++ b/client/src/file/KnowledgeGraphStatus.container.js
@@ -79,8 +79,8 @@ class KnowledgeGraphStatus extends Component {
           this.setState({ graphStatusWaiting: false });
           if (progress === GraphIndexingStatus.MAX_VALUE || progress === GraphIndexingStatus.NO_WEBHOOK) {
             this.stopPollingProgress();
-            if (progress === GraphIndexingStatus.MAX_VALUE && this.props.retrieveGraph())
-              this.props.retrieveGraph();
+            if (progress === GraphIndexingStatus.MAX_VALUE && this.props.fetchAfterBuild)
+              this.props.fetchAfterBuild();
           }
         }
       });
@@ -115,6 +115,9 @@ class KnowledgeGraphStatus extends Component {
       createWebhook={this.createWebhook.bind(this)}
       forked={this.props.forked}
       error={this.state.error}
+      displaySuccessMessage={this.props.displaySuccessMessage}
+      warningMessage={this.props.warningMessage}
+      isPrivate={this.props.isPrivate}
     />;
   }
 }

--- a/client/src/file/KnowledgeGraphStatus.present.js
+++ b/client/src/file/KnowledgeGraphStatus.present.js
@@ -18,11 +18,26 @@
 
 import React from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
+import { faInfoCircle, faCheck, faExclamationTriangle, faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";
 import { Button, Alert, Progress } from "reactstrap";
 
 import { Loader } from "../utils/UIComponents";
 import { GraphIndexingStatus } from "../project/Project";
+
+function KnowledgeGraphPrivateInfo(props) {
+  if (!props.isPrivate) return null;
+  return (
+    <p className="font-italic small">
+      This is a private project. Though contents remain private,
+      the Knowledge Graph may make some metadata public. Only activate if that is acceptable.
+      <br />
+      <a href="https://renku.readthedocs.io/en/latest/user/knowledge-graph.html"
+        target="_blank" rel="noopener noreferrer">
+        <FontAwesomeIcon icon={faExternalLinkAlt} /> Read more about the Knowledge Graph integration.
+      </a>
+    </p>
+  );
+}
 
 function KnowledgeGraphStatus(props) {
   const { error, progress, webhookJustCreated } = props;
@@ -52,12 +67,18 @@ function KnowledgeGraphStatus(props) {
     }
 
     const action = props.maintainer ?
-      <Button color="warning" onClick={props.createWebhook}>Activate Knowledge Graph</Button> :
+      <Button color="warning" onClick={props.createWebhook}>Activate</Button> :
       <span>You do not have sufficient rights, but a project owner can do this.</span>;
 
     return (
       <Alert color="warning">
-        Knowledge Graph integration must be activated to view the lineage.&nbsp;
+        <FontAwesomeIcon icon={faExclamationTriangle} />&nbsp;
+        {props.warningMessage ?
+          props.warningMessage :
+          "Knowledge Graph integration must be activated to view the lineage."}
+        <br />
+        <KnowledgeGraphPrivateInfo isPrivate={props.isPrivate} />
+        <br />
         {action}
       </Alert>
     );
@@ -94,7 +115,14 @@ function KnowledgeGraphStatus(props) {
         </Alert>
       </div>
     );
-  } return null;
+  }
+  else if (props.displaySuccessMessage) {
+    return <Alert color="success">
+      <FontAwesomeIcon icon={faCheck} /> Knowledge Graph integration is active.
+    </Alert>;
+  }
+
+  return null;
 }
 
 export { KnowledgeGraphStatus };

--- a/client/src/file/Lineage.present.js
+++ b/client/src/file/Lineage.present.js
@@ -207,7 +207,7 @@ class FileLineage extends Component {
     ) {
       return <KnowledgeGraphStatus
         fetchGraphStatus={this.props.fetchGraphStatus}
-        retrieveGraph={this.props.retrieveGraph}
+        fetchAfterBuild={this.props.retrieveGraph}
         createGraphWebhook={this.props.createGraphWebhook}
         maintainer={this.props.maintainer}
         forked={this.props.forked}

--- a/client/src/project/Project.js
+++ b/client/src/project/Project.js
@@ -371,14 +371,16 @@ class View extends Component {
   }
 
   subComponents(projectId, ownProps) {
-    const accessLevel = this.projectState.get("visibility.accessLevel");
+    const visibility = this.projectState.get("visibility");
+    const isPrivate = visibility && visibility.level === "private";
+    const accessLevel = visibility.accessLevel;
     const externalUrl = this.projectState.get("core.external_url");
     const httpProjectUrl = this.projectState.get("system.http_url");
     const updateProjectView = this.forceUpdate.bind(this);
     const filesTree = this.projectState.get("filesTree");
     const datasets = this.projectState.get("core.datasets");
     const graphProgress = this.projectState.get("webhook.progress");
-    const maintainer = this.projectState.get("visibility.accessLevel") >= ACCESS_LEVELS.MAINTAINER ?
+    const maintainer = visibility.accessLevel >= ACCESS_LEVELS.MAINTAINER ?
       true :
       false;
     const forkedData = this.projectState.get("system.forked_from_project");
@@ -452,7 +454,7 @@ class View extends Component {
           filesTree.hash[p.location.pathname.replace(pathComponents.baseUrl + "/files/blob/", "")] :
           undefined} />,
 
-      datasetView: (p) => <ShowDataset
+      datasetView: (p, projectInsideKg) => <ShowDataset
         key="datasetpreview" {...subProps}
         maintainer={maintainer}
         insideProject={true}
@@ -468,6 +470,8 @@ class View extends Component {
         projectId={projectId}
         httpProjectUrl={httpProjectUrl}
         graphStatus={this.isGraphReady()}
+        overviewStatusUrl={subUrls.overviewStatusUrl}
+        projectInsideKg={projectInsideKg}
       />,
 
       newDataset: (p) => <ChangeDataset
@@ -541,13 +545,17 @@ class View extends Component {
         client={this.props.client}
         user={this.props.user} />,
 
-      kgStatusView: () =>
+      kgStatusView: (displaySuccessMessage = false) =>
         <KnowledgeGraphStatus
           fetchGraphStatus={this.eventHandlers.fetchGraphStatus}
           createGraphWebhook={this.eventHandlers.createGraphWebhook}
           maintainer={maintainer}
           forked={forked}
           progress={graphProgress}
+          displaySuccessMessage={displaySuccessMessage}
+          warningMessage="Knowledge Graph integration has not been turned on."
+          fetchAfterBuild={this.eventHandlers.fetchDatasets}
+          isPrivate={isPrivate}
         />
     };
   }


### PR DESCRIPTION
Unified status sign for /projects/datasets

![image](https://user-images.githubusercontent.com/42647877/98130783-eafafe00-1eba-11eb-84c3-5203ade750d4.png)

In case the general sign is present there is no sign when entering a dataset view /projects/datasets/dataset-name 
(i deleted the big purple sign here)

![image](https://user-images.githubusercontent.com/42647877/98130895-0a922680-1ebb-11eb-9b3c-a966a9ddb770.png)

In case the general sign is not present, there is a sign inside the dataset (This can happen if the dataset was recently added or the kg recently activated)

![image](https://user-images.githubusercontent.com/42647877/98131239-60ff6500-1ebb-11eb-88fb-7fd97e6e34d7.png)

This alerts redirect the user to the status page

![image](https://user-images.githubusercontent.com/42647877/98131102-3dd4b580-1ebb-11eb-922a-bfb4c0c7580c.png)

When the users activate the kg ---> here we use the same component as we use inside files (We could think about removing this in a future issue)
![image](https://user-images.githubusercontent.com/42647877/98131151-4a590e00-1ebb-11eb-9809-c0f8829d90b9.png)

Testing: virginia.dev.renku.ch