### PR TITLE
refactor: add an id to every projects link

### DIFF
--- a/client/src/landing/NavBar.js
+++ b/client/src/landing/NavBar.js
@@ -226,7 +226,7 @@ class LoggedInNavBar extends Component {
 
             <div className="d-flex flex-grow-1">
               <ul className="navbar-nav mr-auto">
-                <RenkuNavLink to="/projects" title="Projects" />
+                <RenkuNavLink to="/projects" title="Projects" id="link-projects" />
                 <RenkuNavLink to="/datasets" title="Datasets" />
                 <RenkuNavLink to="/environments" title="Environments" />
               </ul>
@@ -272,7 +272,7 @@ class AnonymousNavBar extends Component {
 
             <div className="d-flex flex-grow-1">
               <ul className="navbar-nav mr-auto">
-                <RenkuNavLink to="/projects" title="Projects" />
+                <RenkuNavLink to="/projects" title="Projects" id="link-projects" />
                 <RenkuNavLink to="/datasets" title="Datasets" />
                 <RenkuNavLink to="/environments" title="Environments" />
               </ul>

--- a/client/src/project/list/ProjectList.present.js
+++ b/client/src/project/list/ProjectList.present.js
@@ -306,13 +306,16 @@ function ProjectListNav(props) {
       <Col>
         <Nav pills className="nav-pills-underline mb-4">
           <NavItem>
-            <RenkuNavLink to={getPreciseUrl(sectionsMap.own)} noSubPath={true} title="Your Projects" />
+            <RenkuNavLink title="Your Projects" id="link-projects-your"
+              to={getPreciseUrl(sectionsMap.own)} noSubPath={true} />
           </NavItem>
           <NavItem>
-            <RenkuNavLink exact={false} to={getPreciseUrl(sectionsMap.starred)} title="Starred Projects" />
+            <RenkuNavLink title="Starred Projects" id="link-projects-starred"
+              to={getPreciseUrl(sectionsMap.starred)} exact={false} />
           </NavItem>
           <NavItem>
-            <RenkuNavLink exact={false} to={getPreciseUrl(sectionsMap.all)} title="All Projects" />
+            <RenkuNavLink title="All Projects" id="link-projects-all"
+              to={getPreciseUrl(sectionsMap.all)} exact={false} />
           </NavItem>
         </Nav>
       </Col>


### PR DESCRIPTION
This PR adds an `id` to the links to "Projects" pages.
It's useful to make our acceptance tests more robust and it doesn't introduce any change visible to users.

P.S. feel free to suggest a different naming.
