### PR TITLE
ci: provide chart name when publishing chart

### DIFF
--- a/.github/workflows/test-and-ci.yml
+++ b/.github/workflows/test-and-ci.yml
@@ -79,6 +79,7 @@ jobs:
       uses: SwissDataScienceCenter/renku/actions/publish-chart@master
       env:
         GITHUB_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
+        CHART_NAME: renku-ui
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
     - name: Wait for chart to get published
@@ -86,5 +87,5 @@ jobs:
     - name: Update component version
       uses: SwissDataScienceCenter/renku/actions/update-component-version@master
       env:
-        CHART_NAME: renku-ui
         GITHUB_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
+        CHART_NAME: renku-ui


### PR DESCRIPTION
Fixes this error https://github.com/SwissDataScienceCenter/renku-ui/runs/2276583841
It has been tested on #1300 with this successful result https://github.com/SwissDataScienceCenter/renku-ui/runs/2276677109