### PR TITLE
fix: prevent accessing stats for non existing projects

### DIFF
--- a/client/src/project/Project.state.js
+++ b/client/src/project/Project.state.js
@@ -408,7 +408,7 @@ class ProjectCoordinator {
   }
 
   setProjectData(data, statistics = false) {
-    let metadata;
+    let metadata, statsObject;
 
     // set metadata
     if (!data) {
@@ -416,6 +416,13 @@ class ProjectCoordinator {
         $set: {
           ...projectGlobalSchema.createInitialized().metadata,
           exists: false,
+          fetched: new Date(),
+          fetching: false
+        }
+      };
+      statsObject = {
+        $set: {
+          ...projectGlobalSchema.createInitialized().statistics,
           fetched: new Date(),
           fetching: false
         }
@@ -436,19 +443,18 @@ class ProjectCoordinator {
         fetched: new Date(),
         fetching: false
       };
-    }
 
-    // set statistics
-    let statsObject = {};
-    if (statistics) {
-      const stats = data.all.statistics ?
-        data.all.statistics :
-        projectGlobalSchema.createInitialized().statistics.data;
-      statsObject = {
-        data: { $set: stats },
-        fetched: new Date(),
-        fetching: false
-      };
+      // set statistics
+      if (statistics) {
+        const stats = data.all && data.all.statistics ?
+          data.all.statistics :
+          projectGlobalSchema.createInitialized().statistics.data;
+        statsObject = {
+          data: { $set: stats },
+          fetched: new Date(),
+          fetching: false
+        };
+      }
     }
 
     this.model.setObject({ metadata: metadata, statistics: statsObject });


### PR DESCRIPTION
The error was not affecting the usability of the UI.
It happened when trying to access a project that either doesn't exist or requires privileges.
Sentry caught that, it's good to fix it.

**How to test**: when the deployment is ready, compare accessing the following with the console open. The first should trigger an error, the second doesn't.
https://dev.renku.ch/projects/lorenzo.cavazzi.tech/idontexists
https://renku-ci-ui-1235.dev.renku.ch/projects/lorenzo.cavazzi.tech/idontexists

fix #1234
/deploy