### PR TITLE
fix notifications and change notebook notifications

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -61,7 +61,8 @@ class App extends Component {
     const blockAnonymous = !user.logged && !this.props.params["ANONYMOUS_SESSIONS"];
 
     // setup notification system
-    const notifications = new NotificationsManager(this.props.model, this.props.client, this.props.location);
+    const getLocation = () => this.props.location;
+    const notifications = new NotificationsManager(this.props.model, this.props.client, getLocation);
 
     return (
       <Fragment>

--- a/client/src/model/RenkuModels.js
+++ b/client/src/model/RenkuModels.js
@@ -507,9 +507,14 @@ const statuspageSchema = new Schema({
 const notificationsSchema = new Schema({
   unread: { [Prop.INITIAL]: 0, [Prop.MANDATORY]: true },
   all: { [Prop.INITIAL]: [], [Prop.MANDATORY]: true },
+  dropdown: {
+    [Prop.SCHEMA]: new Schema({
+      enabled: { [Prop.INITIAL]: false, [Prop.MANDATORY]: true },
+    })
+  },
   toast: {
     [Prop.SCHEMA]: new Schema({
-      enabled: { [Prop.INITIAL]: true, [Prop.MANDATORY]: true },
+      enabled: { [Prop.INITIAL]: false, [Prop.MANDATORY]: true },
       timeout: { [Prop.INITIAL]: 7500, [Prop.MANDATORY]: true },
       position: { [Prop.INITIAL]: "top-right", [Prop.MANDATORY]: true },
     })

--- a/client/src/notebooks/Notebooks.container.js
+++ b/client/src/notebooks/Notebooks.container.js
@@ -343,11 +343,12 @@ class StartNotebookServer extends Component {
       // add a notification
       // TODO: once we will get the info from ui-server, notify only when the environment is ready
       const info = NotebooksHelper.cleanAnnotations(data.annotations);
+      const projectEnvironments = location.state.successUrl;
       this.notifications.addSuccess(
         this.notifications.Topics.ENVIRONMENT_START,
         `An interactive environment for the project ${info["namespace"]}/${info["projectName"]} will be available soon`,
-        data.url, "Open environment",
-        [location.state.successUrl, "/environments"],
+        projectEnvironments, "Show environments",
+        [projectEnvironments, "/environments", `${projectEnvironments}/new`],
         `Branch: ${info["branch"]}; Commit: ${info["commit-sha"]}`
       );
 
@@ -370,7 +371,7 @@ class StartNotebookServer extends Component {
           // crafting notification
           const fullError = `An error occurred when trying to start a new Interactive environment.
           Error message: "${error.message}", Stack trace: "${error.stack}"`;
-          this.notifications.addWarning(
+          this.notifications.addError(
             this.notifications.Topics.ENVIRONMENT_START,
             "Unable to start the interactive environment.",
             this.props.location.pathname, "Try again",

--- a/client/src/notifications/Notifications.container.js
+++ b/client/src/notifications/Notifications.container.js
@@ -47,13 +47,14 @@ const NotificationTypes = {
  *
  * @param {Object} client - api-client used to query the gateway
  * @param {Object} model - global model for the ui
- * @param {Object} location - react location object
+ * @param {function} getLocation - function to invoke to get the up-to-date react location object
  */
 class NotificationsManager {
-  constructor(model, client, location) {
-    this.location = location;
+  constructor(model, client, getLocation) {
     this.model = model.subModel("notifications");
-    this.coordinator = new NotificationsCoordinator(client, this.model);
+    this.client = client;
+    this.getLocation = getLocation;
+    this.coordinator = new NotificationsCoordinator(this.client, this.model);
     this.Levels = NotificationsInfo.Levels;
     this.Topics = NotificationsInfo.Topics;
 
@@ -80,7 +81,7 @@ class NotificationsManager {
     let forceRead = level === this.Levels.INFO ?
       true :
       false;
-    if (!forceRead && locations.length && locations.includes(this.location.pathname))
+    if (!forceRead && locations.length && locations.includes(this.getLocation().pathname))
       forceRead = true;
 
     // add the notification

--- a/client/src/notifications/Notifications.container.js
+++ b/client/src/notifications/Notifications.container.js
@@ -174,7 +174,8 @@ class NotificationsMenu extends Component {
     return {
       handlers: this.handlers,
       notifications: state.notifications.all,
-      unread: state.notifications.unread
+      unread: state.notifications.unread,
+      enabled: state.notifications.dropdown.enabled
     };
   }
 

--- a/client/src/notifications/Notifications.present.js
+++ b/client/src/notifications/Notifications.present.js
@@ -166,6 +166,9 @@ class NotificationLink extends Component {
 
 class NotificationsMenu extends Component {
   render() {
+    if (!this.props.enabled)
+      return null;
+
     const badge = this.props.unread ?
       (<Badge color="danger" className="notification-badge">{this.props.unread}</Badge>) :
       null;


### PR DESCRIPTION
This includes 2 changes
1. fix: use the current location for notifications

2. refactor: change environments notifications
   * Use error notifications when starting an environment fails
   * Prevent successful notification from generating a toast when not needed (i.e. the user is on a environment page relevant for that project)
   * Change link on the successful notification from the JupiterHub url to the project environments page

***Preview***: https://lorenzotest2.dev.renku.ch