### PR TITLE
fix: prevent ui crashes after project creation

### DIFF
--- a/client/src/project/new/ProjectNew.state.js
+++ b/client/src/project/new/ProjectNew.state.js
@@ -624,6 +624,7 @@ class NewProjectCoordinator {
     if (!creation.createError && !creation.kgError && !creation.projectError) {
       const pristineModel = newProjectSchema.createInitialized();
       modelUpdates.input = pristineModel.input;
+      modelUpdates.automated = pristineModel.automated;
       modelUpdates.meta.validation = pristineModel.meta.validation;
     }
 


### PR DESCRIPTION
This happens sometimes when the project creation process started from a link with embedded metadata.
E.G. https://dev.renku.ch/projects/new?data=eyJ0aXRsZSI6InRlc3QgcHl0aG9uIHRlbXBsYXRlIDAuMTQuMiIsInVybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9Td2lzc0RhdGFTY2llbmNlQ2VudGVyL3Jlbmt1LXByb2plY3QtdGVtcGxhdGUiLCJyZWYiOiJ1cGRhdGUtcmVua3UtdjAuMTQuMiIsInRlbXBsYXRlIjoiQ3VzdG9tL3B5dGhvbi1taW5pbWFsIn0%3D

Compare with https://renku-ci-ui-1325.dev.renku.ch/projects/new?data=eyJ0aXRsZSI6InRlc3QgcHl0aG9uIHRlbXBsYXRlIDAuMTQuMiIsInVybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9Td2lzc0RhdGFTY2llbmNlQ2VudGVyL3Jlbmt1LXByb2plY3QtdGVtcGxhdGUiLCJyZWYiOiJ1cGRhdGUtcmVua3UtdjAuMTQuMiIsInRlbXBsYXRlIjoiQ3VzdG9tL3B5dGhvbi1taW5pbWFsIn0%3D

fix #1324

/deploy #notest