### PR TITLE
build: set autoscaling for uiserver

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -64,7 +64,7 @@ jobs:
         body: |
           You can access the deployment of this PR at https://renku-ci-ui-${{ github.event.number }}.dev.renku.ch
     - name: Build and deploy
-      uses: SwissDataScienceCenter/renku/actions/deploy-renku@master
+      uses: SwissDataScienceCenter/renku/actions/deploy-renku@0000-fix-uiserver
       env:
         RANCHER_PROJECT_ID: ${{ secrets.CI_RANCHER_PROJECT }}
         DOCKER_PASSWORD: ${{ secrets.RENKU_DOCKER_PASSWORD }}

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -81,7 +81,6 @@ jobs:
         RENKU_TESTS_ENABLED: true
         TEST_ARTIFACTS_PATH: "tests-artifacts-${{ github.sha }}"
         renku_ui: "@${{ github.head_ref }}"
-        renku_ui_server: "@${{ github.head_ref }}"
         renku: "${{ needs.check-deploy.outputs.renku }}"
         renku_core: "${{ needs.check-deploy.outputs.renku-core }}"
         renku_gateway: "${{ needs.check-deploy.outputs.renku-gateway }}"

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -81,6 +81,7 @@ jobs:
         RENKU_TESTS_ENABLED: true
         TEST_ARTIFACTS_PATH: "tests-artifacts-${{ github.sha }}"
         renku_ui: "@${{ github.head_ref }}"
+        renku_ui_server: "@${{ github.head_ref }}"
         renku: "${{ needs.check-deploy.outputs.renku }}"
         renku_core: "${{ needs.check-deploy.outputs.renku-core }}"
         renku_gateway: "${{ needs.check-deploy.outputs.renku-gateway }}"

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -64,7 +64,7 @@ jobs:
         body: |
           You can access the deployment of this PR at https://renku-ci-ui-${{ github.event.number }}.dev.renku.ch
     - name: Build and deploy
-      uses: SwissDataScienceCenter/renku/actions/deploy-renku@0000-fix-uiserver
+      uses: SwissDataScienceCenter/renku/actions/deploy-renku@master
       env:
         RANCHER_PROJECT_ID: ${{ secrets.CI_RANCHER_PROJECT }}
         DOCKER_PASSWORD: ${{ secrets.RENKU_DOCKER_PASSWORD }}

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ..
-  Copyright 2017-2020 - Swiss Data Science Center (SDSC)
+  Copyright 2017-2021 - Swiss Data Science Center (SDSC)
   A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
   Eidgenössische Technische Hochschule Zürich (ETHZ).
 

--- a/helm-chart/renku-ui-server/templates/deployment.yaml
+++ b/helm-chart/renku-ui-server/templates/deployment.yaml
@@ -5,7 +5,9 @@ metadata:
   labels:
 {{ include "ui-server.labels" . | indent 4 }}
 spec:
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "ui-server.name" . }}

--- a/helm-chart/renku-ui-server/templates/hpa.yaml
+++ b/helm-chart/renku-ui-server/templates/hpa.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "ui-server.fullname" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "ui-server.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  targetCPUUtilizationPercentage: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/helm-chart/renku-ui-server/templates/hpa.yaml
+++ b/helm-chart/renku-ui-server/templates/hpa.yaml
@@ -16,5 +16,5 @@ spec:
       name: cpu
       target:
         type: Utilization
-        averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        averageUtilization: {{ .Values.autoscaling.cpuUtilization }}
 {{- end }}

--- a/helm-chart/renku-ui-server/templates/hpa.yaml
+++ b/helm-chart/renku-ui-server/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "ui-server.fullname" . }}
@@ -10,5 +10,11 @@ spec:
     name: {{ include "ui-server.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
-  targetCPUUtilizationPercentage: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
 {{- end }}

--- a/helm-chart/renku-ui-server/values.yaml
+++ b/helm-chart/renku-ui-server/values.yaml
@@ -54,7 +54,7 @@ autoscaling:
   enabled: true
   minReplicas: 1
   maxReplicas: 5
-  targetCPUUtilizationPercentage: 80
+  cpuUtilization: 80
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/helm-chart/renku-ui-server/values.yaml
+++ b/helm-chart/renku-ui-server/values.yaml
@@ -58,8 +58,8 @@ autoscaling:
 
 resources:
   limits:
-    cpu: 500m
-    memory: 2Gi
+    cpu: 100m
+    memory: 128Mi
   requests:
     cpu: 100m
     memory: 128Mi

--- a/helm-chart/renku-ui-server/values.yaml
+++ b/helm-chart/renku-ui-server/values.yaml
@@ -51,7 +51,7 @@ ingress:
 
 ## Configure autoscaling
 autoscaling:
-  enabled: false
+  enabled: true
   minReplicas: 1
   maxReplicas: 5
   targetCPUUtilizationPercentage: 50

--- a/helm-chart/renku-ui-server/values.yaml
+++ b/helm-chart/renku-ui-server/values.yaml
@@ -49,6 +49,13 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+## Configure autoscaling
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 50
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/helm-chart/renku-ui-server/values.yaml
+++ b/helm-chart/renku-ui-server/values.yaml
@@ -54,7 +54,7 @@ autoscaling:
   enabled: true
   minReplicas: 1
   maxReplicas: 5
-  targetCPUUtilizationPercentage: 50
+  targetCPUUtilizationPercentage: 80
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/helm-chart/renku-ui-server/values.yaml
+++ b/helm-chart/renku-ui-server/values.yaml
@@ -56,17 +56,13 @@ autoscaling:
   maxReplicas: 5
   cpuUtilization: 80
 
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+resources:
+  limits:
+    cpu: 500m
+    memory: 2Gi
+  requests:
+    cpu: 100m
+    memory: 128Mi
 
 nodeSelector: {}
 


### PR DESCRIPTION
This should set the autoscaling for the UI server component.
Something is probably wrong because I tried to enable the policy and to load the UI server pod CPU to >50%, but it doesn't spawn a second pod. Maybe @ableuler could help?

fix #1092

/deploy