### PR TITLE
refactor: add dropdown indicator on autosuggest

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -16726,24 +16726,15 @@
       }
     },
     "react-autosuggest": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/react-autosuggest/-/react-autosuggest-10.0.0.tgz",
-      "integrity": "sha512-WFCeRuYv6YCY9Ch4BodXPASWJXDh32ehQQHA2eLNhOBhu3Xcank+5W4wcEN+oqdAX1fvKROZRQRF2fpNZaZaxA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-autosuggest/-/react-autosuggest-10.1.0.tgz",
+      "integrity": "sha512-/azBHmc6z/31s/lBf6irxPf/7eejQdR0IqnZUzjdSibtlS8+Rw/R79pgDAo6Ft5QqCUTyEQ+f0FhL+1olDQ8OA==",
       "requires": {
         "es6-promise": "^4.2.8",
         "prop-types": "^15.7.2",
-        "react-autowhatever": "^10.2.1",
-        "shallow-equal": "^1.2.1"
-      }
-    },
-    "react-autowhatever": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/react-autowhatever/-/react-autowhatever-10.2.1.tgz",
-      "integrity": "sha512-5gQyoETyBH6GmuW1N1J81CuoAV+Djeg66DEo03xiZOl3WOwJHBP5LisKUvCGOakjrXU4M3hcIvCIqMBYGUmqOA==",
-      "requires": {
-        "prop-types": "^15.5.8",
         "react-themeable": "^1.1.0",
-        "section-iterator": "^2.0.0"
+        "section-iterator": "^2.0.0",
+        "shallow-equal": "^1.2.1"
       }
     },
     "react-base16-styling": {

--- a/client/package.json
+++ b/client/package.json
@@ -33,7 +33,7 @@
     "popper.js": "^1.16.0",
     "query-string": "^6.8.3",
     "react": "^16.11.0",
-    "react-autosuggest": "^10.0.0",
+    "react-autosuggest": "^10.1.0",
     "react-clipboard.js": "^2.0.16",
     "react-collapse": "^5.0.0",
     "react-cookie-consent": "^5.1.2",

--- a/client/src/project/new/Project.style.css
+++ b/client/src/project/new/Project.style.css
@@ -2,14 +2,7 @@
   position: relative;
 }
 
-/* Overridden in the theme to use bootstrap form-control
-.react-autosuggest__input {
-  width: 100%;
-  padding: 10px 20px;
-  border: 1px solid #aaa;
-  border-radius: 4px;
-}
-*/
+/* Overridden in the theme to use bootstrap form-control */
 
 .react-autosuggest__input--focused {
   outline: none;
@@ -73,4 +66,25 @@
 
 svg.no-pointer {
   cursor: default;
+}
+
+/* Custom dropdown symbol taken from bootstrap custom-select class */
+/* ? The Autoselect theme fails on the input, otherwise the original boostrap class could be used directly  */
+.react-autosuggest__container > input {
+  display: inline-block;
+  width: 100%;
+  height: calc(1.5em + 0.75rem + 2px);
+  padding: 0.375rem 1.75rem 0.375rem 0.75rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5;
+  color: #495057;
+  vertical-align: middle;
+  background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 5'%3e%3cpath fill='%23343a40' d='M2 0L0 2h4zm0 5L0 3h4z'/%3e%3c/svg%3e") no-repeat right 0.75rem center/8px 10px;
+  background-color: #fff;
+  border: 1px solid #ced4da;
+  border-radius: 0.25rem;
+  -webkit-appearance: none;
+     -moz-appearance: none;
+          appearance: none;
 }

--- a/client/src/project/new/ProjectNew.present.js
+++ b/client/src/project/new/ProjectNew.present.js
@@ -465,7 +465,7 @@ class Visibility extends Component {
     else {
       const options = meta.namespace.visibilities.map(v => <option key={v} value={v}>{capitalize(v)}</option>);
       main = (
-        <Input id="visibility" type="select" placeholder="Choose visibility..."
+        <Input id="visibility" type="select" placeholder="Choose visibility..." className="custom-select"
           value={input.visibility} feedback={error} invalid={error && !input.visibilityPristine}
           onChange={(e) => handlers.setProperty("visibility", e.target.value)} >
           <option key="" value="" disabled>Choose visibility...</option>
@@ -657,7 +657,7 @@ class Template extends Component {
         <option key={t.id} value={t.id}>{`${t.parentRepo} / ${t.name}`}</option>)
       );
       main = (
-        <Input id="template" type="select" placeholder="Select template..."
+        <Input id="template" type="select" placeholder="Select template..." className="custom-select"
           value={input.template} feedback={error} invalid={invalid}
           onChange={(e) => handlers.setProperty("template", e.target.value)} >
           <option key="" value="" disabled>Select a template...</option>


### PR DESCRIPTION
~That was not planned for this sprint but~
I was checking something on bootstrap and I accidentally found the `custom-select` class to style an input element as a dropdown.
Sadly, I had to re-implement the same styling because the Autosuggest element has a minor bug preventing adding a class on the main `input` element when untouched.

/deploy
fix #1271