### PR TITLE
ci: create ui-server pr for bumping version

### DIFF
--- a/.github/workflows/test-and-ci.yml
+++ b/.github/workflows/test-and-ci.yml
@@ -84,8 +84,13 @@ jobs:
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
     - name: Wait for chart to get published
       run: sleep 120
-    - name: Update component version
+    - name: Update ui version
       uses: SwissDataScienceCenter/renku/actions/update-component-version@master
       env:
         GITHUB_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
         CHART_NAME: renku-ui
+    - name: Update ui-server version
+      uses: SwissDataScienceCenter/renku/actions/update-component-version@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
+        CHART_NAME: renku-ui-server


### PR DESCRIPTION
The charts and images are created together, but the `update-component-version` considers each component separately ( SwissDataScienceCenter/renku#2059 ).
This change manually opens another PR in the Renku repository for bumping the ui-server component on new tags