### PR TITLE
ci: remove unneeded requirements on cleanup job

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -72,7 +72,7 @@ jobs:
         renku_ui: "@${{ github.head_ref }}"
 
   cleanup:
-    needs: [check-deploy, cleanup-previous-runs]
+    needs: check-deploy
     if: github.event.action == 'closed' && needs.check-deploy.outputs.pr-contains-string == 'true'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This fix is required to properly trigger the `cleanup` action whenever a PR is merged or closed in any way.

In short, the `cleanup` action required another step to start, but that could never happen because that step doesn't run on `close` events.

P.S. This has been tested here #1203 