### PR TITLE
Read encoded metadata from the URL when creating new project

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2377,6 +2377,15 @@
         "@hapi/hoek": "^8.3.0"
       }
     },
+    "@hypnosphi/create-react-context": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@hypnosphi/create-react-context/-/create-react-context-0.3.1.tgz",
+      "integrity": "sha512-V1klUed202XahrWJLLOT3EXNeCpFHCcJntdFGI15ntCwau+jfT386w7OFTMaCqOgXUH1fa0w/I1oZs+i/Rfr0A==",
+      "requires": {
+        "gud": "^1.0.0",
+        "warning": "^4.0.3"
+      }
+    },
     "@jest/console": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
@@ -7456,7 +7465,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
       "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
-      "dev": true,
       "requires": {
         "is-arguments": "^1.0.4",
         "is-date-object": "^1.0.1",
@@ -11538,8 +11546,7 @@
     "is-arguments": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
-      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
-      "dev": true
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -14479,14 +14486,12 @@
     "object-inspect": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
-      "dev": true
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
     },
     "object-is": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
       "integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
@@ -14496,7 +14501,6 @@
           "version": "1.17.6",
           "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
           "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
-          "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
@@ -14515,7 +14519,6 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
           "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-          "dev": true,
           "requires": {
             "is-callable": "^1.1.4",
             "is-date-object": "^1.0.1",
@@ -14525,20 +14528,17 @@
         "has-symbols": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-          "dev": true
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
         },
         "is-callable": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
-          "dev": true
+          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw=="
         },
         "is-regex": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
           "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
-          "dev": true,
           "requires": {
             "has-symbols": "^1.0.1"
           }
@@ -17524,16 +17524,44 @@
       }
     },
     "reactstrap": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-8.1.1.tgz",
-      "integrity": "sha512-m4IIdTHBT5wtcPts4w4rYngKuqIUC1BpncVxCTeIj4BQDxwjdab0gGyKJKfgXgArn6iI6syiDyez/h2tLWFjsw==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-8.9.0.tgz",
+      "integrity": "sha512-pmf33YjpNZk1IfrjqpWCUMq9hk6GzSnMWBAofTBNIRJQB1zQ0Au2kzv3lPUAFsBYgWEuI9iYa/xKXHaboSiMkQ==",
       "requires": {
-        "@babel/runtime": "^7.2.0",
+        "@babel/runtime": "^7.12.5",
         "classnames": "^2.2.3",
         "prop-types": "^15.5.8",
-        "react-lifecycles-compat": "^3.0.4",
-        "react-popper": "^1.3.3",
+        "react-popper": "^1.3.6",
         "react-transition-group": "^2.3.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "react-popper": {
+          "version": "1.3.11",
+          "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.11.tgz",
+          "integrity": "sha512-VSA/bS+pSndSF2fiasHK/PTEEAyOpX60+H5EPAjoArr8JGm+oihu4UbrqcEBpQibJxBVCpYyjAX7abJ+7DoYVg==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "@hypnosphi/create-react-context": "^0.3.1",
+            "deep-equal": "^1.1.1",
+            "popper.js": "^1.14.4",
+            "prop-types": "^15.6.1",
+            "typed-styles": "^0.0.7",
+            "warning": "^4.0.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+        }
       }
     },
     "read-pkg": {
@@ -17719,7 +17747,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
       "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1"
@@ -17729,7 +17756,6 @@
           "version": "1.17.4",
           "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
           "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
-          "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
@@ -17748,7 +17774,6 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
           "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-          "dev": true,
           "requires": {
             "is-callable": "^1.1.4",
             "is-date-object": "^1.0.1",
@@ -17758,20 +17783,17 @@
         "has-symbols": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-          "dev": true
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
         },
         "is-callable": {
           "version": "1.1.5",
           "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
-          "dev": true
+          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
         },
         "is-regex": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
           "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
-          "dev": true,
           "requires": {
             "has": "^1.0.3"
           }
@@ -17779,14 +17801,12 @@
         "object-inspect": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-          "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
-          "dev": true
+          "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
         },
         "string.prototype.trimleft": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
           "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
