### PR TITLE
feat: add websocket and query to servers API

### DIFF
--- a/helm-chart/renku-ui-server/templates/deployment.yaml
+++ b/helm-chart/renku-ui-server/templates/deployment.yaml
@@ -33,6 +33,11 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+          env:
+            - name: BASE_URL
+              value: {{ .Values.baseUrl | default (printf "%s://%s" (include "ui.protocol" .) .Values.global.renku.domain) | quote }}
+            - name: GATEWAY_URL
+              value: {{ .Values.gatewayUrl | default (printf "%s://%s/api" (include "ui.protocol" .) .Values.global.renku.domain) | quote }}
           livenessProbe:
             httpGet:
               path: /liveness

--- a/server/docker-entrypoint.sh
+++ b/server/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017-2018 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2021 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -185,17 +185,6 @@
         "@types/range-parser": "*"
       }
     },
-    "@types/express-ws": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/express-ws/-/express-ws-3.0.0.tgz",
-      "integrity": "sha512-GxsWec7Vp6h7sJuK0PwnZHeXNZnOwQn8kHAbCfvii66it5jXHTWzSg5cgHVtESwJfBLOe9SJ5wmM7C6gsDoyQw==",
-      "dev": true,
-      "requires": {
-        "@types/express": "*",
-        "@types/express-serve-static-core": "*",
-        "@types/ws": "*"
-      }
-    },
     "@types/json-schema": {
       "version": "7.0.7",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
@@ -221,6 +210,12 @@
       "version": "14.14.41",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.41.tgz",
       "integrity": "sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g==",
+      "dev": true
+    },
+    "@types/object-hash": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/object-hash/-/object-hash-2.1.0.tgz",
+      "integrity": "sha512-RW3VRiuQIMo5PJ4Q1IwBtdLHL/t8ACpzUY40norN9ejE6CUBwKetmSxJnITJ0NlzN/ymF1nvPvlpvegtns7yOg==",
       "dev": true
     },
     "@types/qs": {
@@ -498,10 +493,13 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
       "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
     },
-    "async-limiter": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
+    "axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -1367,24 +1365,6 @@
         "vary": "~1.1.2"
       }
     },
-    "express-ws": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/express-ws/-/express-ws-4.0.0.tgz",
-      "integrity": "sha512-KEyUw8AwRET2iFjFsI1EJQrJ/fHeGiJtgpYgEWG3yDv4l/To/m3a2GaYfeGyB3lsWdvbesjF5XCMx+SVBgAAYw==",
-      "requires": {
-        "ws": "^5.2.0"
-      },
-      "dependencies": {
-        "ws": {
-          "version": "5.2.2",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-          "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
-          "requires": {
-            "async-limiter": "~1.0.0"
-          }
-        }
-      }
-    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1497,6 +1477,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
+    },
+    "follow-redirects": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.0.tgz",
+      "integrity": "sha512-0vRwd7RKQBTt+mgu87mtYeofLFZpTas2S9zY+jIeuLJMNvudIgF52nr19q40HOwH5RrhWIPuj9puybzSJiRrVg=="
     },
     "forwarded": {
       "version": "0.1.2",
@@ -2237,6 +2222,11 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
       "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
       "dev": true
+    },
+    "object-hash": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.1.1.tgz",
+      "integrity": "sha512-VOJmgmS+7wvXf8CjbQmimtCnEx3IAoLxI3fp2fbWehxrWBcAQFbk+vcwb6vzR0VZv/eNCJ/27j151ZTwqW/JeQ=="
     },
     "on-finished": {
       "version": "2.3.0",

--- a/server/package.json
+++ b/server/package.json
@@ -19,8 +19,10 @@
     "dev-debug-brk": "concurrently \"npm:build:dev\" \"npm:start:dev-debug-brk\""
   },
   "dependencies": {
+    "axios": "^0.21.1",
     "express": "^4.17.1",
     "morgan": "^1.10.0",
+    "object-hash": "^2.1.1",
     "winston": "^3.3.3",
     "ws": "^7.4.4"
   },
@@ -28,6 +30,7 @@
     "@types/express": "^4.17.11",
     "@types/morgan": "^1.9.2",
     "@types/node": "^14.14.41",
+    "@types/object-hash": "^2.1.0",
     "@types/ws": "^7.4.1",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",

