### PR TITLE
fix: handle namespaces that start with numbers

### DIFF
--- a/client/src/project/Project-Route.test.js
+++ b/client/src/project/Project-Route.test.js
@@ -87,6 +87,18 @@ describe("basic route extraction", () => {
     expect(pathComponents.baseUrl).toEqual("/projects/namespace/project-name");
     expect(pathComponents.namespace).toEqual("namespace");
   });
+  it("handles project-with-numeric-namespace routes", () => {
+    const pathComponents = splitProjectSubRoute("/projects/1namespace/project-name");
+    expect(pathComponents.projectPathWithNamespace).toEqual("1namespace/project-name");
+    expect(pathComponents.baseUrl).toEqual("/projects/1namespace/project-name");
+    expect(pathComponents.namespace).toEqual("1namespace");
+  });
+  it("handles project-with-numeric-namespace sub routes", () => {
+    const pathComponents = splitProjectSubRoute("/projects/21namespace/project-name/overview");
+    expect(pathComponents.projectPathWithNamespace).toEqual("21namespace/project-name");
+    expect(pathComponents.baseUrl).toEqual("/projects/21namespace/project-name");
+    expect(pathComponents.namespace).toEqual("21namespace");
+  });
 });
 
 describe("id route extraction", () => {

--- a/client/src/project/Project.js
+++ b/client/src/project/Project.js
@@ -73,7 +73,7 @@ const subRoutes = {
 // SubRoutes grouped by depth
 const srMap = _.groupBy(Object.values(subRoutes), v => v.split("/").length);
 const maxSrMapDepth = Math.max(...Object.keys(srMap).map(k => Number.parseInt(k)));
-const projectIdRegex = /^\d+/;
+const projectIdRegex = /^\d+$/;
 
 /**
  * Check if the components need to be added to the projectPathWithNamespace


### PR DESCRIPTION
Fix #1257

# Testing

Namespaces that start with numbers are now correctly handled.

Compare the following:

New: https://renku-ci-ui-1359.dev.renku.ch/projects/123testgroup/testing-project
Old: https://dev.renku.ch/projects/123testgroup/testing-project (endless spinning wheel)

New: https://renku-ci-ui-1359.dev.renku.ch/projects/123testgroup/987test-project
Old: https://dev.renku.ch/projects/123testgroup/987test-project (endless spinning wheel)

If you wish, create new project in a namespace that starts with a number and see that you get properly redirected to the project after it is created.

/deploy