### PR TITLE
fix: mardown breaks when it has a file inside

### DIFF
--- a/client/src/file/File.container.js
+++ b/client/src/file/File.container.js
@@ -90,7 +90,8 @@ class FilePreview extends React.Component {
       return null;
 
     // LFS files and big files
-    if (this.fileIsLfs() || (this.props.file.size > this.props.previewThreshold.soft && !this.state.previewAnyway)) {
+    if (this.fileIsLfs() || (this.props.previewThreshold &&
+      this.props.file.size > this.props.previewThreshold.soft && !this.state.previewAnyway)) {
       return (
         <FileNoPreview
           url={this.props.downloadLink}

--- a/client/src/utils/Markdown.js
+++ b/client/src/utils/Markdown.js
@@ -82,7 +82,6 @@ function FileAndWrapper(props) {
         <input type="checkbox" id={togglerId} className="visually-hidden fake-toggle" />
         <div className="hide-show-me">
           <FilePreview
-            previewThreshold={{ soft: 1048576, hard: 10485760 }}
             file={props.file}
             {...props}
             springConfig={props.springConfig}

--- a/client/src/utils/Markdown.js
+++ b/client/src/utils/Markdown.js
@@ -82,6 +82,7 @@ function FileAndWrapper(props) {
         <input type="checkbox" id={togglerId} className="visually-hidden fake-toggle" />
         <div className="hide-show-me">
           <FilePreview
+            previewThreshold={{ soft: 1048576, hard: 10485760 }}
             file={props.file}
             {...props}
             springConfig={props.springConfig}


### PR DESCRIPTION
When markdown has a file inside it breaks because of the new threshold variable.

I set this for markdown. Another option would be to use a default threshold variable for all file previews instead.

Example:
https://dev.renku.ch/projects/virginiafriedrich/project-11

/deploy
