### PR TITLE
testing: dummy page to test iframe settings

### DIFF
--- a/client/run-telepresence.sh
+++ b/client/run-telepresence.sh
@@ -128,9 +128,4 @@ EOF
 # suid bins need to run. Please switch the following two lines when trying to run multiple telepresence.
 # Reference: https://www.telepresence.io/reference/methods
 
-if [[ "$OSTYPE" == "linux-gnu" ]]
-then
-  BROWSER=none telepresence --swap-deployment ${SERVICE_NAME} --namespace ${DEV_NAMESPACE} --expose 3000:8080 --run npm start
-else
-  BROWSER=none telepresence --swap-deployment ${SERVICE_NAME} --namespace ${DEV_NAMESPACE} --method inject-tcp --expose 3000:8080 --run npm start
-fi
+BROWSER=none telepresence --swap-deployment ${SERVICE_NAME} --namespace ${DEV_NAMESPACE} --expose 3000:8080 --run npm start

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -35,6 +35,7 @@ import DatasetList from "./dataset/list/DatasetList.container";
 import { Landing, RenkuNavBar, FooterNavbar } from "./landing";
 import { Notebooks } from "./notebooks";
 import { Login, LoginHelper } from "./authentication";
+import { IFrameTest } from "./IFrameTest";
 import Help from "./help";
 import NotFound from "./not-found";
 import ShowDataset from "./dataset/Dataset.container";
@@ -85,6 +86,8 @@ class App extends Component {
           <Switch>
             <Route exact path="/login" render={
               p => <Login key="login" {...p} {...this.props} />} />
+            <Route exact path="/iframe" render={
+              p => <IFrameTest key="iframe" {...p} {...this.props} />} />              
             <Route exact path={Url.get(Url.pages.landing)} render={
               p => <Landing.Home
                 key="landing" welcomePage={this.props.params["WELCOME_PAGE"]}

--- a/client/src/IFrameTest.js
+++ b/client/src/IFrameTest.js
@@ -1,0 +1,58 @@
+/*!
+ * Copyright 2021 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  IFrameTest.js
+ *  Components for testing IFrames
+ */
+
+ import React, { useState } from "react";
+
+  import { FieldGroup } from "./utils/UIComponents";
+
+ 
+ function IFrameTest(props) {
+    const [srcUrl, setSrcUrl] = useState("https://www.wikipedia.org/");
+    const [sandboxPolicy, setSandboxPolicy] = useState("allow-forms allow-same-origin allow-scripts allow-top-navigation")
+    
+ 
+    return [
+    <div key="form">
+      <FieldGroup id="iframe_src" type="text" label="iframe src"
+        value={srcUrl}
+        placeholder="Enter a src for the iframe component" 
+        help="E.g., https://dev.renku.ch/jupyterhub/user/cramakri/ROS-Examples-da378888/"
+        onChange={(e) => setSrcUrl(e.target.value)} />
+
+    <FieldGroup id="sandbox" type="text" label="iframe sandbox"
+        value={sandboxPolicy}
+        placeholder="Enter a sandbox for the iframe component" 
+        help="E.g., allow-forms allow-same-origin allow-scripts allow-top-navigation"
+        onChange={(e) => setSandboxPolicy(e.target.value)} />        
+    </div>,
+    <iframe key="iframe" id="iframe_iframe" title="iframe test" src={srcUrl} width="100%" height="800px" referrerPolicy="origin"
+        sandbox={sandboxPolicy}>
+    </iframe>
+    ]
+ }
+ 
+ 
+ export { IFrameTest };
+ 


### PR DESCRIPTION
This is just for testing of iframe configuration.

On the page 

  https://renku-ci-ui-1292.dev.renku.ch/iframe 

you can enter a URL and sandbox options to test the behavior of the iframe configuration. You will want to view the developer tools to see the messages that appear.

/deploy #notest renku-notebooks=532-enable-iframe