### PR TITLE
feat: show environments in iframe

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.action != 'closed'
     steps:
-    - uses: rokroskar/workflow-run-cleanup-action@v0.3.0
+    - uses: rokroskar/workflow-run-cleanup-action@v0.3.3
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/test-and-ci.yml
+++ b/.github/workflows/test-and-ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     if: "!startsWith(github.ref, 'refs/tags/')"
     steps:
-    - uses: rokroskar/workflow-run-cleanup-action@v0.3.0
+    - uses: rokroskar/workflow-run-cleanup-action@v0.3.3
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -180,6 +180,7 @@
           "grayscale",
           "hljs",
           "href",
+          "iframe",
           "iids",
           "interruptable",
           "ipynb",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2377,15 +2377,6 @@
         "@hapi/hoek": "^8.3.0"
       }
     },
-    "@hypnosphi/create-react-context": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@hypnosphi/create-react-context/-/create-react-context-0.3.1.tgz",
-      "integrity": "sha512-V1klUed202XahrWJLLOT3EXNeCpFHCcJntdFGI15ntCwau+jfT386w7OFTMaCqOgXUH1fa0w/I1oZs+i/Rfr0A==",
-      "requires": {
-        "gud": "^1.0.0",
-        "warning": "^4.0.3"
-      }
-    },
     "@jest/console": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
@@ -7455,6 +7446,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
       "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+      "dev": true,
       "requires": {
         "is-arguments": "^1.0.4",
         "is-date-object": "^1.0.1",
@@ -11521,7 +11513,8 @@
     "is-arguments": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
-      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
+      "dev": true
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -14461,12 +14454,14 @@
     "object-inspect": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+      "dev": true
     },
     "object-is": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
       "integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
@@ -14476,6 +14471,7 @@
           "version": "1.17.6",
           "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
           "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
@@ -14494,6 +14490,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
           "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+          "dev": true,
           "requires": {
             "is-callable": "^1.1.4",
             "is-date-object": "^1.0.1",
@@ -14503,17 +14500,20 @@
         "has-symbols": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+          "dev": true
         },
         "is-callable": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw=="
+          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
+          "dev": true
         },
         "is-regex": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
           "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
+          "dev": true,
           "requires": {
             "has-symbols": "^1.0.1"
           }
@@ -17687,6 +17687,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
       "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1"
@@ -17696,6 +17697,7 @@
           "version": "1.17.4",
           "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
           "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
+          "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
@@ -17714,6 +17716,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
           "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+          "dev": true,
           "requires": {
             "is-callable": "^1.1.4",
             "is-date-object": "^1.0.1",
@@ -17723,17 +17726,20 @@
         "has-symbols": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+          "dev": true
         },
         "is-callable": {
           "version": "1.1.5",
           "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
+          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+          "dev": true
         },
         "is-regex": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
           "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+          "dev": true,
           "requires": {
             "has": "^1.0.3"
           }
@@ -17741,12 +17747,14 @@
         "object-inspect": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-          "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
+          "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+          "dev": true
         },
         "string.prototype.trimleft": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
           "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+          "dev": true,
           "requires": {
             "define-properties": "^1.1.3",
             "function-bind": "^1.1.1"
@@ -17756,6 +17764,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
           "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+          "dev": true,
           "requires": {
             "define-properties": "^1.1.3",
             "function-bind": "^1.1.1"
@@ -19718,6 +19727,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
       "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
@@ -19727,6 +19737,7 @@
           "version": "1.17.6",
           "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
           "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
@@ -19745,6 +19756,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
           "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+          "dev": true,
           "requires": {
             "is-callable": "^1.1.4",
             "is-date-object": "^1.0.1",
@@ -19754,17 +19766,20 @@
         "has-symbols": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+          "dev": true
         },
         "is-callable": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw=="
+          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
+          "dev": true
         },
         "is-regex": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
           "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
+          "dev": true,
           "requires": {
             "has-symbols": "^1.0.1"
           }
@@ -19795,6 +19810,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
       "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
@@ -19804,6 +19820,7 @@
           "version": "1.17.6",
           "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
           "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
@@ -19822,6 +19839,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
           "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+          "dev": true,
           "requires": {
             "is-callable": "^1.1.4",
             "is-date-object": "^1.0.1",
@@ -19831,17 +19849,20 @@
         "has-symbols": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+          "dev": true
         },
         "is-callable": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw=="
+          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
+          "dev": true
         },
         "is-regex": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
           "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
