### PR TITLE
ci: deploy new environments on PRs on request

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -14,116 +14,86 @@ on:
     - helm-chart/**
 
 jobs:
-  deploy-pr:
-    if: github.event.action != 'closed'
+  cleanup-previous-runs:
     runs-on: ubuntu-latest
+    if: github.event.action != 'closed'
+    steps:
+    - uses: rokroskar/workflow-run-cleanup-action@master
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+  check-deploy:
+    runs-on: ubuntu-latest
+    outputs:
+      pr-contains-string: ${{ steps.deploy-comment.outputs.pr-contains-string }}
+    steps:
+      - id: deploy-comment
+        uses: SwissDataScienceCenter/renku/actions/check-pr-description@master
+        with:
+          string: /deploy
+          pr_ref: ${{ github.event.number }}
+
+  deploy-pr:
+    needs: [check-deploy, cleanup-previous-runs]
+    if: github.event.action != 'closed' && needs.check-deploy.outputs.pr-contains-string == 'true'
+    runs-on: ubuntu-latest
+    environment:
+      name: ci-ui-${{ github.event.number }}
     steps:
     - uses: actions/checkout@v2
-    - name: Get the latest commit on PR
-      id: latestcommit
-      uses: ActionsRML/get-PR-latest-commit@master
-    - name: Find Comment
+    - name: Find deplyoment url
       uses: peter-evans/find-comment@v1
-      id: findcomment
+      id: deploymentUrlMessage
       with:
         issue-number: ${{ github.event.pull_request.number }}
-        comment-author: 'RenkuBot'
-    - name: Create comment pre deploy
-      if: ${{ steps.findcomment.outputs.comment-id == 0 }}
+        comment-author: "RenkuBot"
+        body-includes: "You can access the deployment of this PR at"
+    - name: Create comment deployment url
+      if: steps.deploymentUrlMessage.outputs.comment-id == 0
       uses: peter-evans/create-or-update-comment@v1
       with:
         token: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
         issue-number: ${{ github.event.pull_request.number }}
         body: |
-          A deployment for this PR is being prepared based on the commit ${{ steps.latestcommit.outputs.latest_commit_sha }}.
-
-          You will be able to access it at https://ci-ui-${{ github.event.number }}-renku.dev.renku.ch
-
-          *If you try to access it now, it may be either unavailable or based on a previous commit.*
-    - name: Update comment pre deploy
-      if: ${{ steps.findcomment.outputs.comment-id != 0 }}
-      uses: peter-evans/create-or-update-comment@v1
-      with:
-        token: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
-        comment-id: ${{ steps.findcomment.outputs.comment-id }}
-        edit-mode: replace
-        body: |
-          A deployment for this PR is being prepared based on the commit ${{ steps.latestcommit.outputs.latest_commit_sha }}.
-
-          You will be able to access it at https://ci-ui-${{ github.event.number }}-renku.dev.renku.ch
-
-          *If you try to access it now, it may be either unavailable or based on a previous commit.*
+          You can access the deployment of this PR at https://ci-ui-${{ github.event.number }}.dev.renku.ch
     - name: Build and deploy
-      uses: SwissDataScienceCenter/renku/actions/deploy-renku@000-deploy-action
+      uses: SwissDataScienceCenter/renku/actions/deploy-renku@master
       env:
         RANCHER_PROJECT_ID: ${{ secrets.CI_RANCHER_PROJECT }}
         DOCKER_PASSWORD: ${{ secrets.RENKU_DOCKER_PASSWORD }}
         DOCKER_USERNAME: ${{ secrets.RENKU_DOCKER_USERNAME }}
         GITLAB_TOKEN: ${{ secrets.DEV_GITLAB_TOKEN }}
         KUBECONFIG: "${{ github.workspace }}/renkubot-kube.config"
-        RENKU_NAMESPACE: ci-ui-${{ github.event.number }}-renku
-        RENKU_TMP_NAMESPACE: ci-ui-${{ github.event.number }}-renku-tmp
-        RENKU_RELEASE: ci-ui-${{ github.event.number }}-renku
+        RENKU_RELEASE: ci-ui-${{ github.event.number }}
         RENKU_VALUES_FILE: "${{ github.workspace }}/values.yaml"
         RENKU_VALUES: ${{ secrets.CI_RENKU_VALUES }}
         RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
         RENKUBOT_RANCHER_BEARER_TOKEN: ${{ secrets.RENKUBOT_RANCHER_BEARER_TOKEN }}
-        renku: "@development"
         renku_ui: "@${{ github.head_ref }}"
-    - name: Find comment post deploy
-      if: ${{ always() }}
-      uses: peter-evans/find-comment@v1
-      id: findcommentpost
-      with:
-        issue-number: ${{ github.event.pull_request.number }}
-        comment-author: 'RenkuBot'
-    - name: Update comment post deploy
-      if: ${{ steps.findcomment.outputs.comment-id != 0 }}
-      uses: peter-evans/create-or-update-comment@v1
-      with:
-        token: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
-        comment-id: ${{ steps.findcommentpost.outputs.comment-id }}
-        edit-mode: replace
-        body: |
-          A deployment is ready for this PR :tada:. Currently, the source commit is ${{ steps.latestcommit.outputs.latest_commit_sha }}.
-
-          You can access it at https://ci-ui-${{ github.event.number }}-renku.dev.renku.ch
-    - name: Update comment failed deploy
-      if: ${{ failure() && steps.findcomment.outputs.comment-id != 0 }}
-      uses: peter-evans/create-or-update-comment@v1
-      with:
-        token: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
-        comment-id: ${{ steps.findcommentpost.outputs.comment-id }}
-        edit-mode: replace
-        body: |
-          Trying to create a deployment based on ${{ steps.latestcommit.outputs.latest_commit_sha }} resulted in a failure :scream:
-
-          The access to https://ci-ui-${{ github.event.number }}-renku.dev.renku.ch may be broken or outdated.
 
   cleanup:
-    if: github.event.action == 'closed'
+    needs: [check-deploy, cleanup-previous-runs]
+    if: github.event.action == 'closed' && needs.check-deploy.outputs.pr-contains-string == 'true'
     runs-on: ubuntu-latest
     steps:
-    - uses: SwissDataScienceCenter/renku/actions/teardown-renku@000-deploy-action
+    - name: Find deplyoment url
+      uses: peter-evans/find-comment@v1
+      id: deploymentUrlMessage
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        comment-author: "RenkuBot"
+        body-includes: "Tearing down the temporary RenkuLab deplyoment"
+    - name: Create comment deployment url
+      if: steps.deploymentUrlMessage.outputs.comment-id == 0
+      uses: peter-evans/create-or-update-comment@v1
+      with:
+        token: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
+        issue-number: ${{ github.event.pull_request.number }}
+        body: |
+          Tearing down the temporary RenkuLab deplyoment for this PR.
+    - uses: SwissDataScienceCenter/renku/actions/teardown-renku@master
       env:
         GITLAB_TOKEN: ${{ secrets.GITLAB_DEV_TOKEN }}
         KUBECONFIG: ${{ github.workspace }}/renkubot-kube.config
-        RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_KUBECONFIG }}
-        RENKU_RELEASE: "ci-ui-${{ github.event.number }}-renku"
-        RENKU_NAMESPACE: "ci-ui-${{ github.event.number }}-renku"
-        RENKU_TMP_NAMESPACE: "ci-ui-${{ github.event.number }}-renku-tmp"
-    - name: Find Comment
-      uses: peter-evans/find-comment@v1
-      id: findcomment
-      with:
-        issue-number: ${{ github.event.pull_request.number }}
-        comment-author: 'RenkuBot'
-    - name: Update comment delete
-      if: ${{ steps.findcomment.outputs.comment-id != 0 }}
-      uses: peter-evans/create-or-update-comment@v1
-      with:
-        token: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
-        comment-id: ${{ steps.findcomment.outputs.comment-id }}
-        edit-mode: replace
-        body: |
-          The PR has been closed and the deployment cleaned up.
+        RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
+        RENKU_RELEASE: "ci-ui-${{ github.event.number }}"

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -1,0 +1,129 @@
+name: Acceptance tests
+
+on:
+  pull_request:
+    types:
+    - opened
+    - edited
+    - synchronize
+    - reopened
+    - closed
+    paths:
+    - client/**
+    - server/**
+    - helm-chart/**
+
+jobs:
+  deploy-pr:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Get the latest commit on PR
+      id: latestcommit
+      uses: ActionsRML/get-PR-latest-commit@master
+    - name: Find Comment
+      uses: peter-evans/find-comment@v1
+      id: findcomment
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        comment-author: 'RenkuBot'
+    - name: Create comment pre deploy
+      if: ${{ steps.findcomment.outputs.comment-id == 0 }}
+      uses: peter-evans/create-or-update-comment@v1
+      with:
+        token: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
+        issue-number: ${{ github.event.pull_request.number }}
+        body: |
+          A deployment for this PR is being prepared based on the commit ${{ steps.latestcommit.outputs.latest_commit_sha }}.
+
+          You will be able to access it at https://ci-ui-${{ github.event.number }}-renku.dev.renku.ch
+
+          *If you try to access it now, it may be either unavailable or based on a previous commit.*
+    - name: Update comment pre deploy
+      if: ${{ steps.findcomment.outputs.comment-id != 0 }}
+      uses: peter-evans/create-or-update-comment@v1
+      with:
+        token: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
+        comment-id: ${{ steps.findcomment.outputs.comment-id }}
+        edit-mode: replace
+        body: |
+          A deployment for this PR is being prepared based on the commit ${{ steps.latestcommit.outputs.latest_commit_sha }}.
+
+          You will be able to access it at https://ci-ui-${{ github.event.number }}-renku.dev.renku.ch
+
+          *If you try to access it now, it may be either unavailable or based on a previous commit.*
+    - name: Build and deploy
+      uses: SwissDataScienceCenter/renku/actions/deploy-renku@000-deploy-action
+      env:
+        RANCHER_PROJECT_ID: ${{ secrets.CI_RANCHER_PROJECT }}
+        DOCKER_PASSWORD: ${{ secrets.RENKU_DOCKER_PASSWORD }}
+        DOCKER_USERNAME: ${{ secrets.RENKU_DOCKER_USERNAME }}
+        GITLAB_TOKEN: ${{ secrets.DEV_GITLAB_TOKEN }}
+        KUBECONFIG: "${{ github.workspace }}/renkubot-kube.config"
+        RENKU_NAMESPACE: ci-ui-${{ github.event.number }}-renku
+        RENKU_TMP_NAMESPACE: ci-ui-${{ github.event.number }}-renku-tmp
+        RENKU_RELEASE: ci-ui-${{ github.event.number }}-renku
+        RENKU_VALUES_FILE: "${{ github.workspace }}/values.yaml"
+        RENKU_VALUES: ${{ secrets.CI_RENKU_VALUES }}
+        RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
+        RENKUBOT_RANCHER_BEARER_TOKEN: ${{ secrets.RENKUBOT_RANCHER_BEARER_TOKEN }}
+        renku: "@development"
+        renku_ui: "@${{ github.head_ref }}"
+    - name: Find comment post deploy
+      if: ${{ always() }}
+      uses: peter-evans/find-comment@v1
+      id: findcommentpost
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        comment-author: 'RenkuBot'
+    - name: Update comment post deploy
+      if: ${{ steps.findcomment.outputs.comment-id != 0 }}
+      uses: peter-evans/create-or-update-comment@v1
+      with:
+        token: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
+        comment-id: ${{ steps.findcommentpost.outputs.comment-id }}
+        edit-mode: replace
+        body: |
+          A deployment is ready for this PR :tada:. Currently, the source commit is ${{ steps.latestcommit.outputs.latest_commit_sha }}.
+
+          You can access it at https://ci-ui-${{ github.event.number }}-renku.dev.renku.ch
+    - name: Update comment failed deploy
+      if: ${{ failure() && steps.findcomment.outputs.comment-id != 0 }}
+      uses: peter-evans/create-or-update-comment@v1
+      with:
+        token: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
+        comment-id: ${{ steps.findcommentpost.outputs.comment-id }}
+        edit-mode: replace
+        body: |
+          Trying to create a deployment based on ${{ steps.latestcommit.outputs.latest_commit_sha }} resulted in a failure :scream:
+
+          The access to https://ci-ui-${{ github.event.number }}-renku.dev.renku.ch may be broken or outdated.
+
+  cleanup:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: SwissDataScienceCenter/renku/actions/teardown-renku@000-deploy-action
+      env:
+        GITLAB_TOKEN: ${{ secrets.GITLAB_DEV_TOKEN }}
+        KUBECONFIG: ${{ github.workspace }}/renkubot-kube.config
+        RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_KUBECONFIG }}
+        RENKU_RELEASE: "ci-ui-${{ github.event.number }}-renku"
+        RENKU_NAMESPACE: "ci-ui-${{ github.event.number }}-renku"
+        RENKU_TMP_NAMESPACE: "ci-ui-${{ github.event.number }}-renku-tmp"
+    - name: Find Comment
+      uses: peter-evans/find-comment@v1
+      id: findcomment
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        comment-author: 'RenkuBot'
+    - name: Update comment delete
+      if: ${{ steps.findcomment.outputs.comment-id != 0 }}
+      uses: peter-evans/create-or-update-comment@v1
+      with:
+        token: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
+        comment-id: ${{ steps.findcomment.outputs.comment-id }}
+        edit-mode: replace
+        body: |
+          The PR has been closed and the deployment cleaned up.

--- a/.github/workflows/test-and-ci.yml
+++ b/.github/workflows/test-and-ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Test and CI
 
 on: [push]
 

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ..
-  Copyright 2017-2018 - Swiss Data Science Center (SDSC)
+  Copyright 2017-2020 - Swiss Data Science Center (SDSC)
   A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
   Eidgenössische Technische Hochschule Zürich (ETHZ).
 
@@ -20,12 +20,17 @@
     :alt: Pull reminders
     :align: right
 
+.. image:: https://github.com/SwissDataScienceCenter/renku-ui/actions?query=branch%3Amaster+workflow%3A%22Test+and+CI%22
+   :target: https://github.com/SwissDataScienceCenter/renku-ui/workflows/Test%20and%20CI/badge.svg
+   :alt: Test and CI
+   :align: right
+
 ================
  Renku-UI
 ================
 
-**The Renku platform is under very active development and should be considered highly
-volatile.**
+*The Renku platform is under very active development and should be considered highly
+volatile.*
 
 Quickstart
 ----------
@@ -37,47 +42,65 @@ that acts as an interface to all backend services APIs, handling authentication
 and exchanging access tokens.
 Clone the main Renku repository and follow these instructions_ to get Renku up
 and running.
+You can also deploy an environment in a remote development cluster.
 
 .. _instructions: https://renku.readthedocs.io/en/latest/developer/setup.html
 
 Developing the UI
 -----------------
-Once you have a instance of Renku running locally, you could modify the ui code
-and restart the platform through the `make minikube-deploy` command. However,
-this will make for a very poor development experience as the build process of the
-ui is optimized for production.
-Instead we recommend installing telepresence_ on your system. Once telepresence
-is installed, type:
-
-.. _telepresence: https://www.telepresence.io/reference/install
+Once you have a development instance of Renku running locally or in the cloud,
+you can install telepresence_ locally and run the ``run-telepresence.sh`` script
+in the `client` or the `server` folder. Don't forget to run `npm install` before
+running telepresence for the first time or after any package change.
 
 ::
 
+    $ cd client   # or server if you need to work there
     $ npm install
-    $ make dev
+    $ ./run-telepresence.sh
 
+Telepresence replaces the selected UI pod in the target Kubernetes instance. All the
+traffic is then redirected to a local process, making all the changes to files almost
+immediately available in your development RenkuLab instance.
 
-Note that the :code:`npm install` step is only necessary the first time you are running the ui
-locally or after the dependencies specified in `package.json` have changes. The command
-:code:`make dev` launches telepresence which swaps the renku-ui service in your minikube
-deployment with a locally running version of the ui served by a development server
-which watches your code for changes and performs live updates.
+The ``run-telepresence.sh`` scripts support out-of-the-box telepresence_ minikube and
+the Renku team `switch-dev` cloud. You need to properly set the environment variable
+``CURRENT_CONTEXT`` to either ``"minikube"`` or ``"switch-dev"``.
 
-The ui in dev setting is now available under the ip-address of your minikube
-cluster (:code:`minikube ip`).
+There are a few other environment variables you may want to set when starting telepresence
+if you are going to to take advantage of the Renku team internal development infrastructure:
 
+- SENTRY: set to `1` to redirect the exceptions to the dev sentry_ deployment
+- PR: set to the target PR number in the renku-ui_ repo to work in the corresponding CI deployment
+
+::
+
+    $ SENTRY=0 PR=1166 ./run-telepresence.sh
+
+There are other variables used in the ``run-telepresence.sh`` script. For specific use
+cases, you may want to modify some values manually.
 
 Tests
 -----
 
-You can run tests with
+We use jest_ as our default testing framework and eslint_ as linter.
+Mind that we require both commands to terminate without warnings before we merge a PR.
+You can manually run tests using the following commands:
 
 ::
 
-    $ make test/renku-ui
+    $ cd client   # or server if you need to work there
+    $ npm test
+    $ npm run lint
 
-or
+Some linting errors can be automatically fixed by running ``npm run lint-fix``. We suggest
+using an IDE that supports eslint (like vscode_ or similar) to get realtime feedback
+when modifying the code.
 
-::
-
-    $ docker run -e CI=true renku/renku-ui:latest npm test
+.. _minikube: https://minikube.sigs.k8s.io
+.. _telepresence: https://www.telepresence.io/reference/install
+.. _sentry: https://sentry.dev.renku.ch
+.. _renku-ui: https://github.com/SwissDataScienceCenter/renku-ui/pulls
+.. _jest: https://jestjs.io
+.. _eslint: https://eslint.org/
+.. _vscode: https://code.visualstudio.com

--- a/client/run-telepresence.sh
+++ b/client/run-telepresence.sh
@@ -43,8 +43,8 @@ if [ -z "$STATUSPAGE_ID" ]; then STATUSPAGE_ID="r3j2c84ftq49"; else echo "STATUS
 
 if [[ -n $PR ]]
 then
-  DEV_NAMESPACE=ci-ui-${PR}-renku
-  SERVICE_NAME=ci-ui-${PR}-renku-ui
+  DEV_NAMESPACE=ci-ui-${PR}
+  SERVICE_NAME=ci-ui-${PR}-ui
   echo "Deploying to environment for PR ${PR}: (https://ci-ui-$PR-renku.dev.renku.ch)"
 fi
 

--- a/client/run-telepresence.sh
+++ b/client/run-telepresence.sh
@@ -41,6 +41,13 @@ fi
 
 if [ -z "$STATUSPAGE_ID" ]; then STATUSPAGE_ID="r3j2c84ftq49"; else echo "STATUSPAGE_ID is set to '$STATUSPAGE_ID'"; fi
 
+if [[ -n $PR ]]
+then
+  DEV_NAMESPACE=ci-ui-${PR}-renku
+  SERVICE_NAME=ci-ui-${PR}-renku-ui
+  echo "Deploying to environment for PR ${PR}: (https://ci-ui-$PR-renku.dev.renku.ch)"
+fi
+
 if [[ $CURRENT_CONTEXT == 'minikube' ]]
 then
   echo "Exchanging k8s deployments using the following context: ${CURRENT_CONTEXT}"
@@ -74,7 +81,11 @@ else
     echo "Exchanging k8s deployments for the following context/namespace: ${CURRENT_CONTEXT}/${DEV_NAMESPACE}"
   fi
   BASE_URL=https://${DEV_NAMESPACE}.dev.renku.ch
-  SERVICE_NAME=${DEV_NAMESPACE}-renku-ui
+
+  if [[ ! $SERVICE_NAME ]]
+  then
+    SERVICE_NAME=${DEV_NAMESPACE}-renku-ui
+  fi
 fi
 
 # set sentry dns if explicitly required by the user


### PR DESCRIPTION
This has finally reached a mergeable state.

A new GitHub action allows developers to request an automatic RenkuLab deployment for any PR.
The trigger is the string `/deploy` anywhere in the PR message. It works even if the message is changed later.
The action will also automatically clean up the environment once the PR is closed.

This PR also includes a simplified way to start telepresence on a specific test PR (thanks @ciyer for that part! And sorry for melding the commit into the others), and a refresh on the `README` file.

re #1165 