### PR TITLE
Support deploy command for specifying components versions

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -35,7 +35,7 @@ jobs:
       test-enabled: ${{ steps.deploy-comment.outputs.test-enabled}}
     steps:
       - id: deploy-comment
-        uses: SwissDataScienceCenter/renku/actions/check-pr-description@master
+        uses: SwissDataScienceCenter/renku/actions/check-pr-description@1959-deploy-commands
         with:
           string: /deploy
           pr_ref: ${{ github.event.number }}
@@ -64,7 +64,7 @@ jobs:
         body: |
           You can access the deployment of this PR at https://renku-ci-ui-${{ github.event.number }}.dev.renku.ch
     - name: Build and deploy
-      uses: SwissDataScienceCenter/renku/actions/deploy-renku@master
+      uses: SwissDataScienceCenter/renku/actions/deploy-renku@1959-deploy-commands
       env:
         RANCHER_PROJECT_ID: ${{ secrets.CI_RANCHER_PROJECT }}
         DOCKER_PASSWORD: ${{ secrets.RENKU_DOCKER_PASSWORD }}

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -27,6 +27,12 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       pr-contains-string: ${{ steps.deploy-comment.outputs.pr-contains-string }}
+      renku: ${{ steps.deploy-comment.outputs.renku}}
+      renku-core: ${{ steps.deploy-comment.outputs.renku-core}}
+      renku-gateway: ${{ steps.deploy-comment.outputs.renku-gateway}}
+      renku-graph: ${{ steps.deploy-comment.outputs.renku-graph}}
+      renku-notebooks: ${{ steps.deploy-comment.outputs.renku-notebooks}}
+      test-enabled: ${{ steps.deploy-comment.outputs.test-enabled}}
     steps:
       - id: deploy-comment
         uses: SwissDataScienceCenter/renku/actions/check-pr-description@master
@@ -75,7 +81,11 @@ jobs:
         RENKU_TESTS_ENABLED: true
         TEST_ARTIFACTS_PATH: "tests-artifacts-${{ github.sha }}"
         renku_ui: "@${{ github.head_ref }}"
-        # renku: "@master"
+        renku: "${{ needs.check-deploy.outputs.renku }}"
+        renku_core: "${{ needs.check-deploy.outputs.renku-core }}"
+        renku_gateway: "${{ needs.check-deploy.outputs.renku-gateway }}"
+        renku_graph: "${{ needs.check-deploy.outputs.renku-graph }}"
+        renku_notebooks: "${{ needs.check-deploy.outputs.renku-notebooks }}"
 
   run-acceptance-tests:
     needs: [check-deploy, deploy-pr]
@@ -87,7 +97,7 @@ jobs:
       with:
         python-version: 3.8
     - name: Test the PR
-      if: needs.check-deploy.outputs.pr-contains-string == 'true'
+      if: "needs.check-deploy.outputs.pr-contains-string == 'true' && needs.check-deploy.outputs.test-enabled == 'true'"
       env:
         KUBECONFIG: ${{ github.workspace }}/renkubot-kube.config
         RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -35,7 +35,7 @@ jobs:
       test-enabled: ${{ steps.deploy-comment.outputs.test-enabled}}
     steps:
       - id: deploy-comment
-        uses: SwissDataScienceCenter/renku/actions/check-pr-description@1959-deploy-commands
+        uses: SwissDataScienceCenter/renku/actions/check-pr-description@master
         with:
           string: /deploy
           pr_ref: ${{ github.event.number }}
@@ -64,7 +64,7 @@ jobs:
         body: |
           You can access the deployment of this PR at https://renku-ci-ui-${{ github.event.number }}.dev.renku.ch
     - name: Build and deploy
-      uses: SwissDataScienceCenter/renku/actions/deploy-renku@1959-deploy-commands
+      uses: SwissDataScienceCenter/renku/actions/deploy-renku@master
       env:
         RANCHER_PROJECT_ID: ${{ secrets.CI_RANCHER_PROJECT }}
         DOCKER_PASSWORD: ${{ secrets.RENKU_DOCKER_PASSWORD }}


### PR DESCRIPTION
Integrates the support for reading a command provided after the `/deploy` string.
It's possible to specify components versions (e.g. a tag `renku-core=v0.14.0` or a branch `renku-notebooks=debug-with-vscode-k8s`)) and provide a `#notest` switch to turn off the acceptance tests

re SwissDataScienceCenter/renku#1959

/deploy #notest renku-core=v0.14.0 renku-notebooks=debug-with-vscode-k8s renku=6435400de6e5d79798c75f8112289880805e2e34
