### PR TITLE
Prevent sending to Sentry useless client-side errors

### DIFF
--- a/client/src/api-client/index.js
+++ b/client/src/api-client/index.js
@@ -130,6 +130,8 @@ class APIClient {
         // It should be solved in a more elegant way once we support interruptable fetch #776
         if (!response && anonymousLogin)
           return returnType === RETURN_TYPES.json ? { data: {} } : "";
+        else if (!response)
+          return null;
         switch (returnType) {
           case RETURN_TYPES.json:
             return response.json().then(data => {

--- a/client/src/api-client/utils.js
+++ b/client/src/api-client/utils.js
@@ -49,7 +49,7 @@ function renkuFetch(url, options) {
 
     // Label an error raised here already as networking problem.
     .catch((fetchError) => {
-      const networkError = new APIError();
+      const networkError = new APIError(API_ERRORS.networkError);
       networkError.case = API_ERRORS.networkError;
       networkError.error = fetchError;
       return Promise.reject(networkError);


### PR DESCRIPTION
This PR filters client-side errors that are not relevant to RenkuLab.
* Network errors: these happen when invoking `fetch` without reaching the url.
* Errors triggered after the `beforeunload` event: these seem to be Firefox specific. When the user manually navigate to another page, any ongoing `fetch` get interrupted and generate an error.

Testing is tricky, especially in the automatically deployed environment. In my dev environment, I hijacked some APIs to slow them down and trigger errors easily, or I manually faked extra network errors.

/deploy
fix #1141, fix #1106