### PR TITLE
feat: show lineage on folders

### DIFF
--- a/client/src/file/File.container.js
+++ b/client/src/file/File.container.js
@@ -298,13 +298,29 @@ class JupyterButton extends React.Component {
 class ShowFile extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { file: null, commit: null, error: null };
+    this.state = { file: null, commit: null, error: null, fileInfo: null };
   }
 
   // TODO: Write a wrapper to make promises cancellable to avoid usage of this._isMounted
   componentDidMount() {
     this._isMounted = true;
     this.retrieveFile();
+  }
+
+  componentDidUpdate() {
+    // save information about the file once available
+    if (this.props.filesTree && this.props.filesTree.hash) {
+      const path = this.props.filePath.endsWith("/") ?
+        this.props.filePath.substring(0, this.props.filePath.length - 1) :
+        this.props.filePath;
+      const fileInfo = this.props.filesTree.hash[path];
+      if (fileInfo) {
+        if (!this.state.fileInfo)
+          this.setState({ fileInfo });
+        else if (fileInfo.path !== this.state.fileInfo.path)
+          this.setState({ fileInfo });
+      }
+    }
   }
 
   componentWillUnmount() { this._isMounted = false; }
@@ -380,6 +396,7 @@ class ShowFile extends React.Component {
       fileSize={fileSize}
       history={this.props.history}
       previewThreshold={previewThreshold}
+      fileInfo={this.state.fileInfo}
     />;
   }
 }

