### PR TITLE
fix: update environments section name

### DIFF
--- a/client/src/notebooks/Notebooks.state.js
+++ b/client/src/notebooks/Notebooks.state.js
@@ -29,7 +29,8 @@ import { parseINIString } from "../utils/HelperFunctions";
 const POLLING_INTERVAL = 3000;
 const IMAGE_BUILD_JOB = "image_build";
 const RENKU_INI_PATH = ".renku/renku.ini";
-const RENKU_INI_SECTION = `renku "interactive"`;
+const RENKU_INI_SECTION_LEGACY = `renku "interactive"`;
+const RENKU_INI_SECTION = "interactive";
 
 const PIPELINE_TYPES = {
   anonymous: "registries",
@@ -123,8 +124,11 @@ const NotebooksHelper = {
       parsedData = {};
     }
     // check single props when the environment sections is available
-    if (parsedData[RENKU_INI_SECTION]) {
-      const parsedOptions = parsedData[RENKU_INI_SECTION];
+    let parsedOptions = parsedData[RENKU_INI_SECTION];
+    // check also the previous section name for compatibility reasons
+    if (!parsedOptions)
+      parsedOptions = parsedData[RENKU_INI_SECTION_LEGACY];
+    if (parsedOptions) {
       Object.keys(parsedOptions).forEach(parsedOption => {
         // treat "default_url" as "defaultUrl" to allow name consistency in the the .ini file
         let option = parsedOption;

--- a/client/src/notebooks/Notebooks.test.js
+++ b/client/src/notebooks/Notebooks.test.js
@@ -100,7 +100,7 @@ describe("notebook server clean annotation", () => {
 describe("parse project level environment options", () => {
   it("valid content", () => {
     const content = `
-      [renku "interactive"]
+      [interactive]
       default_url = /tree
       mem_request = 2
       lfs_auto_fetch = True
@@ -254,7 +254,7 @@ describe("verify project/global options merging", () => {
     };
 
     const projectOptionsIni = `
-      [renku "interactive"]
+      [interactive]
       default_url = /tree
       cpu_request = 4
       mem_request = 8G


### PR DESCRIPTION
The UI now supports both the new and the previous environments options section name in the renki.ini file .
This problem should not exist anymore once #1114 will be implemented.

/deploy
fix #1306
