### PR TITLE
ci: improve robustness to missing privacy values

### DIFF
--- a/helm-chart/renku-ui/templates/deployment.yaml
+++ b/helm-chart/renku-ui/templates/deployment.yaml
@@ -66,10 +66,17 @@ spec:
               value: {{ .Values.global.anonymousSessions.enabled | default (printf "false") | quote }}
             - name: PRIVACY_ENABLED
               value: {{ .Values.privacy.enabled | quote }}
+            {{- if .Values.privacy.enabled }}
             - name: PRIVACY_BANNER_CONTENT
               value: {{ .Values.privacy.banner.content | default (printf "") | b64enc | quote }}
             - name: PRIVACY_BANNER_LAYOUT
-              value: {{ toJson .Values.privacy.banner.layout | quote }}
+              value: {{ toJson .Values.privacy.banner.layout | default (printf "") | quote }}
+            {{ else }}
+            - name: PRIVACY_BANNER_CONTENT
+              value: ""
+            - name: PRIVACY_BANNER_LAYOUT
+              value: "{}"
+            {{- end }}
             - name: TEMPLATES
               value: {{ toJson .Values.templates | quote }}
             - name: PREVIEW_THRESHOLD


### PR DESCRIPTION
This PR makes the `PRIVACY_BANNER_CONTENT` and `PRIVACY_BANNER_LAYOUT` env variables robust to missing values when the privacy `enabled` flag is `false`.

Tbh it was unlikely to mess up since default are assigned in the local values file, but it was tecnically possible. Considering how env variable values are consumed in "docker-entrypoint.sh", en empty `PRIVACY_BANNER_CONTENT` would have crashed the UI because of an invalid `config.json` file
> Uncaught (in promise) SyntaxError: JSON.parse: unexpected character at line 11 column 28 of the JSON data

/deploy
fix #1045