### PR TITLE
fix: datasets ordered by dates created

### DIFF
--- a/client/src/dataset/Dataset.present.js
+++ b/client/src/dataset/Dataset.present.js
@@ -130,12 +130,14 @@ export default function DatasetView(props) {
   const datasetPublished = dataset.published !== undefined && dataset.published.datePublished
     !== undefined && dataset.published.datePublished !== null;
 
+  let dateCreated = datasetPublished ? dataset.published.datePublished : dataset.created;
+
   return <Col>
     <Row>
       <Col md={8} sm={12}>
-        { datasetPublished ?
+        { dateCreated ?
           <small style={{ display: "block", paddingBottom: "8px" }} className="font-weight-light font-italic">
-            Uploaded on {Time.getReadableDate(dataset.published.datePublished.replace(/ /g, "T"))}.
+            Created on {Time.getReadableDate(dateCreated.replace(/ /g, "T"))}.
           </small>
           : null
         }

--- a/client/src/dataset/Dataset.present.js
+++ b/client/src/dataset/Dataset.present.js
@@ -130,14 +130,15 @@ export default function DatasetView(props) {
   const datasetPublished = dataset.published !== undefined && dataset.published.datePublished
     !== undefined && dataset.published.datePublished !== null;
 
-  let dateCreated = datasetPublished ? dataset.published.datePublished : dataset.created;
+  let datasetDate = datasetPublished ? dataset.published.datePublished : dataset.created;
 
   return <Col>
     <Row>
       <Col md={8} sm={12}>
-        { dateCreated ?
+        { datasetDate ?
           <small style={{ display: "block", paddingBottom: "8px" }} className="font-weight-light font-italic">
-            Created on {Time.getReadableDate(dateCreated.replace(/ /g, "T"))}.
+            {datasetPublished ? "Published on " : "Created on "}
+            {Time.getReadableDate(datasetDate.replace(/ /g, "T"))}.
           </small>
           : null
         }

--- a/client/src/dataset/DatasetFunctions.js
+++ b/client/src/dataset/DatasetFunctions.js
@@ -13,9 +13,9 @@ function mapDataset(dataset_core, dataset_kg, core_files) {
       name: dataset_core.name,
       title: dataset_core.title,
       description: dataset_core.description,
+      created: dataset_core.created_at,
       published: {
-        creator: dataset_core.creators,
-        datePublished: dataset_core.created_at
+        creator: dataset_core.creators
       },
       identifier: dataset_core.identifier,
       keywords: dataset_core.keywords,
@@ -26,6 +26,8 @@ function mapDataset(dataset_core, dataset_kg, core_files) {
       dataset.sameAs = dataset_kg.sameAs;
       dataset.isPartOf = dataset_kg.isPartOf;
       dataset.insideKg = true;
+      dataset.published.datePublished = dataset_kg.published && dataset_kg.published.datePublished ?
+        dataset_kg.published.datePublished : undefined;
     }
     else {
       dataset.insideKg = false;

--- a/client/src/dataset/Datasets.test.js
+++ b/client/src/dataset/Datasets.test.js
@@ -100,8 +100,8 @@ describe("Dataset functions", () => {
         "email": null,
         "affiliation": "Some Affiliation"
       }],
-      "datePublished": "01/01/2001",
     },
+    "created": "01/01/2001",
     "identifier": "79215657-4319-4fcf-82b9-58267f2a1db8",
     "keywords": ["test1", "test2", "test3"],
     "hasPart": [
@@ -131,8 +131,8 @@ describe("Dataset functions", () => {
         "email": null,
         "affiliation": "Some Affiliation"
       }],
-      "datePublished": "01/01/2001",
     },
+    "created": "01/01/2001",
     "identifier": "79215657-4319-4fcf-82b9-58267f2a1db8",
     "keywords": ["test1", "test2", "test3"],
     "hasPart": [
@@ -146,6 +146,17 @@ describe("Dataset functions", () => {
     ...kg_dataset,
     "insideKg": true
   };
+
+  const core_dataset_import = { ...core_dataset };
+  delete core_dataset_import.created_at;
+
+  const kg_dataset_import = { ...kg_dataset };
+
+  const result_dataset_import = {
+    ...result_dataset_in_kg
+  };
+  delete result_dataset_import.created;
+  result_dataset_import.published.datePublished = "01/01/2001";
 
 
   const core_files = [
@@ -163,6 +174,10 @@ describe("Dataset functions", () => {
 
   it("maps core dataset into kg dataset outside of a project - kg only", () => {
     expect(mapDataset(undefined, kg_dataset, undefined)).toEqual(result_dataset_only_kg);
+  });
+
+  it("maps core dataset into kg dataset in a project for imported dataset", () => {
+    expect(mapDataset(core_dataset_import, kg_dataset_import, core_files)).toEqual(result_dataset_import);
   });
 
 });

--- a/client/src/dataset/list/DatasetList.container.js
+++ b/client/src/dataset/list/DatasetList.container.js
@@ -146,8 +146,8 @@ class List extends Component {
     switch (this.model.get("orderBy")) {
       case orderByValuesMap.TITLE:
         return "title";
-      case orderByValuesMap.DATE_PUBLISHED:
-        return "date published";
+      case orderByValuesMap.DATE_CREATED:
+        return "date created";
       case orderByValuesMap.PROJECTSCOUNT:
         return "projects count";
       default:

--- a/client/src/dataset/list/DatasetList.container.js
+++ b/client/src/dataset/list/DatasetList.container.js
@@ -146,8 +146,8 @@ class List extends Component {
     switch (this.model.get("orderBy")) {
       case orderByValuesMap.TITLE:
         return "title";
-      case orderByValuesMap.DATE_CREATED:
-        return "date created";
+      case orderByValuesMap.DATE:
+        return "date";
       case orderByValuesMap.PROJECTSCOUNT:
         return "projects count";
       default:

--- a/client/src/dataset/list/DatasetList.present.js
+++ b/client/src/dataset/list/DatasetList.present.js
@@ -58,9 +58,9 @@ class DatasetListRow extends Component {
             : null
         }
         {
-          dataset.published !== undefined && dataset.published.datePublished !== undefined ?
+          dataset.created !== undefined && dataset.created !== undefined ?
             <small className="font-italic">
-              {"Date published: " + new Date(dataset.published.datePublished).toLocaleDateString()}
+              {"Date created: " + new Date(dataset.created).toLocaleDateString()}
             </small>
             : null
         }
@@ -100,10 +100,10 @@ class DatasetSearchForm extends Component {
                 {this.props.orderBy === this.props.orderByValuesMap.TITLE ?
                   <FontAwesomeIcon icon={faCheck} /> : null} Title
               </DropdownItem>
-              <DropdownItem value={this.props.orderByValuesMap.DATE_PUBLISHED}
+              <DropdownItem value={this.props.orderByValuesMap.DATE_CREATED}
                 onClick={this.props.handlers.changeSearchDropdownOrder}>
-                {this.props.orderBy === this.props.orderByValuesMap.DATE_PUBLISHED ?
-                  <FontAwesomeIcon icon={faCheck} /> : null} Date Published
+                {this.props.orderBy === this.props.orderByValuesMap.DATE_CREATED ?
+                  <FontAwesomeIcon icon={faCheck} /> : null} Date Created
               </DropdownItem>
               <DropdownItem value={this.props.orderByValuesMap.PROJECTSCOUNT}
                 onClick={this.props.handlers.changeSearchDropdownOrder}>

--- a/client/src/dataset/list/DatasetList.present.js
+++ b/client/src/dataset/list/DatasetList.present.js
@@ -58,9 +58,11 @@ class DatasetListRow extends Component {
             : null
         }
         {
-          dataset.created !== undefined && dataset.created !== undefined ?
+          dataset.date ?
             <small className="font-italic">
-              {"Date created: " + new Date(dataset.created).toLocaleDateString()}
+              {dataset.published && dataset.published.datePublished ?
+                "Published on: " : "Created on: "}
+              {new Date(dataset.date).toLocaleDateString()}
             </small>
             : null
         }
@@ -100,10 +102,10 @@ class DatasetSearchForm extends Component {
                 {this.props.orderBy === this.props.orderByValuesMap.TITLE ?
                   <FontAwesomeIcon icon={faCheck} /> : null} Title
               </DropdownItem>
-              <DropdownItem value={this.props.orderByValuesMap.DATE_CREATED}
+              <DropdownItem value={this.props.orderByValuesMap.DATE}
                 onClick={this.props.handlers.changeSearchDropdownOrder}>
-                {this.props.orderBy === this.props.orderByValuesMap.DATE_CREATED ?
-                  <FontAwesomeIcon icon={faCheck} /> : null} Date Created
+                {this.props.orderBy === this.props.orderByValuesMap.DATE ?
+                  <FontAwesomeIcon icon={faCheck} /> : null} Date
               </DropdownItem>
               <DropdownItem value={this.props.orderByValuesMap.PROJECTSCOUNT}
                 onClick={this.props.handlers.changeSearchDropdownOrder}>

--- a/client/src/dataset/list/DatasetList.state.js
+++ b/client/src/dataset/list/DatasetList.state.js
@@ -27,7 +27,7 @@ import { Schema, StateKind, StateModel } from "../../model/Model";
 
 const orderByValuesMap = {
   TITLE: "title",
-  DATE_CREATED: "dateCreated",
+  DATE: "date",
   PROJECTSCOUNT: "projectsCount"
 };
 
@@ -104,8 +104,8 @@ class DatasetListModel extends StateModel {
     switch (this.get("orderBy")) {
       case orderByValuesMap.TITLE:
         return "title:" + searchOrder;
-      case orderByValuesMap.DATE_CREATED:
-        return "dateCreated:" + searchOrder;
+      case orderByValuesMap.DATE:
+        return "date:" + searchOrder;
       case orderByValuesMap.PROJECTSCOUNT:
         return "projectsCount:" + searchOrder;
       default:

--- a/client/src/dataset/list/DatasetList.state.js
+++ b/client/src/dataset/list/DatasetList.state.js
@@ -27,7 +27,7 @@ import { Schema, StateKind, StateModel } from "../../model/Model";
 
 const orderByValuesMap = {
   TITLE: "title",
-  DATE_PUBLISHED: "datePublished",
+  DATE_CREATED: "dateCreated",
   PROJECTSCOUNT: "projectsCount"
 };
 
@@ -104,8 +104,8 @@ class DatasetListModel extends StateModel {
     switch (this.get("orderBy")) {
       case orderByValuesMap.TITLE:
         return "title:" + searchOrder;
-      case orderByValuesMap.DATE_PUBLISHED:
-        return "datePublished:" + searchOrder;
+      case orderByValuesMap.DATE_CREATED:
+        return "dateCreated:" + searchOrder;
       case orderByValuesMap.PROJECTSCOUNT:
         return "projectsCount:" + searchOrder;
       default:

--- a/client/src/project/datasets/DatasetsListView.js
+++ b/client/src/project/datasets/DatasetsListView.js
@@ -44,7 +44,7 @@ function DatasetListRow(props) {
         {
           dataset.created_at !== undefined && dataset.created_at !== null ?
             <small className="font-italic">
-              {"Published: " + new Date(dataset.created_at.replace(/ /g, "T")).toLocaleDateString()}
+              {"Created: " + new Date(dataset.created_at.replace(/ /g, "T")).toLocaleDateString()}
             </small>
             : null
         }


### PR DESCRIPTION
There was a bug in dataset search that was not ordering datasets per imported date.

I revised the way we handle dates in datasets to display it in a more accurate way.

**Datasets Search**
We get from the KG "date" we check if the dataset was published or not (we do this by checking if it has a datePublished or not) we display "Published date" or "Created date" and the date.

**Dataset Display**
For datasets inside projects:
- Datasets created in renku: Inside projects we get created_at from the core service we map this to created
- Imported datasets: we get datePublished from the KG and we use this since we get nothing from core

For datasets inside the kg (display from search)
- Datasets created in renku have created
- Imported datasets have published date

For datasets that are not in the KG(only inside projects):
We only get a date_created for datasets created in the KG so we display this (we map it to created)

Closes #1226 

/deploy