--- a/server/src/api-client/index.ts
+++ b/server/src/api-client/index.ts
@@ -1,0 +1,138 @@
+/*!
+ * Copyright 2021 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import winston from "winston";
+import hash from "object-hash"; // ? use to compare servers response hashes
+import axios, { Method } from "axios"; // ? https://blog.logrocket.com/axios-or-fetch-api/
+
+
+const FETCH_DEFAULT = {
+  method: "get" as Method,
+  headers: {
+    "Content-Type": "application/json",
+    "Accept": "application/json",
+    "Credentials": "same-origin",
+    "X-Requested-With": "XMLHttpRequest"
+  },
+  reLogin: true,
+  timeout: 60000 // ? in ms. 0 means no timeout
+};
+
+interface ApiClient {
+  logger: winston.Logger,
+  baseUrl: string,
+  gatewayUrl: string,
+}
+
+class ApiClient {
+  constructor(logger: winston.Logger, baseUrl: string, gatewayUrl: string) {
+    this.logger = logger;
+    this.baseUrl = baseUrl;
+    this.gatewayUrl = gatewayUrl;
+  }
+
+  async tryRelogin(headers: Record<string, string>): Promise<void> {
+    // This is invoked to try to refresh authentication.
+    // ? window.location = `${this.baseUrl}/auth/login?redirect_url=${encodeURIComponent(window.location.href)}`;
+    const url = `${this.gatewayUrl}/auth/login?redirect_url=${encodeURIComponent(this.baseUrl)}`;
+    return axios.get(url, { headers, maxRedirects: 100, withCredentials: true, responseType: "text" })
+      .then(result => {
+        this.logger.info(result);
+
+        // ?  USE result.request.res.responseUrl instead of result.request.path
+        // ? REF: https://stackoverflow.com/questions/54384896/handling-redirects-with-axios-in-browser
+        if (result && result.request && result.request.res && result.request.res.responseUrl) {
+          if (result.headers["set-cookie"] && result.headers["set-cookie"].length) {
+            const newUrl = result.request.res.responseUrl;
+            const mappedCookies = result.headers["set-cookie"]
+              .map((cont: string) => cont.substring(0, cont.indexOf(";")));
+            const newCookies = mappedCookies.join(";");
+            // ! This is not needed. Using `withCredentials: true` automatically set the incoming cookies
+            const newHeaders = { cookie: newCookies, accept: "text/html" };
+            return axios.get(newUrl, { headers: newHeaders, maxRedirects: 100, withCredentials: true })
+              .then(result2 => {
+                this.logger.info(result2);
+              })
+              .catch(error => {
+                this.logger.error(error);
+              });
+          }
+        }
+      })
+      .catch(error => {
+        this.logger.error(error);
+      });
+  }
+
+  async clientFetch(
+    url: string,
+    headers: Record<string, string> = null,
+    method: Method = FETCH_DEFAULT.method,
+    queryParams: Record<string, string> = null,
+    data: Record<string, string> = null,
+    reLogin: boolean = FETCH_DEFAULT.reLogin,
+    timeout: number = FETCH_DEFAULT.timeout
+  ): Promise<any> {
+    // Include query params
+    const urlObject = new URL(url);
+    if (queryParams) {
+      for (const param of Object.keys(queryParams))
+        urlObject.searchParams.append(param, queryParams[param]);
+    }
+
+
+    // create query object
+    const headersWithDefault = { ...FETCH_DEFAULT.headers, ...headers };
+    const axiosOptions = { url, headers: headersWithDefault, method, timeout, data };
+
+    return axios.request(axiosOptions)
+      .catch((error) => {
+        // For permission errors we try to re-login
+        if (reLogin && error.isAxiosError && error.response.status === 401)
+          this.tryRelogin(headers);
+          // ! TODO: this should wait for the tryRelogin and, if successful, invoke again the query.
+          // ! Not returning anything here tryiggers an early error and return a wrong response
+        else
+          return Promise.reject(error);
+      })
+      .then(response => {
+        this.logger.info(response.status);
+        // TODO - improve
+        return {
+          data: response.data,
+          pagination: {} //processPaginationHeaders(response.headers)
+        };
+      });
+  }
+
+  // TODO: move this to an extentions. Even better, use the `declare module` on a `d.ts` file.
+  async getNotebookServers(cookies: string = null): Promise<Record<string, Record<string, unknown>>> {
+    const headers = { "cookie": cookies };
+    const url = `${this.gatewayUrl}/notebooks/servers`;
+    return this.clientFetch(url, headers)
+      .then(response => {
+        return response.data.servers;
+      })
+      .catch(error => {
+        return this.logger.error(error);
+      });
+  }
+}
+
+export { ApiClient };
+export default ApiClient;

--- a/server/src/api-client/pagination.ts
+++ b/server/src/api-client/pagination.ts
@@ -1,0 +1,88 @@
+/*!
+ * Copyright 2021 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const PAGINATION_LINK_NAMES = {
+  first: "firstPageLink",
+  last: "lastPageLink",
+  prev: "previousPageLink",
+  next: "nextPageLink"
+};
+
+const NUMERICAL_X_HEADERS = {
+  "X-Next-Page": "nextPage",
+  "X-Page": "currentPage",
+  "X-Per-Page": "perPage",
+  "X-Prev-Page": "previousPage",
+  "X-Total": "totalItems",
+  "X-Total-Pages": "totalPages",
+};
+
+const NUMERICAL_PAGINATION_HEADERS = {
+  "Next-Page": "nextPage",
+  "Page": "currentPage",
+  "Per-Page": "perPage",
+  "Total": "totalItems",
+  "Total-Pages": "totalPages",
+};
+
+// In this function we just parse the pagination related header
+// information. The idea that methods performing the the request to
+// to fetch the next page has been dropped because we prefer to
+// keep the state of the corresponding components serializable.
+// // function processPaginationHeaders(headers: Headers) {
+// //   let paginationDetail = {};
+
+// //   // Parse the link header if it exists
+// //   if (headers.get("Link")) {
+// //     const paginationLinks = processLinkHeader(headers.get("Link"));
+// //     paginationDetail = { ...paginationDetail, ...paginationLinks };
+// //   }
+
+// //   // Parse the pagination related X-... headers
+// //   Object.keys(NUMERICAL_X_HEADERS).forEach((header) => {
+// //     paginationDetail[NUMERICAL_X_HEADERS[header]] =
+// //       parseInt(headers.get(header), 10) || undefined;
+// //   });
+
+// //   // Parse the pagination related headers (non-X)
+// //   if (!headers.get("X-Page")) {
+// //     Object.keys(NUMERICAL_PAGINATION_HEADERS).forEach((header) => {
+// //       paginationDetail[NUMERICAL_PAGINATION_HEADERS[header]] =
+// //         parseInt(headers.get(header), 10) || undefined;
+// //     });
+// //   }
+
+// //   return paginationDetail;
+// // }
+
+// // function processLinkHeader(linkHeader: string) {
+// //   const paginationLinks: Record<string, string | number> = {};
+
+// //   const linksRegex = /<([^>]*?)>;\srel="(.*?)"/g;
+
+// //   let match = linksRegex.exec(linkHeader);
+
+// //   while (match) {
+// //     paginationLinks[PAGINATION_LINK_NAMES[match[2]]] = match[1];
+// //     match = linksRegex.exec(linkHeader);
+// //   }
+
+// //   return paginationLinks;
+// // }
+
+// // export { processPaginationHeaders };

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -20,6 +20,9 @@ import express from "express";
 import logger from "./logger";
 import routes from "./routes";
 import morgan from "morgan";
+import websockets from "./websockets";
+import ApiClient from "./api-client";
+
 
 const app = express();
 const port = 8080; // default port to listen
@@ -32,13 +35,41 @@ const logStream = {
 };
 app.use(morgan("combined", { stream: logStream }));
 
+// create api client
+const apiClient = new ApiClient(logger, process.env.BASE_URL, process.env.GATEWAY_URL);
 
 routes.register(app);
 
 // start the Express server
 const server = app.listen(port, () => {
-  logger.info(`server started at http://localhost:${port}`);
+  logger.info(`Server started at http://localhost:${port}`);
+  logger.info(`Gateway URL: ${process.env.GATEWAY_URL}`);
 });
+
+// setup WebSockets
+websockets.websocketsSetup(server, logger, apiClient);
+
+// JUST A TEST -- TO BE EXPLORED BETTER
+// handle upgrade of the request
+// ? REF: https://dev.to/ksankar/websockets-with-react-express-part-1-4o68
+// wsServer.on("upgrade", function upgrade(request, socket, head) {
+//   try {
+//     // authentication and some other steps will come here
+//     // we can choose whether to upgrade or not
+
+//     wsServer.handleUpgrade(request, socket, head, function done(ws) {
+//       wsServer.emit("connection", ws, request);
+//     });
+//   } catch (err) {
+//     console.log("upgrade exception", err);
+//     socket.write("HTTP/1.1 401 Unauthorized\r\n\r\n");
+//     socket.destroy();
+//     return;
+//   }
+// });
+
+// ? REF: https://masteringjs.io/tutorials/express/websockets
+// ? REF: https://stackoverflow.com/questions/63099518/sending-a-websocket-message-from-a-post-request-handler-in-express
 
 process.on("SIGTERM", () => {
   server.close(() => {

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2020 - Swiss Data Science Center (SDSC)
+ * Copyright 2021 - Swiss Data Science Center (SDSC)
  * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
  * Eidgenössische Technische Hochschule Zürich (ETHZ).
  *

--- a/server/src/websockets/index.ts
+++ b/server/src/websockets/index.ts
@@ -1,0 +1,100 @@
+/*!
+ * Copyright 2021 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import winston from "winston";
+import http from "http";
+import ws from "ws";
+import hash from "object-hash";
+import ApiClient from "../api-client";
+
+
+function websocketsSetup(server: http.Server, logger: winston.Logger, client: ApiClient): void {
+  const wss = new ws.Server({ server });
+  // ? REF: https://github.com/websockets/ws/blob/master/doc/ws.md
+
+  // Emitted when the handshake is complete.
+  wss.on("connection", function connection(socket, request) {
+    const cookies = request.headers.cookie ?
+      request.headers.cookie :
+      "";
+
+    const monitor = {
+      sessions: {
+        enabled: true,
+        previous: null as string
+      }
+    };
+
+    // Resource monitor
+    // ? TMP DISABLED
+    // // const interval = setInterval(() => {
+    // //   const mex = cookies && cookies.length ?
+    // //     cookies.substring(0, 30) :
+    // //     "anonym";
+    // //   logger.info("test, " + mex);
+
+    // //   // business logic
+
+    // //   // sessions
+    // //   if (monitor.sessions.enabled) {
+    // //     try {
+    // //       const url = `${process.env.GATEWAY_URL}/notebooks/servers`;
+    // //       // TODO: use got? https://www.npmjs.com/package/got
+    // //       // ? check HERE for reference, but fetch may be good enough
+    // //       // ? https://nodesource.com/blog/express-going-into-maintenance-mode
+    // //       // ! TODO: from here
+    // //       const serverPromise = fetch(url);
+    // //       serverPromise.then(servers => {
+    // //         const hashed = hash(servers);
+    // //         if (monitor.sessions.previous !== null) {
+    // //           if (hashed !== monitor.sessions.previous)
+    // //             socket.send("{sessions: changed}");
+    // //         }
+    // //         monitor.sessions.previous = hashed;
+    // //       });
+    // //     }
+    // //     catch (e) {
+    // //       logger.info("Error! " + JSON.stringify(e));
+    // //     }
+    // //   }
+
+    // // }, 3000);
+
+    // // socket.on("close", (code, reason) => {
+    // //   clearInterval(interval);
+    // //   logger.info(`CLOSED with number ${code} for the following reason: ${reason}`);
+    // // });
+
+    socket.send("Connection enstablished");
+    socket.on("message", async (message) => {
+      logger.info(`Message received: ${message}`);
+      socket.send(`Received: ${message}`);
+      if (message === "servers") {
+        socket.send(`COMMAND: checking servers`);
+        // send back response
+        const servers = await client.getNotebookServers(cookies);
+        const length = Object.keys(servers) && Object.keys(servers).length ?
+          Object.keys(servers).length :
+          0;
+        socket.send(`COMMAND: found ${length} servers`);
+      }
+    });
+  });
+}
+
+export default { websocketsSetup };


### PR DESCRIPTION
This is a demonstration of how to set up a WebSocket channel using the `ws` package, and how to query other renku APIs with the `axios` library.

*How to test*: You need to create a user and login into the test deployment. From that page, open the developer console and create a WebSocket object:

```
webSocket = new WebSocket("wss://renku-ci-ui-1331.dev.renku.ch/ui-server");
webSocket.onmessage = function (event) {
    console.log('Message from server ', event.data);
};
```

You can now send messages using `webSocket.send()`.
```
webSocket.send("test"); // get the message back -- work with any other text
webSocket.send("servers"); // get the number of running interactive environments
```

/deploy
re #1264