### PR TITLE
feat: add preview for common hidden files

### DIFF
--- a/client/src/file/File.container.js
+++ b/client/src/file/File.container.js
@@ -34,7 +34,8 @@ const CODE_EXTENSIONS = [
   "c", "cc", "cxx", "cpp", "h", "hh", "hxx", "hpp", // C++
   "f", "for", "ftn", "fpp", "f90", "f95", "f03", "f08" // Fortran
 ];
-const TEXT_EXTENSIONS = ["txt", "csv"];
+// eslint-disable-next-line
+const TEXT_EXTENSIONS = ["csv", "dockerignore", "gitattributes", "gitkeep", "gitignore", "renkulfsignore", "txt"];
 
 // FIXME: Unify the file viewing for issues (embedded) and independent file viewing.
 // FIXME: Fix positioning of input tags when rendering Jupyter Notebooks.


### PR DESCRIPTION
_(from offline discusison https://swiss-data-science.slack.com/archives/G67N59QL8/p1615489091082400 )_
Preview the following hidden files: .dockerignore, .gitattributes, .gitkeep, .gitignore, .renkulfsignore

/deploy
