### PR TITLE
ci: increase helm test timeout

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -104,7 +104,7 @@ jobs:
         RENKU_RELEASE: renku-ci-ui-${{ github.event.number }}
       run: |
         echo "$RENKUBOT_KUBECONFIG" > ${{ github.workspace }}/renkubot-kube.config
-        helm test ${RENKU_RELEASE} --namespace ${RENKU_RELEASE} --timeout 40m --logs
+        helm test ${RENKU_RELEASE} --namespace ${RENKU_RELEASE} --timeout 80m --logs
     - name: Download artifact for packaging on failure
       if: failure()
       uses: SwissDataScienceCenter/renku/actions/download-test-artifacts@master


### PR DESCRIPTION
It seems that the CI tests are often failing due to a 40 minutes timeout in the `helm test` command.
We should increase that, as already done in the main renku repository SwissDataScienceCenter/renku#2041

/deploy