-          "dev": true,
           "requires": {
             "define-properties": "^1.1.3",
             "function-bind": "^1.1.1"
@@ -17796,7 +17816,6 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
           "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
-          "dev": true,
           "requires": {
             "define-properties": "^1.1.3",
             "function-bind": "^1.1.1"
@@ -19759,7 +19778,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
       "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
@@ -19769,7 +19787,6 @@
           "version": "1.17.6",
           "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
           "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
-          "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
@@ -19788,7 +19805,6 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
           "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-          "dev": true,
           "requires": {
             "is-callable": "^1.1.4",
             "is-date-object": "^1.0.1",
@@ -19798,20 +19814,17 @@
         "has-symbols": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-          "dev": true
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
         },
         "is-callable": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
-          "dev": true
+          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw=="
         },
         "is-regex": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
           "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
-          "dev": true,
           "requires": {
             "has-symbols": "^1.0.1"
           }
@@ -19842,7 +19855,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
       "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
@@ -19852,7 +19864,6 @@
           "version": "1.17.6",
           "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
           "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
-          "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
@@ -19871,7 +19882,6 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
           "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-          "dev": true,
           "requires": {
             "is-callable": "^1.1.4",
             "is-date-object": "^1.0.1",
@@ -19881,20 +19891,17 @@
         "has-symbols": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-          "dev": true
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
         },
         "is-callable": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
-          "dev": true
+          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw=="
         },
         "is-regex": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
           "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
-          "dev": true,
           "requires": {
             "has-symbols": "^1.0.1"
           }

--- a/client/package.json
+++ b/client/package.json
@@ -45,7 +45,7 @@
     "react-router-dom": "^5.1.2",
     "react-sticky": "^6.0.3",
     "react-toastify": "^6.0.8",
-    "reactstrap": "^8.1.1",
+    "reactstrap": "^8.9.0",
     "redux": "^4.0.4",
     "redux-thunk": "^2.2.0",
     "sass": "^1.23.7",

--- a/client/src/model/RenkuModels.js
+++ b/client/src/model/RenkuModels.js
@@ -198,6 +198,28 @@ const newProjectSchema = new Schema({
       variables: { [Prop.INITIAL]: {}, [Prop.MANDATORY]: true }, // contains pairs "var1": "value1"
     })
   },
