### PR TITLE
feat: sync tabs on authentication events

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12370,6 +12370,12 @@
         "pretty-format": "^24.9.0"
       }
     },
+    "jest-localstorage-mock": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/jest-localstorage-mock/-/jest-localstorage-mock-2.4.3.tgz",
+      "integrity": "sha512-UgifkHKoWVRUoSqO4Z4Z+Hl1NbiYBVDlmkmulFFeRRneGECWAlAdGWJdyz+2NisjOZnnQoxQl0s5dQ7ch62Jxw==",
+      "dev": true
+    },
     "jest-matcher-utils": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -76,6 +76,7 @@
     "eslint-plugin-spellcheck": "0.0.17",
     "fetch-mock": "^7.7.0",
     "history": "^4.10.1",
+    "jest-localstorage-mock": "^2.4.3",
     "node-fetch": "^2.6.0",
     "react-scripts": "^3.4.1",
     "typescript": "^3.8.2"

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -32,7 +32,7 @@ import Project from "./project/Project";
 import DatasetList from "./dataset/list/DatasetList.container";
 import { Landing, RenkuNavBar, FooterNavbar } from "./landing";
 import { Notebooks } from "./notebooks";
-import { Login } from "./authentication";
+import { Login, LoginHelper } from "./authentication";
 import Help from "./help";
 import NotFound from "./not-found";
 import ShowDataset from "./dataset/Dataset.container";
