### PR TITLE
feat(design): generic component to map items into a list applied to projects and datasets

### DIFF
--- a/client/src/dataset/list/DatasetList.container.js
+++ b/client/src/dataset/list/DatasetList.container.js
@@ -37,6 +37,7 @@ class List extends Component {
       changeSearchDropdownOrder: this.changeSearchDropdownOrder.bind(this),
       toggleSearchSorting: this.toggleSearchSorting.bind(this),
       onPaginationPageChange: this.onPaginationPageChange.bind(this),
+      onGridDisplayToggle: this.onGridDisplayToggle.bind(this),
     };
   }
 
@@ -106,8 +107,8 @@ class List extends Component {
     this.model.setQueryAndSortInSearch(query, orderBy, orderSearchAsc, pathName, pageNumber);
   }
 
-  onPaginationPageChange(pageNumber) {
-    this.model.setPage(pageNumber);
+  onPaginationPageChange({ page }) {
+    this.model.setPage(page);
     this.model.performSearch();
     this.pushNewSearchToHistory();
   }
@@ -142,6 +143,10 @@ class List extends Component {
     this.pushNewSearchToHistory();
   }
 
+  onGridDisplayToggle() {
+    this.model.setGridDisplay(!this.model.get("gridDisplay"));
+  }
+
   getOrderByLabel() {
     switch (this.model.get("orderBy")) {
       case orderByValuesMap.TITLE:
@@ -174,7 +179,9 @@ class List extends Component {
       currentPage: this.model.get("currentPage"),
       perPage: this.model.get("perPage"),
       totalItems: this.model.get("totalItems"),
+      gridDisplay: this.model.get("gridDisplay"),
       onPageChange: this.handlers.onPaginationPageChange,
+      onGridDisplayToggle: this.handlers.onGridDisplayToggle,
     };
   }
 

--- a/client/src/dataset/list/DatasetList.present.js
+++ b/client/src/dataset/list/DatasetList.present.js
@@ -162,6 +162,30 @@ class DatasetsRows extends Component {
 
     const { currentPage, perPage, search, totalItems, gridDisplay } = this.props;
 
+    const datasetItems = datasets.map(dataset => {
+      const projectsCount = dataset.projectsCount > 1
+        ? `In ${dataset.projectsCount} projects`
+        : `In ${dataset.projectsCount} project`;
+
+      return {
+        id: dataset.identifier,
+        url: `${datasetsUrl}/${encodeURIComponent(dataset.identifier)}`,
+        stringScore: stringScore(dataset.identifier) % 3,
+        title: dataset.title || dataset.name,
+        description: dataset.description !== undefined && dataset.description !== null ?
+          <Fragment>
+            <MarkdownTextExcerpt markdownText={dataset.description} singleLine={gridDisplay ? false : true}
+              charsLimit={gridDisplay ? 200 : 100} />
+            <span className="ms-1">{dataset.description.includes("\n") ? " [...]" : ""}</span>
+          </Fragment>
+          : null,
+        timeCaption: new Date(dataset.date),
+        labelCaption: projectsCount + ". Created",
+        creators: dataset.published !== undefined && dataset.published.creator !== undefined ?
+          dataset.published.creator : null,
+      };
+    });
+
     return <ListDisplay
       itemsType="dataset"
       search={search}
@@ -169,24 +193,7 @@ class DatasetsRows extends Component {
       gridDisplay={gridDisplay}
       totalItems={totalItems}
       perPage={perPage}
-      items={datasets.map(dataset => {
-        const projectsCount = dataset.projectsCount > 1
-          ? `In ${dataset.projectsCount} projects`
-          : `In ${dataset.projectsCount} project`;
-        return {
-          id: dataset.identifier,
-          url: `${datasetsUrl}/${encodeURIComponent(dataset.identifier)}`,
-          stringScore: stringScore(dataset.identifier) % 3,
-          title: dataset.title || dataset.name,
-          description: dataset.description !== undefined && dataset.description !== null ?
-            <MarkdownTextExcerpt markdownText={dataset.description} charsLimit={gridDisplay ? 200 : 500} />
-            : null,
-          timeCaption: new Date(dataset.date),
-          labelCaption: projectsCount + ". Created",
-          creators: dataset.published !== undefined && dataset.published.creator !== undefined ?
-            dataset.published.creator : null,
-        };
-      })}
+      items={datasetItems}
     />;
 
   }

--- a/client/src/dataset/list/DatasetList.present.js
+++ b/client/src/dataset/list/DatasetList.present.js
@@ -17,75 +17,16 @@
  */
 
 import React, { Component, Fragment } from "react";
-import { Link, Route, Switch } from "react-router-dom";
+import { Route, Switch } from "react-router-dom";
 import { Row, Col, Alert, Card, CardBody } from "reactstrap";
 import { Button, Form, FormText, Input, Label, InputGroup, UncontrolledCollapse } from "reactstrap";
 import { DropdownToggle, DropdownMenu, DropdownItem } from "reactstrap";
 import { stringScore } from "../../utils/HelperFunctions";
-import { Loader, Pagination, MarkdownTextExcerpt, TimeCaption } from "../../utils/UIComponents";
-import { faCheck, faSortAmountUp, faSortAmountDown, faSearch } from "@fortawesome/free-solid-svg-icons";
+import { MarkdownTextExcerpt, ListDisplay } from "../../utils/UIComponents";
+import { faCheck, faSortAmountUp, faSortAmountDown, faSearch, faBars, faTh } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { ButtonDropdown } from "reactstrap/lib";
 
-
-class DatasetListRow extends Component {
-
-  render() {
-    const datasetsUrl = this.props.datasetsUrl;
-    const dataset = this.props.dataset;
-    const projectsCountLabel = dataset.projectsCount > 1
-      ? `In ${dataset.projectsCount} projects`
-      : `In ${dataset.projectsCount} project`;
-
-    const colorsArray = ["green", "pink", "yellow"];
-    const color = colorsArray[stringScore(dataset.name) % 3];
-    const datasetDate = new Date(dataset.date);
-
-    return <Link className="d-flex flex-row rk-search-result"
-      to={`${datasetsUrl}/${encodeURIComponent(dataset.identifier)}`}>
-      <span className={"circle me-3 mt-2 " + color}></span>
-      <Col className="d-flex align-items-start flex-column col-10 overflow-hidden">
-        <div className="title d-inline-block text-truncate">
-          {dataset.title || dataset.name}
-        </div>
-        <div className="creators text-truncate text-rk-text">
-          {
-            dataset.published !== undefined && dataset.published.creator !== undefined ?
-              <small style={{ display: "block" }} className="font-weight-light">
-                {dataset.published.creator.slice(0, 3).map((creator) => creator.name).join(", ")}
-                {dataset.published.creator.length > 3 ? ", et al." : null}
-              </small>
-              : null
-          }
-        </div>
-        <div className="description text-truncate text-rk-text">
-          {
-            dataset.description !== undefined && dataset.description !== null ?
-              <div className="datasetDescriptionText font-weight-normal">
-                <MarkdownTextExcerpt markdownText={dataset.description} charsLimit={500} />
-              </div>
-              : null
-          }
-        </div>
-        <div className="mt-auto">
-          {
-            dataset.date ?
-              <TimeCaption caption="Created"
-                time={datasetDate} className="text-secondary"/>
-              : null
-          }
-        </div>
-      </Col>
-      <Col className="d-flex justify-content-end flex-shrink-0">
-        <span className="text-secondary">
-          <small>
-            {projectsCountLabel}
-          </small>
-        </span>
-      </Col>
-    </Link>;
-  }
-}
 
 function OrderByDropdown(props) {
   return <Fragment>
@@ -163,6 +104,16 @@ class DatasetSearchForm extends Component {
               <FontAwesomeIcon icon={faSearch} />
             </Button>
           </Col>
+          <Col className="col-auto">
+            <Button color="rk-white" id="displayButton"
+              onClick={() => this.props.onGridDisplayToggle()}>
+              {
+                this.props.gridDisplay ?
+                  <FontAwesomeIcon icon={faBars} /> :
+                  <FontAwesomeIcon icon={faTh} />
+              }
+            </Button>
+          </Col>
         </Form>
         <Col sm={12}>
           <FormText key="help" color="rk-text">
@@ -206,50 +157,82 @@ class DatasetSearchForm extends Component {
 
 class DatasetsRows extends Component {
   render() {
-    if (this.props.loading) return <Col md={{ size: 2, offset: 3 }}><Loader /></Col>;
     const datasets = this.props.datasets || [];
-    const rows = datasets.map((p) => <DatasetListRow key={p.identifier}
-      datasetsUrl={this.props.urlMap.datasetsUrl}
-      dataset={p} />);
-    return <div className="mb-4">{rows}</div>;
+    const datasetsUrl = this.props.datasetsUrl;
+
+    const { currentPage, perPage, search, totalItems, gridDisplay } = this.props;
+
+    return <ListDisplay
+      itemsType="dataset"
+      search={search}
+      currentPage={currentPage}
+      gridDisplay={gridDisplay}
+      totalItems={totalItems}
+      perPage={perPage}
+      items={datasets.map(dataset => {
+        const projectsCount = dataset.projectsCount > 1
+          ? `In ${dataset.projectsCount} projects`
+          : `In ${dataset.projectsCount} project`;
+        return {
+          id: dataset.identifier,
+          url: `${datasetsUrl}/${encodeURIComponent(dataset.identifier)}`,
+          stringScore: stringScore(dataset.identifier) % 3,
+          title: dataset.title || dataset.name,
+          description: dataset.description !== undefined && dataset.description !== null ?
+            <MarkdownTextExcerpt markdownText={dataset.description} charsLimit={gridDisplay ? 200 : 500} />
+            : null,
+          timeCaption: new Date(dataset.date),
+          labelCaption: projectsCount + ". Created",
+          creators: dataset.published !== undefined && dataset.published.creator !== undefined ?
+            dataset.published.creator : null,
+        };
+      })}
+    />;
+
   }
 }
 
 
-class DatasetsSearch extends Component {
-  render() {
-    const loading = this.props.loading || false;
-    return [
-      <div key="form">
-        {
-          (this.props.loggedOutMessage !== undefined) ?
-            <Col bg={6} md={8} sm={12} ><span>{this.props.loggedOutMessage}</span><br /><br /></Col>
-            :
-            <span></span>
-        }
-        <div className="pb-2 rk-search-bar">
-          <DatasetSearchForm
-            searchQuery={this.props.searchQuery}
-            handlers={this.props.handlers}
-            errorMessage={this.props.errorMessage}
-            orderByValuesMap={this.props.orderByValuesMap}
-            orderBy={this.props.orderBy}
-            orderByDropdownOpen={this.props.orderByDropdownOpen}
-            orderSearchAsc={this.props.orderSearchAsc}
-            orderByLabel={this.props.orderByLabel}
-          />
-        </div>
-      </div>,
-      <DatasetsRows
-        key="datasets"
-        datasets={this.props.datasets}
-        urlMap={this.props.urlMap}
-        loading={loading}
-      />,
-      <Pagination key="pagination" {...this.props}
-        className="d-flex justify-content-center rk-search-pagination"/>
-    ];
-  }
+function DatasetsSearch(props) {
+
+  const loading = props.loading || false;
+
+  return [
+    <div key="form">
+      {
+        (props.loggedOutMessage !== undefined) ?
+          <Col bg={6} md={8} sm={12} ><span>{props.loggedOutMessage}</span><br /><br /></Col>
+          :
+          <span></span>
+      }
+      <div className="pb-2 rk-search-bar">
+        <DatasetSearchForm
+          searchQuery={props.searchQuery}
+          handlers={props.handlers}
+          errorMessage={props.errorMessage}
+          orderByValuesMap={props.orderByValuesMap}
+          orderBy={props.orderBy}
+          orderByDropdownOpen={props.orderByDropdownOpen}
+          orderSearchAsc={props.orderSearchAsc}
+          orderByLabel={props.orderByLabel}
+          gridDisplay={props.gridDisplay}
+          onGridDisplayToggle={props.onGridDisplayToggle}
+        />
+      </div>
+    </div>,
+    <DatasetsRows
+      key="datasets"
+      datasets={props.datasets}
+      loading={loading}
+      currentPage={props.currentPage}
+      totalItems={props.totalItems}
+      perPage={props.perPage}
+      search={props.onPageChange}
+      gridDisplay={props.gridDisplay}
+      datasetsUrl={props.urlMap.datasetsUrl}
+    />
+  ];
+
 }
 
 class NotFoundInsideDataset extends Component {
@@ -270,24 +253,22 @@ class NotFoundInsideDataset extends Component {
   }
 }
 
-class DatasetList extends Component {
-  render() {
-    const urlMap = this.props.urlMap;
+function DatasetList(props) {
 
-    return <Fragment>
-      <Row className="pt-2 pb-3">
-        <Col className="d-flex mb-2">
-          <h2 className="me-4">Renku Datasets</h2>
-        </Col>
-      </Row>
-      <Switch>
-        <Route exact path={urlMap.datasetsUrl}
-          render={props => <DatasetsSearch {...this.props} />} />
-        <Route component={NotFoundInsideDataset} />
-      </Switch>
-    </Fragment>;
-  }
+  const urlMap = props.urlMap;
+
+  return <Fragment>
+    <Row className="pt-2 pb-3">
+      <Col className="d-flex mb-2">
+        <h2 className="me-4">Renku Datasets</h2>
+      </Col>
+    </Row>
+    <Switch>
+      <Route exact path={urlMap.datasetsUrl}
+        render={p => <DatasetsSearch {...props} />} />
+      <Route component={NotFoundInsideDataset} />
+    </Switch>
+  </Fragment>;
 }
 
 export default DatasetList;
-export { DatasetListRow };

--- a/client/src/dataset/list/DatasetList.state.js
+++ b/client/src/dataset/list/DatasetList.state.js
@@ -38,11 +38,12 @@ const datasetListSchema = new Schema({
   orderSearchAsc: { initial: false, mandatory: true },
   currentPage: { initial: 1, mandatory: true },
   totalItems: { initial: 0, mandatory: true },
-  perPage: { initial: 10, mandatory: true },
+  perPage: { initial: 12, mandatory: true },
   pathName: { initial: "" },
   initialized: { initial: true },
   datasets: { initial: [] },
-  errorMessage: { initial: "" }
+  errorMessage: { initial: "" },
+  gridDisplay: { initial: true }
 });
 
 class DatasetListModel extends StateModel {
@@ -80,7 +81,11 @@ class DatasetListModel extends StateModel {
   }
 
   setPage(page) {
-    this.set("currentPage", parseInt(page, 10));
+    this.set("currentPage", parseInt(page, 12));
+  }
+
+  setGridDisplay(gridDisplay) {
+    this.set("gridDisplay", gridDisplay);
   }
 
   setQueryAndSortInSearch(query, orderBy, orderSearchAsc, pathName, pageNumber) {

--- a/client/src/project/list/ProjectList.present.js
+++ b/client/src/project/list/ProjectList.present.js
@@ -26,7 +26,7 @@ import { faCheck, faSearch, faSortAmountDown, faSortAmountUp, faBars, faTh } fro
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { stringScore } from "../../utils/HelperFunctions";
 import {
-  Loader, ProjectAvatar, RenkuMarkdown, RenkuNavLink, TimeCaption, ListDisplay
+  Loader, ProjectAvatar, RenkuMarkdown, RenkuNavLink, TimeCaption, ListDisplay, MarkdownTextExcerpt
 } from "../../utils/UIComponents";
 import { ProjectTagList } from "../shared";
 import { Url } from "../../utils/url";
@@ -87,6 +87,28 @@ function ProjectListRowBar(props) {
 function ProjectListRows(props) {
   const { currentPage, perPage, projects, search, totalItems, gridDisplay } = props;
 
+  const projectItems = projects.map(project => {
+    const namespace = project.namespace ? project.namespace.full_path : "";
+    const path = project.path;
+    const url = Url.get(Url.pages.project, { namespace, path });
+    return {
+      id: project.id,
+      url: url,
+      stringScore: stringScore(project.path_with_namespace) % 3,
+      title: project.path_with_namespace,
+      description: project.description ?
+        <Fragment>
+          <MarkdownTextExcerpt markdownText={project.description} singleLine={gridDisplay ? false : true}
+            charsLimit={gridDisplay ? 200 : 150} />
+          <span className="ms-1">{project.description.includes("\n") ? " [...]" : ""}</span>
+        </Fragment>
+        : " ",
+      tagList: project.tag_list,
+      timeCaption: project.last_activity_at,
+      mediaContent: project.avatar_url
+    };
+  });
+
   return <ListDisplay
     itemsType="project"
     search={search}
@@ -94,26 +116,7 @@ function ProjectListRows(props) {
     gridDisplay={gridDisplay}
     totalItems={totalItems}
     perPage={perPage}
-    items={projects.map(project => {
-      const namespace = project.namespace ? project.namespace.full_path : "";
-      const path = project.path;
-      const url = Url.get(Url.pages.project, { namespace, path });
-      return {
-        id: project.id,
-        url: url,
-        stringScore: stringScore(project.path_with_namespace) % 3,
-        title: project.path_with_namespace,
-        description: project.description ?
-          <Fragment>
-            <RenkuMarkdown markdownText={project.description} fixRelativePaths={false} singleLine={true} />
-            <span className="ms-1">{project.description.includes("\n") ? " [...]" : ""}</span>
-          </Fragment>
-          : " ",
-        tagList: project.tag_list,
-        timeCaption: project.last_activity_at,
-        mediaContent: project.avatar_url
-      };
-    })}
+    items={projectItems}
   />;
 }
 

--- a/client/src/project/list/ProjectList.present.js
+++ b/client/src/project/list/ProjectList.present.js
@@ -26,61 +26,13 @@ import { faCheck, faSearch, faSortAmountDown, faSortAmountUp, faBars, faTh } fro
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { stringScore } from "../../utils/HelperFunctions";
 import {
-  Loader, Pagination, ProjectAvatar, RenkuMarkdown, RenkuNavLink, TimeCaption
+  Loader, ProjectAvatar, RenkuMarkdown, RenkuNavLink, TimeCaption, ListDisplay
 } from "../../utils/UIComponents";
 import { ProjectTagList } from "../shared";
 import { Url } from "../../utils/url";
 import "../Project.css";
 import { Label } from "reactstrap/lib";
-import Masonry from "react-masonry-css";
 
-
-function ProjectListRowCard(props) {
-  const {
-    path, path_with_namespace, last_activity_at, description, tag_list
-  } = props;
-  const namespace = props.namespace.full_path;
-
-  const url = Url.get(Url.pages.project, { namespace, path });
-  const title = path_with_namespace || "no title";
-
-
-  const colorsArray = ["green", "pink", "yellow"];
-  const color = colorsArray[stringScore(title) % 3];
-
-  return (
-    <div className="col text-decoration-none p-2 rk-search-result-card">
-      <Link to={url} className="col text-decoration-none">
-        <div className="card card-body border-0">
-          <span className={"circle me-3 mt-2 mb-2 " + color}></span>
-          <div className="title lh-sm mb-2">
-            {title}
-          </div>
-          <p className="card-text text-rk-text mb-2">
-            {description ? description : null}
-          </p>
-          {tag_list.length > 0 ?
-            <Fragment>
-              <div className="tagList mt-auto mb-2">
-                <ProjectTagList tagList={tag_list} />
-              </div>
-              <p className="card-text ">
-                <TimeCaption caption="Updated" time={last_activity_at} className="text-secondary"/>
-              </p>
-            </Fragment>
-            : <p className="card-text mt-auto">
-              <TimeCaption caption="Updated" time={last_activity_at} className="text-secondary"/>
-            </p>
-          }
-          {props.avatar_url ?
-            <img src={props.avatar_url} alt=" " className="card-img-bottom"/>
-            : null
-          }
-        </div>
-      </Link>
-    </div>
-  );
-}
 
 function ProjectListRowBar(props) {
   const {
@@ -90,7 +42,6 @@ function ProjectListRowBar(props) {
 
   const url = Url.get(Url.pages.project, { namespace, path });
   const title = path_with_namespace || "no title";
-
 
   const colorsArray = ["green", "pink", "yellow"];
   const color = colorsArray[stringScore(title) % 3];
@@ -134,39 +85,36 @@ function ProjectListRowBar(props) {
 }
 
 function ProjectListRows(props) {
-  const { currentPage, getAvatar, perPage, projects, search, totalItems, gridDisplay } = props;
+  const { currentPage, perPage, projects, search, totalItems, gridDisplay } = props;
 
-  if (!projects || !projects.length)
-    return (<p>We could not find any matching projects.</p>);
-
-  const rows = gridDisplay ?
-    projects.map(project => <ProjectListRowCard key={project.id} getAvatar={getAvatar} {...project} />)
-    : projects.map(project => <ProjectListRowBar key={project.id} getAvatar={getAvatar} {...project} />);
-
-  const onPageChange = (page) => { search({ page }); };
-
-  return gridDisplay ?
-    <div>
-      <Masonry
-        className="rk-search-result-grid mb-4"
-        breakpointCols={{
-          default: 4,
-          1100: 3,
-          700: 2,
-          500: 1
-        }}
-      >
-        {rows}
-      </Masonry>
-      <Pagination currentPage={currentPage} perPage={perPage} totalItems={totalItems} onPageChange={onPageChange}
-        className="d-flex justify-content-center rk-search-pagination"/>
-    </div>
-    :
-    <div>
-      <div className="mb-4">{rows}</div>
-      <Pagination currentPage={currentPage} perPage={perPage} totalItems={totalItems} onPageChange={onPageChange}
-        className="d-flex justify-content-center rk-search-pagination"/>
-    </div>;
+  return <ListDisplay
+    itemsType="project"
+    search={search}
+    currentPage={currentPage}
+    gridDisplay={gridDisplay}
+    totalItems={totalItems}
+    perPage={perPage}
+    items={projects.map(project => {
+      const namespace = project.namespace ? project.namespace.full_path : "";
+      const path = project.path;
+      const url = Url.get(Url.pages.project, { namespace, path });
+      return {
+        id: project.id,
+        url: url,
+        stringScore: stringScore(project.path_with_namespace) % 3,
+        title: project.path_with_namespace,
+        description: project.description ?
+          <Fragment>
+            <RenkuMarkdown markdownText={project.description} fixRelativePaths={false} singleLine={true} />
+            <span className="ms-1">{project.description.includes("\n") ? " [...]" : ""}</span>
+          </Fragment>
+          : " ",
+        tagList: project.tag_list,
+        timeCaption: project.last_activity_at,
+        mediaContent: project.avatar_url
+      };
+    })}
+  />;
 }
 
 function SearchInFilter(props) {

--- a/client/src/utils/List.js
+++ b/client/src/utils/List.js
@@ -1,3 +1,21 @@
+/*!
+ * Copyright 2021 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { Fragment } from "react";
 import { Link } from "react-router-dom";
 import { Col } from "reactstrap";
@@ -5,7 +23,18 @@ import { Pagination, TimeCaption } from "./UIComponents";
 import Masonry from "react-masonry-css";
 import { ProjectTagList } from "../project/shared/ProjectTag.container";
 
-
+/**
+ * ListCard/ListBar returns a card or a bar displaying an item in a List.
+ *
+ * @param url containing a link to the item details.
+ * @param title title of the item.
+ * @param description description of the item.
+ * @param tagList tag list of the item.
+ * @param timeCaption date to put inside the time caption of the item.
+ * @param labelCaption label to put inside the time caption of the item, if empty defaults to Updated.
+ * @param mediaContent image of the item.
+ * @param creators creators of the item, if more than 3 they will be cropped at 3.
+ */
 function ListCard(props) {
   const { url, color, title, description, tagList, timeCaption, labelCaption, mediaContent, creators } = props;
 
@@ -99,6 +128,18 @@ function ListBar(props) {
     </Col>
   </Link>;
 }
+
+/**
+ * This class receives a list of "items" and displays them either in a grid or in classic list.
+ *
+ * @param itemsType string containing the type of items in the list, this is only used to display an empty message.
+ * @param search search function used inside the pagination.
+ * @param currentPage current page used in the pagination.
+ * @param gridDisplay if true the list will be displayed in grid mode.
+ * @param totalItems total items, used in the pagination.
+ * @param perPage items per page, used in the pagination.
+ * @param items items to display, documented on top on ListCard.
+ */
 
 function ListDisplay(props) {
 

--- a/client/src/utils/List.js
+++ b/client/src/utils/List.js
@@ -1,0 +1,142 @@
+import React, { Fragment } from "react";
+import { Link } from "react-router-dom";
+import { Col } from "reactstrap";
+import { Pagination, TimeCaption } from "./UIComponents";
+import Masonry from "react-masonry-css";
+import { ProjectTagList } from "../project/shared/ProjectTag.container";
+
+
+function ListCard(props) {
+  const { url, color, title, description, tagList, timeCaption, labelCaption, mediaContent, creators } = props;
+
+  return (
+    <div className="col text-decoration-none p-2 rk-search-result-card">
+      <Link to={url} className="col text-decoration-none">
+        <div className="card card-body border-0">
+          <span className={"circle me-3 mt-2 mb-2 " + color}> </span>
+          <div className="title lh-sm">
+            {title}
+          </div>
+          {
+            creators ?
+              <div className="card-text creators text-truncate text-rk-text mt-1">
+                <small style={{ display: "block" }} className="font-weight-light">
+                  {creators.slice(0, 3).map((creator) => creator.name).join(", ")}
+                  {creators.length > 3 ? ", et al." : null}
+                </small>
+              </div>
+              : null
+          }
+          <div className="card-text text-rk-text mt-3 mb-2">
+            {description ? description : null}
+          </div>
+          {tagList && tagList.length > 0 ?
+            <Fragment>
+              <div className="tagList mt-auto mb-2">
+                <ProjectTagList tagList={tagList} />
+              </div>
+              <p className="card-text ">
+                <TimeCaption caption={labelCaption || "Updated"} time={timeCaption} className="text-secondary"/>
+              </p>
+            </Fragment>
+            : <p className="card-text mt-auto">
+              <TimeCaption caption={labelCaption || "Updated"} time={timeCaption} className="text-secondary"/>
+            </p>
+          }
+          {mediaContent ?
+            <img src={mediaContent} alt=" " className="card-img-bottom"/>
+            : null
+          }
+        </div>
+      </Link>
+    </div>
+  );
+}
+
+function ListBar(props) {
+
+  const { url, color, title, description, tagList, timeCaption, labelCaption, mediaContent, creators } = props;
+
+  return <Link className="d-flex flex-row rk-search-result" to={url}>
+    <span className={"circle me-3 mt-2 " + color}></span>
+    <Col className="d-flex align-items-start flex-column col-10 overflow-hidden">
+      <div className="title d-inline-block text-truncate">
+        {title}
+      </div>
+      {
+        creators ?
+          <div className="creators text-truncate text-rk-text">
+            <small style={{ display: "block" }} className="font-weight-light">
+              {creators.slice(0, 3).map((creator) => creator.name).join(", ")}
+              {creators.length > 3 ? ", et al." : null}
+            </small>
+          </div>
+          : null
+      }
+      <div className="description text-truncate text-rk-text d-flex">
+        {description}
+      </div>
+      {
+        tagList ?
+          <div className="tagList">
+            <ProjectTagList tagList={tagList} />
+          </div>
+          : null
+      }
+      {
+        timeCaption ?
+          <div className="mt-auto">
+            <TimeCaption caption={labelCaption || "Updated"} time={timeCaption} className="text-secondary"/>
+          </div>
+          : null
+      }
+    </Col>
+    <Col className="d-flex justify-content-end align-self-center flex-shrink-0">
+      {mediaContent ?
+        <img src={mediaContent} alt=" " className="card-img-bottom"/>
+        : null
+      }
+    </Col>
+  </Link>;
+}
+
+function ListDisplay(props) {
+
+  const { currentPage, perPage, items, search, totalItems, gridDisplay, itemsType } = props;
+
+  if (!items || !items.length)
+    return (<p>We could not find any matching {itemsType}s.</p>);
+
+  const colorsArray = ["green", "pink", "yellow"];
+
+  const rows = gridDisplay ?
+    items.map(item => <ListCard key={item.id} {...item} color={colorsArray[item.stringScore]}/>)
+    : items.map(item => <ListBar key={item.id} {...item} color={colorsArray[item.stringScore]}/>);
+
+  const onPageChange = (page) => { search({ page }); };
+
+  return gridDisplay ?
+    <div>
+      <Masonry
+        className="rk-search-result-grid mb-4"
+        breakpointCols={{
+          default: 4,
+          1100: 3,
+          700: 2,
+          500: 1
+        }}
+      >
+        {rows}
+      </Masonry>
+      <Pagination currentPage={currentPage} perPage={perPage} totalItems={totalItems} onPageChange={onPageChange}
+        className="d-flex justify-content-center rk-search-pagination"/>
+    </div>
+    :
+    <div>
+      <div className="mb-4">{rows}</div>
+      <Pagination currentPage={currentPage} perPage={perPage} totalItems={totalItems} onPageChange={onPageChange}
+        className="d-flex justify-content-center rk-search-pagination"/>
+    </div>;
+
+}
+export default ListDisplay;

--- a/client/src/utils/UIComponents.js
+++ b/client/src/utils/UIComponents.js
@@ -44,6 +44,7 @@ import {
 import { sanitizedHTMLFromMarkdown, simpleHash } from "./HelperFunctions";
 import FileExplorer, { getFilesTree } from "./FileExplorer";
 import RenkuMarkdownWithPathTranslation from "./Markdown";
+import ListDisplay from "./List";
 
 /**
  * Show user avatar
@@ -490,7 +491,9 @@ function MarkdownTextExcerpt(props) {
   const style = props.heightLimit ?
     { maxHeight: `${props.heightLimit}ch` }
     : { maxWidth: `${props.charsLimit}ch` };
-  return <RenkuMarkdown markdownText={props.markdownText} singleLine={false} style={style} />;
+  const text = props.charsLimit && props.markdownText.length > props.charsLimit ?
+    props.markdownText.slice(0, props.charsLimit) + "..." : props.markdownText;
+  return <RenkuMarkdown markdownText={text} singleLine={false} style={style} />;
 }
 
 /**
@@ -814,5 +817,5 @@ export {
   UserAvatar, TimeCaption, FieldGroup, RenkuNavLink, Pagination, RenkuMarkdown, ExternalLink, ExternalDocsLink,
   ExternalIconLink, IconLink, RefreshButton, Loader, InfoAlert, SuccessAlert, WarnAlert, ErrorAlert, JupyterIcon,
   Clipboard, ThrottledTooltip, TooltipToggleButton, ProjectAvatar, ButtonWithMenu, FileExplorer, getFilesTree,
-  MarkdownTextExcerpt, GoBackButton
+  MarkdownTextExcerpt, GoBackButton, ListDisplay
 };

--- a/client/src/utils/UIComponents.js
+++ b/client/src/utils/UIComponents.js
@@ -491,9 +491,9 @@ function MarkdownTextExcerpt(props) {
   const style = props.heightLimit ?
     { maxHeight: `${props.heightLimit}ch` }
     : { maxWidth: `${props.charsLimit}ch` };
-  const text = props.charsLimit && props.markdownText.length > props.charsLimit ?
+  const text = props.charsLimit && (props.markdownText.length > props.charsLimit) ?
     props.markdownText.slice(0, props.charsLimit) + "..." : props.markdownText;
-  return <RenkuMarkdown markdownText={text} singleLine={false} style={style} />;
+  return <RenkuMarkdown markdownText={text} singleLine={props.singleLine || false} style={style} />;
 }
 
 /**


### PR DESCRIPTION
I created a List component that receives a list of items with different fields and maps them to a grid or list (depending on what the user wants).

![image](https://user-images.githubusercontent.com/42647877/120316181-6bf96700-c2dd-11eb-9968-efbf2907c20a.png)

It looks like the project grid, there is a benefit here... if we want to implement a generic search in the KG (for projects, datasets, etc) we could use this generic component to display a list of mixed elements.

I applied this to datasets and projects. I see the project row is used in the landing page as well, we could delete this code after we adapt the landing page to using this.

/deploy renku=ui-design-2021