### PR TITLE
refactor: update login to preserve query params

### DIFF
--- a/client/src/dataset/Dataset.present.js
+++ b/client/src/dataset/Dataset.present.js
@@ -31,6 +31,7 @@ import { ProjectsCoordinator } from "../project/shared";
 import AddDataset from "./addtoproject/DatasetAdd.container";
 import DeleteDataset from "../project/datasets/delete/index";
 import Time from "../utils/Time";
+import { Url } from "../utils/url";
 
 
 function DisplayFiles(props) {
@@ -118,9 +119,8 @@ function DatasetError(props) {
   // login helper
   let loginHelper = null;
   if (!logged) {
-    const postLoginUrl = location.pathname;
-    const to = { "pathname": "/login", "state": { previous: postLoginUrl } };
-    const link = (<Link className="btn btn-primary btn-sm" to={to} previous={postLoginUrl}>Log in</Link>);
+    const to = Url.get(Url.pages.login.link, { pathname: location.pathname });
+    const link = (<Link className="btn btn-primary btn-sm" to={to}>Log in</Link>);
     loginHelper = (
       <p className="mb-0">
         <FontAwesomeIcon icon={faInfoCircle} /> You might need to be logged in to see this dataset.

--- a/client/src/landing/NavBar.js
+++ b/client/src/landing/NavBar.js
@@ -76,6 +76,7 @@ class RenkuToolbarItemUser extends Component {
 
     return (
       <li className="nav-item dropdown">
+        { /* eslint-disable-next-line */ }
         <a key="button" className="nav-link dropdown-toggle" id="profile-dropdown" role="button"
           data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
           {this.props.userAvatar}

--- a/client/src/landing/NavBar.js
+++ b/client/src/landing/NavBar.js
@@ -35,6 +35,7 @@ import logo from "./logo.svg";
 import { ExternalDocsLink, ExternalLink, Loader, RenkuNavLink, UserAvatar } from "../utils/UIComponents";
 import { getActiveProjectPathWithNamespace, gitLabUrlFromProfileUrl } from "../utils/HelperFunctions";
 import QuickNav from "../utils/quicknav";
+import { Url } from "../utils/url";
 import { NotificationsMenu } from "../notifications";
 import { LoginHelper } from "../authentication";
 
@@ -62,30 +63,31 @@ function gitLabSettingsUrlFromProfileUrl(webUrl) {
 
 class RenkuToolbarItemUser extends Component {
   render() {
-    const { user } = this.props;
+    const { location, user } = this.props;
     const gatewayURL = this.props.params.GATEWAY_URL;
     const redirect_url = encodeURIComponent(this.props.params.BASE_URL);
-    if (!user.fetched)
+    if (!user.fetched) {
       return <Loader size="16" inline="true" />;
+    }
+    else if (!user.logged) {
+      const to = Url.get(Url.pages.login.link, { pathname: location.pathname });
+      return (<RenkuNavLink to={to} title="Login" />);
+    }
 
-    else if (!user.data.id)
-      return <RenkuNavLink to="/login" title="Login" previous={this.props.location.pathname} />;
-
-
-    return <li className="nav-item dropdown">
-      { /* eslint-disable-next-line */ }
-      <a key="button" className="nav-link dropdown-toggle" id="profile-dropdown" role="button"
-        data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-        {this.props.userAvatar}
-      </a>
-      <div key="menu" className="dropdown-menu dropdown-menu-right" aria-labelledby="profile-dropdown">
-        <ExternalLink url={`${gatewayURL}/auth/user-profile`} title="Account" className="dropdown-item" role="link" />
-        <DropdownItem divider />
-        <a id="logout-link" className="dropdown-item" onClick={() => { LoginHelper.notifyLogout(); }}
-          href={`${gatewayURL}/auth/logout?redirect_url=${redirect_url}`}>Logout</a>
-      </div>
-    </li>;
-
+    return (
+      <li className="nav-item dropdown">
+        <a key="button" className="nav-link dropdown-toggle" id="profile-dropdown" role="button"
+          data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          {this.props.userAvatar}
+        </a>
+        <div key="menu" className="dropdown-menu dropdown-menu-right" aria-labelledby="profile-dropdown">
+          <ExternalLink url={`${gatewayURL}/auth/user-profile`} title="Account" className="dropdown-item" role="link" />
+          <DropdownItem divider />
+          <a id="logout-link" className="dropdown-item" onClick={() => { LoginHelper.notifyLogout(); }}
+            href={`${gatewayURL}/auth/logout?redirect_url=${redirect_url}`}>Logout</a>
+        </div>
+      </li>
+    );
   }
 }
 

--- a/client/src/notebooks/Notebooks.present.js
+++ b/client/src/notebooks/Notebooks.present.js
@@ -44,14 +44,15 @@ import "./Notebooks.css";
 
 class NotebooksDisabled extends Component {
   render() {
-    const postLoginUrl = this.props.location ? this.props.location.pathname : null;
-    const to = { "pathname": "/login", "state": { previous: postLoginUrl } };
-    const info = postLoginUrl == null ?
+    const { location } = this.props;
+
+    const to = Url.get(Url.pages.login.link, { pathname: location.pathname });
+    const info = !location ?
       null :
       (
         <InfoAlert timeout={0} key="login-info">
           <p className="mb-0">
-            <Link className="btn btn-primary btn-sm" to={to} previous={postLoginUrl}>Log in</Link> to use
+            <Link className="btn btn-primary btn-sm" to={to}>Log in</Link> to use
             interactive environments.
           </p>
         </InfoAlert>

--- a/client/src/notebooks/Notebooks.test.js
+++ b/client/src/notebooks/Notebooks.test.js
@@ -281,13 +281,14 @@ describe("rendering", () => {
     project: "fake",
     branch: { name: "master" }
   };
+  const fakeLocation = { pathname: "" };
 
   it("renders NotebooksDisabled", () => {
     const div = document.createElement("div");
     document.body.appendChild(div);
     ReactDOM.render(
       <MemoryRouter>
-        <NotebooksDisabled />
+        <NotebooksDisabled location={fakeLocation} />
       </MemoryRouter>, div);
   });
 

--- a/client/src/project/Project.present.js
+++ b/client/src/project/Project.present.js
@@ -41,6 +41,7 @@ import {
   Clipboard, ExternalLink, Loader, RenkuNavLink, TimeCaption,
   ButtonWithMenu, InfoAlert, GoBackButton, RenkuMarkdown,
 } from "../utils/UIComponents";
+import { Url } from "../utils/url";
 import { SpecialPropVal } from "../model/Model";
 import { ProjectTags, ProjectTagList } from "./shared";
 import { Notebooks, StartNotebookServer } from "../notebooks";
@@ -949,7 +950,7 @@ class ProjectEnvironments extends Component {
 
 function notebookWarning(userLogged, accessLevel, fork, postLoginUrl, externalUrl) {
   if (!userLogged) {
-    const to = { "pathname": "/login", "state": { previous: postLoginUrl } };
+    const to = Url.get(Url.pages.login.link, { pathname: postLoginUrl });
     return (
       <InfoAlert timeout={0} key="permissions-warning">
         <p>
@@ -959,7 +960,7 @@ function notebookWarning(userLogged, accessLevel, fork, postLoginUrl, externalUr
           you cannot save your work.
         </p>
         <p className="mb-0">
-          <Link className="btn btn-primary btn-sm" to={to} previous={postLoginUrl}>Log in</Link> for
+          <Link className="btn btn-primary btn-sm" to={to}>Log in</Link> for
           full access.
         </p>
       </InfoAlert>
@@ -1224,12 +1225,11 @@ class ProjectViewNotFound extends Component {
       </InfoAlert>;
     }
     else {
-      const postLoginUrl = this.props.location.pathname;
-      const to = { "pathname": "/login", "state": { previous: postLoginUrl } };
+      const to = Url.get(Url.pages.login.link, { pathname: this.props.location.pathname });
       tip = <InfoAlert timeout={0}>
         <p className="mb-0">
           <FontAwesomeIcon icon={faInfoCircle} /> You might need to be logged in to see this project.
-          Please try to <Link className="btn btn-primary btn-sm" to={to} previous={postLoginUrl}>Log in</Link>
+          Please try to <Link className="btn btn-primary btn-sm" to={to}>Log in</Link>
         </p>
       </InfoAlert>;
     }

--- a/client/src/project/new/ProjectNew.present.js
+++ b/client/src/project/new/ProjectNew.present.js
@@ -37,6 +37,7 @@ import { faInfoCircle, faSyncAlt } from "@fortawesome/free-solid-svg-icons";
 import { FieldGroup, Loader, ExternalLink } from "../../utils/UIComponents";
 import { slugFromTitle } from "../../utils/HelperFunctions";
 import { capitalize } from "../../utils/formgenerator/FormGenerator.present";
+import { Url } from "../../utils/url";
 import "./Project.style.css";
 
 
@@ -167,16 +168,15 @@ function ForkProjectContent(props) {
 
 class NewProject extends Component {
   render() {
-    const { user, config, input } = this.props;
+    const { config, input, location, user } = this.props;
     if (!user.logged) {
-      const postLoginUrl = this.props.location ? this.props.location.pathname : null;
-      const to = { "pathname": "/login", "state": { previous: postLoginUrl } };
+      const to = Url.get(Url.pages.login.link, { pathname: location.pathname });
       return (
         <Fragment>
           <p>Only authenticated users can create new projects.</p>
           <Alert color="primary">
             <p className="mb-0">
-              <Link className="btn btn-primary btn-sm" to={to} previous={postLoginUrl}>Log in</Link> to
+              <Link className="btn btn-primary btn-sm" to={to}>Log in</Link> to
               create a new project.
             </p>
           </Alert>

--- a/client/src/utils/url/Url.js
+++ b/client/src/utils/url/Url.js
@@ -159,6 +159,28 @@ function projectPageUrlBuilder(subSection) {
   };
 }
 
+/**
+ * Construct a URL object for a project page.
+ * @returns {function} A function to construct a URL object.
+ */
+function loginUrlObject() {
+  return (data) => {
+    const url = "/login";
+    const pathname = data.pathname ?
+      data.pathname :
+      document.location.pathname;
+    const search = data.search ?
+      data.search :
+      document.location.search;
+    return {
+      pathname: url,
+      state: {
+        previous: pathname + search
+      }
+    };
+  };
+}
+
 
 /** Module-level variable for the base URL. Set only once */
 let baseUrl = null;
@@ -222,6 +244,15 @@ const Url = {
       documentation: "/help/docs",
       features: "/help/features",
       status: "/help/status",
+    },
+    login: {
+      base: "/login",
+      link: new UrlRule(
+        loginUrlObject(), [], null, [
+          "{ pathname: '/login', state: { previous: '/projects' } }",
+          "{ pathname: '/login', state: { previous: '/projects/new?data=eyJ0aXRsZSI6InRlCc3QifQ==' } }"
+        ]
+      ),
     },
     projects: {
       base: new UrlRule(


### PR DESCRIPTION
While working on #1194 , I had to update the login mechanism to preserve the query parameters on the return URL.
I decided to split this out to simplify testing and merging separately.

/deploy
re #1194 