### PR TITLE
refactor: add copy to clipboard on registry popover

### DIFF
--- a/client/src/notebooks/Notebooks.present.js
+++ b/client/src/notebooks/Notebooks.present.js
@@ -562,6 +562,7 @@ class NotebooksServerRowStatusIcon extends Component {
           <PopoverHeader>Details</PopoverHeader>
           <PopoverBody>
             <span className="font-weight-bold">Image source:</span> {image}
+            <span className="ml-1"><Clipboard clipboardText={image} /></span>
             {policy}
           </PopoverBody>
         </UncontrolledPopover>


### PR DESCRIPTION
Minor change: adds the "copy to clipboard" icon to the image source URI in the popover on the interactive environment row status.

![Screenshot_20210325_151103](https://user-images.githubusercontent.com/43481553/112487133-c7a6f180-8d7c-11eb-839b-82f5f97d0bca.png)

/deploy
