### PR TITLE
refactor: route all the kg requests through the gateway

### DIFF
--- a/client/src/api-client/dataset.js
+++ b/client/src/api-client/dataset.js
@@ -1,7 +1,7 @@
 export default function addDatasetMethods(client) {
 
   client.searchDatasets = (queryParams = { query: "" }) => {
-    const url = `${client.baseUrl.replace("/api", "")}/knowledge-graph/datasets`;
+    const url = `${client.baseUrl}/kg/datasets`;
     const headers = client.getBasicHeaders();
 
     return client.clientFetch(url, {

--- a/client/src/api-client/index.js
+++ b/client/src/api-client/index.js
@@ -69,7 +69,7 @@ class APIClient {
     this.baseUrl = baseUrl;
     this.returnTypes = RETURN_TYPES;
     this.graphqlClient = new ApolloClient({
-      uri: `${baseUrl}/graphql`
+      uri: `${baseUrl}/kg/graphql`
     });
 
     addProjectMethods(this);

--- a/client/src/api-client/project.js
+++ b/client/src/api-client/project.js
@@ -319,37 +319,16 @@ function addProjectMethods(client) {
       .then(result => yaml.load(result));
   };
 
-  client.fetchDatasetFromKG = (datasetLink) => {
+  client.fetchDatasetFromKG = async (id) => {
+    const url = `${client.baseUrl}/kg/datasets/${id}`;
     const headers = client.getBasicHeaders();
-    const datasetPromise = client.clientFetch(datasetLink, { method: "GET", headers });
-    return Promise.resolve(datasetPromise)
-      .then(dataset => dataset.data);
+    return client.clientFetch(url, { method: "GET", headers }).then(dataset => dataset.data);
   };
 
   client.getProjectDatasetsFromKG = (projectPath) => {
-    let url = `${client.baseUrl}/knowledge-graph/projects/${projectPath}/datasets`;
-    url = url.replace("/api", "");//The url should change in the backend so we don't have to do this
+    const url = `${client.baseUrl}/kg/projects/${projectPath}/datasets`;
     const headers = client.getBasicHeaders();
-    return client.clientFetch(url, { method: "GET", headers }).then((resp) => {
-      return resp.data;
-    }).then(resp => {
-      let fullDatasets = resp.map(dataset =>
-        client.fetchDatasetFromKG(dataset._links[0].href));
-      return Promise.all(fullDatasets).then(datasets => {
-        //in case one of the dataset fetch fails we return the ones that didn't fail
-        return datasets.filter(dataset => dataset !== "error");
-      });
-    });
-  };
-
-  //in the future we will get all the info we need for the dataset list from this call...
-  client.getProjectDatasetsFromKG_short = (projectPath) => {
-    let url = `${client.baseUrl}/knowledge-graph/projects/${projectPath}/datasets`;
-    url = url.replace("/api", "");//The url should change in the backend so we don't have to do this
-    const headers = client.getBasicHeaders();
-    return client.clientFetch(url, { method: "GET", headers }).then((resp) => {
-      return resp.data;
-    });
+    return client.clientFetch(url, { method: "GET", headers }).then(resp => resp.data);
   };
 
   client.getProjectDatasets = (projectId) => {

--- a/client/src/dataset/Dataset.container.js
+++ b/client/src/dataset/Dataset.container.js
@@ -60,8 +60,7 @@ export default function ShowDataset(props) {
     if (datasetKg === undefined && ((props.insideProject && dataset.identifier && props.graphStatus)
     || (props.identifier !== undefined))) {
       const id = props.insideProject ? dataset.identifier : props.identifier;
-      props.client
-        .fetchDatasetFromKG(props.client.baseUrl.replace("api", "knowledge-graph/datasets/") + id)
+      props.client.fetchDatasetFromKG(id)
         .then((datasetInfo) => {
           if (!unmounted && datasetKg === undefined && datasetInfo !== undefined)
             setDatasetKg(datasetInfo);

--- a/client/src/project/Project.state.js
+++ b/client/src/project/Project.state.js
@@ -269,7 +269,7 @@ class ProjectModel extends StateModel {
   fetchProjectDatasetsFromKg(client) { //from KG
     if (this.get("core.datasets_kg") === SpecialPropVal.UPDATING) return;
     this.setUpdating({ core: { datasets_kg: true } });
-    return client.getProjectDatasetsFromKG_short(this.get("core.path_with_namespace"))
+    return client.getProjectDatasetsFromKG(this.get("core.path_with_namespace"))
       .then(datasets => {
         const updatedState = { datasets_kg: { $set: datasets }, transient: { requests: { datasets_kg: false } } };
         this.setObject({ core: updatedState });


### PR DESCRIPTION
This routes all the knowledge-graph API through the gateway using the prefix `/api/kg`

Since it requires SwissDataScienceCenter/renku-gateway#382 , I manually created a deployment to test it
https://lorenzotest.dev.renku.ch

/deploy
fix #1053