### PR TITLE
feat: add Url helper class

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -39,6 +39,7 @@ import ShowDataset from "./dataset/Dataset.container";
 import { Loader } from "./utils/UIComponents";
 import { Cookie, Privacy } from "./privacy";
 import { NotificationsManager, NotificationsPage } from "./notifications";
+import { Url } from "./utils/url";
 
 import "./App.css";
 import "react-toastify/dist/ReactToastify.css";
@@ -82,7 +83,7 @@ class App extends Component {
           <Switch>
             <Route exact path="/login" render={
               p => <Login key="login" {...p} {...this.props} />} />
-            <Route exact path="/" render={
+            <Route exact path={Url.get(Url.pages.landing)} render={
               p => <Landing.Home
                 key="landing" welcomePage={this.props.params["WELCOME_PAGE"]}
                 user={this.props.user}
@@ -90,10 +91,11 @@ class App extends Component {
                 model={this.props.model}
                 statuspageId={this.props.statuspageId}
                 {...p} />} />
-            <Route path="/help" render={
+            <Route path={Url.get(Url.pages.help)} render={
               p => <Help key="help" {...p} statuspageId={this.props.statuspageId} {...this.props} />} />
-            <Route exact path={["/projects", "/projects/starred", "/projects/all"]} render={
-              p => <Project.List
+            <Route exact
+              path={[Url.get(Url.pages.projects), Url.get(Url.pages.projects.starred), Url.get(Url.pages.projects.all)]}
+              render={p => <Project.List
                 key="projects"
                 user={this.props.user}
                 client={this.props.client}
@@ -101,7 +103,7 @@ class App extends Component {
                 {...p}
               />}
             />
-            <Route exact path="/projects/new" render={
+            <Route exact path={Url.get(Url.pages.project.new)} render={
               p => <Project.New
                 key="newProject"
                 client={this.props.client}

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -16,6 +16,7 @@ import APIClient from "./api-client";
 import { UserCoordinator } from "./user";
 import { LoginHelper } from "./authentication";
 import { StateModel, globalSchema } from "./model";
+import { Url } from "./utils/url";
 
 const configFetch = fetch("/config.json");
 const privacyFetch = fetch("/privacy-statement.md");
@@ -49,6 +50,9 @@ Promise.all([configFetch, privacyFetch]).then(valuesRead => {
       ReactDOM.render(<Maintenance info={maintenance} />, document.getElementById("root"));
       return;
     }
+
+    // configure base url
+    Url.setBaseUrl(params["BASE_URL"]);
 
     // create client to be passed to coordinators
     const client = new APIClient(params.GATEWAY_URL);

--- a/client/src/landing/Landing.js
+++ b/client/src/landing/Landing.js
@@ -30,14 +30,15 @@ import { createStore } from "../utils/EnhancedState";
 import Present from "./Landing.present";
 import State from "./Landing.state";
 import { ProjectsCoordinator } from "../project/shared";
+import { Url } from "../utils/url";
 
 function urlMap() {
   return {
-    projectsUrl: "/projects",
-    projectNewUrl: "/projects/new",
-    projectsSearchUrl: "/projects/all",
-    projectsStarredUrl: "/projects/starred",
-    siteStatusUrl: "/help/status"
+    projectsUrl: Url.get(Url.pages.projects),
+    projectNewUrl: Url.get(Url.pages.project.new),
+    projectsSearchUrl: Url.get(Url.pages.projects.all),
+    projectsStarredUrl: Url.get(Url.pages.projects.starred),
+    siteStatusUrl: Url.get(Url.pages.help.status)
   };
 }
 

--- a/client/src/notebooks/Notebooks.present.js
+++ b/client/src/notebooks/Notebooks.present.js
@@ -38,6 +38,7 @@ import {
 } from "../utils/UIComponents";
 import Time from "../utils/Time";
 import Sizes from "../utils/Media";
+import { Url } from "../utils/url";
 
 import "./Notebooks.css";
 
@@ -575,8 +576,10 @@ class NotebooksServerRowStatusIcon extends Component {
 class NotebookServerRowProject extends Component {
   render() {
     const { annotations } = this.props;
-    const url = `${annotations["namespace"]}/${annotations["projectName"]}`;
-    return (<Link to={`/projects/${url}`}>{url}</Link>);
+    const fullPath = `${annotations["namespace"]}/${annotations["projectName"]}`;
+    const data = { namespace: annotations["namespace"], path: annotations["projectName"] };
+    const url = Url.get(Url.pages.project, data);
+    return (<Link to={url}>{fullPath}</Link>);
   }
 }
 

--- a/client/src/utils/url/Url.js
+++ b/client/src/utils/url/Url.js
@@ -1,0 +1,264 @@
+/*!
+ * Copyright 2021 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  Url.js
+ *  Url helper class.
+ */
+
+/** Class to represent a set of rules to derive a specific URL */
+class UrlRule {
+  /**
+   * Create a set of metadata to construct and validate URLs, throwing early errors to help developers in
+   * preventing bugs.
+   *
+   * @param {function} output - function to derive the relative URL. If any member is required, it must have one
+   *   argument, used to assign a data object.
+   * @param {string[]} [required] - array of strings corresponding to the required members of the data object, if any.
+   * @param {function} [validation] - function to further validate the data parameters. Must return `true` to succeed.
+   *   Throw meaningful errors otherwise.
+   * @param {string[]} examples - a list of valid URLs. Useful as a reference for the developers, especially when
+   *   the output function consumes a lots of data parameters.
+   */
+  constructor(output, required = [], validation = null, examples = []) {
+    // check required
+    if (!Array.isArray(required))
+      throw new Error("The <required> parameter must be an array.");
+    else if (required.some(v => typeof v !== "string"))
+      throw new Error("The <required> parameter must contain only strings representing the required data fields.");
+    else
+      this.required = required;
+
+    // check output
+    if (typeof output !== "function")
+      throw new Error("The required <output> parameter must be a function.");
+    else if (required.length && output.length !== 1)
+      throw new Error("The <output> function must have an argument to assign an object since fields are required.");
+    else
+      this.output = output;
+
+    // check validation
+    if (validation) {
+      if (typeof validation !== "function")
+        throw new Error("The optional <validation> parameter must be a function.");
+      else
+        this.validation = validation;
+    }
+
+    // check examples
+    if (examples) {
+      if (!Array.isArray(examples))
+        throw new Error("The optional <examples> parameter must be an array.");
+      else if (examples.some(v => typeof v !== "string"))
+        throw new Error("The <examples> parameter must contain only strings representing valid URLs.");
+      else
+        this.examples = examples;
+    }
+  }
+
+  /**
+   * Get the url given the data parameters, where required
+   *
+   * @param {object} [data] - context data for the url creation
+   */
+  get(data = {}) {
+    // Verify data is an object
+    if (data != null && typeof data !== "object")
+      throw new Error(`The <data> object, when provided, must be an object.`);
+
+    // Check data are passed.
+    if (this.required.length) {
+      const providedFields = Object.keys(data);
+      for (const required of this.required) {
+        if (!providedFields.includes(required))
+          throw new Error(`The <data> object must include a <${required}> field.`);
+      }
+    }
+
+    // Further validate data if a custom function is specified.
+    if (this.validation) {
+      const valid = this.validation(data);
+      if (!valid) {
+        const functionCode = this.validation.toString();
+        throw new Error(`Invalid data, reason unspecified. You can inspect the validation function: ${functionCode}`);
+      }
+    }
+
+    // create and return final url
+    return this.output(data);
+  }
+}
+
+/** Helper class to handle URLs */
+class Url {
+  // Mind that validations and rules are private. It's just here for convenience.
+  static _validations = {
+    projects: (data) => {
+      // validate optional data fields
+      const allowedParams = ["q", "page", "orderBy", "orderSearchAsc", "searchIn"];
+      const receivedParams = Object.keys(data);
+      for (const param of receivedParams) {
+        if (!allowedParams.includes(param))
+          throw new Error(`The <data> variable can't include ${param}.`);
+      }
+      return true;
+    },
+    project: (data) => {
+      if (typeof data.namespace !== "string" || !data.namespace.length)
+        throw new Error("The <data.namespace> field must be a non empty string.");
+      if (typeof data.path !== "string" || !data.namespace.path)
+        throw new Error("The <data.namespace> field must be a non empty string.");
+      return true;
+    }
+  }
+  static _outputs = {
+    projects: (subSection) => {
+      return (data) => {
+        // create base url
+        let url = subSection ?
+          `/projects/${subSection}` :
+          "/projects";
+
+        // add optional parameters
+        if (!data || !Object.keys(data).length)
+          return url;
+        const search = new URLSearchParams();
+        for (const [key, value] of Object.entries(data))
+          search.append(key, value);
+        return `${url}?${search.toString()}`;
+      };
+    },
+    project: (subSection) => {
+      return (data) => {
+        let url = `/projects/${data.namespace}/${data.path}`;
+        if (subSection)
+          return url + subSection;
+        return url;
+      };
+    }
+  }
+  static _rules = {
+    projects: {
+      base: new UrlRule(
+        this._outputs.projects(), [], this._validations.projects, [
+          "/projects",
+          "/projects?q=test&page=1&orderBy=last_activity_at&orderSearchAsc=false&searchIn=projects"
+        ]
+      ),
+      all: new UrlRule(
+        this._outputs.projects("all"), [], this._validations.projects, [
+          "/projects/all",
+          "/projects/all?q=test&page=1&orderBy=last_activity_at&orderSearchAsc=false&searchIn=projects"
+        ]
+      ),
+      starred: new UrlRule(
+        this._outputs.projects("starred"), [], this._validations.projects, [
+          "/projects/starred",
+          "/projects/starred?q=test&page=1&orderBy=last_activity_at&orderSearchAsc=false&searchIn=projects"
+        ]
+      )
+    },
+    project: {
+      base: new UrlRule(
+        this._outputs.project(""), ["namespace", "path"], this._outputs.project, [
+          "/projects/namespace/path",
+          "/projects/group/subgroup/path",
+        ]
+      )
+    }
+  };
+
+  // One of these pages will be provided by the user as `target` argument in the `get` function.
+  // Mind that the final `base` can be omitted. E.G. `pages.help` is equivalent to `pages.help.base`.
+  // Please assign only strings or UrlRule objects.
+  static pages = {
+    landing: "/",
+    help: {
+      base: "/help",
+      documentation: "/help/docs",
+      features: "/help/features",
+      status: "/help/status",
+    },
+    projects: {
+      base: this._rules.projects.base,
+      own: this._rules.projects.base,
+      all: this._rules.projects.all,
+      starred: this._rules.projects.starred
+    },
+    project: {
+      base: this._rules.project.base,
+      new: "/projects/new",
+    }
+  }
+
+  static baseUrl = null;
+
+  /**
+  * Create a Url based on the target page. Depending on the specific page, it may require context data.
+  *
+  * @param {object} target - the page you are targeting, as contained in the `pages` static member
+  *   (e.g. pages.landing, pages.project.stats, ...).
+  * @param {object} [data] - the context data you need to provide, if any
+  *   (e.g. for project, you need to provide a `namespace` and a `path`).
+  * @param {boolean} [full] - switch between full or relative path. The default is `false`.
+  */
+  static get(target, data, full = false) {
+    // One can always omit the final `base` node. In that case, add it automatically.
+    if (typeof target === "object" && !(target instanceof UrlRule) && target.base)
+      target = target.base;
+
+    // Return url or throw error based on the type of target.
+    let url;
+    if (typeof target === "string")
+      url = target;
+    else if (typeof target === "object" && target instanceof UrlRule)
+      url = target.get(data);
+    else
+      throw new Error("Unexpected <target>. Please pick one from the static object <Url.pages>");
+
+    // Add the base url when needed and available.
+    if (full) {
+      if (this.baseUrl == null)
+        throw new Error("The base url is not properly set");
+      return this.baseUrl + url;
+    }
+    return url;
+  }
+
+  /**
+   * Set the base url for the full paths. This must be invoked only once at startup.
+   *
+   * @param {string} url - base url
+   */
+  static setBaseUrl(url) {
+    if (this.baseUrl != null)
+      throw new Error("The base url can't be set multiple times");
+    const cleanUrl = url.trim();
+    this.baseUrl = cleanUrl.endsWith("/") ?
+      url.slice(0, -1) :
+      url;
+  }
+}
+
+
+export { Url };
+
+// testing only
+export { UrlRule };

--- a/client/src/utils/url/Url.test.js
+++ b/client/src/utils/url/Url.test.js
@@ -1,0 +1,203 @@
+/*!
+ * Copyright 2021 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  Url.test.js
+ *  Tests for Url.
+ */
+
+import { UrlRule, Url } from "./Url";
+
+
+describe("UrlRule private class", () => {
+  it("Initialization values and errors", () => {
+    // Verify all the parameters, and try to trigger all possible errors based on wrong parameters.
+    let rule;
+
+    // output
+    expect(() => new UrlRule("wrong_type"))
+      .toThrow("required <output> parameter must be a function");
+    rule = new UrlRule(() => "/");
+    expect(rule.output).toBeInstanceOf(Function);
+    expect(rule.required).toBeInstanceOf(Array);
+    expect(rule.required).toHaveLength(0);
+
+    // required
+    expect(() => new UrlRule(() => "/", "wrong_type"))
+      .toThrow("<required> parameter must be an array");
+    expect(() => new UrlRule(() => "/", ["input1", "input2"]))
+      .toThrow("<output> function must have an argument to assign an object");
+    expect(() => new UrlRule(() => "/", ["input1", 21]))
+      .toThrow("<required> parameter must contain only strings");
+    rule = new UrlRule((data) => "/", ["input1", "input2"]);
+    expect(rule.required).toBeInstanceOf(Array);
+    expect(rule.required).toHaveLength(2);
+
+    // validation
+    expect(() => new UrlRule((data) => "/", ["input1", "input2"], "wrong_type"))
+      .toThrow("optional <validation> parameter must be a function");
+    rule = new UrlRule((data) => "/", ["input1", "input2"], (data) => true);
+    expect(rule.validation).toBeInstanceOf(Function);
+
+    // examples
+    expect(() => new UrlRule(() => "/", [], null, "wrong_type"))
+      .toThrow("optional <examples> parameter must be an array");
+    expect(() => new UrlRule(() => "/", [], null, ["input1", 21]))
+      .toThrow("<examples> parameter must contain only strings");
+    rule = new UrlRule(() => "/", [], null, ["/", "/test"]);
+    expect(rule.examples).toBeInstanceOf(Array);
+    expect(rule.examples).toHaveLength(2);
+  });
+
+  it("Methods", () => {
+    // Create static rule.
+    let rule;
+    rule = new UrlRule(() => "/");
+    expect(rule.get()).toBe("/");
+
+    // Create dynamic rule without validation.
+    rule = new UrlRule((data) => `/${data.param1}/something`, ["param1"]);
+    expect(() => rule.get({ wrongParam: "test" })).toThrow();
+    expect(() => rule.get("wrong_type")).toThrow();
+    expect(() => rule.get({ param1: false })).not.toThrow();
+    expect(rule.get({ param1: "test" })).toBe("/test/something");
+
+    // Create dynamic rule with validation.
+    rule = new UrlRule(
+      (data) => `/${data.param1}/something`,
+      ["param1"],
+      (data) => { if (typeof data.param1 !== "string") throw new Error("You must specify <param1>"); return true; }
+    );
+    expect(() => rule.get({ wrongParam: "test" })).toThrow();
+    expect(() => rule.get({ param1: false })).toThrow();
+    expect(rule.get({ param1: "test" })).toBe("/test/something");
+  });
+
+  it("Realistic rule example", () => {
+    // Create a realistic rule.
+    const projectValidation = (data) => {
+      if (typeof data.namespace !== "string")
+        throw new Error("Project url requires a <namespace> of type string.");
+      else if (data.namespace.length < 3)
+        throw new Error("Project url requires a <namespace> of minimum 3 letters.");
+      else if (typeof data.path !== "string")
+        throw new Error("Project url requires a <path> of type string.");
+      else if (data.path.length < 3)
+        throw new Error("Project url requires a <path> of minimum 3 letters.");
+      return true;
+    };
+    const rule = new UrlRule(
+      (data) => `/projects/${data.namespace}/${data.path}`,
+      ["namespace", "path"],
+      projectValidation,
+      ["/projects/fake-user/fake-project"]
+    );
+
+    // Verify single properties and try to manually invoke functions.
+    expect(rule.output).toBeInstanceOf(Function);
+    expect(rule.required).toBeInstanceOf(Array);
+    expect(rule.required).toHaveLength(2);
+    expect(rule.validation).toBeInstanceOf(Function);
+    expect(rule.examples).toBeInstanceOf(Array);
+    expect(rule.examples).toHaveLength(1);
+    expect(rule.examples[0]).toBe("/projects/fake-user/fake-project");
+
+    const data = { namespace: "fake-user", path: "fake-project" };
+    expect(() => rule.validation({})).toThrow();
+    expect(() => rule.validation({ ...data, path: 12345 })).toThrow();
+    expect(() => rule.validation(data)).not.toThrow();
+    expect(rule.output(data)).toBe(rule.examples[0]);
+    expect(rule.output({})).not.toBe(rule.examples[0]);
+
+    // Compare with the `get` method.
+    expect(() => rule.get({ ...data, path: 12345 })).toThrow();
+    expect(() => rule.get({})).toThrow();
+    expect(rule.get(data)).toBe(rule.examples[0]);
+  });
+});
+
+describe("Url helper class", () => {
+  it("Test string page", () => {
+    Url.pages.hijacked = "staticPage";
+    const url = Url.get(Url.pages.hijacked);
+    expect(url).toBe("staticPage");
+  });
+
+  it("Test UrlRule page", () => {
+    // Create fake UrlRule
+    const projectValidation = (data) => {
+      if (data.path && typeof data.path !== "string")
+        throw new Error("Project path must be a string.");
+      return true;
+    };
+    const rule = new UrlRule(
+      (data) => `/projects/${data.namespace}/${data.path ? data.path : ""}`,
+      ["namespace"],
+      projectValidation,
+      ["/projects/ns/", "/projects/ns/ph"]
+    );
+    Url.pages.hijacked = rule;
+
+    // Check successful query and errors
+    expect(() => { Url.get(Url.pages.hijacked); }).toThrow();
+    expect(() => { Url.get(Url.pages.hijacked, "wrong_type"); }).toThrow();
+    expect(() => { Url.get(Url.pages.hijacked, { namespace: 123 }); }).not.toThrow();
+    expect(() => { Url.get(Url.pages.hijacked, { namespace: "ns" }); }).not.toThrow();
+    expect(() => { Url.get(Url.pages.hijacked, { path: 123 }); }).toThrow();
+    expect(() => { Url.get(Url.pages.hijacked, { path: "ph" }); }).toThrow();
+    expect(() => { Url.get(Url.pages.hijacked, { namespace: 123, path: "ph" }); }).not.toThrow();
+
+    expect(Url.get(Url.pages.hijacked, { namespace: "ns" })).toBe(rule.examples[0]);
+    expect(Url.get(Url.pages.hijacked, { namespace: "ns", path: "ph" })).toBe(rule.examples[1]);
+  });
+
+  it("Omit `base`", () => {
+    Url.pages.hijacked = { base: "/staticPage" };
+    const url = Url.get(Url.pages.hijacked);
+    expect(url).toBe("/staticPage");
+    expect(url).toBe(Url.get(Url.pages.hijacked.base));
+  });
+
+  it("Get full Url", () => {
+    Url.pages.hijacked = "/staticPage";
+    expect(Url.get(Url.pages.hijacked)).toBe("/staticPage");
+    expect(() => { Url.get(Url.pages.hijacked, {}, false); }).not.toThrow();
+    expect(() => { Url.get(Url.pages.hijacked, {}, true); }).toThrow();
+    const fakeBaseUrl = "https://Ican'texists/sub/";
+    Url.setBaseUrl(fakeBaseUrl);
+    expect(() => { Url.get(Url.pages.hijacked, {}, true); }).not.toThrow();
+    expect(Url.get(Url.pages.hijacked, {}, true)).toBe("https://Ican'texists/sub/staticPage");
+    expect(() => { Url.setBaseUrl("http://AnotherUrl"); }).toThrow("base url can't be set multiple times");
+  });
+
+  it("Test specific pages", () => {
+    const { get, pages } = Url;
+    expect(get(pages.landing)).toBe("/");
+
+    expect(get(pages.projects)).toBe("/projects");
+    expect(get(pages.projects.all)).toBe("/projects/all");
+    expect(get(pages.projects.all, { q: "test", searchIn: "projects" }))
+      .toBe("/projects/all?q=test&searchIn=projects");
+
+    expect(() => { get(pages.project); }).toThrow();
+    expect(get(pages.project, { namespace: "ns", path: "ph" })).toBe("/projects/ns/ph");
+    expect(get(pages.project, { namespace: "gr1/gr2", path: "ph" })).toBe("/projects/gr1/gr2/ph");
+  });
+});

--- a/client/src/utils/url/index.js
+++ b/client/src/utils/url/index.js
@@ -1,0 +1,28 @@
+/*!
+ * Copyright 2021 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  utils/url
+ *  Components for the Url helper class
+ */
+
+import { Url } from "./Url";
+
+export { Url };


### PR DESCRIPTION
Adds a `Url` helper class with static methods and properties that simplifies getting a URL form wherever in the application.

Most of the URLs are static strings, but some are more complex (e.g. project in subgroups, projects search page). Those can now be built on the fly and even validated.
The PR also includes a thorough list of tests acting as documentation, and a few first examples.

The goal is to remove all the duplicate codes to create URLs on the fly (sometimes faulty, especially for project pages). We can either:

1. Gradually change the URL code when addressing issues impacting it.
2. Try to remove all the duplicates and fix the problems as part of this PR.
3. Create a follow-up issue for `2)`

I'm undecided between `1)` and `2)`, let me know if you have any preference.

**How to test**: try to start a new interactive environment and, from the global `environments` page, click on the project link.

fix #779 
/deploy
