### PR TITLE
feat(design): project header nav and overview redesigned

### DIFF
--- a/client/src/landing/NavBar.js
+++ b/client/src/landing/NavBar.js
@@ -352,7 +352,7 @@ class FooterNavbar extends Component {
       (<RenkuNavLink to="/privacy" title="Privacy" />) :
       null;
     return (
-      <footer className="footer mt-auto">
+      <footer className="footer mt-auto pt-4">
         <Navbar className="container-fluid flex-wrap flex-lg-nowrap renku-container navbar bg-primary">
           <span className="text-white">&copy; SDSC {(new Date()).getFullYear()}</span>
           <Nav className="ms-auto">

--- a/client/src/notebooks/Notebooks.css
+++ b/client/src/notebooks/Notebooks.css
@@ -1,6 +1,5 @@
 .alternateToggleStyle {
   white-space: nowrap;
-  border-radius: 0.2rem !important;
   padding-right: 0.5625rem;
   padding-left: 0.5625rem;
 }

--- a/client/src/project/Project.css
+++ b/client/src/project/Project.css
@@ -4,14 +4,6 @@ Button.alert-link {
   vertical-align: bottom;
 }
 
-.visibilityLabel {
-  display: inline;
-  color: rgba(0, 0, 0, 0.5);
-  /* color: black; */
-  margin-left: 0.1em;
-  font-size: 0.55em;
-}
-
 .warningLabel {
   display: inline;
   color: #ffc107;

--- a/client/src/project/Project.present.js
+++ b/client/src/project/Project.present.js
@@ -28,7 +28,7 @@ import React, { Component, Fragment, useState, useEffect } from "react";
 import { Link, Route, Switch } from "react-router-dom";
 import {
   Alert, Button, ButtonGroup, Card, CardBody, CardHeader, Col, DropdownItem, Form, FormGroup,
-  FormText, Input, Label, Row, Table, Nav, NavItem, UncontrolledTooltip, Modal
+  FormText, Input, Label, Row, Table, Nav, NavItem, UncontrolledTooltip, Modal, Badge
 } from "reactstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faStar as faStarRegular } from "@fortawesome/free-regular-svg-icons";
@@ -85,11 +85,11 @@ class ProjectVisibilityLabel extends Component {
   render() {
     switch (this.props.visibilityLevel) {
       case "private":
-        return <span className="visibilityLabel"><FontAwesomeIcon icon={faLock} /> Private</span>;
+        return <span><Badge color="secondary"><FontAwesomeIcon icon={faLock} /> Private</Badge>&nbsp;</span>;
       case "internal":
-        return <span className="visibilityLabel"><FontAwesomeIcon icon={faUserFriends} /> Internal</span>;
+        return <span><Badge color="secondary"><FontAwesomeIcon icon={faUserFriends} /> Internal</Badge>&nbsp;</span>;
       case "public":
-        return <span className="visibilityLabel"><FontAwesomeIcon icon={faGlobe} /> Public</span>;
+        return <span><Badge color="secondary"><FontAwesomeIcon icon={faGlobe} /> Public</Badge>&nbsp;</span>;
       default:
         return null;
     }
@@ -210,7 +210,7 @@ class ForkProjectModal extends Component {
     }
     return (
       <Fragment>
-        <Button outline color="primary" onClick={this.toggleFunction}>
+        <Button outline color="primary" className="border-light" onClick={this.toggleFunction}>
           <FontAwesomeIcon icon={faCodeBranch} /> fork
         </Button>
         <Modal isOpen={this.state.open} toggle={this.toggleFunction}>
@@ -268,56 +268,75 @@ class ProjectViewHeaderOverview extends Component {
     const gitlabIDEUrl = this.props.externalUrl !== "" && this.props.externalUrl.includes("/gitlab/") ?
       this.props.externalUrl.replace("/gitlab/", "/gitlab/-/ide/project/") : null;
     return (
-      <Row>
-        <Col xs={12} md>
-          <h3>
-            <ProjectStatusIcon
-              history={this.props.history}
-              webhook={this.props.webhook}
-              overviewStatusUrl={this.props.overviewStatusUrl}
-              migration_required={this.props.migration.migration_required}
-              template_update_possible={this.props.migration.template_update_possible}
-              docker_update_possible={this.props.migration.docker_update_possible}
-            />{core.title} <ProjectVisibilityLabel visibilityLevel={this.props.visibility.level} />
-          </h3>
-          <p>
-            <span>{this.props.core.path_with_namespace}{forkedFrom}</span> <br />
-          </p>
-        </Col>
-        <Col xs={12} md="auto">
-          <div className="d-flex mb-2">
-            <ButtonGroup size="sm">
-              <ForkProjectModal
-                client={this.props.client}
-                history={this.props.history}
-                model={this.props.model}
-                notifications={this.props.notifications}
-                title={this.props.core && this.props.core.title ? this.props.core.title : ""}
-                id={this.props.core && this.props.core.id ? this.props.core.id : 0}
-              />
-              <Button outline color="primary"
-                href={`${this.props.externalUrl}/forks`} target="_blank" rel="noreferrer noopener">
-                {system.forks_count}
-              </Button>
-            </ButtonGroup>
-            <ButtonGroup size="sm" className="ml-1">
-              <Button outline color="primary"
-                disabled={this.state.updating_star}
-                onClick={this.star.bind(this)}>
-                {starElement} {starText}
-              </Button>
-              <Button outline color="primary" style={{ cursor: "default" }}>{system.star_count}</Button>
-            </ButtonGroup>
-          </div>
-
-          <div className="d-flex flex-md-row-reverse mb-2">
-            <GitLabConnectButton size="sm"
-              externalUrl={this.props.externalUrl}
-              gitlabIDEUrl={gitlabIDEUrl}
-              userLogged={this.props.user.logged} />
-          </div>
-        </Col>
-      </Row>
+      <Fragment>
+        <Row className="pt-2 pb-3">
+          <Col className="d-flex mb-2 justify-content-between">
+            <div>
+              <h2>
+                <ProjectStatusIcon
+                  history={this.props.history}
+                  webhook={this.props.webhook}
+                  overviewStatusUrl={this.props.overviewStatusUrl}
+                  migration_required={this.props.migration.migration_required}
+                  template_update_possible={this.props.migration.template_update_possible}
+                  docker_update_possible={this.props.migration.docker_update_possible}
+                />{core.title}
+              </h2>
+              <div className="text-rk-text">
+                <span>{this.props.core.path_with_namespace}{forkedFrom}</span>
+              </div>
+              <div className="text-rk-text">
+                {this.props.core.description || " "}
+              </div>
+            </div>
+            <div className="d-flex flex-column align-items-end justify-content-between">
+              <div>
+                <ButtonGroup size="sm">
+                  <ForkProjectModal
+                    client={this.props.client}
+                    history={this.props.history}
+                    model={this.props.model}
+                    notifications={this.props.notifications}
+                    title={this.props.core && this.props.core.title ? this.props.core.title : ""}
+                    id={this.props.core && this.props.core.id ? this.props.core.id : 0}
+                  />
+                  <Button
+                    outline
+                    color="primary"
+                    className="border-light"
+                    href={`${this.props.externalUrl}/forks`} target="_blank" rel="noreferrer noopener">
+                    {system.forks_count}
+                  </Button>
+                </ButtonGroup>
+                <ButtonGroup size="sm" className="ms-2">
+                  <Button outline color="primary"
+                    className="border-light"
+                    disabled={this.state.updating_star}
+                    onClick={this.star.bind(this)}>
+                    {starElement} {starText}
+                  </Button>
+                  <Button outline color="primary"
+                    className="border-light"
+                    style={{ cursor: "default" }}>{system.star_count}</Button>
+                </ButtonGroup>
+                <ButtonGroup size="sm" className="ms-2">
+                  <GitLabConnectButton size="sm"
+                    externalUrl={this.props.externalUrl}
+                    gitlabIDEUrl={gitlabIDEUrl}
+                    userLogged={this.props.user.logged} />
+                </ButtonGroup>
+              </div>
+              <div className="pt-2">
+                <ProjectVisibilityLabel visibilityLevel={this.props.visibility.level} />
+                <ProjectTagList tagList={this.props.system.tag_list} />
+              </div>
+              <div className="pt-1">
+                <TimeCaption key="time-caption" time={this.props.core.last_activity_at} />
+              </div>
+            </div>
+          </Col>
+        </Row>
+      </Fragment>
     );
   }
 }
@@ -343,27 +362,31 @@ class ProjectViewHeader extends Component {
 class ProjectNav extends Component {
   render() {
     return (
-      <Nav pills className={"nav-pills-underline"}>
-        <NavItem>
-          <RenkuNavLink to={this.props.baseUrl} alternate={this.props.overviewUrl} title="Overview" />
-        </NavItem>
-        <NavItem>
-          <RenkuNavLink exact={false} to={this.props.issuesUrl}
-            alternate={this.props.collaborationUrl} title="Collaboration" />
-        </NavItem>
-        <NavItem>
-          <RenkuNavLink exact={false} to={this.props.filesUrl} title="Files" />
-        </NavItem>
-        <NavItem>
-          <RenkuNavLink exact={false} to={this.props.datasetsUrl} title="Datasets" />
-        </NavItem>
-        <NavItem>
-          <RenkuNavLink exact={false} to={this.props.notebookServersUrl} title="Environments" />
-        </NavItem>
-        <NavItem>
-          <RenkuNavLink exact={false} to={this.props.settingsUrl} title="Settings" />
-        </NavItem>
-      </Nav>
+      <div className="pb-3 rk-search-bar">
+        <Col className="d-flex pb-2 mb-1 justify-content-left " md={12} lg={12}>
+          <Nav pills className="nav-pills-underline">
+            <NavItem>
+              <RenkuNavLink to={this.props.baseUrl} alternate={this.props.overviewUrl} title="Overview" />
+            </NavItem>
+            <NavItem>
+              <RenkuNavLink exact={false} to={this.props.issuesUrl}
+                alternate={this.props.collaborationUrl} title="Collaboration" />
+            </NavItem>
+            <NavItem>
+              <RenkuNavLink exact={false} to={this.props.filesUrl} title="Files" />
+            </NavItem>
+            <NavItem>
+              <RenkuNavLink exact={false} to={this.props.datasetsUrl} title="Datasets" />
+            </NavItem>
+            <NavItem>
+              <RenkuNavLink exact={false} to={this.props.notebookServersUrl} title="Environments" />
+            </NavItem>
+            <NavItem>
+              <RenkuNavLink exact={false} to={this.props.settingsUrl} title="Settings" />
+            </NavItem>
+          </Nav>
+        </Col>
+      </div>
     );
   }
 }
@@ -401,9 +424,9 @@ class ProjectViewReadme extends Component {
       return <Loader />;
 
     return (
-      <Card className="border-0">
-        <CardHeader>README.md</CardHeader>
-        <CardBody style={{ overflow: "auto" }}>
+      <Card className="border-rk-light">
+        <CardHeader className="bg-white p-3 ps-4">README.md</CardHeader>
+        <CardBody style={{ overflow: "auto" }} className="p-4">
           <RenkuMarkdown
             projectPathWithNamespace = {this.props.core.path_with_namespace}
             filePath={""}
@@ -428,10 +451,12 @@ function ProjectKGStatus(props) {
     body = props.kgStatusView(true);
 
   return (
-    <Card className="border-0">
-      <CardHeader>Knowledge Graph integration</CardHeader>
-      <CardBody>
-        <Row><Col>{body}</Col></Row>
+    <Card className="border-rk-light">
+      <CardHeader className="bg-white p-3 ps-4">Knowledge Graph Integration</CardHeader>
+      <CardBody className="p-4 pt-3 pb-3 lh-lg">
+        <Row>
+          <Col>{body}</Col>
+        </Row>
       </CardBody>
     </Card>
   );
@@ -445,15 +470,12 @@ class ProjectViewOverviewNav extends Component {
     //   <RenkuNavLink to={`${this.props.overviewUrl}/results`} title="Results" />
     // </NavItem>
     return (
-      <Nav pills className={"flex-column"}>
+      <Nav className="flex-column nav-light">
         <NavItem>
           <RenkuNavLink to={this.props.baseUrl} title="Description" />
         </NavItem>
         <NavItem>
           <RenkuNavLink to={`${this.props.statsUrl}`} title="Stats" />
-        </NavItem>
-        <NavItem>
-          <RenkuNavLink to={`${this.props.overviewDatasetsUrl}`} title="Datasets" />
         </NavItem>
         <NavItem>
           <RenkuNavLink to={`${this.props.overviewCommitsUrl}`} title="Commits" />
@@ -467,25 +489,8 @@ class ProjectViewOverviewNav extends Component {
 
 class ProjectViewOverview extends Component {
   render() {
-    const { core, system, projectCoordinator } = this.props;
-    const description = core.description ?
-      (<Fragment><span className="lead">{core.description}</span><br /></Fragment>) :
-      null;
-
+    const { projectCoordinator } = this.props;
     return <Col key="overview">
-      <Row>
-        <Col xs={12} md={9}>
-          <p>
-            {description}
-            <TimeCaption key="time-caption" time={core.last_activity_at} />
-          </p>
-        </Col>
-        <Col xs={12} md={3}>
-          <p className="text-md-right">
-            <ProjectTagList tagList={system.tag_list} />
-          </p>
-        </Col>
-      </Row>
       <Row>
         <Col key="nav" sm={12} md={2}>
           <ProjectViewOverviewNav {...this.props} />
@@ -501,9 +506,6 @@ class ProjectViewOverview extends Component {
                 branches={this.props.system.branches}
               />
             }
-            />
-            <Route exact path={this.props.overviewDatasetsUrl} render={props =>
-              <ProjectViewDatasetsOverview {...this.props} />}
             />
             <Route exact path={this.props.overviewCommitsUrl} render={props =>
               <ProjectOverviewCommits
@@ -874,51 +876,6 @@ class ProjectViewFiles extends Component {
   }
 }
 
-class OverviewDatasetRow extends Component {
-  render() {
-    return <tr>
-      <td className="align-middle">
-        <Link to={this.props.fullDatasetUrl}>{this.props.name}</Link>
-      </td>
-    </tr>;
-  }
-}
-
-class ProjectViewDatasetsOverview extends Component {
-
-  componentDidMount() {
-    this.props.fetchDatasets(false);
-  }
-
-  render() {
-    const datasetsList = this.props.core.datasets;
-
-    if (datasetsList === undefined || datasetsList === SpecialPropVal.UPDATING)
-      return <Loader />;
-
-    if (datasetsList.length === 0)
-      return <p>No datasets to display.</p>;
-
-    let datasets = datasetsList.map((dataset) =>
-      <OverviewDatasetRow
-        key={dataset.name}
-        name={dataset.title || dataset.name}
-        fullDatasetUrl={`${this.props.datasetsUrl}/${encodeURIComponent(dataset.name)}`}
-      />
-    );
-
-    return <Col xs={12} md={10} lg={10}>
-      <Table bordered>
-        <thead className="thead-light">
-          <tr><th className="align-middle">Datasets</th></tr>
-        </thead>
-        <tbody>
-          {datasets}
-        </tbody>
-      </Table>
-    </Col>;
-  }
-}
 
 class ProjectEnvironments extends Component {
   render() {
@@ -1311,9 +1268,8 @@ class ProjectView extends Component {
     }
 
     return [
-      <Row key="header"><Col xs={12}><ProjectViewHeader key="header" {...this.props} /></Col></Row>,
-      <Row key="nav"><Col xs={12}><ProjectNav key="nav" {...this.props} /></Col></Row>,
-      <Row key="space"><Col key="space" xs={12}>&nbsp;</Col></Row>,
+      <ProjectViewHeader key="header" {...this.props} />,
+      <ProjectNav key="nav" {...this.props} />,
       <Row key="content">
         <Switch>
           <Route exact path={this.props.baseUrl}

--- a/client/src/project/overview/ProjectOverview.present.js
+++ b/client/src/project/overview/ProjectOverview.present.js
@@ -74,63 +74,67 @@ class OverviewStats extends Component {
 
     // TODO: provide a refresh button once all the data can be refreshed at once (see container)
     return (
-      <Card className="border-0">
-        <CardHeader>Project Statistics</CardHeader>
-        <CardBody><Row><Col>
-          {info}
-          <Table className="table-responsive" key="stats-table" size="sm">
-            <tbody>
-              <tr>
-                <th className="align-middle" scope="row">Number of Branches</th>
-                <td className="px-3 px-lg-4 align-middle">{branchesCount}</td>
-                <td>
-                  <ExternalLink role="text" showLinkIcon={true}
-                    url={`${metadata.repositoryUrl}/branches`} title="Branches in GitLab" />
-                </td>
-              </tr>
-              <tr>
-                <th className="align-middle" scope="row">Number of Forks</th>
-                <td className="px-3 px-lg-4 align-middle">{metadata.forksCount}</td>
-                <td>
-                  <ExternalLink role="text" showLinkIcon={true}
-                    url={`${metadata.repositoryUrl}/forks`} title="Forks in GitLab" />
-                </td>
-              </tr>
-              <tr>
-                <th className="align-middle" scope="row">Number of Stars</th>
-                <td className="px-3 px-lg-4 align-middle">{metadata.starCount}</td>
-                <td>
-                  <ExternalLink role="text" showLinkIcon={true}
-                    url={`${metadata.repositoryUrl}/-/starrers`} title="Stars in GitLab" />
-                </td>
-              </tr>
-              <tr>
-                <th className="align-middle" scope="row">Number of Commits</th>
-                <td className="px-3 px-lg-4 align-middle">{commitsCount}</td>
-                <td>
-                  <ExternalLink role="text" showLinkIcon={true}
-                    url={`${metadata.repositoryUrl}/commits`} title="Commits in GitLab" />
-                </td>
-              </tr>
-              <tr>
-                <th scope="row">Storage Size</th>
-                <td className="px-3 px-lg-4 align-middle">{storageSize}</td>
-                <td className="align-middle" rowSpan="3">
-                  <ExternalLink role="text" showLinkIcon={true}
-                    url={metadata.repositoryUrl} title="Sizes in GitLab" />
-                </td>
-              </tr>
-              <tr>
-                <th className="align-middle" scope="row">Repository Size</th>
-                <td className="px-3 px-lg-4 align-middle">{repositorySize}</td>
-              </tr>
-              <tr>
-                <th className="align-middle" scope="row">LFS Size</th>
-                <td className="px-3 px-lg-4 align-middle">{lfsSize}</td>
-              </tr>
-            </tbody>
-          </Table>
-        </Col></Row></CardBody>
+      <Card className="border-rk-light">
+        <CardHeader className="bg-white p-3 ps-4">Project Statistics</CardHeader>
+        <CardBody className="p-4 pt-3 pb-3 lh-lg">
+          <Row>
+            <Col>
+              {info}
+              <Table className="table-responsive" key="stats-table" size="sm">
+                <tbody>
+                  <tr>
+                    <th className="align-middle" scope="row">Number of Branches</th>
+                    <td className="px-3 px-lg-4 align-middle">{branchesCount}</td>
+                    <td>
+                      <ExternalLink role="text" showLinkIcon={true}
+                        url={`${metadata.repositoryUrl}/branches`} title="Branches in GitLab" />
+                    </td>
+                  </tr>
+                  <tr>
+                    <th className="align-middle" scope="row">Number of Forks</th>
+                    <td className="px-3 px-lg-4 align-middle">{metadata.forksCount}</td>
+                    <td>
+                      <ExternalLink role="text" showLinkIcon={true}
+                        url={`${metadata.repositoryUrl}/forks`} title="Forks in GitLab" />
+                    </td>
+                  </tr>
+                  <tr>
+                    <th className="align-middle" scope="row">Number of Stars</th>
+                    <td className="px-3 px-lg-4 align-middle">{metadata.starCount}</td>
+                    <td>
+                      <ExternalLink role="text" showLinkIcon={true}
+                        url={`${metadata.repositoryUrl}/-/starrers`} title="Stars in GitLab" />
+                    </td>
+                  </tr>
+                  <tr>
+                    <th className="align-middle" scope="row">Number of Commits</th>
+                    <td className="px-3 px-lg-4 align-middle">{commitsCount}</td>
+                    <td>
+                      <ExternalLink role="text" showLinkIcon={true}
+                        url={`${metadata.repositoryUrl}/commits`} title="Commits in GitLab" />
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Storage Size</th>
+                    <td className="px-3 px-lg-4 align-middle">{storageSize}</td>
+                    <td className="align-middle" rowSpan="3">
+                      <ExternalLink role="text" showLinkIcon={true}
+                        url={metadata.repositoryUrl} title="Sizes in GitLab" />
+                    </td>
+                  </tr>
+                  <tr>
+                    <th className="align-middle" scope="row">Repository Size</th>
+                    <td className="px-3 px-lg-4 align-middle">{repositorySize}</td>
+                  </tr>
+                  <tr>
+                    <th className="align-middle" scope="row">LFS Size</th>
+                    <td className="px-3 px-lg-4 align-middle">{lfsSize}</td>
+                  </tr>
+                </tbody>
+              </Table>
+            </Col>
+          </Row>
+        </CardBody>
       </Card>
     );
   }
@@ -146,7 +150,7 @@ class OverviewCommits extends Component {
 
     const commitBadgeNumber = `${commits.list.length}${tooMany ? "+" : ""}`;
     const badge = commits.fetched && !commits.fetching ?
-      (<Badge color="primary">{commitBadgeNumber}</Badge>) :
+      (<Badge color="primary" className="ms-2 me-2">{commitBadgeNumber}</Badge>) :
       null;
     const buttonGit = (
       <Fragment>
@@ -155,7 +159,7 @@ class OverviewCommits extends Component {
           id="commitLink"
           title={<FontAwesomeIcon icon={faGitlab} />}
           url={gitlabCommitsUrl}
-          className="text-primary btn ml-2 p-0"
+          className="text-primary btn ml-2 p-0 ms-2"
         />
         <UncontrolledTooltip placement="top" target="commitLink">
           Open in GitLab
@@ -170,13 +174,20 @@ class OverviewCommits extends Component {
       (<Loader />) :
       (<OverviewCommitsBody {...this.props} />);
     return (
-      <Card className="border-0">
-        <CardHeader>
-          Commits {badge}
-          <RefreshButton action={commits.refresh} updating={commits.fetching} message="Refresh commits" />
-          {buttonGit}
+
+      <Card className="border-rk-light">
+        <CardHeader className="bg-white p-3 ps-4 d-flex">
+          <span className="align-text-bottom">
+            Commits
+          </span>
+          <div>
+            {badge}
+            <RefreshButton action={commits.refresh} updating={commits.fetching} message="Refresh commits" />
+            {buttonGit}
+          </div>
         </CardHeader>
-        <CardBody className="pl-0 pr-0">
+        <CardBody className="p-4 pt-3 pb-3 lh-lg">
+          {/* <CardBody className="p-0 lh-lg"> */}
           {body}
           {info}
         </CardBody>
@@ -235,11 +246,11 @@ class OverviewCommitsBody extends Component {
           urlDiff={`${metadata.repositoryUrl}/commit/`}
         />
         <Pagination
-          className="mt-2"
           currentPage={currentPage}
           perPage={perPage}
           totalItems={commits.list.length}
           onPageChange={this.onPageChange.bind(this)}
+          className="mt-4 d-flex justify-content-center rk-search-pagination pagination-sm"
         />
       </Fragment>
     );

--- a/client/src/project/status/ProjectVersionStatus.present.js
+++ b/client/src/project/status/ProjectVersionStatus.present.js
@@ -271,10 +271,10 @@ function ProjectVersionStatusBody(props) {
 
   if (!isLogged && !props.loading) return null;
 
-  return (
-    <Card className="border-0">
-      <CardHeader>Renku Version</CardHeader>
-      <CardBody>
+  return [
+    <Card key="renkuVersion" className="border-rk-light mb-4">
+      <CardHeader className="bg-white p-3 ps-4">Renku Version</CardHeader>
+      <CardBody className="p-4 pt-3 pb-3 lh-lg">
         <Row><Col>
           <RenkuVersionStatusBody
             {...props}
@@ -282,8 +282,10 @@ function ProjectVersionStatusBody(props) {
             maintainer={maintainer}/>
         </Col></Row>
       </CardBody>
-      <CardHeader>Template Version</CardHeader>
-      <CardBody>
+    </Card>,
+    <Card key="templateVersion" className="border-rk-light mb-4">
+      <CardHeader className="bg-white p-3 ps-4">Template Version</CardHeader>
+      <CardBody className="p-4 pt-3 pb-3 lh-lg pb-2">
         <Row><Col>
           <TemplateStatusBody
             {...props}
@@ -292,6 +294,6 @@ function ProjectVersionStatusBody(props) {
         </Col></Row>
       </CardBody>
     </Card>
-  );
+  ];
 }
 export default ProjectVersionStatusBody;

--- a/client/src/styles/bootstrap_ext/_button.scss
+++ b/client/src/styles/bootstrap_ext/_button.scss
@@ -32,3 +32,10 @@
     color:$rk-text;
   }
 }
+
+.btn-outline-primary.border-light:hover{
+  background-color: $light;
+  //not sure if this border color looks good
+  border-color:$primary !important;
+  color: $primary
+}

--- a/client/src/styles/bootstrap_ext/_nav.scss
+++ b/client/src/styles/bootstrap_ext/_nav.scss
@@ -1,0 +1,14 @@
+.nav.nav-light{
+  .nav-link{
+    padding-left:0em;
+    color: $rk-text;
+  }
+  
+  .nav-link:hover{
+    color :$rk-dark;
+  }
+
+  .nav-link.active{
+    color :$rk-dark;
+  }
+}

--- a/client/src/styles/bootstrap_ext/_underline_pill_nav.scss
+++ b/client/src/styles/bootstrap_ext/_underline_pill_nav.scss
@@ -35,6 +35,7 @@ $nav-pills-underline-border-color:    map-get($theme-colors, "dark");
       border-bottom-width: $nav-pills-underline-border-width;
       border-bottom-style: solid;
       border-bottom-color: transparent;
+      padding-bottom: 0.5rem;
     }
 
     > a.nav-link.active,

--- a/client/src/styles/index.scss
+++ b/client/src/styles/index.scss
@@ -47,6 +47,7 @@
 
 @import './bootstrap_ext/badge';
 @import './bootstrap_ext/button';
+@import './bootstrap_ext/nav';
 @import './bootstrap_ext/nav_bar';
 @import './bootstrap_ext/underline_pill_nav';
 

--- a/client/src/utils/Commits.css
+++ b/client/src/utils/Commits.css
@@ -15,4 +15,19 @@
   font-weight: bold;
   padding-top: 0.25rem;
   padding-bottom: 0.25rem;
+  background-color: #F5F5F5;
+  border:unset;
+}
+
+.commit-date:first-of-type{
+  border-top: 1px solid #E4E7EA;
+}
+
+.commit-object{
+  border-bottom: 1px solid #E4E7EA;
+  line-height: 1.5rem;
+}
+
+.commit-cut-message > a {
+  text-decoration: none;
 }

--- a/client/src/utils/Commits.js
+++ b/client/src/utils/Commits.js
@@ -136,8 +136,8 @@ function SingleCommit(props) {
           </Col>
           <Col xs={12} md="auto" className="d-md-flex">
             <ButtonGroup className="text-monospace m-auto" size="sm">
-              <Button color="light" className="border" disabled>{props.commit.short_id}</Button>
-              <Button color="light" className="border" id={idCopyButton}>
+              <Button color="rk-background" className="border" disabled>{props.commit.short_id}</Button>
+              <Button color="rk-background" className="border" id={idCopyButton}>
                 <Clipboard clipboardText={props.commit.id} />
               </Button>
               <UncontrolledTooltip placement="top" target={idCopyButton}>
@@ -147,7 +147,8 @@ function SingleCommit(props) {
                 id={idBrowseButton}
                 title={<FontAwesomeIcon icon={faFolderOpen} />}
                 url={urlBrowse}
-                className="border btn-light"
+                color="rk-background"
+                className="border text-primary"
               />
               <UncontrolledTooltip placement="top" target={idBrowseButton}>
                 Browse files

--- a/client/src/utils/UIComponents.js
+++ b/client/src/utils/UIComponents.js
@@ -200,13 +200,15 @@ class Pagination extends Component {
 }
 
 function ExternalLinkButton(props) {
-  let className = "btn btn-primary";
+  let className = "btn";
   if (props.size != null)
     className += ` btn-${props.size}`;
   if (props.disabled)
     className += " disabled";
   if (props.color)
     className += ` btn-${props.color}`;
+  else
+    className += ` btn-primary`;
   if (props.className)
     className += ` ${props.className}`;
 


### PR DESCRIPTION
Header redesigned... this is a proposal, might make project path and description with a lighter font or in italics.

Decided to move the project visibility like a tag, but I'm not sure this is the best. I thought next to the title it didn't look so good.

This doesn't shrink well but will fix it once we like the design for it unshrinked

![image](https://user-images.githubusercontent.com/42647877/114156789-3c546100-9923-11eb-9d5c-838f9b78fcff.png)


Menu...
![image](https://user-images.githubusercontent.com/42647877/114157259-be448a00-9923-11eb-9775-ad1e8bb5afa2.png)

Readme
![image](https://user-images.githubusercontent.com/42647877/114157312-cef50000-9923-11eb-816a-b0beec17518a.png)

Stats
![image](https://user-images.githubusercontent.com/42647877/114157349-d7e5d180-9923-11eb-9a3f-8563a466376f.png)

Commits
![image](https://user-images.githubusercontent.com/42647877/114157378-de744900-9923-11eb-9748-cb4daa5a1876.png)

Status
![image](https://user-images.githubusercontent.com/42647877/114157412-e6cc8400-9923-11eb-95ef-b6c08be6dbd4.png)

/deploy