+          "dev": true,
           "requires": {
             "has-symbols": "^1.0.1"
           }

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -230,3 +230,8 @@ body {
 .fake-toggle:checked ~ .hide-show-me {
   display: block;
 }
+
+iframe.invisible {
+  height: 0;
+  width: 0;
+}

--- a/client/src/notebooks/Notebooks.container.js
+++ b/client/src/notebooks/Notebooks.container.js
@@ -21,10 +21,107 @@ import { connect } from "react-redux";
 
 import { NotebooksCoordinator } from "./Notebooks.state";
 import {
-  StartNotebookServer as StartNotebookServerPresent, NotebooksDisabled, Notebooks as NotebooksPresent, CheckNotebookIcon
+  StartNotebookServer as StartNotebookServerPresent, NotebooksDisabled, Notebooks as NotebooksPresent,
+  CheckNotebookIcon, ShowSession as ShowSessionPresent
 } from "./Notebooks.present";
 import { StatusHelper } from "../model/Model";
 import { ProjectCoordinator } from "../project";
+
+
+/**
+ * This component is needed to map properties from the redux store and keep local states cleared by the
+ * mapping function. We can remove it when we switch to the useSelector hook
+
+ * @param {Object} client - api-client used to query the gateway
+ * @param {Object} model - global model for the ui
+ * @param {boolean} blockAnonymous - When true, block non logged in users
+ * @param {Object} scope - object containing filtering parameters
+ * @param {string} scope.namespace - full path of the reference namespace
+ * @param {string} scope.project - path of the reference project
+ * @param {Object} [location] - react location object
+ */
+class ShowSession extends Component {
+  constructor(props) {
+    super(props);
+    this.model = props.model.subModel("notebooks");
+    this.userModel = props.model.subModel("user");
+    this.coordinator = new NotebooksCoordinator(props.client, this.model, this.userModel);
+    this.coordinator.reset();
+    this.target = props.match.params.server;
+
+    if (props.scope)
+      this.coordinator.setNotebookFilters(props.scope, true);
+
+    this.handlers = {
+      stopNotebook: this.stopNotebook.bind(this),
+      fetchLogs: this.fetchLogs.bind(this),
+    };
+  }
+
+  componentDidMount() {
+    if (!this.props.blockAnonymous)
+      this.coordinator.startNotebookPolling();
+  }
+
+  componentWillUnmount() {
+    this.coordinator.stopNotebookPolling();
+  }
+
+  stopNotebook(serverName, force) {
+    this.coordinator.stopNotebook(serverName, force);
+  }
+
+  async fetchLogs(serverName, full = false) {
+    if (!serverName)
+      return;
+    return this.coordinator.fetchLogs(serverName, full);
+  }
+
+  mapStateToProps(state, ownProps) {
+    const notebooks = state.notebooks.notebooks;
+    const available = notebooks.all[this.target] ?
+      true :
+      false;
+    const notebook = {
+      available,
+      fetched: notebooks.fetched,
+      fetching: notebooks.fetching,
+      data: available ?
+        notebooks.all[this.target] :
+        {},
+      logs: state.notebooks.logs
+    };
+    return {
+      handlers: this.handlers,
+      target: this.target,
+      filters: state.notebooks.filters,
+      notebook
+    };
+  }
+
+
+  render() {
+    if (this.props.blockAnonymous)
+      return <NotebooksDisabled location={this.props.location} />;
+
+    const ShowSessionMapped = connect(this.mapStateToProps.bind(this))(ShowSessionPresent);
+    return (
+      <ShowSessionMapped
+        store={this.model.reduxStore}
+      />
+    );
+  }
+}
+
+//* /environments/session/<id>
+/**
+ * Display the notebook in an embedded iframe
+ *
+ * @param {props.}
+ */
+// function ShowSession(props) {
+//   return null;
+// }
 
 /**
  * Display the list of Notebook servers
@@ -63,6 +160,7 @@ class Notebooks extends Component {
       stopNotebook: this.stopNotebook.bind(this),
       fetchLogs: this.fetchLogs.bind(this),
       toggleLogs: this.toggleLogs.bind(this),
+      // ! TODO: something is not working as expected here
       fetchCommit: this.fetchCommit.bind(this)
     };
   }
@@ -502,4 +600,4 @@ class CheckNotebookStatus extends Component {
   }
 }
 
-export { Notebooks, StartNotebookServer, CheckNotebookStatus };
+export { CheckNotebookStatus, Notebooks, ShowSession, StartNotebookServer };

--- a/client/src/notebooks/Notebooks.container.js
+++ b/client/src/notebooks/Notebooks.container.js
@@ -113,16 +113,6 @@ class ShowSession extends Component {
   }
 }
 
-//* /environments/session/<id>
-/**
- * Display the notebook in an embedded iframe
- *
- * @param {props.}
- */
-// function ShowSession(props) {
-//   return null;
-// }
-
 /**
  * Display the list of Notebook servers
  *

--- a/client/src/notebooks/Notebooks.container.js
+++ b/client/src/notebooks/Notebooks.container.js
@@ -150,7 +150,6 @@ class Notebooks extends Component {
       stopNotebook: this.stopNotebook.bind(this),
       fetchLogs: this.fetchLogs.bind(this),
       toggleLogs: this.toggleLogs.bind(this),
-      // ! TODO: something is not working as expected here
       fetchCommit: this.fetchCommit.bind(this)
     };
   }

--- a/client/src/notebooks/Notebooks.css
+++ b/client/src/notebooks/Notebooks.css
@@ -43,3 +43,14 @@
 .modal-body wrap-word {
   white-space: pre-line;
 }
+
+/* sessions page borders */
+
+.sessions-iframe-border {
+  border-width: 1px 0 0 0 !important;
+}
+@media (min-width: 992px) { 
+  .sessions-iframe-border {
+    border-width: 1px 0 0 1px !important;
+  }
+}

--- a/client/src/notebooks/Notebooks.present.js
+++ b/client/src/notebooks/Notebooks.present.js
@@ -34,7 +34,7 @@ import { StatusHelper } from "../model/Model";
 import { NotebooksHelper } from "./index";
 import { formatBytes, simpleHash } from "../utils/HelperFunctions";
 import {
-  ButtonWithMenu, Clipboard, ExternalIconLink, ExternalLink, InfoAlert, JupyterIcon, Loader,
+  ButtonWithMenu, Clipboard, ExternalLink, InfoAlert, JupyterIcon, Loader,
   ThrottledTooltip, TimeCaption, WarnAlert
 } from "../utils/UIComponents";
 import Time from "../utils/Time";
@@ -539,8 +539,9 @@ class NotebookServerRowCommitInfo extends Component {
   }
 
   render() {
-    const { commit, url } = this.props;
+    const { commit } = this.props;
     const uid = `${this.props.uid}-commit`;
+
     let content;
     if (!commit || !commit.data || !commit.data.id || (!commit.fetching && !commit.fetched)) {
       content = (<span>Data not available.</span>);
@@ -551,15 +552,17 @@ class NotebookServerRowCommitInfo extends Component {
     else {
       content = (
         <Fragment>
-          <span className="font-weight-bold">Author:</span> <span>{commit.data.author_name}</span><br />
+          <span className="fw-bold">Author:</span> <span>{commit.data.author_name}</span><br />
           <span>
-            <span className="font-weight-bold">Date:</span>
+            <span className="fw-bold">Date:</span>
             {" "}<span>{Time.toIsoTimezoneString(commit.data.committed_date, "datetime-short")}</span>
             {" "}<TimeCaption caption="~" endPunctuation=" " time={commit.data.committed_date} />
             <br />
           </span>
-          <span className="font-weight-bold">Message:</span> <span>{commit.data.message}</span><br />
-          <span className="font-weight-bold">Full SHA:</span> <span>{commit.data.id}</span><br />
+          <span className="fw-bold">Message:</span> <span>{commit.data.message}</span><br />
+          <span className="fw-bold">Full SHA:</span> <span>{commit.data.id}</span><br />
+          <span className="fw-bold">Details:</span>
+          <ExternalLink url={commit.data.web_url} title="Open commit in GitLab" role="text" showLinkIcon={true} />
         </Fragment>
       );
     }
@@ -570,12 +573,7 @@ class NotebookServerRowCommitInfo extends Component {
         <UncontrolledPopover target={uid} trigger="legacy" placement="bottom"
           isOpen={this.state.isOpen} toggle={() => this.toggle()}>
           <PopoverHeader>Commit details</PopoverHeader>
-          <PopoverBody>
-            {content}<br/>
-            <div className="pt-2">
-              Commit in GitLab <ExternalIconLink url={url} icon={faExternalLinkAlt} className="text-dark"/>
-            </div>
-          </PopoverBody>
+          <PopoverBody>{content}</PopoverBody>
         </UncontrolledPopover>
       </span>
     );

--- a/client/src/notebooks/Notebooks.present.js
+++ b/client/src/notebooks/Notebooks.present.js
@@ -62,6 +62,18 @@ const formatResources = function (resources) {
   return resources;
 };
 
+/** Helper function for formatting the resource list */
+
+function formattedResourceList(resources) {
+  const resourcesKeys = Object.keys(resources);
+  const resourceList = resourcesKeys.map((name, index) => {
+    return (<span key={name} className="text-nowrap">
+      <span className="fw-bold">{resources[name]} </span>
+      {name}{resourcesKeys.length - 1 === index ? " " : " | " }</span>);
+  });
+  return resourceList;
+}
+
 // * Jupyter Session code * //
 function ShowSession(props) {
   const { handlers, notebook } = props;
@@ -113,12 +125,7 @@ function SessionInformation(props) {
     branch: `${annotations["repository"]}/tree/${annotations["branch"]}`,
     commit: `${annotations["repository"]}/tree/${annotations["commit-sha"]}`
   };
-  const resourceList = Object.keys(resources).map((name, num) =>
-    (<span key={name}>
-      {name}: {resources[name]}
-      {num < Object.keys(resources).length - 1 ? ", " : ""}
-    </span>)
-  );
+  const resourceList = formattedResourceList(resources);
 
   return (
     <div className="d-flex flex-wrap">
@@ -609,12 +616,7 @@ class NotebookServerRowFull extends Component {
       </Fragment>
     );
 
-    const resourcesKeys = Object.keys(resources);
-    const resourceList = resourcesKeys.map((name, index) => {
-      return (<span key={name} className="text-nowrap">
-        <span className="fw-bold">{resources[name]} </span>
-        {name}{resourcesKeys.length - 1 === index ? " " : " | " }</span>);
-    });
+    const resourceList = formattedResourceList(resources);
 
     const statusOut = <NotebooksServerRowStatus
       details={details} status={status} uid={uid} startTime={this.props.startTime} annotations={annotations}/>;
@@ -703,12 +705,7 @@ class NotebookServerRowCompact extends Component {
       {" "}<NotebookServerRowCommitInfo uid={uid} name={name} commit={commitDetails} fetchCommit={fetchCommit}/>
       <br />
     </Fragment>);
-    const resourceList = Object.keys(resources).map((name, num) =>
-      (<span key={name} className="text-nowrap">
-        {name}: <span className="fw-bold">{resources[name]}</span>
-        {num < Object.keys(resources).length - 1 ? ", " : ""}
-      </span>)
-    );
+    const resourceList = formattedResourceList(resources);
     const resourceObject = (<Fragment>
       <span className="fw-bold">Resources: </span>
       <span>{resourceList}</span>

--- a/client/src/notebooks/Notebooks.present.js
+++ b/client/src/notebooks/Notebooks.present.js
@@ -882,7 +882,7 @@ class NotebookServerRowAction extends Component {
     }
 
     return (
-      <ButtonWithMenu size="sm" default={defaultAction} color="secondary">
+      <ButtonWithMenu className="sessionsButton" size="sm" default={defaultAction} color="secondary">
         {actions.openExternal}
         {actions.stop}
         {actions.logs}

--- a/client/src/notebooks/Notebooks.present.js
+++ b/client/src/notebooks/Notebooks.present.js
@@ -228,6 +228,8 @@ function SessionLogs(props) {
     }
   }
 
+  // ? Having a minHeight prevent losing the vertical scroll position.
+  // TODO: Revisit after #1219
   return (
     <Fragment>
       <div className="p-2 p-lg-3 text-nowrap">
@@ -236,7 +238,7 @@ function SessionLogs(props) {
           <FontAwesomeIcon icon={faSyncAlt} /> Refresh logs
         </Button>
       </div>
-      <div className="p-2 p-lg-3 border-top">
+      <div className="p-2 p-lg-3 border-top" style={{ minHeight: 800 }}>
         {body}
       </div>
     </Fragment>
@@ -274,7 +276,7 @@ function SessionJupyter(props) {
     const status = NotebooksHelper.getStatus(notebook.data.status);
     if (status === "running") {
       const localClass = invisible ?
-        "invisible" :
+        "invisible position-absolute" : // ? position-absolute prevent showing extra margins
         "";
       content = (
         <iframe id="session-iframe" title="session iframe" src={notebook.data.url} className={localClass}

--- a/client/src/notebooks/Notebooks.present.js
+++ b/client/src/notebooks/Notebooks.present.js
@@ -123,25 +123,25 @@ function SessionInformation(props) {
   return (
     <div className="d-flex flex-wrap">
       <div className="p-2 p-lg-3 text-nowrap">
-        <span className="fw-bold text-rk-text">Branch: </span>
+        <span className="fw-bold">Branch: </span>
         <ExternalLink url={repositoryLinks.branch} title={annotations["branch"]} role="text"
-          showLinkIcon={true} iconAfter={true} />
+          showLinkIcon={true} />
       </div>
       <div className="p-2 p-lg-3 text-nowrap">
-        <span className="fw-bold text-rk-text">Commit: </span>
+        <span className="fw-bold">Commit: </span>
         <ExternalLink url={repositoryLinks.commit} title={annotations["commit-sha"].substring(0, 8)}
-          role="text" showLinkIcon={true} iconAfter={true} />
+          role="text" showLinkIcon={true} />
       </div>
       <div className="p-2 p-lg-3 text-nowrap">
-        <span className="fw-bold text-rk-text">Running since: </span>
-        <TimeCaption noCaption={true} endPunctuation=" " time={notebook.data.started} />
-      </div>
-      <div className="p-2 p-lg-3 text-nowrap">
-        <span className="fw-bold text-rk-text">Resources: </span>
+        <span className="fw-bold">Resources: </span>
         <span>{resourceList}</span>
       </div>
       <div className="p-2 p-lg-3 text-nowrap">
-        <ExternalLink url={url} title="Open in new tab" role="text" showLinkIcon={true} iconAfter={true} />
+        <span className="fw-bold">Running since: </span>
+        <TimeCaption noCaption={true} endPunctuation=" " time={notebook.data.started} />
+      </div>
+      <div className="p-2 p-lg-3 text-nowrap">
+        <ExternalLink url={url} title="Open in new tab" role="text" showLinkIcon={true} />
       </div>
     </div>
   );
@@ -599,22 +599,21 @@ class NotebookServerRowFull extends Component {
       (<NotebookServerRowProject annotations={annotations} />) :
       null;
 
-    const branch = <span>
-      {annotations["branch"]}&nbsp;
-      <ExternalIconLink url={repositoryLinks.branch} icon={faExternalLinkAlt} className="text-dark"/>
-    </span>;
+    const branch = (
+      <ExternalLink url={repositoryLinks.branch} title={annotations["branch"]} role="text" showLinkIcon={true} />
+    );
 
-    const commit = (<span>
-      {annotations["commit-sha"].substring(0, 8)}
-      {" "}<span className="text-dark">
-        <NotebookServerRowCommitInfo uid={uid} name={name} commit={commitDetails}
-          fetchCommit={fetchCommit} url={repositoryLinks.commit}/>
-      </span></span>);
+    const commit = (
+      <Fragment>
+        <ExternalLink url={repositoryLinks.commit}
+          title={annotations["commit-sha"].substring(0, 8)} role="text" showLinkIcon={true} />
+        {" "}<NotebookServerRowCommitInfo uid={uid} name={name} commit={commitDetails} fetchCommit={fetchCommit} />
+      </Fragment>
+    );
 
     const resourcesKeys = Object.keys(resources);
-
     const resourceList = resourcesKeys.map((name, index) => {
-      return (<span key={name} className="text-nowrap text-center fw-normal">
+      return (<span key={name} className="text-nowrap">
         <span className="fw-bold">{resources[name]} </span>
         {name}{resourcesKeys.length - 1 === index ? " " : " | " }</span>);
     });
@@ -650,34 +649,22 @@ class NotebookServerRowFull extends Component {
           <table>
             <tbody className="gx-4 text-rk-text">
               <tr>
-                <td className="text-dark fw-bold">
-                  Branch
-                </td>
-                <td>
-                  {branch}
-                </td>
+                <td className="text-dark fw-bold">Branch</td>
+                <td className="text-dark">{branch}</td>
               </tr>
               <tr>
-                <td className="text-dark fw-bold">
-                  Commit
-                </td>
-                <td>
-                  {commit}
-                </td>
+                <td className="text-dark fw-bold">Commit</td>
+                <td className="text-dark">{commit}</td>
               </tr>
               <tr>
-                <td className="pe-3 text-dark fw-bold">
-                  Resources
-                </td>
-                <td>
-                  {resourceList}
-                </td>
+                <td className="pe-3 text-dark fw-bold">Resources</td>
+                <td className="text-dark">{resourceList}</td>
+              </tr>
+              <tr>
+                <td colSpan="2">{statusOut}</td>
               </tr>
             </tbody>
           </table>
-          <div className="mt-auto">
-            {statusOut}
-          </div>
         </Col>
         <Col className="d-flex align-items-end flex-column flex-shrink-0">
           {action}
@@ -690,7 +677,8 @@ class NotebookServerRowFull extends Component {
 class NotebookServerRowCompact extends Component {
   render() {
     const {
-      annotations, details, status, url, uid, resources, repositoryLinks, name, commitDetails, fetchCommit, image
+      annotations, commitDetails, details, fetchCommit, image, localUrl, logs, name, repositoryLinks,
+      resources, standalone, startTime, status, uid, url
     } = this.props;
 
     const icon = <span>
@@ -698,32 +686,33 @@ class NotebookServerRowCompact extends Component {
         details={details} status={status} uid={uid} image={image} annotations={annotations}
       />
     </span>;
-    const project = this.props.standalone ?
+    const project = standalone ?
       (<Fragment>
-        <span className="fw-bold text-rk-text">Project: </span>
-        <span><NotebookServerRowProject annotations={this.props.annotations} /></span>
+        <span className="fw-bold">Project: </span>
+        <span><NotebookServerRowProject annotations={annotations} /></span>
         <br />
       </Fragment>) :
       null;
     const branch = (<Fragment>
-      <span className="fw-bold text-rk-text">Branch: </span>
-      <ExternalLink url={repositoryLinks.branch} title={annotations["branch"]} role="text" />
+      <span className="fw-bold">Branch: </span>
+      <ExternalLink url={repositoryLinks.branch} title={annotations["branch"]} role="text" showLinkIcon={true} />
       <br />
     </Fragment>);
     const commit = (<Fragment>
-      <span className="fw-bold text-rk-text">Commit: </span>
-      <ExternalLink url={repositoryLinks.commit} title={annotations["commit-sha"].substring(0, 8)} role="text" />
+      <span className="fw-bold">Commit: </span>
+      <ExternalLink url={repositoryLinks.commit}
+        title={annotations["commit-sha"].substring(0, 8)} role="text" showLinkIcon={true} />
       {" "}<NotebookServerRowCommitInfo uid={uid} name={name} commit={commitDetails} fetchCommit={fetchCommit}/>
       <br />
     </Fragment>);
     const resourceList = Object.keys(resources).map((name, num) =>
-      (<span key={name} className="text-nowrap text-rk-text">
-        {name}: {resources[name]}
+      (<span key={name} className="text-nowrap">
+        {name}: <span className="fw-bold">{resources[name]}</span>
         {num < Object.keys(resources).length - 1 ? ", " : ""}
       </span>)
     );
     const resourceObject = (<Fragment>
-      <span className="font-weight-bold text-rk-text">Resources: </span>
+      <span className="fw-bold">Resources: </span>
       <span>{resourceList}</span>
       <br />
     </Fragment>);
@@ -733,13 +722,14 @@ class NotebookServerRowCompact extends Component {
         details={details}
         status={status}
         uid={uid}
-        startTime={this.props.startTime}
+        startTime={startTime}
         annotations={annotations}
       />
     </span>);
     const action = (<span>
       <NotebookServerRowAction
-        name={this.props.name}
+        localUrl={localUrl}
+        name={name}
         status={status}
         stopNotebook={this.props.stopNotebook}
         toggleLogs={this.props.toggleLogs}
@@ -748,14 +738,14 @@ class NotebookServerRowCompact extends Component {
       <EnvironmentLogs
         fetchLogs={this.props.fetchLogs}
         toggleLogs={this.props.toggleLogs}
-        logs={this.props.logs}
-        name={this.props.name}
+        logs={logs}
+        name={name}
         annotations={annotations}
       />
     </span>);
 
     return (
-      <div className="rk-search-result-compact">
+      <div className="rk-search-result-compact cursor-auto">
         {project}
         {branch}
         {commit}
@@ -881,7 +871,7 @@ class NotebookServerRowAction extends Component {
     </DropdownItem>);
 
     if (status === "running") {
-      defaultAction = (<Link className="btn btn-secondary" to={this.props.localUrl}>Open</Link>);
+      defaultAction = (<Link className="btn btn-secondary text-white" to={this.props.localUrl}>Open</Link>);
       actions.openExternal = (<DropdownItem href={this.props.url} target="_blank" >
         <FontAwesomeIcon icon={faExternalLinkAlt} /> Open in new tab
       </DropdownItem>);

--- a/client/src/notebooks/Notebooks.state.js
+++ b/client/src/notebooks/Notebooks.state.js
@@ -45,13 +45,15 @@ const VALID_SETTINGS = [
 const ExpectedAnnotations = {
   domain: "renku.io",
   "renku.io": {
-    required: ["branch", "commit-sha", "default_image_used", "namespace", "projectId", "projectName", "repository"],
+    required: [
+      "branch", "commit-sha", "default_image_used", "namespace", "gitlabProjectId", "projectName", "repository"
+    ],
     default: {
       "branch": "unknown",
       "commit-sha": "00000000",
       "default_image_used": false,
       "namespace": "unknown",
-      "projectId": 0,
+      "gitlabProjectId": 0,
       "projectName": "unknown",
       "repository": "https://none"
     }
@@ -488,10 +490,10 @@ class NotebooksCoordinator {
     if (!target || !target.annotations)
       return;
     const annotations = NotebooksHelper.cleanAnnotations(target.annotations);
-    if (!annotations || !annotations["commit-sha"] || !annotations["projectId"])
+    if (!annotations || !annotations["commit-sha"] || !annotations["gitlabProjectId"])
       return;
     const commitSha = annotations["commit-sha"];
-    const projectId = annotations["projectId"];
+    const gitlabProjectId = annotations["gitlabProjectId"];
 
     // verify if the commit data are already cached
     const oldCommits = this.model.get("data.commits");
@@ -506,7 +508,7 @@ class NotebooksCoordinator {
 
     let fetched = null;
     try {
-      commitData = await this.client.getRepositoryCommit(projectId, commitSha);
+      commitData = await this.client.getRepositoryCommit(gitlabProjectId, commitSha);
       fetched = new Date();
     }
     catch (error) {

--- a/client/src/notebooks/Notebooks.test.js
+++ b/client/src/notebooks/Notebooks.test.js
@@ -27,7 +27,9 @@ import ReactDOM from "react-dom";
 import { act } from "react-dom/test-utils";
 import { MemoryRouter } from "react-router-dom";
 
-import { NotebooksHelper, Notebooks, StartNotebookServer, CheckNotebookStatus, NotebooksDisabled } from "./index";
+import {
+  CheckNotebookStatus, Notebooks, NotebooksDisabled, NotebooksHelper, ShowSession, StartNotebookServer
+} from "./index";
 import { mergeEnumOptions } from "./Notebooks.present";
 import { ExpectedAnnotations } from "./Notebooks.state";
 import { StateModel, globalSchema } from "../model";
@@ -290,6 +292,23 @@ describe("rendering", () => {
       <MemoryRouter>
         <NotebooksDisabled location={fakeLocation} />
       </MemoryRouter>, div);
+  });
+
+  it("renders ShowSession", async () => {
+    const props = {
+      client,
+      model,
+      match: { params: { server: "server-session-fake-name" } }
+    };
+
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    await act(async () => {
+      ReactDOM.render(
+        <MemoryRouter>
+          <ShowSession {...props} urlNewEnvironment="new_environment"/>
+        </MemoryRouter>, div);
+    });
   });
 
   it("renders Notebooks", async () => {

--- a/client/src/notebooks/index.js
+++ b/client/src/notebooks/index.js
@@ -23,8 +23,11 @@
  *
  */
 
-import { Notebooks, StartNotebookServer, CheckNotebookStatus } from "./Notebooks.container";
+import { ShowSession, Notebooks, StartNotebookServer, CheckNotebookStatus } from "./Notebooks.container";
 import { CheckNotebookIcon, NotebooksDisabled } from "./Notebooks.present";
 import { NotebooksHelper } from "./Notebooks.state";
 
-export { Notebooks, StartNotebookServer, NotebooksHelper, CheckNotebookStatus, CheckNotebookIcon, NotebooksDisabled };
+export {
+  ShowSession,
+  Notebooks, StartNotebookServer, NotebooksHelper, CheckNotebookStatus, CheckNotebookIcon, NotebooksDisabled
+};

--- a/client/src/project/Project.js
+++ b/client/src/project/Project.js
@@ -67,7 +67,8 @@ const subRoutes = {
   workflows: "files/workflows",
   settings: "settings",
   environments: "environments",
-  environmentNew: "environments/new"
+  environmentNew: "environments/new",
+  showSession: "environments/show/:server"
 };
 
 // SubRoutes grouped by depth
@@ -352,7 +353,8 @@ class View extends Component {
       mrOverviewUrl: `${baseUrl}/pending`,
       mrUrl: `${baseUrl}/pending/:mrIid`,
       launchNotebookUrl: `${baseUrl}/environments/new`,
-      notebookServersUrl: `${baseUrl}/environments`
+      notebookServersUrl: `${baseUrl}/environments`,
+      sessionShowUrl: `${baseUrl}/environments/show/:server`
     };
   }
 

--- a/client/src/project/Project.present.js
+++ b/client/src/project/Project.present.js
@@ -45,9 +45,11 @@ import {
 import { Url } from "../utils/url";
 import { SpecialPropVal } from "../model/Model";
 import { ProjectAvatarEdit, ProjectTags, ProjectTagList } from "./shared";
-import { Notebooks, StartNotebookServer } from "../notebooks";
+import { ShowSession, Notebooks, StartNotebookServer } from "../notebooks";
 import Issue from "../collaboration/issue/Issue";
-import { CollaborationList, collaborationListTypeMap, itemsStateMap } from "../collaboration/lists/CollaborationList.container";
+import {
+  CollaborationList, collaborationListTypeMap, itemsStateMap
+} from "../collaboration/lists/CollaborationList.container";
 import FilesTreeView from "./filestreeview/FilesTreeView";
 import DatasetsListView from "./datasets/DatasetsListView";
 import { ACCESS_LEVELS } from "../api-client";
@@ -920,19 +922,26 @@ class ProjectViewFiles extends Component {
 
 class ProjectEnvironments extends Component {
   render() {
+    const backButton = (<GoBackButton label="Back to environments list" url={this.props.notebookServersUrl} />);
     return [
       <Col key="content" xs={12}>
         <Switch>
           <Route exact path={this.props.notebookServersUrl}
             render={props => <ProjectNotebookServers {...this.props} />} />
           <Route path={this.props.launchNotebookUrl}
-            render={props => [
-              <Col key="btn" md={12}>
-                <GoBackButton key="backToListBtn" label="Back to environments list"
-                  url={this.props.notebookServersUrl}/>
-              </Col>,
-              <ProjectStartNotebookServer key="startNotebookForm" {...this.props} />
-            ]} />
+            render={props => (
+              <Fragment>
+                {backButton}
+                <ProjectStartNotebookServer key="startNotebookForm" {...this.props} />
+              </Fragment>
+            )} />
+          <Route path={this.props.sessionShowUrl}
+            render={props => (
+              <Fragment>
+                {backButton}
+                <ProjectShowSession {...this.props} match={props.match} />
+              </Fragment>
+            )} />
         </Switch>
       </Col>
     ];
@@ -984,6 +993,29 @@ function notebookWarning(userLogged, accessLevel, fork, postLoginUrl, externalUr
     );
   }
   return null;
+}
+
+
+class ProjectShowSession extends Component {
+  render() {
+    const {
+      client, model, user, visibility, toggleForkModal, location, externalUrl, launchNotebookUrl,
+      blockAnonymous, match
+    } = this.props;
+    const warning = notebookWarning(
+      user.logged, visibility.accessLevel, toggleForkModal, location.pathname, externalUrl
+    );
+
+    return (
+      <ShowSession standalone={false} client={client} model={model} location={location}
+        match={match}
+        message={warning}
+        urlNewEnvironment={launchNotebookUrl}
+        blockAnonymous={blockAnonymous}
+        scope={{ namespace: this.props.core.namespace_path, project: this.props.core.project_path }}
+      />
+    );
+  }
 }
 
 class ProjectNotebookServers extends Component {

--- a/client/src/utils/UIComponents.js
+++ b/client/src/utils/UIComponents.js
@@ -123,11 +123,16 @@ class TimeCaption extends Component {
     const time = this.props.time;
     const timeDiff = (new Date() - new Date(time)) / 1000;
     const displayTime = timeDiff < 3 ? "just now" : human(timeDiff);
-    const caption = (this.props.caption) ? this.props.caption : "Updated";
+    let caption = (this.props.caption) ? this.props.caption : "Updated";
     const endCaption = (this.props.endCaption) ? " " + this.props.endCaption : "";
     const endPunctuation = (this.props.endPunctuation) ? this.props.endPunctuation : ".";
-    const className = this.props.className || "";
-    return <span className={"time-caption " + className}>{caption} {displayTime}{endCaption}{endPunctuation}</span>;
+    let className = this.props.className || "";
+    const noCaption = this.props.noCaption;
+    if (noCaption)
+      caption = "";
+    else
+      className = "time-caption " + className;
+    return <span className={className}>{caption} {displayTime}{endCaption}{endPunctuation}</span>;
   }
 }
 

--- a/client/src/utils/UIComponents.js
+++ b/client/src/utils/UIComponents.js
@@ -756,6 +756,7 @@ function ButtonWithMenu(props) {
   const size = (props.size) ? props.size : "md";
 
   return <ButtonDropdown
+    className={props.className}
     size={size}
     isOpen={dropdownOpen}
     toggle={toggleOpen}

--- a/client/src/utils/url/Url.js
+++ b/client/src/utils/url/Url.js
@@ -176,6 +176,16 @@ function projectPageUrlBuilder(subSection) {
 }
 
 /**
+ * Construct a URL for a project page.
+ * @returns {function} A function to construct a URL from data.
+ */
+function projectSessionUrlBuilder() {
+  return (data) => {
+    return `/projects/${data.namespace}/${data.path}/environments/show/${data.server}`;
+  };
+}
+
+/**
  * Construct a URL object for a project page.
  * @returns {function} A function to construct a URL object.
  */
@@ -302,7 +312,30 @@ const Url = {
           "/projects/new",
           "/projects/new?data=eyJ0aXRsZSI6InRlC3QifQ==",
         ]
-      )
+      ),
+      session: {
+        base: new UrlRule(
+          projectPageUrlBuilder("/environments"), ["namespace", "path"], null, [
+            "/projects/namespace/path/environments",
+            "/projects/group/subgroup/path/environments",
+          ]
+        ),
+        new: new UrlRule(
+          projectPageUrlBuilder("/environments/new"), ["namespace", "path"], null, [
+            "/projects/namespace/path/environments/new",
+            "/projects/group/subgroup/path/environments/new",
+          ]
+        ),
+        show: new UrlRule(
+          projectSessionUrlBuilder(), ["namespace", "path", "server"], null, [
+            "/projects/namespace/path/environments/show/server-id",
+            "/projects/group/subgroup/path/environments/show/server-id",
+          ]
+        )
+      }
+    },
+    sessions: {
+      base: "/environments",
     }
   },
 


### PR DESCRIPTION
Embed running sessions in RenkuLab using an `<iframe>`, allowing use to also access logs and docs on the same page.

From the test environment, it seems that SwissDataScienceCenter/renku-notebooks#606 is not a requirement since the iframe's content is loaded correctly even without that PR.

![Screenshot_20210510_162201](https://user-images.githubusercontent.com/43481553/117674377-e84fcd00-b1ab-11eb-9620-49badfcbc32a.png)

/deploy renku=ui-design-test-update-iframe
fix #1220
