### PR TITLE
refactor: update property on datasets kg query

### DIFF
--- a/client/src/api-client/test-client.js
+++ b/client/src/api-client/test-client.js
@@ -155,7 +155,7 @@ const methods = {
     ],
     "url": "https://dev.renku.ch/datasets/79215657-4319-4fcf-82b9-58267f2a1db8",
     "sameAs": "https://dev.renku.ch/datasets/79215657-4319-4fcf-82b9-58267f2a1db8",
-    "isPartOf": []
+    "usedIn": []
   }
 };
 

--- a/client/src/dataset/Dataset.present.js
+++ b/client/src/dataset/Dataset.present.js
@@ -323,7 +323,7 @@ export default function DatasetView(props) {
     />
     <br />
     <DisplayProjects
-      projects={dataset.isPartOf}
+      projects={dataset.usedIn}
       projectsUrl={props.projectsUrl}
     />
     {

--- a/client/src/dataset/DatasetFunctions.js
+++ b/client/src/dataset/DatasetFunctions.js
@@ -24,7 +24,7 @@ function mapDataset(dataset_core, dataset_kg, core_files) {
     if (dataset_kg) {
       dataset.url = dataset_kg.url;
       dataset.sameAs = dataset_kg.sameAs;
-      dataset.isPartOf = dataset_kg.isPartOf;
+      dataset.usedIn = dataset_kg.usedIn;
       dataset.insideKg = true;
       dataset.published.datePublished = dataset_kg.published && dataset_kg.published.datePublished ?
         dataset_kg.published.datePublished : undefined;

--- a/client/src/dataset/Datasets.test.js
+++ b/client/src/dataset/Datasets.test.js
@@ -115,7 +115,7 @@ describe("Dataset functions", () => {
     ],
     "url": "https://dev.renku.ch/datasets/79215657-4319-4fcf-82b9-58267f2a1db8",
     "sameAs": "https://dev.renku.ch/datasets/79215657-4319-4fcf-82b9-58267f2a1db8",
-    "isPartOf": []
+    "usedIn": []
   };
 
   const result_dataset_in_kg = {


### PR DESCRIPTION
Replace the `isPartOf` property with `usedIn` on the query `GET /knowledge-graph/datasets/:id` as request from the KG team.

/deploy
fix #1275