### PR TITLE
Fix wrong commit list when starting new environment

### DIFF
--- a/client/src/notebooks/Notebooks.container.js
+++ b/client/src/notebooks/Notebooks.container.js
@@ -157,7 +157,7 @@ class StartNotebookServer extends Component {
     this.coordinator = new NotebooksCoordinator(props.client, this.model, this.userModel);
     // TODO: this should go away when moving all project content to projectCoordinator
     this.projectModel = props.model.subModel("project");
-    this.projectCoordinator = new ProjectCoordinator(props.client, props.model.subModel("project"));
+    this.projectCoordinator = new ProjectCoordinator(props.client, this.projectModel, props.notifications);
     this.notifications = props.notifications;
     // temporarily reset data since notebooks model was not designed to be static
     this.coordinator.reset();

--- a/client/src/notebooks/Notebooks.present.js
+++ b/client/src/notebooks/Notebooks.present.js
@@ -754,6 +754,7 @@ class StartNotebookServer extends Component {
     const messageOutput = message ?
       (<div key="message">{message}</div>) :
       null;
+    const disabled = fetching.branches || fetching.commits;
 
     return (
       <Row>
@@ -761,8 +762,8 @@ class StartNotebookServer extends Component {
           <h3>Start a new interactive environment</h3>
           {messageOutput}
           <Form>
-            <StartNotebookBranches {...this.props} />
-            {show.commits ? <StartNotebookCommits {...this.props} /> : null}
+            <StartNotebookBranches {...this.props} disabled={disabled} />
+            {show.commits ? <StartNotebookCommits {...this.props} disabled={disabled} /> : null}
             {show.pipelines ? <StartNotebookPipelines {...this.props}
               ignorePipeline={this.state.ignorePipeline}
               setIgnorePipeline={this.setIgnorePipeline.bind(this)} /> : null}
@@ -777,6 +778,7 @@ class StartNotebookServer extends Component {
 class StartNotebookBranches extends Component {
   render() {
     const { branches } = this.props.data;
+    const { disabled } = this.props;
     let content;
     if (StatusHelper.isUpdating(branches)) {
       content = (
@@ -835,7 +837,7 @@ class StartNotebookBranches extends Component {
               <StartNotebookBranchesUpdate {...this.props} />
               <StartNotebookBranchesOptions {...this.props} />
             </Label>
-            <Input type="select" id="selectBranch" name="selectBranch"
+            <Input type="select" id="selectBranch" name="selectBranch" disabled={disabled}
               value={this.props.filters.branch.name ? this.props.filters.branch.name : ""}
               onChange={(event) => { this.props.handlers.setBranch(event.target.value); }}>
               <option disabled hidden></option>
@@ -857,7 +859,7 @@ class StartNotebookBranchesUpdate extends Component {
   render() {
     return [
       <Button key="button" className="ml-2 p-0" color="link" size="sm"
-        id="branchUpdateButton"
+        id="branchUpdateButton" disabled={this.props.disabled}
         onClick={this.props.handlers.refreshBranches}>
         <FontAwesomeIcon icon={faSyncAlt} />
       </Button>,
@@ -872,7 +874,7 @@ class StartNotebookBranchesOptions extends Component {
   render() {
     return [
       <Button key="button" className="ml-2 p-0" color="link" size="sm"
-        id="branchOptionsButton"
+        id="branchOptionsButton" disabled={this.props.disabled}
         onClick={() => { }}>
         <FontAwesomeIcon icon={faCogs} />
       </Button>,
@@ -1136,7 +1138,7 @@ class StartNotebookCommits extends Component {
     if (fetching)
       return (<Label>Updating commits... <Loader size="14" inline="true" /></Label>);
 
-    const { filters } = this.props;
+    const { filters, disabled } = this.props;
     const { displayedCommits } = filters;
     const filteredCommits = displayedCommits && displayedCommits > 0 ?
       commits.slice(0, displayedCommits) :
@@ -1176,7 +1178,7 @@ class StartNotebookCommits extends Component {
           <StartNotebookCommitsUpdate {...this.props} />
           <StartNotebookCommitsOptions {...this.props} />
         </Label>
-        <Input type="select" id="selectCommit" name="selectCommit"
+        <Input type="select" id="selectCommit" name="selectCommit" disabled={disabled}
           value={filters.commit && filters.commit.id ? filters.commit.id : ""}
           onChange={(event) => { this.props.handlers.setCommit(event.target.value); }}>
           <option disabled hidden></option>
@@ -1192,7 +1194,7 @@ class StartNotebookCommitsUpdate extends Component {
   render() {
     return [
       <Button key="button" className="ml-2 p-0" color="link" size="sm"
-        id="commitUpdateButton"
+        id="commitUpdateButton" disabled={this.props.disabled}
         onClick={this.props.handlers.refreshCommits}>
         <FontAwesomeIcon icon={faSyncAlt} />
       </Button>,
@@ -1207,7 +1209,7 @@ class StartNotebookCommitsOptions extends Component {
   render() {
     return [
       <Button key="button" className="ml-2 p-0" color="link" size="sm"
-        id="commitOptionsButton"
+        id="commitOptionsButton" disabled={this.props.disabled}
         onClick={() => { }}>
         <FontAwesomeIcon icon={faCogs} />
       </Button>,

--- a/client/src/notebooks/Notebooks.present.js
+++ b/client/src/notebooks/Notebooks.present.js
@@ -748,7 +748,7 @@ class StartNotebookServer extends Component {
 
     let show = {};
     show.commits = !fetching.branches && branch.name ? true : false;
-    show.pipelines = show.commits && !fetching.commits && commit.id;
+    show.pipelines = show.commits && !fetching.commits && commit && commit.id;
     show.options = show.pipelines && pipelines.fetched && (anyPipeline || noPipelinesNeeded);
 
     const messageOutput = message ?
@@ -1136,7 +1136,8 @@ class StartNotebookCommits extends Component {
     if (fetching)
       return (<Label>Updating commits... <Loader size="14" inline="true" /></Label>);
 
-    const { displayedCommits } = this.props.filters;
+    const { filters } = this.props;
+    const { displayedCommits } = filters;
     const filteredCommits = displayedCommits && displayedCommits > 0 ?
       commits.slice(0, displayedCommits) :
       commits;
@@ -1152,8 +1153,8 @@ class StartNotebookCommits extends Component {
       );
     });
     let commitComment = null;
-    if (this.props.filters.commit.id) {
-      const autosaveExists = autosavedCommits.includes(this.props.filters.commit.id.substr(0, 7)) ?
+    if (filters.commit && filters.commit.id) {
+      const autosaveExists = autosavedCommits.includes(filters.commit.id.substr(0, 7)) ?
         true :
         false;
       if (autosaveExists) {
@@ -1176,7 +1177,7 @@ class StartNotebookCommits extends Component {
           <StartNotebookCommitsOptions {...this.props} />
         </Label>
         <Input type="select" id="selectCommit" name="selectCommit"
-          value={this.props.filters.commit.id ? this.props.filters.commit.id : ""}
+          value={filters.commit && filters.commit.id ? filters.commit.id : ""}
           onChange={(event) => { this.props.handlers.setCommit(event.target.value); }}>
           <option disabled hidden></option>
           {commitOptions}

--- a/client/src/notebooks/Notebooks.state.js
+++ b/client/src/notebooks/Notebooks.state.js
@@ -306,8 +306,8 @@ class NotebooksCoordinator {
     return {
       namespace: filters.namespace,
       project: filters.project,
-      branch: filters.branch.name ? filters.branch.name : null,
-      commit: filters.commit.id ? filters.commit.id : null
+      branch: filters.branch && filters.branch.name ? filters.branch.name : null,
+      commit: filters.commit && filters.commit.id ? filters.commit.id : null
     };
   }
 
@@ -756,8 +756,8 @@ class NotebooksCoordinator {
     const filters = this.model.get("filters");
     const namespace = filters.namespace;
     const project = filters.project;
-    const branch = filters.branch.name ? filters.branch.name : "master";
-    const commit = filters.commit.id ? filters.commit.id : "latest";
+    const branch = filters.branch && filters.branch.name ? filters.branch.name : "master";
+    const commit = filters.commit && filters.commit.id ? filters.commit.id : "latest";
     const projectOptions = this.model.get("options.project");
     const image = projectOptions.image ?
       projectOptions.image :

--- a/client/src/notifications/Notifications.state.js
+++ b/client/src/notifications/Notifications.state.js
@@ -31,9 +31,10 @@ const NotificationsInfo = {
     ERROR: "error",
   },
   Topics: {
-    ENVIRONMENT_START: "Interactive environment",
     AUTHENTICATION: "Authentication",
     DATASET_CREATE: "Dataset creation",
+    ENVIRONMENT_START: "Interactive environment",
+    PROJECT_API: "Project data",
   },
 };
 


### PR DESCRIPTION
In specific circumstances, it was possible to get outdated content after changing branch / commit.
In practice, that seems to happen only when changing the branch while commits fetch wasn't complete yet (it's not too tricky on projects with 1000+ commits).

I tried a few solutions, but I settled on disabling the branch / commit dropdown while fetching resources. Other solutions were potentially better but required a lot of changes in the code for minimal benefit.
The PR also implements better error handling when fetching commits fails.

Test environment: https://lorenzotest.dev.renku.ch

***How to test***: you can use a project with 1000+ commit, like `covid-19/covid-19-public-data`. Previously, changing the branch quickly after clicking on the "Environments --> New" tab resulted in wrong commits. That is not possible anymore.
https://lorenzotest.dev.renku.ch/projects/covid-19/covid-19-public-data/environments/new

fix #1127