### PR TITLE
ci: remove unneeded requirements on cleanup job

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -72,7 +72,7 @@ jobs:
         renku_ui: "@${{ github.head_ref }}"
 
   cleanup:
-    needs: [check-deploy, cleanup-previous-runs]
+    needs: check-deploy
     if: github.event.action == 'closed' && needs.check-deploy.outputs.pr-contains-string == 'true'
     runs-on: ubuntu-latest
     steps:

--- a/client/src/project/overview/ProjectOverview.container.js
+++ b/client/src/project/overview/ProjectOverview.container.js
@@ -39,6 +39,7 @@ import {
 class OverviewStats extends Component {
   constructor(props) {
     super(props);
+
     this.projectCoordinator = props.projectCoordinator;
 
     this.handlers = {


### PR DESCRIPTION
Remove precedence on `cleanup` job to prevent skipping it on `close` events

/deploy