### PR TITLE
ci: use a smaller footprint image in docker

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -11,7 +11,7 @@ COPY src /app/src/
 RUN npm install --silent && \
     npm run-script build
 
-FROM node:10.22-alpine
+FROM mhart/alpine-node:slim-10.22
 
 COPY --from=builder /app/dist app/dist
 COPY --from=builder /app/node_modules app/node_modules


### PR DESCRIPTION
Reduces the footprint of the ui-server chart

![Screenshot_20210409_160303](https://user-images.githubusercontent.com/43481553/114191780-1348c600-994d-11eb-81e5-c660c4c0d50c.png)

**How to test**: Query the `GET /ui-server` endpoint and verify it returns a valid response

![Screenshot_20210409_160423](https://user-images.githubusercontent.com/43481553/114192664-0a0c2900-994e-11eb-97f8-97253c600325.png)

/deploy #notest

fix #1091