### PR TITLE
Expand sentry configuration and prevent sending notebook errors

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -157,7 +157,7 @@
           "starrers",
           "statuspage",
           "stdout",
-          "textarea",
+          "telepresence",
           "textarea",
           "thead",
           "toastify",

--- a/client/docker-entrypoint.sh
+++ b/client/docker-entrypoint.sh
@@ -20,6 +20,7 @@ export NGINX_PATH=/usr/share/nginx/html
 
 echo "Config file contains the following settings:"
 echo "==================================================="
+echo " UI_VERSION=${UI_VERSION}"
 echo " GATEWAY_URL=${GATEWAY_URL:-http://gateway.renku.build}"
 echo " BASE_URL=${BASE_URL:-http://renku.build}"
 echo " SENTRY_URL=${SENTRY_URL}"
@@ -41,6 +42,7 @@ echo "==================================================="
 
 tee > "${NGINX_PATH}/config.json" << EOF
 {
+  "UI_VERSION": "${UI_VERSION}",
   "BASE_URL": "${BASE_URL:-http://renku.build}",
   "GATEWAY_URL": "${GATEWAY_URL:-http://gateway.renku.build}",
   "WELCOME_PAGE": "${WELCOME_PAGE}",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2889,59 +2889,59 @@
       }
     },
     "@sentry/browser": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.12.1.tgz",