--- a/client/src/file/File.present.js
+++ b/client/src/file/File.present.js
@@ -138,15 +138,23 @@ class ShowFile extends React.Component {
     );
 
     if (this.props.error !== null) {
+      const { fileInfo } = this.props;
+      const filePath = fileInfo && fileInfo.path ?
+        fileInfo.path :
+        this.props.gitLabFilePath.split("\\").pop().split("/").pop();
+      const body = fileInfo && fileInfo.type === "tree" ?
+        (<Card className="border-rk-light"><CardBody>Cannot preview a folder</CardBody></Card>) :
+        this.props.error;
+
       return (
         <FileCard
           gitLabUrl={this.props.externalUrl}
-          filePath={this.props.gitLabFilePath.split("\\").pop().split("/").pop()}
+          filePath={filePath}
           commit={this.props.commit}
           buttonGraph={buttonGraph}
           buttonGit={buttonGit}
           buttonJupyter={this.props.buttonJupyter}
-          body={this.props.error}
+          body={body}
           isLFSBadge={null}
           fileSize={this.props.fileSize}
         />

--- a/client/src/file/File.present.js
+++ b/client/src/file/File.present.js
@@ -143,7 +143,7 @@ class ShowFile extends React.Component {
         fileInfo.path :
         this.props.gitLabFilePath.split("\\").pop().split("/").pop();
       const body = fileInfo && fileInfo.type === "tree" ?
-        (<Card className="border-rk-light"><CardBody>This is a folder.</CardBody></Card>) :
+        (<Card className="border-rk-light"><CardBody>Folder</CardBody></Card>) :
         this.props.error;
 
       return (

--- a/client/src/file/File.present.js
+++ b/client/src/file/File.present.js
@@ -143,7 +143,7 @@ class ShowFile extends React.Component {
         fileInfo.path :
         this.props.gitLabFilePath.split("\\").pop().split("/").pop();
       const body = fileInfo && fileInfo.type === "tree" ?
-        (<Card className="border-rk-light"><CardBody>Cannot preview a folder</CardBody></Card>) :
+        (<Card className="border-rk-light"><CardBody>This is a folder.</CardBody></Card>) :
         this.props.error;
 
       return (

--- a/client/src/project/Project.present.js
+++ b/client/src/project/Project.present.js
@@ -904,10 +904,10 @@ class ProjectViewFiles extends Component {
 
   render() {
     return [
-      <Col key="files" sm={12} md={2}>
+      <Col key="files" md={4} lg={3} xl={2}>
         <ProjectFilesNav {...this.props} />
       </Col>,
-      <Col key="content" sm={12} md={10}>
+      <Col key="content" md={8} lg={9} xl={10}>
         <Switch>
           <Route path={this.props.lineageUrl}
             render={p => this.props.lineageView(p)} />

--- a/client/src/project/filestreeview/FilesTreeView.js
+++ b/client/src/project/filestreeview/FilesTreeView.js
@@ -1,9 +1,10 @@
-import React, { Component } from "react";
+import React, { Component, Fragment } from "react";
 import { Link } from "react-router-dom";
 import { StickyContainer, Sticky } from "react-sticky";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faFile, faFolder as faFolderClosed, faFolderOpen } from "@fortawesome/free-solid-svg-icons";
 import { Button, ButtonGroup } from "reactstrap";
+
 import "./treeviewstyle.css";
 
 
@@ -39,15 +40,6 @@ class TreeNode extends Component {
   }
 
   render() {
-    const icon = this.props.node.type === "tree" ?
-      (this.state.childrenOpen === false ?
-        <FontAwesomeIcon className="link-primary" icon={faFolderClosed} />
-        : <FontAwesomeIcon className="link-primary" icon={faFolderOpen} />)
-      : <FontAwesomeIcon className="link-rk-text" icon={faFile} />;
-
-    const order = this.props.node.type === "tree" ? "order-second" : "order-third";
-    const hidden = this.props.node.name.startsWith(".") ? " rk-opacity-50 " : "";
-
     const children = this.props.node.children ?
       this.props.node.children.map((node) => {
         return <TreeNode
@@ -64,46 +56,51 @@ class TreeNode extends Component {
           nodeInsideIsSelected={this.props.currentUrl.endsWith(node.path)}
           currentUrl={this.props.currentUrl}
           savePosition={this.props.savePosition}
+          history={this.props.history}
         />;
       })
       : null;
 
-    let elementToRender;
-    let selected = this.props.nodeInsideIsSelected ? " selected-file " : "";
+    const icon = this.props.node.type === "tree" ?
+      (this.state.childrenOpen === false ?
+        <FontAwesomeIcon className="link-primary" icon={faFolderClosed} />
+        : <FontAwesomeIcon className="link-primary" icon={faFolderOpen} />)
+      : <FontAwesomeIcon className="link-rk-text" icon={faFile} />;
 
-    if (this.props.node.type === "blob" || this.props.node.type === "commit") {
-      elementToRender =
-        <div className={order + " " + hidden + " " + selected}>
-          <div className={"fs-element"} onClick={this.handleFileClick}>
-            { this.props.fileView ?
-              <Link to= {`${this.props.projectUrl}/${this.props.node.jsonObj.path}`} >
-                <div className={"fs-element"}>
-                  {icon} {this.props.node.name}
-                </div>
-              </Link>
-              :
-              <Link to= {`${this.props.lineageUrl}/${this.props.node.jsonObj.path}`} >
-                <div className={"fs-element"}>
-                  {icon} {this.props.node.name}
-                </div>
-              </Link>
-            }
-          </div>
+    const order = this.props.node.type === "tree" ?
+      "order-second" :
+      "order-third";
+    const hidden = this.props.node.name.startsWith(".") ?
+      "rk-opacity-50" :
+      "";
+    const selected = this.props.nodeInsideIsSelected ?
+      "selected-file" :
+      "";
+
+    const urlPrefix = this.props.fileView ?
+      this.props.projectUrl :
+      this.props.lineageUrl;
+    const targetUrl = `${urlPrefix}/${this.props.node.jsonObj.path}`;
+
+    let innerElement = (<Fragment>{icon} {this.props.node.name}</Fragment>);
+    if (!(this.props.fileView && this.props.node.type === "tree"))
+      innerElement = (<Link to={targetUrl}>{innerElement}</Link>);
+    const clickHandler = this.props.node.type === "tree" ?
+      this.handleIconClick :
+      this.handleFileClick;
+
+    const childrenOpen = children && this.state.childrenOpen ?
+      (<div className="ps-3">{children}</div>) :
+      null;
+
+    return (
+      <div className={`${order} ${hidden} ${selected}`}>
+        <div className="fs-element" onClick={clickHandler}>
+          {innerElement}
         </div>
-      ;
-    }
-    else {
-      const childrenOpen = this.state.childrenOpen ? <div className="ps-3">{children}</div> : null;
-      elementToRender =
-        <div className={order + " " + hidden} >
-          <div className={"fs-element"} onClick={this.handleIconClick} >
-            {icon} {this.props.node.name}
-          </div>
-          {childrenOpen}
-        </div>;
-    }
-
-    return elementToRender;
+        {childrenOpen}
+      </div>
+    );
   }
 }
 
@@ -180,6 +177,7 @@ class FilesTreeView extends Component {
           nodeInsideIsSelected={this.props.currentUrl.endsWith(node.path)}
           currentUrl={this.props.currentUrl}
           savePosition={this.savePosition.bind(this)}
+          history={this.props.history}
         />;
       }) :
       null;

--- a/client/src/project/filestreeview/FilesTreeView.js
+++ b/client/src/project/filestreeview/FilesTreeView.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from "react";
+import React, { Component } from "react";
 import { Link } from "react-router-dom";
 import { StickyContainer, Sticky } from "react-sticky";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -82,9 +82,6 @@ class TreeNode extends Component {
       this.props.lineageUrl;
     const targetUrl = `${urlPrefix}/${this.props.node.jsonObj.path}`;
 
-    let innerElement = (<Fragment>{icon} {this.props.node.name}</Fragment>);
-    if (!(this.props.fileView && this.props.node.type === "tree"))
-      innerElement = (<Link to={targetUrl}>{innerElement}</Link>);
     const clickHandler = this.props.node.type === "tree" ?
       this.handleIconClick :
       this.handleFileClick;
@@ -96,7 +93,7 @@ class TreeNode extends Component {
     return (
       <div className={`${order} ${hidden} ${selected}`}>
         <div className="fs-element" onClick={clickHandler}>
-          {innerElement}
+          <Link to={targetUrl}>{icon} {this.props.node.name}</Link>
         </div>
         {childrenOpen}
       </div>


### PR DESCRIPTION
This PR changes the behavior when clicking on folders in the file browser: if the user is visualizing the lineage, it changes the address and fetches the folder's lineage. This doesn't happen when browsing the files.
Mind that it contains a (raw) mechanism to prevent showing a `404` message when trying to visualize a folder in "file mode" -- that may happen when the user switches from the lineage of a folder to the file visualization (this was possible even before this PR, but it's likely to happen more frequently now).

**How to test**: try with a project having lineage on folders. Here is an example (navigate to `data` subfolders and then out):
https://renku-ci-ui-1356.dev.renku.ch/projects/lorenzo.cavazzi.tech/imagej/files/lineage/data/step-1

/deploy renku=ui-design-test-fix
fix #1342