### PR TITLE
feat(design): small fixes for environments inside projects

### DIFF
--- a/client/src/notebooks/Notebooks.present.js
+++ b/client/src/notebooks/Notebooks.present.js
@@ -81,7 +81,8 @@ class Notebooks extends Component {
       <Fragment>
         <Row className="pt-2 pb-3">
           <Col className="d-flex mb-2 justify-content-between">
-            <NotebooksTitle standalone={this.props.standalone} />
+            <NotebooksHeader standalone={this.props.standalone}
+              urlNewEnvironment={this.props.urlNewEnvironment}/>
           </Col>
         </Row>
         <NotebookServers
@@ -107,11 +108,20 @@ class Notebooks extends Component {
   }
 }
 
-class NotebooksTitle extends Component {
+class NotebooksHeader extends Component {
   render() {
     if (this.props.standalone)
       return (<h2>Interactive Environments</h2>);
-    return (<h3>Interactive Environments</h3>);
+
+    return (<Fragment>
+      <h3>Interactive Environments</h3>
+      <div>
+        <Link className="btn btn-sm btn-secondary" role="button" to={this.props.urlNewEnvironment}>
+          <span className="arrow-right pt-2 pb-2">  </span>
+          New Environment
+        </Link>
+      </div>
+    </Fragment>);
   }
 }
 
@@ -127,11 +137,11 @@ class NotebooksPopup extends Component {
       let newOutput = "New";
       if (this.props.urlNewEnvironment) {
         newOutput = (<Link className="btn btn-primary btn-sm" role="button" to={this.props.urlNewEnvironment}>
-          New</Link>);
+          New Environment</Link>);
       }
 
       suggestion = (<span>
-        You can start a new interactive environment by clicking on {newOutput} in the side bar.
+        You can start a new interactive environment by clicking on the {newOutput} button on top.
       </span>);
     }
 
@@ -1442,11 +1452,11 @@ class ServerOptionBoolean extends Component {
     // The double negation solves an annoying problem happening when checked=undefined
     // https://stackoverflow.com/a/39709700/1303090
     const selected = !!this.props.selected;
-    return (
+    return (<div className="form-check form-switch">
       <Input type="switch" id={this.props.id} label={this.props.displayName}
-        checked={selected} onChange={this.props.onChange} />
-      // <CustomInput type="switch" id={this.props.id} label={this.props.displayName}
-      //   checked={selected} onChange={this.props.onChange} />
+        checked={selected} onChange={this.props.onChange} className="form-check-input rounded-pill"/>
+      <Label check htmlFor={this.props.id}>{this.props.displayName}</Label>
+    </div>
     );
   }
 }

--- a/client/src/project/Project.present.js
+++ b/client/src/project/Project.present.js
@@ -880,22 +880,18 @@ class ProjectViewFiles extends Component {
 class ProjectEnvironments extends Component {
   render() {
     return [
-      <Col key="nav" xs={12} md={2}>
-        <Nav pills className="flex-column mb-3">
-          <NavItem>
-            <RenkuNavLink to={this.props.notebookServersUrl} title="Running" />
-          </NavItem>
-          <NavItem>
-            <RenkuNavLink to={this.props.launchNotebookUrl} title="New" />
-          </NavItem>
-        </Nav>
-      </Col>,
-      <Col key="content" xs={12} md={10}>
+      <Col key="content" xs={12}>
         <Switch>
           <Route exact path={this.props.notebookServersUrl}
             render={props => <ProjectNotebookServers {...this.props} />} />
           <Route path={this.props.launchNotebookUrl}
-            render={props => <ProjectStartNotebookServer {...this.props} />} />
+            render={props => [
+              <Col key="btn" md={12}>
+                <GoBackButton key="backToListBtn" label="Back to environments list"
+                  url={this.props.notebookServersUrl}/>
+              </Col>,
+              <ProjectStartNotebookServer key="startNotebookForm" {...this.props} />
+            ]} />
         </Switch>
       </Col>
     ];

--- a/client/src/styles/icons/icons.scss
+++ b/client/src/styles/icons/icons.scss
@@ -4,6 +4,7 @@
   display: inline-flex;
   background-repeat: no-repeat;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8.157' height='12.232' viewBox='0 0 8.157 12.232'%3E%3Cg id='Group_13150' data-name='Group 13150' transform='translate(-1768.922 3036.348)'%3E%3Cg id='Group_13126' data-name='Group 13126' transform='translate(577.519 -2034.265) rotate(-90)'%3E%3Cpath id='Path_285' data-name='Path 285' d='M993.93,1193.442a2.039,2.039,0,1,1-2.039-2.039,2.04,2.04,0,0,1,2.039,2.039' transform='translate(0)' fill='%23fff'/%3E%3Cpath id='Path_286' data-name='Path 286' d='M1007.46,1193.442a2.039,2.039,0,1,1-2.039-2.039,2.04,2.04,0,0,1,2.039,2.039' transform='translate(-5.376)' fill='%23fff'/%3E%3Cpath id='Path_287' data-name='Path 287' d='M1000.695,1200.21a2.039,2.039,0,1,1-2.039-2.039,2.039,2.039,0,0,1,2.039,2.039' transform='translate(-2.688 -2.689)' fill='%23fff'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E%0A");
+  background-position-y: bottom;
 }
 
 .circle {


### PR DESCRIPTION
Deleted side tabs, so now when you enter environments inside projects you see this...
![image](https://user-images.githubusercontent.com/42647877/115252477-cbcff000-a12b-11eb-917f-e1a1f1983ac8.png)


Form switch fix...
![image](https://user-images.githubusercontent.com/42647877/115252444-c377b500-a12b-11eb-8c43-f6863df65c9a.png)


Shall we delete the info message?
Shall we make the width of all forms be 12 (max)?

/deploy