-      "integrity": "sha512-Zl7VdppUxctyaoqMSEhnDJp2rrupx8n8N2n3PSooH74yhB2Z91nt84mouczprBsw3JU1iggGyUw9seRFzDI1hw==",
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.30.0.tgz",
+      "integrity": "sha512-rOb58ZNVJWh1VuMuBG1mL9r54nZqKeaIlwSlvzJfc89vyfd7n6tQ1UXMN383QBz/MS5H5z44Hy5eE+7pCrYAfw==",
       "requires": {
-        "@sentry/core": "5.12.0",
-        "@sentry/types": "5.12.0",
-        "@sentry/utils": "5.12.0",
+        "@sentry/core": "5.30.0",
+        "@sentry/types": "5.30.0",
+        "@sentry/utils": "5.30.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/core": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.12.0.tgz",
-      "integrity": "sha512-wY4rsoX71QsGpcs9tF+OxKgDPKzIFMRvFiSRcJoPMfhFsTilQ/CBMn/c3bDtWQd9Bnr/ReQIL6NbnIjUsPHA4Q==",
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.30.0.tgz",
+      "integrity": "sha512-TmfrII8w1PQZSZgPpUESqjB+jC6MvZJZdLtE/0hZ+SrnKhW3x5WlYLvTXZpcWePYBku7rl2wn1RZu6uT0qCTeg==",
       "requires": {
-        "@sentry/hub": "5.12.0",
-        "@sentry/minimal": "5.12.0",
-        "@sentry/types": "5.12.0",
-        "@sentry/utils": "5.12.0",
+        "@sentry/hub": "5.30.0",
+        "@sentry/minimal": "5.30.0",
+        "@sentry/types": "5.30.0",
+        "@sentry/utils": "5.30.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.12.0.tgz",
-      "integrity": "sha512-3k7yE8BEVJsKx8mR4LcI4IN0O8pngmq44OcJ/fRUUBAPqsT38jsJdP2CaWhdlM1jiNUzUDB1ktBv6/lY+VgcoQ==",
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.30.0.tgz",
+      "integrity": "sha512-2tYrGnzb1gKz2EkMDQcfLrDTvmGcQPuWxLnJKXJvYTQDGLlEvi2tWz1VIHjunmOvJrB5aIQLhm+dcMRwFZDCqQ==",
       "requires": {
-        "@sentry/types": "5.12.0",
-        "@sentry/utils": "5.12.0",
+        "@sentry/types": "5.30.0",
+        "@sentry/utils": "5.30.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.12.0.tgz",
-      "integrity": "sha512-fk73meyz4k4jCg9yzbma+WkggsfEIQWI2e2TWfYsRGcrV3RnlSrXyM4D91/A8Bjx10SNezHPUFHjasjlHXOkyA==",
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.30.0.tgz",
+      "integrity": "sha512-BwWb/owZKtkDX+Sc4zCSTNcvZUq7YcH3uAVlmh/gtR9rmUvbzAA3ewLuB3myi4wWRAMEtny6+J/FN/x+2wn9Xw==",
       "requires": {
-        "@sentry/hub": "5.12.0",
-        "@sentry/types": "5.12.0",
+        "@sentry/hub": "5.30.0",
+        "@sentry/types": "5.30.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.12.0.tgz",
-      "integrity": "sha512-aZbBouBLrKB8wXlztriIagZNmsB+wegk1Jkl6eprqRW/w24Sl/47tiwH8c5S4jYTxdAiJk+SAR10AAuYmIN3zg=="
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.30.0.tgz",
+      "integrity": "sha512-R8xOqlSTZ+htqrfteCWU5Nk0CDN5ApUTvrlvBuiH1DyP6czDZ4ktbZB0hAgBlVcK0U+qpD3ag3Tqqpa5Q67rPw=="
     },
     "@sentry/utils": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.12.0.tgz",
-      "integrity": "sha512-fYUadGLbfTCbs4OG5hKCOtv2jrNE4/8LHNABy9DwNJ/t5DVtGqWAZBnxsC+FG6a3nVqCpxjFI9AHlYsJ2wsf7Q==",
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.30.0.tgz",
+      "integrity": "sha512-zaYmoH0NWWtvnJjC9/CBseXMtKHm/tm40sz3YfJRxeQjyzRqNQPgivpd9R/oDJCYj999mzdW382p/qi2ypjLww==",
       "requires": {
-        "@sentry/types": "5.12.0",
+        "@sentry/types": "5.30.0",
         "tslib": "^1.9.3"
       }
     },

--- a/client/package.json
+++ b/client/package.json
@@ -12,7 +12,7 @@
     "@fortawesome/react-fontawesome": "^0.1.7",
     "@nteract/notebook-render": "^5.0.4-alpha.0",
     "@renku/ckeditor5-build-renku": "0.0.4",
-    "@sentry/browser": "^5.12.1",
+    "@sentry/browser": "^5.30.0",
     "ajv": "^6.10.2",
     "apollo-boost": "^0.4.4",
     "bootstrap": "^4.0.0",

--- a/client/run-telepresence.sh
+++ b/client/run-telepresence.sh
@@ -28,6 +28,8 @@ TEMPLATES='{"custom":true,"repositories":
 {"name":"Telepresence","ref":"0.1.11",
 "url":"https://github.com/SwissDataScienceCenter/renku-project-template"}]}'
 PREVIEW_THRESHOLD='{"soft":"1048576","hard":"10485760"}'
+CURRENT_CHART=`grep -oP "(?<=version: )[.0-9a-f\-]*" ../helm-chart/renku-ui/Chart.yaml`
+CURRENT_COMMIT=`git rev-parse --short HEAD`
 if [[ "$OSTYPE" == "linux-gnu" ]]
 then
   WELCOME_PAGE=`echo "${WELCOME_MESSAGE}" | base64 -w 0`
@@ -91,7 +93,7 @@ fi
 # set sentry dns if explicitly required by the user
 if [[ $SENTRY = 1 ]]
 then
-  SENTRY_URL="https://7539e48042f9425380fc31a04746a044@sentry.dev.renku.ch/5"
+  SENTRY_URL="https://182290b8e1524dd3b7eb5dd051852f9f@sentry.dev.renku.ch/5"
   SENTRY_NAMESPACE="${DEV_NAMESPACE}"
 else
   echo "Errors won't be sent to sentry by default. To enable sentry, use 'SENTRY=1 ./run-telepresence.sh'"