+  automated: {
+    [Prop.SCHEMA]: new Schema({
+      received: { [Prop.INITIAL]: false, [Prop.MANDATORY]: true },
+      valid: { [Prop.INITIAL]: null, [Prop.MANDATORY]: true },
+      data: {
+        [Prop.SCHEMA]: new Schema({
+          title: { [Prop.INITIAL]: "", [Prop.MANDATORY]: false },
+          namespace: { [Prop.INITIAL]: "", [Prop.MANDATORY]: false },
+          visibility: { [Prop.INITIAL]: "", [Prop.MANDATORY]: false },
+          template: { [Prop.INITIAL]: "", [Prop.MANDATORY]: false },
+          url: { [Prop.INITIAL]: "", [Prop.MANDATORY]: false },
+          ref: { [Prop.INITIAL]: "", [Prop.MANDATORY]: false },
+          variables: { [Prop.INITIAL]: {}, [Prop.MANDATORY]: true },
+        })
+      },
+      step: { [Prop.INITIAL]: 0, [Prop.MANDATORY]: true }, // TODO: remove if not useful
+      finished: { [Prop.INITIAL]: false, [Prop.MANDATORY]: true },
+      error: { [Prop.INITIAL]: "", [Prop.MANDATORY]: false },
+      warnings: { [Prop.INITIAL]: [], [Prop.MANDATORY]: false },
+      manuallyReset: { [Prop.INITIAL]: false, [Prop.MANDATORY]: true },
+    })
+  },
   meta: {
     [Prop.SCHEMA]: new Schema({
       namespace: {

--- a/client/src/project/new/ProjectNew.container.js
+++ b/client/src/project/new/ProjectNew.container.js
@@ -31,7 +31,9 @@ import { NewProject as NewProjectPresent, ForkProject as ForkProjectPresent } fr
 import { NewProjectCoordinator, validateTitle, checkTitleDuplicates } from "./ProjectNew.state";
 import { ProjectsCoordinator } from "../shared";
 import { gitLabUrlFromProfileUrl, slugFromTitle, refreshIfNecessary } from "../../utils/HelperFunctions";
-import { Url } from "../../utils/url";
+import { Url, getSearchParams } from "../../utils/url";
+import { atobUTF8, btoaUTF8 } from "../../utils/Encoding";
+import { newProjectSchema } from "../../model/RenkuModels";
 
 const CUSTOM_REPO_NAME = "Custom";
 
@@ -282,27 +284,86 @@ function ForkProject(props) {
   );
 }
 
+/**
+ * Validate and decode query params.
+ *
+ * @param {object} params - query params
+ * @returns {object} parsed parameters, validated and ready to be be used to pre-fill fields.
+ */
+function getDataFromParams(params) {
+  if (params && Object.keys(params).length) {
+    if (params.data) {
+      const data = JSON.parse(atobUTF8(params.data));
+      if (data && Object.keys(data).length) {
+        // validate metadata
+        const validKeys = Object.keys(newProjectSchema.createEmpty().automated.data);
+        const keys = Object.keys(data);
+        for (let key of keys) {
+          if (!validKeys.includes(key))
+            throw new Error("unexpected project field in the encoded metadata: " + key);
+        }
+      }
+      return data;
+    }
+    // Unrecognized params: should we notify? Let's start without notifications.
+    return null;
+  }
+}
+
 class NewProject extends Component {
   constructor(props) {
     super(props);
+    // Create model and reset inputs
     this.model = props.model;
     this.coordinator = new NewProjectCoordinator(props.client, this.model.subModel("newProject"),
       this.model.subModel("projects"));
     this.coordinator.setConfig(props.templates.custom, props.templates.repositories);
     this.projectsCoordinator = new ProjectsCoordinator(props.client, this.model.subModel("projects"));
     this.coordinator.resetInput();
+    this.removeAutomated();
+    if (!props.user.logged)
+      this.coordinator.resetAutomated();
 
+    // create handlers
     this.handlers = {
-      onSubmit: this.onSubmit.bind(this),
+      createEncodedUrl: this.createEncodedUrl.bind(this),
       getNamespaces: this.getNamespaces.bind(this),
       getTemplates: this.getTemplates.bind(this),
       getUserTemplates: this.getUserTemplates.bind(this),
+      goToProject: this.goToProject.bind(this),
+      onSubmit: this.onSubmit.bind(this),
+      removeAutomated: this.removeAutomated.bind(this),
+      setNamespace: this.setNamespace.bind(this),
       setProperty: this.setProperty.bind(this),
       setTemplateProperty: this.setTemplateProperty.bind(this),
-      setNamespace: this.setNamespace.bind(this),
       setVariable: this.setVariable.bind(this),
-      goToProject: this.goToProject.bind(this)
     };
+
+    // Handle optional param used to pre-fill inputs
+    if (!props.user.logged)
+      return;
+    const params = getSearchParams();
+    try {
+      const data = getDataFromParams(params);
+      if (data)
+        this.coordinator.setAutomated(data);
+      const newUrl = Url.get(Url.pages.project.new);
+      this.props.history.push(newUrl);
+    }
+    catch (e) {
+      this.coordinator.setAutomated(null, e);
+    }
+  }
+
+  removeAutomated(manuallyReset = true) {
+    this.coordinator.resetAutomated(manuallyReset);
+  }
+
+  createEncodedUrl(data) {
+    if (!data || !Object.keys(data).length)
+      return Url.get(Url.pages.project.new, {}, true);
+    const encodedContent = btoaUTF8(JSON.stringify(data));
+    return Url.get(Url.pages.project.new, { data: encodedContent }, true);
   }
 
   async getNamespaces() {
@@ -417,3 +478,6 @@ class NewProject extends Component {
 
 
 export { NewProject, CUSTOM_REPO_NAME, ForkProjectMapper as ForkProject };
+
+// test only
+export { getDataFromParams };

--- a/client/src/project/new/ProjectNew.container.js
+++ b/client/src/project/new/ProjectNew.container.js
@@ -291,23 +291,20 @@ function ForkProject(props) {
  * @returns {object} parsed parameters, validated and ready to be be used to pre-fill fields.
  */
 function getDataFromParams(params) {
-  if (params && Object.keys(params).length) {
-    if (params.data) {
-      const data = JSON.parse(atobUTF8(params.data));
-      if (data && Object.keys(data).length) {
-        // validate metadata
-        const validKeys = Object.keys(newProjectSchema.createEmpty().automated.data);
-        const keys = Object.keys(data);
-        for (let key of keys) {
-          if (!validKeys.includes(key))
-            throw new Error("unexpected project field in the encoded metadata: " + key);
-        }
-      }
-      return data;
-    }
-    // Unrecognized params: should we notify? Let's start without notifications.
-    return null;
+  // Unrecognized params: should we notify? Let's start without notifications.
+  if (!params || !Object.keys(params).length || !params.data)
+    return;
+  const data = JSON.parse(atobUTF8(params.data));
+  if (!data || !Object.keys(data).length)
+    return;
+  // validate metadata
+  const validKeys = Object.keys(newProjectSchema.createEmpty().automated.data);
+  const keys = Object.keys(data);
+  for (let key of keys) {
+    if (!validKeys.includes(key))
+      throw new Error("unexpected project field in the encoded metadata: " + key);
   }
+  return data;
 }
 
 class NewProject extends Component {

--- a/client/src/project/new/ProjectNew.present.js
+++ b/client/src/project/new/ProjectNew.present.js
@@ -218,62 +218,60 @@ function Automated(props) {
   const [showWarnings, setShowWarnings] = useState(false);
   const toggleWarn = () => setShowWarnings(!showWarnings);
 
-  if (automated.received && automated.valid && !automated.finished) {
+  if (!automated.finished) {
     // Show a static modal while loading the data
-    return (<AutomatedModal removeAutomated={removeAutomated}></AutomatedModal>);
+    if (automated.received && automated.valid)
+      return (<AutomatedModal removeAutomated={removeAutomated}></AutomatedModal>);
+    return null;
   }
-  else if (automated.finished) {
-    // Show a feedback when the automated part has finished
-    // errors
-    if (automated.error) {
-      const error = (<pre>{automated.error}</pre>);
-      return (
-        <Alert key="alert" color="danger">
-          <p>
-            <FontAwesomeIcon icon={faExclamationTriangle} />&nbsp;
-            An error occurred while bootstrapping your pre-initialized project.
-          </p>
-          <p>
-            It is possible the metadata are not valid or outdated. You can try to contact who provided you
-            the RenkuLab link asking for a new one.
-          </p>
-
-          <Button color="link" style={{ fontSize: "smaller" }} className="font-italic" onClick={() => toggleError()}>
-            {showError ? "Hide error details" : "Show error details"}
-          </Button>
-          <Fade in={showError} tag="div">{showError ? error : null}</Fade>
-        </Alert>
-      );
-    }
-    // warnings
-    else if (automated.warnings.length) {
-      const warnings = (<pre>{automated.warnings.join("\n")}</pre>);
-      return (
-        <Alert color="warning">
-          <p>
-            <FontAwesomeIcon icon={faExclamationTriangle} />&nbsp;
-            Some pre-initializzation settings could not be applied.
-          </p>
-          <Button color="link" style={{ fontSize: "smaller" }} className="font-italic" onClick={() => toggleWarn()}>
-            {showWarnings ? "Hide warnings" : "Show warnings"}
-          </Button>
-          <Fade in={showWarnings} tag="div">{showWarnings ? warnings : null}</Fade>
-        </Alert>
-      );
-    }
-    // all good
+  // Show a feedback when the automated part has finished
+  // errors
+  if (automated.error) {
+    const error = (<pre>{automated.error}</pre>);
     return (
-      <Alert color="primary">
-        <p className="mb-0">
-          <FontAwesomeIcon icon={faInfoCircle} />&nbsp;
-          Some pre-initializzation settings were applied.
-          <br />You can still change any setting before you create the project.
+      <Alert key="alert" color="danger">
+        <p>
+          <FontAwesomeIcon icon={faExclamationTriangle} />&nbsp;
+          An error occurred while bootstrapping your pre-initialized project.
         </p>
+        <p>
+          It is possible the metadata are outdated or not valid.
+          Please contact the source of the RenkuLab link and ask for a new one.
+        </p>
+
+        <Button color="link" style={{ fontSize: "smaller" }} className="font-italic" onClick={() => toggleError()}>
+          {showError ? "Hide error details" : "Show error details"}
+        </Button>
+        <Fade in={showError} tag="div">{showError ? error : null}</Fade>
       </Alert>
     );
   }
-
-  return null;
+  // warnings
+  else if (automated.warnings.length) {
+    const warnings = (<pre>{automated.warnings.join("\n")}</pre>);
+    return (
+      <Alert color="warning">
+        <p>
+          <FontAwesomeIcon icon={faExclamationTriangle} />&nbsp;
+          Some pre-initialization settings could not be applied.
+        </p>
+        <Button color="link" style={{ fontSize: "smaller" }} className="font-italic" onClick={() => toggleWarn()}>
+          {showWarnings ? "Hide warnings" : "Show warnings"}
+        </Button>
+        <Fade in={showWarnings} tag="div">{showWarnings ? warnings : null}</Fade>
+      </Alert>
+    );
+  }
+  // all good
+  return (
+    <Alert color="primary">
+      <p className="mb-0">
+        <FontAwesomeIcon icon={faInfoCircle} />&nbsp;
+        Some pre-initialization settings were applied.
+        <br />You can still change any setting before you create the project.
+      </p>
+    </Alert>
+  );
 }
 
 

--- a/client/src/project/new/ProjectNew.present.js
+++ b/client/src/project/new/ProjectNew.present.js
@@ -232,10 +232,10 @@ function Automated(props) {
       <Alert key="alert" color="danger">
         <p>
           <FontAwesomeIcon icon={faExclamationTriangle} />&nbsp;
-          An error occurred while bootstrapping your pre-initialized project.
+          We could not pre-fill the fields with the information provided in the RenkuLab project-creation link.
         </p>
         <p>
-          It is possible the metadata are outdated or not valid.
+          It is possible that the link is outdated or not valid.
           Please contact the source of the RenkuLab link and ask for a new one.
         </p>
 
@@ -253,7 +253,7 @@ function Automated(props) {
       <Alert color="warning">
         <p>
           <FontAwesomeIcon icon={faExclamationTriangle} />&nbsp;
-          Some pre-initialization settings could not be applied.
+          Some fields could not be pre-filled with the information provided in the RenkuLab project-creation link.
         </p>
         <Button color="link" style={{ fontSize: "smaller" }} className="font-italic" onClick={() => toggleWarn()}>
           {showWarnings ? "Hide warnings" : "Show warnings"}
@@ -267,8 +267,8 @@ function Automated(props) {
     <Alert color="primary">
       <p className="mb-0">
         <FontAwesomeIcon icon={faInfoCircle} />&nbsp;
-        Some pre-initialization settings were applied.
-        <br />You can still change any setting before you create the project.
+        Some fields were pre-filled.
+        <br />You can still change any values before you create the project.
       </p>
     </Alert>
   );
@@ -286,16 +286,16 @@ function AutomatedModal(props) {
     null :
     (
       <Button color="link" style={{ fontSize: "smaller" }} className="font-italic" onClick={() => toggle()}>
-        Do you prefer a blank project instead?
+        Taking too long?
       </Button>
     );
 
   const to = Url.get(Url.pages.project.new);
   const fadeInContent = (
     <p className="mt-3">
-      Click here to&nbsp;
+      If pre-filling the new project form is taking too long, you can
       <Link className="btn btn-primary btn-sm" to={to} onClick={() => { removeAutomated(); }}>
-        start from scratch
+        use a blank form
       </Link>
     </p>
   );
@@ -305,9 +305,9 @@ function AutomatedModal(props) {
       <ModalBody>
         <Row>
           <Col>
-            <p>You entered a url containing initialization data.</p>
+            <p>You entered a url containing information to pre-fill.</p>
             <span>
-              Please wait, we are fetching the required metadata...&nbsp;
+              Please wait while we fetch the required metadata...&nbsp;
               <Loader inline={true} size={16} />
             </span>
             <div className="mt-2">
@@ -931,7 +931,7 @@ class Create extends Component {
       </Button>
     );
     const createLink = (
-      <DropdownItem onClick={this.toggle}><FontAwesomeIcon icon={faLink} /> Share link</DropdownItem>
+      <DropdownItem onClick={this.toggle}><FontAwesomeIcon icon={faLink} /> Create link</DropdownItem>
     );
     return (
       <Fragment>
@@ -1046,7 +1046,7 @@ function ShareLinkModal(props) {
   const feedback = include.namespace ?
     (
       <FormText color="danger">
-        Including the namespace may lead to errors if the user does not have access to it.
+        Pre-filling the namespace may lead to errors since other users are not guaranteed to have access to it.
       </FormText>
     ) :
     null;
@@ -1058,11 +1058,11 @@ function ShareLinkModal(props) {
         <Row>
           <Col>
             <p>
-              Here is your shareable link, containing the current settings for a new project.
-              Clicking on it will pre-fill the inputs automatically.
+              Here is your shareable link, containing the current values for a new project.
+              Following the link will lead to a <b>New project</b> form with these values pre-filled.
             </p>
             <p>
-              You can review which settings to include in the link metadata.
+              You can control which values should be pre-filled.
             </p>
 
             <Form className="mb-3">

--- a/client/src/project/new/ProjectNew.state.js
+++ b/client/src/project/new/ProjectNew.state.js
@@ -124,6 +124,7 @@ class NewProjectCoordinator {
         ...automated,
         received: true,
         valid: false,
+        finished: true,
         error: error.message ? error.message : error
       };
       this.model.set("automated", automated);

--- a/client/src/project/new/ProjectNew.state.js
+++ b/client/src/project/new/ProjectNew.state.js
@@ -25,7 +25,7 @@
 
 import { CUSTOM_REPO_NAME } from "./ProjectNew.container";
 import { newProjectSchema } from "../../model/RenkuModels";
-import { slugFromTitle, verifyTitleCharacters } from "../../utils/HelperFunctions";
+import { sleep, slugFromTitle, verifyTitleCharacters } from "../../utils/HelperFunctions";
 
 
 // ? reference https://docs.gitlab.com/ce/user/reserved_names.html#reserved-project-names
@@ -103,6 +103,205 @@ class NewProjectCoordinator {
       return { ...values, [variable]: text };
     }, {});
     return values;
+  }
+
+  resetAutomated(manuallyReset = false) {
+    if (this.model.get("automated.received")) {
+      const pristineAutomated = newProjectSchema.createInitialized().automated;
+      this.model.setObject({ automated: { ...pristineAutomated, manuallyReset } });
+    }
+  }
+
+  /**
+   * Set newProject.automated object with new content -- either the provided data or an error
+   * @param {object} data - data to pre-fill
+   * @param {object} [error] - error generated while parsing the data
+   */
+  setAutomated(data, error) {
+    let automated = newProjectSchema.createInitialized().automated;
+    if (error) {
+      automated = {
+        ...automated,
+        received: true,
+        valid: false,
+        error: error.message ? error.message : error
+      };
+      this.model.set("automated", automated);
+    }
+    else {
+      automated = {
+        ...automated,
+        received: true,
+        valid: true,
+        data: { ...automated.data, ...data }
+      };
+      // ? passing the content is more efficient than invoking the `model.set` and then the function.
+      this.autoFill(automated);
+    }
+  }
+
+  /**
+   * Get all the auto-fill content and fill in the provided data.
+   * @param {object} [automatedObject] - pass the up-to-date `automated` object to optimize performance.
+   */
+  async autoFill(automatedObject) {
+    let automated = automatedObject ?
+      automatedObject :
+      newProjectSchema.createInitialized().automated;
+    let availableVariables = [];
+
+    // Step 1: wait for templates and namespaces to be fetched
+    automated.step = 1;
+    this.model.set("automated", { ...automated });
+    // ? since this is triggered elsewhere, we need to use ugly timeouts here
+    const intervalLength = 1;
+    let namespaces = false, templates = false;
+    do {
+      if (this.model.get("automated.manuallyReset")) return;
+
+      // check namespaces availability
+      if (!namespaces) {
+        const namespacesStatus = this.projectsModel.get("namespaces");
+        if (namespacesStatus.fetched && !namespacesStatus.fetching)
+          namespaces = namespacesStatus.list;
+      }
+      // check templates availability
+      if (!templates) {
+        const templatesStatus = this.model.get("templates");
+        if (templatesStatus.fetched && !templatesStatus.fetching)
+          templates = templatesStatus.all;
+      }
+
+      await sleep(intervalLength);
+    } while (!namespaces || !templates);
+    const { data } = automated;
+
+    // Step 2: Set title, namespace, template (if no url/ref). Start fetching visibilities
+    if (this.model.get("automated.manuallyReset")) return;
+    automated.step = 2;
+    this.model.set("automated.step", 2);
+    let newInput = {};
+    if (data.title) {
+      this.setProperty("title", data.title);
+      newInput.title = data.title;
+    }
+    if (data.namespace) {
+      // Check if the namespace is available
+      const namespaces = this.projectsModel.get("namespaces.list");
+      const namespaceAvailable = namespaces.find(namespace => namespace.full_path === data.namespace);
+      if (!namespaceAvailable) {
+        automated.warnings = [
+          ...automated.warnings,
+          `The namespace "${data.namespace}" is not available.`
+        ];
+      }
+      else {
+        this.setProperty("namespace", data.namespace); // full path
+        newInput.namespace = data.namespace;
+        this.getVisibilities(namespaceAvailable);
+      }
+    }
+    if (data.template && !data.url) {
+      // Check if the template is available
+      const templates = this.model.get("templates.all");
+      const templateAvailable = templates.find(template => template.id === data.template);
+      if (!templateAvailable) {
+        automated.error = `The template "${data.template}" is not available.`;
+        automated.finished = true;
+        this.model.set("automated", { ...automated });
+        return;
+      }
+      this.setProperty("template", data.template);
+      newInput.template = data.template;
+      availableVariables = templateAvailable.variables;
+    }
+
+    // Step 3: Set visibility and fetch custom template (requires url/ref).
+    if (this.model.get("automated.manuallyReset")) return;
+    automated.step = 3;
+    this.model.set("automated.step", 3);
+    if (data.template && data.url) {
+      const ref = data.ref ? data.ref : "master";
+      this.setProperty("userRepo", true);
+      this.setTemplateProperty("url", data.url);
+      this.setTemplateProperty("ref", ref);
+      const repositories = [{ name: CUSTOM_REPO_NAME, url: data.url, ref: ref }];
+      const templates = await this.getTemplates(repositories, true);
+      if (this.model.get("automated.manuallyReset")) return;
+      if (!templates || !templates.length) {
+        automated.error = "Something went wrong while fetching the template repositories.";
+        automated.error += "\nSee below for further details.";
+        automated.finished = true;
+        this.model.set("automated", { ...automated });
+        return;
+      }
+      const templateAvailable = templates.find(template => template.id === data.template);
+      if (!templateAvailable) {
+        automated.error = `The template "${data.template}" is not available.`;
+        automated.finished = true;
+        this.model.set("automated", { ...automated });
+        return;
+      }
+      this.setProperty("template", data.template);
+      newInput.template = data.template;
+      availableVariables = templateAvailable.variables;
+    }
+    if (data.visibility) {
+      // wait for namespace visibilities to be available
+      let namespace, visibilities = null;
+      do {
+        // check namespaces availability
+        if (this.model.get("automated.manuallyReset")) return;
+        if (!visibilities) {
+          namespace = this.model.get("meta.namespace");
+          if (namespace.fetched && !namespace.fetching)
+            visibilities = namespace.visibilities;
+        }
+        await sleep(intervalLength);
+      } while (!visibilities);
+
+      if (visibilities.includes(data.visibility)) {
+        this.setProperty("visibility", data.visibility);
+      }
+      else {
+        automated.warnings = [
+          ...automated.warnings,
+          `The visibility "${data.namespace}" is not available in the target namespace.`
+        ];
+      }
+    }
+
+    // Step 4: Set variables.
+    if (this.model.get("automated.manuallyReset")) return;
+    automated.step = 4;
+    this.model.set("automated.step", 4);
+    if (data.template && data.variables && Object.keys(data.variables)) {
+      if (availableVariables && Object.keys(availableVariables)) {
+        // Try to set variables after checking for availability on the target template.
+        const templateVariables = Object.keys(availableVariables);
+        let unavailableVariables = [];
+        for (let variable of Object.keys(data.variables)) {
+          if (templateVariables.includes(variable))
+            this.setVariable(variable, data.variables[variable]);
+          else
+            unavailableVariables = [...unavailableVariables, variable];
+        }
+        if (unavailableVariables.length) {
+          automated.warnings = [
+            ...automated.warnings,
+            `Some variables are not available on this template: ${unavailableVariables.join(", ")}.`
+          ];
+        }
+      }
+      else {
+        automated.warnings = [
+          ...automated.warnings,
+          "No variables available for the target template."
+        ];
+      }
+    }
+    automated.finished = true;
+    this.model.set("automated", { ...automated });
   }
 
   resetInput() {

--- a/client/src/project/new/ProjectNew.test.js
+++ b/client/src/project/new/ProjectNew.test.js
@@ -31,8 +31,10 @@ import { createMemoryHistory } from "history";
 
 import { StateModel, globalSchema } from "../../model";
 import { validateTitle, checkTitleDuplicates, NewProject, ForkProject } from "./index";
+import { getDataFromParams } from "./ProjectNew.container";
 import { RESERVED_TITLE_NAMES } from "./ProjectNew.state";
 import { testClient as client } from "../../api-client";
+import { btoaUTF8 } from "../../utils/Encoding";
 import { generateFakeUser } from "../../user/User.test";
 
 
@@ -91,6 +93,35 @@ describe("helper functions", () => {
     expect(checkTitleDuplicates("exist-different", "username", projectsPaths)).toBe(true);
     expect(checkTitleDuplicates("existä", "group", projectsPaths)).toBe(true);
     expect(checkTitleDuplicates("exist-äõî-different", "username", projectsPaths)).toBe(true);
+  });
+
+  it("getDataFromParams", () => {
+    function encode(params) {
+      return { data: btoaUTF8(JSON.stringify(params)) };
+    }
+
+    let params = { title: "pre-filled" };
+    let urlParams = encode(params);
+
+    // title
+    let decoded = getDataFromParams(urlParams);
+    expect(decoded).toMatchObject(params);
+
+    // complex
+    params = {
+      title: "test",
+      namespace: "renku-qa",
+      template: "Custom/python-minimal",
+      url: "https://github.com/SwissDataScienceCenter/renku-project-template",
+      ref: "0.1.16",
+      visibility: "private",
+      variables: {
+        description: "description here"
+      }
+    };
+    urlParams = encode(params);
+    decoded = getDataFromParams(urlParams);
+    expect(decoded).toMatchObject(params);
   });
 });
 

--- a/client/src/utils/HelperFunctions.js
+++ b/client/src/utils/HelperFunctions.js
@@ -300,8 +300,17 @@ function refreshIfNecessary(fetching, fetched, action, tolerance = 10) {
     return action();
 }
 
+/**
+ * Simulate a sleep function.
+ * @param {number} seconds - length of the sleep time span in seconds
+ * @example await sleep(0.5) // sleep for 0.5 seconds
+ */
+async function sleep(seconds) {
+  await new Promise(r => setTimeout(r, seconds * 1000));
+}
+
 export {
   slugFromTitle, getActiveProjectPathWithNamespace, splitAutosavedBranches, sanitizedHTMLFromMarkdown,
   simpleHash, parseINIString, formatBytes, groupBy, gitLabUrlFromProfileUrl, isURL, verifyTitleCharacters,
-  convertUnicodeToAscii, refreshIfNecessary
+  convertUnicodeToAscii, refreshIfNecessary, sleep
 };

--- a/client/src/utils/UIComponents.js
+++ b/client/src/utils/UIComponents.js
@@ -750,15 +750,23 @@ function ButtonWithMenu(props) {
   const toggleOpen = () => setOpen(!dropdownOpen);
   const size = (props.size) ? props.size : "md";
 
-  return <ButtonDropdown size={size} isOpen={dropdownOpen} toggle={toggleOpen}>
-    {props.default}
-    <DropdownToggle color="primary" className="alternateToggleStyle">
-      <FontAwesomeIcon icon={faEllipsisV} style={{ color: "white", backgroundColor: "#5561A6" }} />
-    </DropdownToggle>
-    <DropdownMenu right={true}>
-      {props.children}
-    </DropdownMenu>
-  </ButtonDropdown>;
+  return (
+    <ButtonDropdown
+      size={size}
+      isOpen={dropdownOpen}
+      toggle={toggleOpen}
+      direction={props.direction}
+      disabled={props.disabled}
+    >
+      {props.default}
+      <DropdownToggle color="primary" className="alternateToggleStyle">
+        <FontAwesomeIcon icon={faEllipsisV} style={{ color: "white", backgroundColor: "#5561A6" }} />
+      </DropdownToggle>
+      <DropdownMenu right={true}>
+        {props.children}
+      </DropdownMenu>
+    </ButtonDropdown>
+  );
 }
 
 /**

--- a/client/src/utils/url/Url.js
+++ b/client/src/utils/url/Url.js
@@ -146,6 +146,22 @@ function projectsSearchUrlBuilder(subSection) {
 }
 
 /**
+ * Construct a URL for a project creation page.
+ * @returns {function} A function to construct a URL from data.
+ */
+function projectNewUrlBuilder() {
+  return (data) => {
+    // create base url
+    let url = "/projects/new";
+    if (!data || !data.data)
+      return url;
+    const search = new URLSearchParams();
+    search.append("data", data.data);
+    return `${url}?${search.toString()}`;
+  };
+}
+
+/**
  * Construct a URL for a project page.
  * @returns {function} A function to construct a URL from data.
  * @param {string} subSection
@@ -281,7 +297,12 @@ const Url = {
           "/projects/group/subgroup/path",
         ]
       ),
-      new: "/projects/new",
+      new: new UrlRule(
+        projectNewUrlBuilder(), [], null, [
+          "/projects/new",
+          "/projects/new?data=eyJ0aXRsZSI6InRlC3QifQ==",
+        ]
+      )
     }
   },
 


### PR DESCRIPTION
Manage metadata from the query paramaters on the "create project page" to automatically fill in some inputs. Thin included the pieces to generate the URL and to read the data:

* Generate URL: click on the dropdown button "share link" to open a modal with the encoded URL. The user can decide which inputs to include in the metadata (screenshot 1).
* Read metadata: detect and read the metadata from the query parameters. The URL resets back to the basic one, then the data are gradually fetched and restored automatically (screenshot 2). Any error (e.g. unexisting template) or warning (e.g namespace unaccessible) will appear on top (screenshot 3).

For testing purposes, you can easily generate the encoded content of the `data` param by using `btoa` and `JSON.stringify` from the browser console (useful to generate errors or warnings on purpose), then add it after `/projects/new?data=`.
This is an example:
```
btoa(JSON.stringify({title:"test", namespace:"renku-qa", template:"Custom/python-minimal", url:"https://github.com/SwissDataScienceCenter/renku-project-template", ref:"0.1.16", visibility:"private", variables: { description: "description here" }}))
```

> eyJ0aXRsZSI6InRlc3QiLCJuYW1lc3BhY2UiOiJyZW5rdS1xYSIsInRlbXBsYXRlIjoiQ3VzdG9tL3B5dGhvbi1taW5pbWFsIiwidXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL1N3aXNzRGF0YVNjaWVuY2VDZW50ZXIvcmVua3UtcHJvamVjdC10ZW1wbGF0ZSIsInJlZiI6IjAuMS4xNiIsInZpc2liaWxpdHkiOiJwcml2YXRlIiwidmFyaWFibGVzIjp7ImRlc2NyaXB0aW9uIjoiZGVzY3JpcHRpb24gaGVyZSJ9fQ==

The final URL is `/projects/new?data=<encoded_data_here>`

fix #1194
/deploy

**INFO**: if this PR works well, we should create a corresponding entry in the documentation for this new feature

### Screenshots

1)
![Screenshot_20210325_085711](https://user-images.githubusercontent.com/43481553/112440000-125b4600-8d4a-11eb-823e-7d9cbac2c535.png)

2)
![Screenshot_20210325_085801](https://user-images.githubusercontent.com/43481553/112440022-1be4ae00-8d4a-11eb-85ca-4c458cf956ec.png)

3)
![Screenshot_20210325_091103](https://user-images.githubusercontent.com/43481553/112440038-20a96200-8d4a-11eb-93a1-d1ebbabb3c76.png)
