### PR TITLE
fix: prevent crashes on lineage for short node labels

### DIFF
--- a/client/src/file/Lineage.present.js
+++ b/client/src/file/Lineage.present.js
@@ -34,17 +34,24 @@ import "./Lineage.css";
 
 function cropLabelStart(limit, label) {
   if (label.length > limit)
-    return "..." + label.substr(label.length - limit);
+    return "<...>" + label.substr(label.length - limit);
   return label;
 }
 
 function getNodeLabel(node, NODE_COUNT, lineagesUrl) {
   if (node.type === "ProcessRun") {
-    const stringArray = node.label.split(" ");
-    const LABEL_LIMIT = 20;
-    const label = stringArray.length > 3 ?
-      cropLabelStart(LABEL_LIMIT, stringArray[2]) + "<br/>" + cropLabelStart(LABEL_LIMIT, stringArray[3])
-      : cropLabelStart(LABEL_LIMIT, stringArray[0]) + " " + cropLabelStart(LABEL_LIMIT, stringArray[1]);
+    const BREAKING_LINE = "<br>";
+    const MISSING_PIECES = "<...>";
+    const LABEL_LIMIT = 30;
+
+    const stringCleaned = "" + node.label.replace(/ +(?= )/g, ""); // remove double space, prevent crash on empty str
+    const stringArray = stringCleaned.split(" "); // split on spaces
+    const smallerArray = stringArray.length > 4 ? // remove when too many arguments
+      stringArray.slice(0, 1).concat(MISSING_PIECES).concat(stringArray.slice(stringArray.length - 3)) :
+      stringArray;
+    const shortenArray = smallerArray.map(e => cropLabelStart(LABEL_LIMIT, e.trim())); // crop long labels
+    const label = shortenArray.join(BREAKING_LINE); // break line at each arg
+
     return '<text><tspan xml:space="preserve" dy="1em" x="1">' + label + "</tspan></text>";
   }
 


### PR DESCRIPTION
The UI seems to crash on the lineage preview when a `label` property of a "ProcessRun" node doesn't contain any space. In the example provided in #1101, the command is `sbt`.

I modified the logic we use to derive the label we show in the graph. Now the output looks fine in most cases, but it can be improved for very long strings. One way would be providing more interactions, like popovers or tooltips for long commands.
I guess this is enough as a bugfix, but we may want to refactor the graph output later to provide a better UX (that would require a design and a deep overhaul).

Please test using different projects, I may very well have missed corner cases.

Preview: https://lorenzotest.dev.renku.ch/

![Screenshot_20210112_180901](https://user-images.githubusercontent.com/43481553/104347768-47a11780-5501-11eb-93b7-58393cd84241.png)

![Screenshot_20210112_175351](https://user-images.githubusercontent.com/43481553/104347373-d5c8ce00-5500-11eb-9d50-d10a68398b93.png)

fix #1101