### PR TITLE
fix: remove flash error when loading datasets

### DIFF
--- a/client/src/dataset/Dataset.container.js
+++ b/client/src/dataset/Dataset.container.js
@@ -36,7 +36,8 @@ export default function ShowDataset(props) {
 
   useEffect(()=>{
     let unmounted = false;
-    if (datasetFiles === undefined && ((dataset && dataset.name) || (props.datasetId !== undefined))) {
+    if (props.insideProject && datasetFiles === undefined
+      && ((dataset && dataset.name) || (props.datasetId !== undefined))) {
       const name = (dataset && dataset.name) ? dataset.name : props.datasetId;
       props.client.fetchDatasetFilesFromCoreService(name, props.httpProjectUrl)
         .then(response => {
@@ -60,7 +61,8 @@ export default function ShowDataset(props) {
     return () => {
       unmounted = true;
     };
-  }, [datasetFiles, props.datasetId, dataset, props.httpProjectUrl, setDatasetFiles, props.client]);
+  }, [datasetFiles, props.datasetId, dataset, props.httpProjectUrl, setDatasetFiles, props.client,
+    props.insideProject]);
 
   useEffect(() => {
     let unmounted = false;

--- a/client/src/dataset/Dataset.present.js
+++ b/client/src/dataset/Dataset.present.js
@@ -32,7 +32,7 @@ import AddDataset from "./addtoproject/DatasetAdd.container";
 import DeleteDataset from "../project/datasets/delete/index";
 import Time from "../utils/Time";
 import { Url } from "../utils/url";
-
+import _ from "lodash";
 
 function DisplayFiles(props) {
   if (props.files === undefined) return null;
@@ -293,7 +293,7 @@ export default function DatasetView(props) {
   const [deleteDatasetModalOpen, setDeleteDatasetModalOpen] = useState(false);
   const dataset = props.dataset;
 
-  if (props.fetchError !== null && dataset === undefined) {
+  if (!_.isEmpty(props.fetchError) && dataset === undefined) {
     return (
       <DatasetError
         fetchError={props.fetchError}


### PR DESCRIPTION
@rokroskar found a bug when accessing datasets in the dataset search.

When accessing a dataset for a second you can see an "error unknown" sign, this was due to a bag if, this has been fixed.

To test you can search for datasets and open one.

Do the same in this deployment and the error shouldn't be there.

I removed an unnecessary call to the core service that was also failing since it was trying to fetch a dataset outside a project.

/deploy