### PR TITLE
Update project fork: default name and namespace handling

### DIFF
--- a/client/src/project/new/ProjectNew.container.js
+++ b/client/src/project/new/ProjectNew.container.js
@@ -143,7 +143,7 @@ class ForkProjectMapper extends Component {
 function ForkProject(props) {
   const { forkedTitle, handlers, namespaces, projects, toggleModal } = props;
 
-  const [title, setTitle] = useState(forkedTitle + " - copy");
+  const [title, setTitle] = useState(forkedTitle);
   const [namespace, setNamespace] = useState(""); // TODO - pick the default namespace if available
   const [projectsPaths, setProjectsPaths] = useState([]);
   const [error, setError] = useState(null);

--- a/client/src/project/new/ProjectNew.container.js
+++ b/client/src/project/new/ProjectNew.container.js
@@ -148,7 +148,7 @@ function ForkProject(props) {
   const { forkedTitle, handlers, namespaces, projects, toggleModal, user } = props;
 
   const [title, setTitle] = useState(forkedTitle);
-  const [namespace, setNamespace] = useState(""); // TODO - pick the default namespace if available
+  const [namespace, setNamespace] = useState("");
   const [projectsPaths, setProjectsPaths] = useState([]);
   const [error, setError] = useState(null);
 

--- a/client/src/project/new/ProjectNew.container.js
+++ b/client/src/project/new/ProjectNew.container.js
@@ -118,6 +118,10 @@ class ForkProjectMapper extends Component {
         fetched: state.projects.featured.fetched,
         fetching: state.projects.featured.fetching,
         list: state.projects.featured.member,
+      },
+      user: {
+        logged: state.user.logged,
+        username: state.user.data && state.user.data.username ? state.user.data.username : null
       }
     };
   }
@@ -141,7 +145,7 @@ class ForkProjectMapper extends Component {
 
 
 function ForkProject(props) {
-  const { forkedTitle, handlers, namespaces, projects, toggleModal } = props;
+  const { forkedTitle, handlers, namespaces, projects, toggleModal, user } = props;
 
   const [title, setTitle] = useState(forkedTitle);
   const [namespace, setNamespace] = useState(""); // TODO - pick the default namespace if available
@@ -273,6 +277,7 @@ function ForkProject(props) {
       projects={projects}
       title={title}
       toggleModal={toggleModal}
+      user={user}
     />
   );
 }
@@ -388,7 +393,8 @@ class NewProject extends Component {
         list: state.projects.namespaces.list
       },
       user: {
-        logged: state.user.logged
+        logged: state.user.logged,
+        username: state.user.data && state.user.data.username ? state.user.data.username : null
       }
     };
 

--- a/client/src/project/new/ProjectNew.present.js
+++ b/client/src/project/new/ProjectNew.present.js
@@ -150,7 +150,7 @@ function ForkProjectStatus(props) {
 }
 
 function ForkProjectContent(props) {
-  const { error, forking, handlers, namespace, namespaces, title } = props;
+  const { error, forking, handlers, namespace, namespaces, title, user } = props;
   if (forking)
     return null;
 
@@ -160,7 +160,7 @@ function ForkProjectContent(props) {
   return (
     <Fragment>
       <Title handlers={handlers} input={input} meta={meta} />
-      <Namespaces handlers={handlers} input={input} namespaces={namespaces} />
+      <Namespaces handlers={handlers} input={input} namespaces={namespaces} user={user} />
       <Home input={input} />
     </Fragment>
   );
@@ -281,10 +281,16 @@ class NamespacesAutosuggest extends Component {
 
   componentDidMount() {
     // set first user namespace as default (at least one should always available)
-    const { namespaces, namespace } = this.props;
+    const { namespaces, namespace, user } = this.props;
     if (namespaces.fetched && namespaces.list.length && !namespace) {
-      const nsUserSorted = namespaces.list.sort((a, b) => (a.kind === "user") ? -1 : 1);
-      const defaultNamespace = nsUserSorted[0];
+      let defaultNamespace = null, personalNs = null;
+      if (user.logged)
+        personalNs = namespaces.list.find(ns => ns.kind === "user" && ns.full_path === user.username);
+      if (personalNs)
+        defaultNamespace = personalNs;
+      else
+        defaultNamespace = namespaces.list.find(ns => ns.kind === "user");
+
       this.props.handlers.setNamespace(defaultNamespace);
       this.setState({ value: defaultNamespace.full_path });
     }


### PR DESCRIPTION
This PR fixes the following:
- Keep the original project name as default when clicking on the `Fork` button.
- Fetch namespaces recursively: now we handle up to 1'000 namespaces -- even though the UX with >50 is not great.
- Automatically select the user namespace if available.

Pinging @rokroskar to verify the last 2 points.

/deploy
fix #1294 