### PR TITLE
Handle markdown in GitLab description

### DIFF
--- a/client/src/project/Project.present.js
+++ b/client/src/project/Project.present.js
@@ -47,7 +47,9 @@ import { SpecialPropVal } from "../model/Model";
 import { ProjectAvatarEdit, ProjectTags, ProjectTagList } from "./shared";
 import { Notebooks, StartNotebookServer } from "../notebooks";
 import Issue from "../collaboration/issue/Issue";
-import { CollaborationList, collaborationListTypeMap, itemsStateMap } from "../collaboration/lists/CollaborationList.container";
+import {
+  CollaborationList, collaborationListTypeMap, itemsStateMap
+} from "../collaboration/lists/CollaborationList.container";
 import FilesTreeView from "./filestreeview/FilesTreeView";
 import DatasetsListView from "./datasets/DatasetsListView";
 import { ACCESS_LEVELS } from "../api-client";
@@ -276,11 +278,15 @@ class ProjectViewHeaderOverview extends Component {
 
     const gitlabIDEUrl = this.props.externalUrl !== "" && this.props.externalUrl.includes("/gitlab/") ?
       this.props.externalUrl.replace("/gitlab/", "/gitlab/-/ide/project/") : null;
+    const description = this.props.core.description ?
+      (<RenkuMarkdown markdownText={this.props.core.description} fixRelativePaths={false} />) :
+      null;
+
     return (
       <Fragment>
         <Row className="pt-2 pb-3">
-          <Col className="d-flex mb-2 justify-content-between">
-            <div>
+          <Col className="d-flex mb-2">
+            <div className="me-2">
               <h2 className="pb-1">
                 <ProjectStatusIcon
                   history={this.props.history}
@@ -295,12 +301,12 @@ class ProjectViewHeaderOverview extends Component {
                 <span>{this.props.core.path_with_namespace}{forkedFrom}</span>
               </div>
               <div className="text-rk-text">
-                {this.props.core.description}
+                {description}
               </div>
             </div>
-            <div className="d-flex flex-column align-items-end justify-content-between">
-              <div>
-                <ButtonGroup size="sm">
+            <div className="d-flex flex-column align-items-end mb-2">
+              <div className="text-end">
+                <ButtonGroup size="sm" className="mb-1 ms-1">
                   <ForkProjectModal
                     client={this.props.client}
                     history={this.props.history}
@@ -317,7 +323,7 @@ class ProjectViewHeaderOverview extends Component {
                     {system.forks_count}
                   </Button>
                 </ButtonGroup>
-                <ButtonGroup size="sm" className="ms-2">
+                <ButtonGroup size="sm" className="mb-1 ms-1">
                   <Button outline color="primary"
                     className="border-light"
                     disabled={this.state.updating_star}
@@ -328,18 +334,18 @@ class ProjectViewHeaderOverview extends Component {
                     className="border-light"
                     style={{ cursor: "default" }}>{system.star_count}</Button>
                 </ButtonGroup>
-                <ButtonGroup size="sm" className="ms-2">
+                <ButtonGroup size="sm" className="mb-1 ms-1">
                   <GitLabConnectButton size="sm"
                     externalUrl={this.props.externalUrl}
                     gitlabIDEUrl={gitlabIDEUrl}
                     userLogged={this.props.user.logged} />
                 </ButtonGroup>
               </div>
-              <div>
+              <div className="text-end mb-2">
                 <ProjectVisibilityLabel visibilityLevel={this.props.visibility.level} />
                 <ProjectTagList tagList={this.props.system.tag_list} />
               </div>
-              <div>
+              <div className="mb-2">
                 <TimeCaption key="time-caption" time={this.props.core.last_activity_at} />
               </div>
             </div>

--- a/client/src/project/Project.present.js
+++ b/client/src/project/Project.present.js
@@ -300,7 +300,7 @@ class ProjectViewHeaderOverview extends Component {
               <div className="text-rk-text">
                 <span>{this.props.core.path_with_namespace}{forkedFrom}</span>
               </div>
-              <div className="text-rk-text">
+              <div className="text-rk-text project-description">
                 {description}
               </div>
             </div>

--- a/client/src/project/list/ProjectList.present.js
+++ b/client/src/project/list/ProjectList.present.js
@@ -19,12 +19,15 @@
 import React, { Fragment, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import {
-  Col, Button, DropdownItem, DropdownMenu, DropdownToggle, Form, Input, InputGroup,
-  Nav, NavItem, Row, ButtonDropdown } from "reactstrap";
-import { faCheck, faSortAmountDown, faSortAmountUp, faSearch } from "@fortawesome/free-solid-svg-icons";
+  Button, ButtonDropdown, Col, DropdownItem, DropdownMenu, DropdownToggle, Form, Input, InputGroup,
+  Nav, NavItem, Row
+} from "reactstrap";
+import { faCheck, faSearch, faSortAmountDown, faSortAmountUp } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { stringScore } from "../../utils/HelperFunctions";
-import { ProjectAvatar, Loader, Pagination, TimeCaption, RenkuNavLink } from "../../utils/UIComponents";
+import {
+  Loader, Pagination, ProjectAvatar, RenkuMarkdown, RenkuNavLink, TimeCaption
+} from "../../utils/UIComponents";
 import { ProjectTagList } from "../shared";
 import { Url } from "../../utils/url";
 import "../Project.css";
@@ -44,6 +47,15 @@ function ProjectListRow(props) {
   const colorsArray = ["green", "pink", "yellow"];
   const color = colorsArray[stringScore(title) % 3];
 
+  const descriptionMarkdown = description ?
+    (
+      <Fragment>
+        <RenkuMarkdown markdownText={description} fixRelativePaths={false} singleLine={true} />
+        <span className="ms-1">{description.includes("\n") ? " [...]" : ""}</span>
+      </Fragment>
+    ) :
+    null;
+
   return (
     <Link className="d-flex flex-row rk-search-result" to={url}>
       <span className={"circle me-3 mt-2 " + color}></span>
@@ -51,8 +63,8 @@ function ProjectListRow(props) {
         <div className="title d-inline-block text-truncate">
           {title}
         </div>
-        <div className="description text-truncate text-rk-text">
-          {description ? description : null}
+        <div className="description text-truncate text-rk-text d-flex">
+          {descriptionMarkdown}
         </div>
         <div className="tagList">
           <ProjectTagList tagList={tag_list} />


### PR DESCRIPTION
The GitLab description field is now translated to HTML when it contains markdown.
The first commit addresses the project overview page (it also changes a bit the header layout, see screenshots), while the second changes the preview in the project list.

**How to test**: try to search for some projects with a description and open the overview page.
E.G. https://dev.renku.ch/projects/lorenzo.cavazzi.tech/test-comment

Here are a few screenshots: on the left the updated version, on the right the previous one.

* PROJECT HEADER - large page
  ![Screenshot_20210519_155114](https://user-images.githubusercontent.com/43481553/118836286-00b69a80-b8c4-11eb-8e8f-4b7c0712b930.png)

* PROJECT HEADER - small page
  ![Screenshot_20210519_155138](https://user-images.githubusercontent.com/43481553/118836342-0ad89900-b8c4-11eb-829d-702ca310e425.png)

* PROJECT LIST
  ![Screenshot_20210519_164819](https://user-images.githubusercontent.com/43481553/118836490-2d6ab200-b8c4-11eb-8dd9-cd7a27b94094.png)

/deploy renku=ui-design-test-fix
fix #1346