### PR TITLE
Replace deprecated set-env commands in the GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
   test-chart:
     needs: test
     runs-on: ubuntu-latest
+    if: "startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
@@ -65,6 +66,7 @@ jobs:
   publish-chart:
     needs: test-chart
     runs-on: ubuntu-latest
+    if: "startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'"
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,6 @@ jobs:
   test-chart:
     needs: test
     runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
@@ -66,7 +65,6 @@ jobs:
   publish-chart:
     needs: test-chart
     runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'"
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,8 +73,8 @@ jobs:
         fetch-depth: 0
     - name: set up environment variables
       run: |
-        echo ::set-env name=GIT_USER::"Renku Bot"
-        echo ::set-env name=GIT_EMAIL::"renku@datascience.ch"
+        echo "GIT_USER=Renku Bot" >> $GITHUB_ENV
+        echo "GIT_EMAIL=renku@datascience.ch" >> $GITHUB_ENV
     - name: Push chart and images
       uses: SwissDataScienceCenter/renku/actions/publish-chart@master
       env:


### PR DESCRIPTION
Reference: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable

~P.S. the second commit is just for testing, I'll remove it as soon as the chart has been published correctly.~
UPDATE: second commit removed, it worked :tada: 
Chart pushed here: https://swissdatasciencecenter.github.io/helm-charts/renku-ui-0.11.2-9af026e.tgz
Chart tested here: https://lorenzo.dev.renku.ch/ (not that this test was very useful since the env variables are used only to push the  chart :grin: )