### PR TITLE
fix: do not attach trailing '/' on routes that end in a number (#1148)

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -25,7 +25,7 @@
 
 import React, { Component, Fragment } from "react";
 import { Jumbotron } from "reactstrap";
-import { Route, Switch, Redirect } from "react-router-dom";
+import { Route, Switch } from "react-router-dom";
 import { ToastContainer } from "react-toastify";
 
 import Project from "./project/Project";
@@ -80,10 +80,8 @@ class App extends Component {
         <main role="main" className="container-fluid">
           <div key="gap">&nbsp;</div>
           <Switch>
-            {/* Route forces trailing slashes on routes ending with a numerical id */}
             <Route exact path="/login" render={
               p => <Login key="login" {...p} {...this.props} />} />
-            <Route exact strict path="/*(\d+)" render={props => <Redirect to={`${props.location.pathname}/`} />} />
             <Route exact path="/" render={
               p => <Landing.Home
                 key="landing" welcomePage={this.props.params["WELCOME_PAGE"]}


### PR DESCRIPTION
There was code in the handling of route that appended '/' to routes that end in number. The line is very old (there at least since 2018), but it looks like it is no longer necessary and was probably causing problems with routing.

Testing:

**Check that routing of projects behaves correctly**

Resolve a project by project id:
- (old) https://dev.renku.ch/projects/7289
- (new) https://sekhar.dev.renku.ch/projects/7289

Resolve a project by project by namespace/path:
- (old) https://dev.renku.ch/projects/cramakri/file-type-test
- (new) https://sekhar.dev.renku.ch/projects/cramakri/file-type-test

Resolve a project by project by namespace/path, when path contains numbers:
- (old) https://dev.renku.ch/projects/renku-qa/1234/
- (new) https://sekhar.dev.renku.ch/projects/renku-qa/1234/


Resolve a file that ends in numbers:
- (old) https://dev.renku.ch/projects/cramakri/file-type-test/files/blob/src/Fortran90.f90
- (new) https://sekhar.dev.renku.ch/projects/cramakri/file-type-test/files/blob/src/Fortran90.f90

Resolve a file that ends in numbers (another one):
- (old) https://dev.renku.ch/projects/renku-qa/1234/files/blob/Fortran90.f90
- (new) https://sekhar.dev.renku.ch/projects/renku-qa/1234/files/blob/Fortran90.f90

/deploy
