### PR TITLE
improvement: mark commits with autodaved content when starting a new environment

### DIFF
--- a/client/src/utils/UIComponents.js
+++ b/client/src/utils/UIComponents.js
@@ -259,21 +259,31 @@ function ExternalLinkText(props) {
 /**
  * Link to external URL.
  *
- * @param {string} [url] - The URL to link to
- * @param {string} [title] - The text to show for the link
- * @param {string} [role] - "link" or "text" to be shown as a link, null for a button
- * @param {string?} [className] - [Optional] Any classes to add, e.g., 'nav-link' or 'dropdown-item'
+ * @param {string} url - The URL to link to
+ * @param {string} title - The text to show for the link
+ * @param {string} [role] - "link" or "text" to be shown as a link, null for a button (default null)
+ * @param {string} [className] - Any classes to add, e.g., 'nav-link' or 'dropdown-item'
  * @param {boolean} [showLinkIcon] - Show the icon to indicate an external link if true (default false)
  * @param {string} [iconSize] - icon size modifier ("lg", "2x", ...)
+ * @param {boolean} [iconSup] - Position the icon as superscript when true (default false)
+ * @param {boolean} [iconAfter] - Position the icon after the text when true (default false)
  * @param {string} [id] - main element's id
  */
 function ExternalLink(props) {
   const role = props.role;
-  const displayTitle = (props.showLinkIcon) ?
-    (<span><FontAwesomeIcon icon={faExternalLinkAlt} size={props.iconSize} color="dark" /> {props.title}</span>) :
-    props.title;
+  const showLinkIcon = props.showLinkIcon || props.iconSup || props.iconAfter || props.iconSize ?
+    true :
+    false;
+  let displayTitle = props.title;
+  if (showLinkIcon) {
+    const icon = props.iconSup ?
+      (<sup><FontAwesomeIcon icon={faExternalLinkAlt} size={props.iconSize} color="dark" /></sup>) :
+      (<FontAwesomeIcon icon={faExternalLinkAlt} size={props.iconSize} color="dark" />);
+    displayTitle = props.iconAfter ?
+      (<span>{props.title} {icon}</span>) :
+      (<span>{icon} {props.title}</span>);
+  }
   const myProps = { ...props, title: displayTitle };
-
   if (role === "link" || role === "text")
     return ExternalLinkText(myProps);
   return ExternalLinkButton(myProps);


### PR DESCRIPTION
Implement the solution suggested in #1113 to make it clear to the users which commits have autosaved content.

***Preview:*** https://lorenzotest.dev.renku.ch/
***How to test:*** Start an interactive environment on any project, modify a file and stop the environment from the environments page in the UI. Try to start a new envireonment and verify that the relevant commit is marked with a `*`. Select it to get a short explanation.

![Screenshot_20201118_152646](https://user-images.githubusercontent.com/43481553/99544513-af7d2b00-29b4-11eb-9863-ee1e1322e0c2.png)

![Screenshot_20201118_152707](https://user-images.githubusercontent.com/43481553/99544489-a7bd8680-29b4-11eb-9034-73fdb2fca7db.png)

fix #1113


