### PR TITLE
fix: markdown with incomplete links in comments

### DIFF
--- a/client/src/utils/Markdown.js
+++ b/client/src/utils/Markdown.js
@@ -210,7 +210,7 @@ function RenkuMarkdownWithPathTranslation(props) {
     + "/" + props.projectPathWithNamespace + "/files/blob/";
 
   for (let link of previewLinks) {
-    if (!link.getAttribute("href").match(patterns.urlRef)) {
+    if (link.getAttribute("href") && !link.getAttribute("href").match(patterns.urlRef)) {
       const newHref = fixRelativePath(link.getAttribute("href"), filesPathArray) ;
       link.href = fullBaseUrl + newHref ;
     }


### PR DESCRIPTION
If markdown contains a line like this it breaks leaving the project not usable:

`# <a name="litterature-review"></a> Litterature review`

This pr fixes that.

@erbou @pameladelgado 

/deploy