### PR TITLE
fix: fail gracefully when a dataset is missing

### DIFF
--- a/client/src/dataset/Dataset.container.js
+++ b/client/src/dataset/Dataset.container.js
@@ -46,7 +46,7 @@ export default function ShowDataset(props) {
                 .map(file => ({ name: file.name, atLocation: file.path })));
             }
             else {
-              setDatasetFiles(response.data);
+              setDatasetFiles([]);
               if (response.data && response.data.error) {
                 if (response.data.error.code === -32100)
                   setFetchError({ code: 404, message: "dataset not found or missing permissions" });

--- a/client/src/dataset/Dataset.container.js
+++ b/client/src/dataset/Dataset.container.js
@@ -60,8 +60,7 @@ export default function ShowDataset(props) {
     return () => {
       unmounted = true;
     };
-  }, [props.insideProject, datasetFiles, props.datasetId,
-    dataset, props.httpProjectUrl, setDatasetFiles, props.client]);
+  }, [datasetFiles, props.datasetId, dataset, props.httpProjectUrl, setDatasetFiles, props.client]);
 
   useEffect(() => {
     let unmounted = false;
@@ -83,8 +82,7 @@ export default function ShowDataset(props) {
     return () => {
       unmounted = true;
     };
-  }, [props.insideProject, props.datasets_kg, props.datasetId, props.identifier,
-    props.client, datasetKg, dataset, props.graphStatus]);
+  }, [props.insideProject, props.identifier, props.client, datasetKg, dataset, props.graphStatus]);
 
   if (props.insideProject && datasetFiles === undefined)
     return <Loader />;

--- a/client/src/dataset/Dataset.container.js
+++ b/client/src/dataset/Dataset.container.js
@@ -32,49 +32,27 @@ export default function ShowDataset(props) {
       : undefined
     , datasetKg, datasetFiles)
   , [props.datasets, datasetKg, props.datasetId, datasetFiles]);
