### PR TITLE
fix: adjust gitlab forks link

### DIFF
--- a/client/src/project/Project.present.js
+++ b/client/src/project/Project.present.js
@@ -319,7 +319,7 @@ class ProjectViewHeaderOverview extends Component {
                     outline
                     color="primary"
                     className="border-light"
-                    href={`${this.props.externalUrl}/forks`} target="_blank" rel="noreferrer noopener">
+                    href={`${this.props.externalUrl}/-/forks`} target="_blank" rel="noreferrer noopener">
                     {system.forks_count}
                   </Button>
                 </ButtonGroup>

--- a/client/src/project/overview/ProjectOverview.present.js
+++ b/client/src/project/overview/ProjectOverview.present.js
@@ -95,7 +95,7 @@ class OverviewStats extends Component {
                     <td className="px-3 px-lg-4 align-middle">{metadata.forksCount}</td>
                     <td>
                       <ExternalLink role="text" showLinkIcon={true}
-                        url={`${metadata.repositoryUrl}/forks`} title="Forks in GitLab" />
+                        url={`${metadata.repositoryUrl}/-/forks`} title="Forks in GitLab" />
                     </td>
                   </tr>
                   <tr>


### PR DESCRIPTION
As pointed out by a user, the links to the forks page in Gitlab were wrong. This PR fixes them.

**How to test**: open any project and click on the fork number in the project header bar. Compare this PR deployment with dev

/deploy renku=ui-design-2021
