### PR TITLE
feat: handle non blocking errors on fork

### DIFF
--- a/client/src/api-client/project.js
+++ b/client/src/api-client/project.js
@@ -230,11 +230,25 @@ function addProjectMethods(client) {
 
     // Wait 1 second before starting the pipeline to prevent errors
     await new Promise(r => setTimeout(r, 1000));
+
     // Start pipeline -- no need to wait for the outcome, the environment page handles this
-    const pipeline = await client.runPipeline(forkedProject.data.id);
+    let pipeline;
+    try {
+      pipeline = await client.runPipeline(forkedProject.data.id);
+    }
+    catch (error) {
+      pipeline = error;
+    }
 
     // Create KG webhook
-    const webhook = await client.createGraphWebhook(forkedProject.data.id);
+    let webhook;
+    try {
+      webhook = await client.createGraphWebhook(forkedProject.data.id);
+    }
+    catch (error) {
+      webhook = error;
+    }
+
     return { project: forkedProject.data, pipeline, webhook };
   };
 

--- a/client/src/project/Project.present.js
+++ b/client/src/project/Project.present.js
@@ -47,7 +47,9 @@ import { SpecialPropVal } from "../model/Model";
 import { ProjectAvatarEdit, ProjectTags, ProjectTagList } from "./shared";
 import { Notebooks, StartNotebookServer } from "../notebooks";
 import Issue from "../collaboration/issue/Issue";
-import { CollaborationList, collaborationListTypeMap, itemsStateMap } from "../collaboration/lists/CollaborationList.container";
+import {
+  CollaborationList, collaborationListTypeMap, itemsStateMap
+} from "../collaboration/lists/CollaborationList.container";
 import FilesTreeView from "./filestreeview/FilesTreeView";
 import DatasetsListView from "./datasets/DatasetsListView";
 import { ACCESS_LEVELS } from "../api-client";

--- a/client/src/project/new/ProjectNew.container.js
+++ b/client/src/project/new/ProjectNew.container.js
@@ -224,7 +224,8 @@ function ForkProject(props) {
           throw new Error(verboseError);
         }
         if (forked.webhook.errorData) {
-          verboseError = "The forked project is available, but knowledge-graph integration failed. You may later be asked to reinitate the integration.";
+          verboseError = "The forked project is available, but knowledge-graph integration failed. ";
+          verboseError += "You may later be asked to initiate the integration.";
           throw new Error(verboseError);
         }
 

--- a/client/src/project/new/ProjectNew.container.js
+++ b/client/src/project/new/ProjectNew.container.js
@@ -215,16 +215,16 @@ function ForkProject(props) {
         let newProjectData = { namespace: forked.project.namespace.full_path, path: forked.project.path };
         setForkUrl(Url.get(Url.pages.project, newProjectData));
 
-        let verboseError;// = "Project forked, but ";
+        let verboseError; // = "Project forked, but ";
         if (forked.pipeline.errorData) {
           verboseError = "pipeline creation failed";
           if (forked.pipeline.errorData.message)
             verboseError += ` (${forked.pipeline.errorData.message})`;
-          verboseError += ". You may not be able to start an interactive environment.";
+          verboseError += ". The forked project is available, but interactive sessions may use a fallback image.";
           throw new Error(verboseError);
         }
         if (forked.webhook.errorData) {
-          verboseError = "Webhook creation failed. You may need to trigger it manually.";
+          verboseError = "The forked project is available, but knowledge-graph integration failed. You may later be asked to reinitate the integration.";
           throw new Error(verboseError);
         }
 

--- a/client/src/project/new/ProjectNew.present.js
+++ b/client/src/project/new/ProjectNew.present.js
@@ -63,7 +63,7 @@ function makeRefreshButton(refresh, tip, disabled) {
 }
 
 function ForkProject(props) {
-  const { error, fork, forkedTitle, forking, namespaces, projects, toggleModal } = props;
+  const { error, fork, forkedTitle, forking, forkUrl, namespaces, projects, toggleModal } = props;
 
   const fetching = {
     projects: projects.fetching,
@@ -74,7 +74,9 @@ function ForkProject(props) {
     <Fragment>
       <ForkProjectHeader forkedTitle={forkedTitle} toggleModal={toggleModal} />
       <ForkProjectBody {...props} fetching={fetching} />
-      <ForkProjectFooter error={error} fetching={fetching} fork={fork} forking={forking} toggleModal={toggleModal} />
+      <ForkProjectFooter
+        error={error} fetching={fetching} fork={fork} forking={forking} forkUrl={forkUrl} toggleModal={toggleModal}
+      />
     </Fragment>
   );
 }
@@ -110,17 +112,24 @@ function ForkProjectBody(props) {
 }
 
 function ForkProjectFooter(props) {
-  const { error, fetching, fork, forking, toggleModal } = props;
+  const { error, fetching, fork, forking, forkUrl, toggleModal } = props;
 
-  const confirmForkButton = forking ?
-    null :
-    (<Button color="primary" disabled={error ? true : false} onClick={fork}>Fork</Button>);
+  let forkButton;
+  if (forking) {
+    forkButton = null;
+  }
+  else {
+    if (forkUrl)
+      forkButton = (<Link className="btn btn-primary" to={forkUrl}>Go to forked project</Link>);
+    else
+      forkButton = (<Button color="primary" disabled={error ? true : false} onClick={fork}>Fork</Button>);
+  }
 
   if (fetching.namespaces || fetching.projects)
     return null;
   return (
     <ModalFooter>
-      {confirmForkButton}
+      {forkButton}
       <Button outline color="primary" onClick={toggleModal}>{forking ? "Close" : "Cancel"}</Button>
     </ModalFooter>
   );


### PR DESCRIPTION
This improves the UX when a non-fatal error occurs while forking (i.e. the pipeline or webhook creation fails)

**How to test**: it's a bit tricky. The easiest way is running telepresence on the PR environment and manually modifying the code in the `client.forkProject` function to trigger the error on the target API (try with the main fork API, then with `runPipeline` and `createGraphWebhook`)

![Screenshot_20210517_144720](https://user-images.githubusercontent.com/43481553/118494098-155b2d00-b722-11eb-9e01-cecd3a35c978.png)

P.S. mind that the error message is slightly different than the suggested one, to keep it coherent with the other cases. Feel free to suggest changes if it's not clear (or change it directly in the PR).

/deploy renku=ui-design-test-fix
fix #1341