### PR TITLE
ci: update helm url

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,8 @@ jobs:
           python-version: 3.7
       - name: Test helm chart
         env:
-          HELM_URL: https://charts.helm.sh/stable
-          HELM_TGZ: helm-v2.16.9-linux-amd64.tar.gz
+          HELM_URL: https://storage.googleapis.com/kubernetes-helm
+          HELM_TGZ: helm-v2.17.0-linux-amd64.tar.gz
           TEMP_DIR: ${{ runner.temp }}
         run: |
           wget -q ${HELM_URL}/${HELM_TGZ} -O ${TEMP_DIR}/${HELM_TGZ}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,6 @@ jobs:
   test-chart:
     needs: test
     runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           python-version: 3.7
       - name: Test helm chart
         env:
-          HELM_URL: https://storage.googleapis.com/kubernetes-helm
+          HELM_URL: https://charts.helm.sh/stable
           HELM_TGZ: helm-v2.16.9-linux-amd64.tar.gz
           TEMP_DIR: ${{ runner.temp }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
   test-chart:
     needs: test
     runs-on: ubuntu-latest
+    if: "startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1


### PR DESCRIPTION
The `test-chart` action uses the helm version `2.16.9`. We need to update to version `>= 2.17.0` to prevent it from failing as in https://github.com/SwissDataScienceCenter/renku-ui/runs/1649868184

Reference: https://helm.sh/blog/new-location-stable-incubator-charts/