@@ -45,6 +45,18 @@ import "react-toastify/dist/ReactToastify.css";
 
 
 class App extends Component {
+  constructor(props) {
+    super(props);
+
+    // Setup notification system
+    const getLocation = () => this.props.location;
+    this.notifications = new NotificationsManager(this.props.model, this.props.client, getLocation);
+
+    // Setup authentication listeners and notifications
+    LoginHelper.setupListener();
+    LoginHelper.triggerNotifications(this.notifications);
+  }
+
   render() {
     // Avoid rendering the application while authenticating the user
     const { user } = this.props;
@@ -60,14 +72,10 @@ class App extends Component {
     // check anonymous sessions settings
     const blockAnonymous = !user.logged && !this.props.params["ANONYMOUS_SESSIONS"];
 
-    // setup notification system
-    const getLocation = () => this.props.location;
-    const notifications = new NotificationsManager(this.props.model, this.props.client, getLocation);
-
     return (
       <Fragment>
         <Route render={props =>
-          <RenkuNavBar {...props} {...this.props} notifications={notifications} />
+          <RenkuNavBar {...props} {...this.props} notifications={this.notifications} />
         } />
         <main role="main" className="container-fluid">
           <div key="gap">&nbsp;</div>
@@ -114,7 +122,7 @@ class App extends Component {
                 model={this.props.model}
                 user={this.props.user}
                 blockAnonymous={blockAnonymous}
-                notifications={notifications}
+                notifications={this.notifications}
                 {...p}
               />}
             />
@@ -157,7 +165,7 @@ class App extends Component {
               p => <NotificationsPage key="notifications"
                 client={this.props.client}
                 model={this.props.model}
-                notifications={notifications}
+                notifications={this.notifications}
                 {...p}
               />}
             />

--- a/client/src/api-client/index.js
+++ b/client/src/api-client/index.js
@@ -221,10 +221,13 @@ class APIClient {
   }
 
   doLogin() {
+    // This is invoked to check authentication.
+    // ? It may be safer to invoke `LoginHelper.notifyLogout()`, but it doesn't seem to be necessary
     window.location = `${this.baseUrl}/auth/login?redirect_url=${encodeURIComponent(window.location.href)}`;
   }
 
   doLogout() {
+    // ? Whenever this will be used, remember to invoke `LoginHelper.notifyLogout()`
     window.location = `${this.baseUrl}/auth/logout?redirect_url=${encodeURIComponent(window.location.href)}`;
   }
 

--- a/client/src/authentication/Authentication.container.js
+++ b/client/src/authentication/Authentication.container.js
@@ -35,6 +35,10 @@ const RenkuQueryParams = {
 
 const LOGOUT_EVENT_TIMEOUT = 5000;
 
+/**
+ * Manages communication of login/logout events between tabs. It uses localStorage to communicate
+ * the events between tabs, and uses sessionStorage to remember an event after a refresh within a tab.
+ */
 const LoginHelper = {
   /**
    * Add the renku login query parameters

--- a/client/src/authentication/Authentication.container.js
+++ b/client/src/authentication/Authentication.container.js
@@ -27,17 +27,110 @@
 import React, { Component } from "react";
 
 
+const RenkuQueryParams = {
+  login: "renku_login",
+  logout: "renku_logout",
+  loginValue: "1"
+};
+
+const LOGOUT_EVENT_TIMEOUT = 5000;
+
+const LoginHelper = {
+  /**
+   * Add the renku login query parameters
+   *
+   * @param {string} url - return url for the authentication backend
+   */
+  createLoginUrl: (url) => {
+    let redirectUrl = new URL(url);
+    if (!redirectUrl.search.includes(RenkuQueryParams.login))
+      redirectUrl.searchParams.append(RenkuQueryParams.login, RenkuQueryParams.loginValue);
+
+    return redirectUrl.toString();
+  },
+  /**
+   * Remove renku login parameters and set localStorage object
+   *
+   * @param {object} history - return url for the authentication backend
+   */
+  handleLoginParams: (history) => {
+    // check if user has just logged in
+    const queryParams = new URLSearchParams(history.location.search);
+    if (queryParams.get(RenkuQueryParams.login) === RenkuQueryParams.loginValue) {
+      // delete the login param
+      queryParams.delete(RenkuQueryParams.login);
+      history.replace({ search: queryParams.toString() });
+
+      // save the login time to localStorage to allow other tabs to handle the event
+      localStorage.setItem(RenkuQueryParams.login, Date.now());
+    }
+  },
+  /**
+   * Set up event listener fol localStorage authentication events. Invoke only once.
+   */
+  setupListener: () => {
+    window.onstorage = (event) => {
+      if (event.key === RenkuQueryParams.logout) {
+        setTimeout(() => {
+          sessionStorage.setItem(RenkuQueryParams.logout, Date.now());
+          window.location.reload();
+        }, LOGOUT_EVENT_TIMEOUT);
+      }
+      else if (event.key === RenkuQueryParams.login) {
+        sessionStorage.setItem(RenkuQueryParams.login, Date.now());
+        window.location.reload();
+      }
+    };
+  },
+  /**
+   * Set up event listener fol localStorage authentication events. Invoke only once.
+   *
+   * @param {object} notifications - notification manager object.
+   */
+  triggerNotifications: (notifications) => {
+    // check login
+    const login = sessionStorage.getItem(RenkuQueryParams.login);
+    if (login) {
+      sessionStorage.removeItem(RenkuQueryParams.login);
+      notifications.addSuccess(
+        notifications.Topics.AUTHENTICATION,
+        "The page was refreshed because the user has recently logged in on a different tab."
+      );
+    }
+
+    // check logout
+    const logout = sessionStorage.getItem(RenkuQueryParams.logout);
+    if (logout) {
+      sessionStorage.removeItem(RenkuQueryParams.logout);
+      notifications.addWarning(
+        notifications.Topics.AUTHENTICATION,
+        "The page was refreshed because you recently logged out on a different tab."
+      );
+    }
+  },
+  /**
+   * Invoke whenever then logout process has been triggered.
+   */
+  notifyLogout: () => {
+    localStorage.setItem(RenkuQueryParams.logout, Date.now());
+  },
+  queryParams: RenkuQueryParams
+};
+
 // always pass "previous" with the current `location.pathname`
 class Login extends Component {
   render() {
-    let redirectUrl = this.props.params.BASE_URL;
+    // build redirect url
+    let url = this.props.params.BASE_URL;
     if (this.props.location.state && this.props.location.state.previous)
-      redirectUrl += this.props.location.state.previous;
+      url += this.props.location.state.previous;
+    const redirectUrl = LoginHelper.createLoginUrl(url);
 
+    // set new location
     window.location =
       `${this.props.params.GATEWAY_URL}/auth/login?redirect_url=${encodeURIComponent(redirectUrl)}`;
     return <p>logging in</p>;
   }
 }
 
-export { Login };
+export { Login, LoginHelper };

--- a/client/src/authentication/Authentication.container.js
+++ b/client/src/authentication/Authentication.container.js
@@ -94,7 +94,7 @@ const LoginHelper = {
       sessionStorage.removeItem(RenkuQueryParams.login);
       notifications.addSuccess(
         notifications.Topics.AUTHENTICATION,
-        "The page was refreshed because the user has recently logged in on a different tab."
+        "The page was refreshed because you recently logged in on a different tab."
       );
     }
 

--- a/client/src/authentication/Authentication.test.js
+++ b/client/src/authentication/Authentication.test.js
@@ -1,0 +1,134 @@
+/*!
+ * Copyright 2020 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  Authentication.test.js
+ *  Tests for authentication.
+ */
+
+import React from "react";
+import { act } from "react-dom/test-utils";
+import ReactDOM from "react-dom";
+import { MemoryRouter } from "react-router-dom";
+
+import { LoginHelper, Login } from "./index";
+
+
+// Mock relevant react objects
+const location = { pathname: "", state: "", previous: "", search: "" };
+const history = { location, replace: () => {} };
+const url = "https://fakedev.renku.ch/";
+
+// Mock localStorage event generator
+function dispatchFakeStorageEvent(key, newValue) {
+  /* eslint-disable no-console */
+  const original = console.error;
+  console.error = jest.fn();
+  window.dispatchEvent(new StorageEvent("storage", { key, newValue }));
+  console.error = original;
+  /* eslint-enable no-console */
+}
+
+
+describe("rendering", () => {
+  const params = { BASE_URL: "https://fake" };
+
+  it("renders Login", async () => {
+    const props = {
+      params,
+      location
+    };
+
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    await act(async () => {
+      ReactDOM.render(<MemoryRouter>
+        <Login {...props} />
+      </MemoryRouter>, div);
+    });
+  });
+});
+
+describe("LoginHelper functions", () => {
+  const { queryParams } = LoginHelper;
+
+  it("createLoginUrl", async () => {
+    const extraParam = `${queryParams.login}=${queryParams.loginValue}`;
+
+    expect(LoginHelper.createLoginUrl(url)).toBe(`${url}?${extraParam}`);
+
+    const urlWithParam = `${url}?test=1`;
+    expect(LoginHelper.createLoginUrl(urlWithParam)).toBe(`${urlWithParam}&${extraParam}`);
+  });
+
+  it("handleLoginParams", async () => {
+    localStorage.clear();
+
+    LoginHelper.handleLoginParams(history);
+    expect(Object.keys(localStorage.__STORE__).length).toBe(0);
+    const loginUrl = LoginHelper.createLoginUrl(url);
+    const loginHistory = { ...history, location: { ...location, search: loginUrl.replace(url, "") } };
+    const datePre = (new Date()).getTime();
+
+    LoginHelper.handleLoginParams(loginHistory);
+    expect(Object.keys(localStorage.__STORE__).length).toBe(1);
+    // ? Alternative to avoid using the localStorage function: localStorage.__STORE__[queryParams.login]
+    const loginDate = parseInt(localStorage.getItem(queryParams.login));
+    expect(loginDate).toBeGreaterThanOrEqual(datePre);
+    const datePost = (new Date()).getTime();
+    expect(loginDate).toBeLessThanOrEqual(datePost);
+  });
+
+  it("setupListener", async () => {
+    localStorage.clear();
+    sessionStorage.clear();
+
+    LoginHelper.setupListener();
+    expect(Object.keys(sessionStorage.__STORE__).length).toBe(0);
+    const datePre = (new Date()).getTime();
+
+    dispatchFakeStorageEvent(queryParams.login, new Date());
+    expect(Object.keys(sessionStorage.__STORE__).length).toBe(1);
+    const sessionStorageDate = parseInt(sessionStorage.getItem(queryParams.login));
+    expect(sessionStorageDate).toBeGreaterThanOrEqual(datePre);
+    const datePost = (new Date()).getTime();
+    expect(sessionStorageDate).toBeLessThanOrEqual(datePost);
+
+    dispatchFakeStorageEvent(queryParams.logout, new Date());
+    expect(Object.keys(sessionStorage.__STORE__).length).toBe(1); // that takes longer due to the timeout
+  });
+
+  it("notifyLogout", async () => {
+    localStorage.clear();
+
+    expect(Object.keys(localStorage.__STORE__).length).toBe(0);
+    const datePre = (new Date()).getTime();
+
+    LoginHelper.notifyLogout();
+    expect(Object.keys(localStorage.__STORE__).length).toBe(1);
+    const localStorageDate = parseInt(localStorage.getItem(queryParams.logout));
+    expect(localStorageDate).toBeGreaterThanOrEqual(datePre);
+    const datePost = (new Date()).getTime();
+    expect(localStorageDate).toBeLessThanOrEqual(datePost);
+
+    dispatchFakeStorageEvent(queryParams.logout, new Date());
+    expect(Object.keys(sessionStorage.__STORE__).length).toBe(1); // that takes longer due to the timeout
+  });
+});

--- a/client/src/authentication/index.js
+++ b/client/src/authentication/index.js
@@ -16,6 +16,6 @@
  * limitations under the License.
  */
 
-import { Login } from "./Authentication.container.js";
+import { Login, LoginHelper } from "./Authentication.container.js";
 
-export { Login };
+export { Login, LoginHelper };

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -14,6 +14,7 @@ import { Maintenance } from "./Maintenance";
 // import registerServiceWorker from './utils/ServiceWorker';
 import APIClient from "./api-client";
 import { UserCoordinator } from "./user";
+import { LoginHelper } from "./authentication";
 import { StateModel, globalSchema } from "./model";
 
 const configFetch = fetch("/config.json");
@@ -86,10 +87,14 @@ Promise.all([configFetch, privacyFetch]).then(valuesRead => {
     const VisibleApp = connect(mapStateToProps)(App);
     ReactDOM.render(
       <Router>
-        <Route render={props =>
-          <VisibleApp client={client} params={params} store={model.reduxStore} model={model}
-            statuspageId={statuspageId} location={props.location} />
-        } />
+        <Route render={props => {
+          LoginHelper.handleLoginParams(props.history);
+          return (
+            <VisibleApp client={client} params={params} store={model.reduxStore} model={model}
+              statuspageId={statuspageId} location={props.location}
+            />
+          );
+        }} />
       </Router>,
       document.getElementById("root")
     );

--- a/client/src/landing/NavBar.js
+++ b/client/src/landing/NavBar.js
@@ -36,6 +36,7 @@ import { ExternalDocsLink, ExternalLink, Loader, RenkuNavLink, UserAvatar } from
 import { getActiveProjectPathWithNamespace, gitLabUrlFromProfileUrl } from "../utils/HelperFunctions";
 import QuickNav from "../utils/quicknav";
 import { NotificationsMenu } from "../notifications";
+import { LoginHelper } from "../authentication";
 
 import "./NavBar.css";
 
@@ -80,7 +81,7 @@ class RenkuToolbarItemUser extends Component {
       <div key="menu" className="dropdown-menu dropdown-menu-right" aria-labelledby="profile-dropdown">
         <ExternalLink url={`${gatewayURL}/auth/user-profile`} title="Account" className="dropdown-item" role="link" />
         <DropdownItem divider />
-        <a id="logout-link" className="dropdown-item"
+        <a id="logout-link" className="dropdown-item" onClick={() => { LoginHelper.notifyLogout(); }}
           href={`${gatewayURL}/auth/logout?redirect_url=${redirect_url}`}>Logout</a>
       </div>
     </li>;

--- a/client/src/model/RenkuModels.js
+++ b/client/src/model/RenkuModels.js
@@ -513,12 +513,12 @@ const notificationsSchema = new Schema({
   all: { [Prop.INITIAL]: [], [Prop.MANDATORY]: true },
   dropdown: {
     [Prop.SCHEMA]: new Schema({
-      enabled: { [Prop.INITIAL]: false, [Prop.MANDATORY]: true },
+      enabled: { [Prop.INITIAL]: true, [Prop.MANDATORY]: true },
     })
   },
   toast: {
     [Prop.SCHEMA]: new Schema({
-      enabled: { [Prop.INITIAL]: false, [Prop.MANDATORY]: true },
+      enabled: { [Prop.INITIAL]: true, [Prop.MANDATORY]: true },
       timeout: { [Prop.INITIAL]: 7500, [Prop.MANDATORY]: true },
       position: { [Prop.INITIAL]: "top-right", [Prop.MANDATORY]: true },
     })

--- a/client/src/notifications/Notifications.present.js
+++ b/client/src/notifications/Notifications.present.js
@@ -48,6 +48,8 @@ import "./Notifications.css";
  */
 class CloseToast extends Component {
   close() {
+    if (this.props.markRead)
+      this.props.markRead();
     if (this.props.closeToast)
       this.props.closeToast();
   }

--- a/client/src/notifications/Notifications.state.js
+++ b/client/src/notifications/Notifications.state.js
@@ -31,8 +31,9 @@ const NotificationsInfo = {
     ERROR: "error",
   },
   Topics: {
-    DATASET_CREATE: "Dataset creation",
     ENVIRONMENT_START: "Interactive environment",
+    AUTHENTICATION: "Authentication",
+    DATASET_CREATE: "Dataset creation",
   },
 };
 

--- a/client/src/setupTests.js
+++ b/client/src/setupTests.js
@@ -1,3 +1,6 @@
+// ? reference: https://www.npmjs.com/package/jest-localstorage-mock#in-create-react-app
+import "jest-localstorage-mock";
+
 if (global.document) {
   document.createRange = () => ({
     setStart: () => {},


### PR DESCRIPTION
This implements a basic mechanism to synchronize tabs on relevant authentication events.

I prepared 2 previews, one with notifications and one without. I believe taking advantage of the notification system is very useful for this case. Otherwise, the user may be confused when he switches to a page that was refreshed without explanations.

***Preview without notifications***: https://lorenzotest2.dev.renku.ch/
***Preview with notifications***:  https://lorenzotest.dev.renku.ch/

***How to test***: Open at least 2 tabs on the same deployment. Try to login/logout in one of them, then check what happens in the other.

fix #1048