### PR TITLE
fix: test lfs status properly on the preview

### DIFF
--- a/client/src/file/File.container.js
+++ b/client/src/file/File.container.js
@@ -59,10 +59,8 @@ class FilePreview extends React.Component {
   fileIsImage = () => IMAGE_EXTENSIONS.indexOf(this.getFileExtension()) >= 0;
   fileHasNoExtension = () => this.getFileExtension() === null;
   fileIsLfs = () => {
-    if (this.props.file && this.props.file.content) {
-      if (atob(this.props.file.content).includes("https://git-lfs.github.com/"))
-        return true;
-    }
+    if (this.props.hashElement && this.props.hashElement.isLfs)
+      return true;
     return false;
   }
 


### PR DESCRIPTION
Some non-lfs files were mistakenly considered as lfs, preventing the preview.

Compare:
- https://dev.renku.ch/projects/lorenzo.cavazzi.tech/csci-e-88b-2021-problem1/files/blob/notebooks/git_lfs.ipynb
- https://renku-ci-ui-1242.dev.renku.ch/projects/lorenzo.cavazzi.tech/csci-e-88b-2021-problem1/files/blob/notebooks/git_lfs.ipynb

/deploy