### PR TITLE
Collection of small fixes

### DIFF
--- a/client/run-telepresence.sh
+++ b/client/run-telepresence.sh
@@ -28,7 +28,7 @@ TEMPLATES='{"custom":true,"repositories":
 {"name":"Telepresence","ref":"0.1.11",
 "url":"https://github.com/SwissDataScienceCenter/renku-project-template"}]}'
 PREVIEW_THRESHOLD='{"soft":"1048576","hard":"10485760"}'
-CURRENT_CHART=`grep -oP "(?<=version: )[.0-9a-f\-]*" ../helm-chart/renku-ui/Chart.yaml`
+CURRENT_CHART=`grep -oE "(^version: )[.0-9a-f\-]*" ../helm-chart/renku-ui/Chart.yaml | cut -d" " -f2`
 CURRENT_COMMIT=`git rev-parse --short HEAD`
 if [[ "$OSTYPE" == "linux-gnu" ]]
 then

--- a/client/src/project/Project.present.js
+++ b/client/src/project/Project.present.js
@@ -639,19 +639,6 @@ function ProjectViewDatasets(props) {
   if (loading)
     return <Loader />;
 
-  //When the core service can return stuff for anonymous users this should be removed
-  if (!props.user.logged) {
-    const postLoginUrl = props.location.pathname;
-    const to = { "pathname": "/login", "state": { previous: postLoginUrl } };
-
-    return <Col sm={12} md={12} lg={8}>
-      <Alert color="primary">You are logged out, please&nbsp;
-        <Link className="btn btn-primary btn-sm" to={to} previous={postLoginUrl}>
-          Log in
-        </Link> to see datasets for this project.</Alert>
-    </Col>;
-  }
-
   if (props.core.datasets.error) {
     return <Col sm={12} md={12} lg={8}>
       <Alert color="danger">

--- a/client/src/utils/UIComponents.js
+++ b/client/src/utils/UIComponents.js
@@ -611,19 +611,29 @@ function Clipboard(props) {
 }
 
 // Throttle toggling -- added to work around a bug that appears in Chrome only
-function throttledToggler(tooltipOpen, setTooltipOpen, lastToggleTime, setLastToggleTime) {
+// commenting out but leaving here in case we need it again.
+// function throttledToggler(tooltipOpen, setTooltipOpen, lastToggleTime, setLastToggleTime) {
+//   return () => {
+//     const now = Date.now();
+//     const sinceLast = now - lastToggleTime;
+//     if (!tooltipOpen && sinceLast > 100) {
+//       setLastToggleTime(now);
+//       return setTooltipOpen(!tooltipOpen);
+//     }
+//     else if (tooltipOpen) {
+//       return setTooltipOpen(!tooltipOpen);
+//     }
+//   };
+// }
+
+
+// Non-throttled toggling
+function standardToggler(tooltipOpen, setTooltipOpen, lastToggleTime, setLastToggleTime) {
   return () => {
-    const now = Date.now();
-    const sinceLast = now - lastToggleTime;
-    if (!tooltipOpen && sinceLast > 100) {
-      setLastToggleTime(now);
-      return setTooltipOpen(!tooltipOpen);
-    }
-    else if (tooltipOpen) {
-      return setTooltipOpen(!tooltipOpen);
-    }
+    return setTooltipOpen(!tooltipOpen);
   };
 }
+
 
 /**
  * ThrottledTooltip
@@ -636,7 +646,7 @@ function ThrottledTooltip(props) {
   const [tooltipOpen, setTooltipOpen] = useState(false);
   const [lastToggleTime, setLastToggleTime] = useState(Date.now());
 
-  const toggle = throttledToggler(tooltipOpen, setTooltipOpen, lastToggleTime, setLastToggleTime);
+  const toggle = standardToggler(tooltipOpen, setTooltipOpen, lastToggleTime, setLastToggleTime);
 
   return <Tooltip placement="top" target={props.target} isOpen={tooltipOpen} toggle={toggle}
     delay={{ show: 25, hide: 250 }}>


### PR DESCRIPTION
Fixes for:
- fix: get datasets even if user is not logged in (#1222)
- refactor: remove superfluous throttling (#1168)
- chore: fix run-telepresence to work with FreeBSD grep

Fix #1222 
Fix #1168

## Testing

Compare:
- https://renku-ci-ui-1223.dev.renku.ch/projects/cramakri/dataset-test-project/datasets
- https://dev.renku.ch/projects/cramakri/dataset-test-project/datasets

In the first one, you will see datasets, on dev you will not.

Look at https://renku-ci-ui-1223.dev.renku.ch/projects/cramakri/collaboration-test/collaboration/issues/1/
(You need to be logged in)

Mouse over the buttons

![image](https://user-images.githubusercontent.com/1196411/106452679-82ef9000-6488-11eb-9006-715374bbc84b.png)

You should see tooltips and they should disappear if you move the mouse off.

/deploy