-  const [fetchError, setFetchError] = useState();
+  const [fetchError, setFetchError] = useState({});
 
   useEffect(()=>{
     let unmounted = false;
-    if (props.insideProject && datasetFiles === undefined && dataset && dataset.name) {
-      props.client.fetchDatasetFilesFromCoreService(dataset.name, props.httpProjectUrl)
-        .then(response =>{
+    if (datasetFiles === undefined && ((dataset && dataset.name) || (props.datasetId !== undefined))) {
+      const name = (dataset && dataset.name) ? dataset.name : props.datasetId;
+      props.client.fetchDatasetFilesFromCoreService(name, props.httpProjectUrl)
+        .then(response => {
           if (!unmounted && datasetFiles === undefined) {
             if (response.data.result) {
               setDatasetFiles(response.data.result.files
                 .map(file => ({ name: file.name, atLocation: file.path })));
             }
-            else { setDatasetFiles(response.data); }
-          }
-        }
-        );
-    }
-    return () => {
-      unmounted = true;
-    };
-  }, [props.insideProject, datasetFiles,
-    dataset, props.httpProjectUrl, setDatasetFiles, props.client]);
-
-  useEffect(() => {
-    let unmounted = false;
-    if (datasetKg === undefined && ((props.insideProject && dataset.identifier && props.graphStatus)
-    || (props.identifier !== undefined))) {
-      const id = props.insideProject ? dataset.identifier : props.identifier;
-      props.client
-        .fetchDatasetFromKG(props.client.baseUrl.replace("api", "knowledge-graph/datasets/") + id)
-        .then((datasetInfo) => {
-          if (!unmounted && datasetKg === undefined && datasetInfo !== undefined)
-            setDatasetKg(datasetInfo);
-        }).catch(error => {
-          if (fetchError === undefined) {
-            if (!unmounted && error.case === API_ERRORS.notFoundError) {
-              setFetchError(props.insideProject ? "Error 404: The dataset that was selected does not exist or" +
-                " could not be accessed. If you just created or imported the dataset try reloading the page."
-                : "Error 404: The dataset that was selected does not exist or" +
-                " could not be accessed.");
-            }
-            else if (!unmounted && error.case === API_ERRORS.internalServerError) {
-              setFetchError("Error 500: The dataset that was selected couldn't be fetched.");
+            else {
+              setDatasetFiles(response.data);
+              if (response.data && response.data.error) {
+                if (response.data.error.code === -32100)
+                  setFetchError({ code: 404, message: "dataset not found or missing permissions" });
+                else
+                  setFetchError({ code: 0, message: "error fetching dataset: " + response.data.error.reason });
+              }
             }
           }
         });
@@ -82,8 +60,31 @@ export default function ShowDataset(props) {
     return () => {
       unmounted = true;
     };
+  }, [props.insideProject, datasetFiles, props.datasetId,
+    dataset, props.httpProjectUrl, setDatasetFiles, props.client]);
+
+  useEffect(() => {
+    let unmounted = false;
+    if (datasetKg === undefined && ((dataset && dataset.identifier && props.graphStatus)
+      || (props.identifier !== undefined))) {
+      const id = props.insideProject ? dataset.identifier : props.identifier;
+      props.client
+        .fetchDatasetFromKG(props.client.baseUrl.replace("api", "knowledge-graph/datasets/") + id)
+        .then((datasetInfo) => {
+          if (!unmounted && datasetKg === undefined && datasetInfo !== undefined)
+            setDatasetKg(datasetInfo);
+        }).catch(error => {
+          if (!unmounted && error.case === API_ERRORS.notFoundError)
+            setFetchError({ code: 404, message: "dataset not found or missing permissions" });
+          else if (!unmounted && error.case === API_ERRORS.internalServerError)
+            setFetchError({ code: 500, message: "cannot fetch selected dataset" });
+        });
+    }
+    return () => {
+      unmounted = true;
+    };
   }, [props.insideProject, props.datasets_kg, props.datasetId, props.identifier,
-    props.client, datasetKg, fetchError, dataset, props.graphStatus]);
+    props.client, datasetKg, dataset, props.graphStatus]);
 
   if (props.insideProject && datasetFiles === undefined)
     return <Loader />;

--- a/client/src/dataset/Dataset.container.js
+++ b/client/src/dataset/Dataset.container.js
@@ -51,7 +51,7 @@ export default function ShowDataset(props) {
                 if (response.data.error.code === -32100)
                   setFetchError({ code: 404, message: "dataset not found or missing permissions" });
                 else
-                  setFetchError({ code: 0, message: "error fetching dataset: " + response.data.error.reason });
+                  setFetchError({ code: 0, message: "error fetching dataset files: " + response.data.error.reason });
               }
             }
           }

--- a/client/src/dataset/Dataset.present.js
+++ b/client/src/dataset/Dataset.present.js
@@ -135,19 +135,14 @@ function DatasetError(props) {
     let errorDetails = null;
     if (fetchError.code === 404) {
       errorDetails = (
-        <Fragment>
-          <p>
-            We could not find the dataset. It is possible is has been deleted by its owner or you don&apos;t have
-            permission to access it.
-          </p>
-        </Fragment>
+        <p>We could not find the dataset. It is possible it has been deleted by its owner.</p>
       );
     }
     else if (fetchError.message) {
       errorDetails = (<p>Error details: {fetchError.message}</p>);
     }
     const tip = logged ?
-      (<p className="mb-0">You can try to select again a dataset ferom the list in the previous page.</p>) :
+      (<p className="mb-0">You can try to select a dataset again from the list in the previous page.</p>) :
       loginHelper;
 
     return (
@@ -183,7 +178,7 @@ function DatasetError(props) {
         <h3>Dataset not found <FontAwesomeIcon icon={faSearch} flip="horizontal" /></h3>
         <div>&nbsp;</div>
         <p>
-          It is possible that the dataset has been deleted by its owner or you don&apos;t have permission
+          It is possible that the dataset has been deleted by its owner or you do not have permission
           to access it.
         </p>
         {info}

--- a/client/src/dataset/Dataset.present.js
+++ b/client/src/dataset/Dataset.present.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import React, { Fragment, useState } from "react";
+import React, { useState } from "react";
 import {
   Alert, Button, Card, CardBody, CardHeader, Col, DropdownItem, DropdownMenu, DropdownToggle, Row,
   Table, UncontrolledButtonDropdown,


### PR DESCRIPTION
Adds a 404 page when the dataset doesn't exist or the user doesn't have access (currently, the access control is not yet enforced by the APIs).
It's similar to the 404 project page when the user is trying to access `/datasets/<id>`, while it's a simpler message when trying to access datasets in a project page.

**Hot to test**: try to access non-existing datasets as anonymous or logged user
1. PR: https://renku-ci-ui-1258.dev.renku.ch/datasets/fake-id
    DEV: https://dev.renku.ch/datasets/fake-id

2. PR: https://renku-ci-ui-1258.dev.renku.ch/projects/lorenzo.cavazzi.tech/dataset-test-project-copy/datasets/fake-id
    DEV: https://dev.renku.ch/projects/lorenzo.cavazzi.tech/dataset-test-project-copy/datasets/fake-id

![Screenshot_20210302_173048](https://user-images.githubusercontent.com/43481553/109680738-14801980-7b7d-11eb-9f4f-0d0db8753a52.png)

/deploy
fix #1003