@@ -99,6 +101,7 @@ fi
 
 tee > ./public/config.json << EOF
 {
+  "UI_VERSION": "telepresence@${CURRENT_CHART}-${CURRENT_COMMIT}",
   "TELEPRESENCE": "true",
   "BASE_URL": "${BASE_URL}",
   "GATEWAY_URL": "${BASE_URL}/api",

--- a/client/run-telepresence.sh
+++ b/client/run-telepresence.sh
@@ -101,7 +101,7 @@ fi
 
 tee > ./public/config.json << EOF
 {
-  "UI_VERSION": "telepresence@${CURRENT_CHART}-${CURRENT_COMMIT}",
+  "UI_VERSION": "${CURRENT_CHART}-${CURRENT_COMMIT}",
   "TELEPRESENCE": "true",
   "BASE_URL": "${BASE_URL}",
   "GATEWAY_URL": "${BASE_URL}/api",

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -66,7 +66,7 @@ Promise.all([configFetch, privacyFetch]).then(valuesRead => {
 
     // configure Sentry
     if (params.SENTRY_URL)
-      Sentry.init(params.SENTRY_URL, params.SENTRY_NAMESPACE, userPromise, params.UI_VERSION);
+      Sentry.init(params.SENTRY_URL, params.SENTRY_NAMESPACE, userPromise, params.UI_VERSION, params.TELEPRESENCE);
     // Map redux data to react - note we are mapping the model, not its whole content (only user)
     // Use model.get("something") and map it wherever needed
     function mapStateToProps(state, ownProps) {

--- a/client/src/utils/sentry/Sentry.js
+++ b/client/src/utils/sentry/Sentry.js
@@ -1,0 +1,141 @@
+/*!
+ * Copyright 2021 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  Sentry.js
+ *  Sentry configuration object.
+ */
+
+import * as SentryLib from "@sentry/browser";
+
+
+const NAMESPACE_DEFAULT = "unknown";
+const VERSION_DEFAULT = "unknown";
+const UI_COMPONENT = "renku-ui";
+const EXCLUDED_URLS = [
+  /extensions\//i, // Chrome extensions 1
+  /^chrome:\/\//i, // Chrome extensions 2
+];
+
+// module variables
+let uiVersion = VERSION_DEFAULT;
+let sentryInitialized = false;
+let sentryUrl = null;
+let sentryNamespace = NAMESPACE_DEFAULT;
+let sentryDenyUrls = [
+  ...EXCLUDED_URLS,
+];
+
+// module functions
+/**
+ * Initialize listener to send frontend exceptions to Sentry. This can invoked only once.
+ *
+ * @param {string} url - Sentry full URL to log errors. This is provided by Sentry when creating
+ *   a new project.
+ * @param {string} [namespace] - Current Namespace used to assign the error a proper tag. If not
+ *   provided, a default value will be used instead.
+ * @param {object} [userPromise] - Optional promise expected to resolve in an abject containing user
+ *   data. When provided, the user metadata will be added to the exception metadata.
+ * @param {string} [version] - UI version.
+ */
+function sentryInit(url, namespace = null, userPromise = null, version = null) {
+  // Prevent re-initializing
+  if (sentryInitialized)
+    throw new Error("Cannot re-initialize the Sentry client.");
+
+  // Check url
+  if (!url || typeof url !== "string")
+    throw new Error("Please provide a Sentry URL to initialize the client.");
+
+  // Check namespace
+  if (namespace != null) {
+    if (typeof namespace !== "string" || !namespace.length)
+      throw new Error("The optional <namespace> must be a valid string identifying the current namespace.");
+    sentryNamespace = namespace;
+  }
+
+  // Check userPromise
+  if (userPromise != null) {
+    if (typeof userPromise !== "object" || !userPromise.then)
+      throw new Error("The optional <userPromise> must be a valid promise resolving with user's data.");
+  }
+
+  // Check namespace
+  if (version != null) {
+    if (typeof version !== "string" || !version.length)
+      throw new Error("The optional <version> must be a valid string identifying the UI version.");
+    uiVersion = version;
+  }
+
+  // Save data
+  sentryUrl = url;
+  sentryNamespace = namespace;
+
+  // Initialize client
+  // ? Reference: https://docs.sentry.io/platforms/javascript/configuration/options/
+  SentryLib.init({
+    dsn: sentryUrl,
+    environment: sentryNamespace,
+    beforeSend: (event) => hookBeforeSend(event),
+    denyUrls: sentryDenyUrls
+  });
+  SentryLib.setTags({
+    component: UI_COMPONENT,
+    version: uiVersion
+  });
+
+  // Handle user data
+  if (userPromise != null) {
+    userPromise.then(data => {
+      const user = data && data.id ?
+        { logged: true, id: data.id, username: data.username, email: data.email, signIn: data.current_sign_in_at } :
+        { logged: false, id: 0, username: "0" };
+      SentryLib.setUser(user);
+
+      // Add username as tag to simplify search
+      SentryLib.setTag("user.username", user.username);
+    });
+  }
+
+  // Finalize and return SentryLib to allow further customization
+  sentryInitialized = true;
+  return SentryLib;
+}
+
+// helper functions
+function hookBeforeSend(event) {
+  // *** Filters ***
+  // errors while previewing the notebooks
+  if (event.request.url.includes("/files/blob/") && event.request.url.endsWith(".ipynb"))
+    return null;
+
+  return event;
+}
+
+// exported object
+const SentrySettings = {
+  initialized: sentryInitialized,
+  url: sentryUrl,
+  namespace: sentryNamespace,
+  init: sentryInit
+};
+
+
+export { SentrySettings as Sentry };

--- a/client/src/utils/sentry/Sentry.test.js
+++ b/client/src/utils/sentry/Sentry.test.js
@@ -1,0 +1,87 @@
+/*!
+ * Copyright 2021 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  Sentry.test.js
+ *  Tests for Sentry.
+ */
+
+// import { Sentry } from "./Sentry";
+
+
+const FAKE = {
+  url: "https://12345abcde@sentry.dev.renku.ch/5",
+  namespace: "fake_namespace",
+  promise: new Promise(() => { }),
+  version: "0.0",
+};
+
+describe("Sentry settings", () => {
+  // Avoid errors triggered by re-initializing the Sentry client.
+  let Sentry;
+  beforeEach(() => {
+    jest.isolateModules(() => {
+      Sentry = require("./Sentry").Sentry;
+    });
+  });
+
+  it("init function - url parameter", () => {
+    expect(() => Sentry.init())
+      .toThrow("provide a Sentry URL");
+    expect(() => Sentry.init(12345))
+      .toThrow("provide a Sentry URL");
+    expect(() => Sentry.init(FAKE.url)).not.toThrow();
+  });
+
+  it("init function - namespace parameter", () => {
+    expect(() => Sentry.init(FAKE.url, 12345))
+      .toThrow("optional <namespace> must be a valid string");
+    expect(() => Sentry.init(FAKE.url, ""))
+      .toThrow("optional <namespace> must be a valid string");
+    expect(() => Sentry.init(FAKE.url, FAKE.namespace)).not.toThrow();
+  });
+
+  it("init function - userPromise parameter", () => {
+    expect(() => Sentry.init(FAKE.url, null, "wrong_type"))
+      .toThrow("optional <userPromise> must be a valid promise");
+    expect(() => Sentry.init(FAKE.url, null, {}))
+      .toThrow("optional <userPromise> must be a valid promise");
+    expect(() => Sentry.init(FAKE.url, null, FAKE.promise)).not.toThrow();
+  });
+
+  it("init function - version parameter", () => {
+    expect(() => Sentry.init(FAKE.url, null, null, 12345))
+      .toThrow("optional <version> must be a valid string");
+    expect(() => Sentry.init(FAKE.url, null, null, ""))
+      .toThrow("optional <version> must be a valid string");
+    expect(() => Sentry.init(FAKE.url, null, null, FAKE.url)).not.toThrow();
+  });
+
+  it("init function - re-initialize", () => {
+    expect(() => Sentry.init(FAKE.url)).not.toThrow();
+    expect(() => Sentry.init(FAKE.url)).toThrow("re-initialize the Sentry client");
+  });
+
+  it("init function - check Sentry object", () => {
+    const sentrySettings = Sentry.init(FAKE.url, FAKE.namespace, FAKE.promise, FAKE.version);
+    expect(sentrySettings).toBeTruthy();
+    expect(sentrySettings.SDK_NAME).toBe("sentry.javascript.browser");
+  });
+});

--- a/client/src/utils/sentry/Sentry.test.js
+++ b/client/src/utils/sentry/Sentry.test.js
@@ -23,8 +23,6 @@
  *  Tests for Sentry.
  */
 
-// import { Sentry } from "./Sentry";
-
 
 const FAKE = {
   url: "https://12345abcde@sentry.dev.renku.ch/5",
@@ -83,5 +81,32 @@ describe("Sentry settings", () => {
     const sentrySettings = Sentry.init(FAKE.url, FAKE.namespace, FAKE.promise, FAKE.version);
     expect(sentrySettings).toBeTruthy();
     expect(sentrySettings.SDK_NAME).toBe("sentry.javascript.browser");
+  });
+});
+
+
+describe("Helper functions", () => {
+  let getRelease;
+  beforeEach(() => {
+    jest.isolateModules(() => {
+      getRelease = require("./Sentry").getRelease;
+    });
+  });
+
+  it("getRelease", () => {
+    const RELEASE = {
+      normal: "1.10.0",
+      short: "1.10",
+      full: "1.10.0-abcd123",
+      wrong: "1.10.0.abcd123"
+    };
+    const DEV_SUFFIX = "-dev";
+
+    expect(getRelease(RELEASE.normal)).toBe(RELEASE.normal);
+    expect(getRelease(RELEASE.short)).toBe(RELEASE.short);
+    expect(getRelease(RELEASE.full)).toBe(RELEASE.normal + DEV_SUFFIX);
+    expect(getRelease(12345)).toBe("unknown");
+    expect(getRelease("abcd")).toBe("unknown");
+    expect(getRelease(RELEASE.wrong)).toBe("unknown");
   });
 });

--- a/client/src/utils/sentry/index.js
+++ b/client/src/utils/sentry/index.js
@@ -1,0 +1,28 @@
+/*!
+ * Copyright 2021 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  utils/sentry
+ *  Components for Sentry
+ */
+
+import { Sentry } from "./Sentry";
+
+export { Sentry };

--- a/helm-chart/renku-ui/templates/deployment.yaml
+++ b/helm-chart/renku-ui/templates/deployment.yaml
@@ -81,6 +81,8 @@ spec:
               value: {{ toJson .Values.templates | quote }}
             - name: PREVIEW_THRESHOLD
               value: {{ toJson .Values.previewSizeThreshold | quote }}
+            - name: UI_VERSION
+              value: {{ .Chart.Version | quote }}
           livenessProbe:
             httpGet:
               path: /

--- a/server/run-telepresence.sh
+++ b/server/run-telepresence.sh
@@ -60,7 +60,7 @@ fi
 # TODO: set sentry dns if explicitly required by the user
 # if [[ $SENTRY = 1 ]]
 # then
-#   SENTRY_URL="https://7539e48042f9425380fc31a04746a044@sentry.dev.renku.ch/5"
+#   SENTRY_URL="https://182290b8e1524dd3b7eb5dd051852f9f@sentry.dev.renku.ch/5"
 #   SENTRY_NAMESPACE="${DEV_NAMESPACE}"
 # else
 #   echo "Errors won't be sent to sentry by default. To enable sentry, use 'SENTRY=1 ./run-telepresence.sh'"


### PR DESCRIPTION
* Move Sentry configuration to a separate object.
* Add more information to exceptions sent to Sentry, including the UI version.
* Add a mechanism to filter events before sending them.
  This has been used to prevent sending notebook preview related exceptions ( fix #1112 ).

**How to test**: try to preview a notebook that triggers an exception. Compare `dev` (exception logged in Sentry) to the auto deployed environment (no exceptions logged).
The following link provides a good test case; the exception is generated after clicking on "preview it anyway" https://dev.renku.ch/projects/cramakri/plotly-test/files/blob/notebooks/Plotly.ipynb

/deploy
