### PR TITLE
feat(design): use of colours to identify entities

### DIFF
--- a/client/src/collaboration/lists/IssueList.present.js
+++ b/client/src/collaboration/lists/IssueList.present.js
@@ -6,7 +6,6 @@ import { faComments } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { RenkuMarkdown, TimeCaption, Pagination, Loader } from "../../utils/UIComponents";
 import { itemsStateMap } from "./CollaborationList.container";
-import { stringScore } from "../../utils/HelperFunctions";
 
 function issueStateBadge(issueStateValue) {
   let issueState = <Badge color="secondary">{issueStateValue}</Badge>;
@@ -24,11 +23,8 @@ class IssueListRow extends Component {
     const issueState = issueStateBadge(this.props.state);
     const titleText = this.props.title || "no title";
 
-    const colorsArray = ["green", "pink", "yellow"];
-    const color = colorsArray[stringScore(titleText) % 3];
-
     return <Link className="d-flex flex-row rk-search-result rk-search-result-100" to={issueUrl}>
-      <span className={"circle me-3 mt-2 " + color}></span>
+      <span className={"circle me-3 mt-2 collaboration"}></span>
       <Col className="d-flex align-items-start flex-column col-10 overflow-hidden">
         <div className="title d-inline-block text-truncate">
           {titleText}

--- a/client/src/collaboration/lists/MergeRequestList.present.js
+++ b/client/src/collaboration/lists/MergeRequestList.present.js
@@ -7,8 +7,6 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { TimeCaption, Pagination, Loader } from "../../utils/UIComponents";
 import { itemsStateMap } from "./CollaborationList.container";
 import { faLongArrowAltLeft as faLeftArrow } from "@fortawesome/free-solid-svg-icons";
-import { stringScore } from "../../utils/HelperFunctions";
-
 
 /**
  * Extract the display info from a merge request object.
@@ -49,11 +47,8 @@ class MergeRequestListRow extends Component {
     const { badgeText, badgeColor, timeCaption } = rowInfo;
     const statusBadge = <Badge color={badgeColor}>{badgeText}</Badge>;
 
-    const colorsArray = ["green", "pink", "yellow"];
-    const color = colorsArray[stringScore(this.props.title) % 3];
-
     return <Link className="d-flex flex-row rk-search-result rk-search-result-100" to={this.props.mrUrl}>
-      <span className={"circle me-3 mt-2 " + color}></span>
+      <span className={"circle me-3 mt-2 collaboration"}></span>
       <Col className="d-flex align-items-start flex-column col-9 overflow-hidden">
         <div className="title d-inline-block text-truncate">
           {this.props.title}

--- a/client/src/dataset/list/DatasetList.present.js
+++ b/client/src/dataset/list/DatasetList.present.js
@@ -168,6 +168,7 @@ class DatasetsRows extends Component {
 
       return {
         id: dataset.identifier,
+        itemType: "dataset",
         url: `${datasetsUrl}/${encodeURIComponent(dataset.identifier)}`,
         title: dataset.title || dataset.name,
         description: dataset.description !== undefined && dataset.description !== null ?

--- a/client/src/dataset/list/DatasetList.present.js
+++ b/client/src/dataset/list/DatasetList.present.js
@@ -170,7 +170,6 @@ class DatasetsRows extends Component {
       return {
         id: dataset.identifier,
         url: `${datasetsUrl}/${encodeURIComponent(dataset.identifier)}`,
-        stringScore: stringScore(dataset.identifier) % 3,
         title: dataset.title || dataset.name,
         description: dataset.description !== undefined && dataset.description !== null ?
           <Fragment>

--- a/client/src/dataset/list/DatasetList.present.js
+++ b/client/src/dataset/list/DatasetList.present.js
@@ -21,7 +21,6 @@ import { Route, Switch } from "react-router-dom";
 import { Row, Col, Alert, Card, CardBody } from "reactstrap";
 import { Button, Form, FormText, Input, Label, InputGroup, UncontrolledCollapse } from "reactstrap";
 import { DropdownToggle, DropdownMenu, DropdownItem } from "reactstrap";
-import { stringScore } from "../../utils/HelperFunctions";
 import { MarkdownTextExcerpt, ListDisplay } from "../../utils/UIComponents";
 import { faCheck, faSortAmountUp, faSortAmountDown, faSearch, faBars, faTh } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";

--- a/client/src/project/datasets/DatasetsListView.js
+++ b/client/src/project/datasets/DatasetsListView.js
@@ -4,17 +4,14 @@ import { Row, Col } from "reactstrap";
 import { ACCESS_LEVELS } from "../../api-client";
 import "../filestreeview/treeviewstyle.css";
 import { Loader, MarkdownTextExcerpt, TimeCaption } from "../../utils/UIComponents";
-import { stringScore } from "../../utils/HelperFunctions";
 import { SpecialPropVal } from "../../model";
 
 function DatasetListRow(props) {
   const dataset = props.dataset;
-  const colorsArray = ["green", "pink", "yellow"];
-  const color = colorsArray[stringScore(dataset.name) % 3];
 
   return <Link className="d-flex flex-row rk-search-result"
     to={`${props.datasetsUrl}/${encodeURIComponent(dataset.name)}/`}>
-    <span className={"circle me-3 mt-2 " + color}></span>
+    <span className={"circle me-3 mt-2 dataset"}></span>
     <Col className="d-flex align-items-start flex-column col-9 overflow-hidden">
       <div className="title d-inline-block text-truncate">
         {dataset.title || dataset.name}

--- a/client/src/project/list/ProjectList.present.js
+++ b/client/src/project/list/ProjectList.present.js
@@ -91,6 +91,7 @@ function ProjectListRows(props) {
       id: project.id,
       url: url,
       title: project.path_with_namespace,
+      itemType: "project",
       description: project.description ?
         <Fragment>
           <MarkdownTextExcerpt markdownText={project.description} singleLine={gridDisplay ? false : true}

--- a/client/src/project/list/ProjectList.present.js
+++ b/client/src/project/list/ProjectList.present.js
@@ -94,7 +94,6 @@ function ProjectListRows(props) {
     return {
       id: project.id,
       url: url,
-      stringScore: stringScore(project.path_with_namespace) % 3,
       title: project.path_with_namespace,
       description: project.description ?
         <Fragment>

--- a/client/src/project/list/ProjectList.present.js
+++ b/client/src/project/list/ProjectList.present.js
@@ -24,7 +24,6 @@ import {
 } from "reactstrap";
 import { faCheck, faSearch, faSortAmountDown, faSortAmountUp, faBars, faTh } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { stringScore } from "../../utils/HelperFunctions";
 import {
   Loader, ProjectAvatar, RenkuMarkdown, RenkuNavLink, TimeCaption, ListDisplay, MarkdownTextExcerpt
 } from "../../utils/UIComponents";
@@ -43,9 +42,6 @@ function ProjectListRowBar(props) {
   const url = Url.get(Url.pages.project, { namespace, path });
   const title = path_with_namespace || "no title";
 
-  const colorsArray = ["green", "pink", "yellow"];
-  const color = colorsArray[stringScore(title) % 3];
-
   const descriptionMarkdown = description ?
     (
       <Fragment>
@@ -57,7 +53,7 @@ function ProjectListRowBar(props) {
 
   return (
     <Link className="d-flex flex-row rk-search-result" to={url}>
-      <span className={"circle me-3 mt-2 " + color}></span>
+      <span className={"circle me-3 mt-2 project"}></span>
       <Col className="d-flex align-items-start flex-column col-10 overflow-hidden">
         <div className="title d-inline-block text-truncate">
           {title}

--- a/client/src/styles/icons/icons.scss
+++ b/client/src/styles/icons/icons.scss
@@ -27,8 +27,13 @@
   background: #009568;
 }
 
-.circle.collaboration {
+.circle.workflow {
   background: #D1BB4C;
+}
+
+// TODO - DELETE WHEN COLLABORATION IFRAME IS MERGED
+.circle.collaboration {
+  background: rgba(128, 128, 128, 0.893);
 }
 
 .circle.dataset {

--- a/client/src/styles/icons/icons.scss
+++ b/client/src/styles/icons/icons.scss
@@ -23,14 +23,14 @@
   display:inline-table;
 }
 
-.circle.green {
+.circle.project {
   background: #009568;
 }
 
-.circle.yellow {
+.circle.collaboration {
   background: #D1BB4C;
 }
 
-.circle.pink {
+.circle.dataset {
   background: #D26A98;
 }

--- a/client/src/utils/HelperFunctions.js
+++ b/client/src/utils/HelperFunctions.js
@@ -309,19 +309,8 @@ async function sleep(seconds) {
   await new Promise(r => setTimeout(r, seconds * 1000));
 }
 
-/**
- * This function returns the score of a string.
- * It adds up the unicode values of it.
- */
-function stringScore(s) {
-  let sum = 0;
-  for (let j = 0; j < s.length; j++)
-    sum += s.charAt(j).charCodeAt(0);
-  return sum;
-}
-
 export {
   slugFromTitle, getActiveProjectPathWithNamespace, splitAutosavedBranches, sanitizedHTMLFromMarkdown,
   simpleHash, parseINIString, formatBytes, groupBy, gitLabUrlFromProfileUrl, isURL, verifyTitleCharacters,
-  convertUnicodeToAscii, refreshIfNecessary, sleep, stringScore
+  convertUnicodeToAscii, refreshIfNecessary, sleep
 };

--- a/client/src/utils/List.js
+++ b/client/src/utils/List.js
@@ -34,6 +34,7 @@ import { ProjectTagList } from "../project/shared/ProjectTag.container";
  * @param labelCaption label to put inside the time caption of the item, if empty defaults to Updated.
  * @param mediaContent image of the item.
  * @param creators creators of the item, if more than 3 they will be cropped at 3.
+ * @param itemType type of the item being rendered, the color of the circle depends on this.
  */
 function ListCard(props) {
   const { url, title, description, tagList, timeCaption, labelCaption, mediaContent, creators, itemType } = props;
@@ -149,8 +150,8 @@ function ListDisplay(props) {
     return (<p>We could not find any matching {itemsType}s.</p>);
 
   const rows = gridDisplay ?
-    items.map(item => <ListCard key={item.id} {...item} itemType={itemsType} />)
-    : items.map(item => <ListBar key={item.id} {...item} itemType={itemsType} />);
+    items.map(item => <ListCard key={item.id} {...item} />)
+    : items.map(item => <ListBar key={item.id} {...item} />);
 
   const onPageChange = (page) => { search({ page }); };
 

--- a/client/src/utils/List.js
+++ b/client/src/utils/List.js
@@ -36,13 +36,13 @@ import { ProjectTagList } from "../project/shared/ProjectTag.container";
  * @param creators creators of the item, if more than 3 they will be cropped at 3.
  */
 function ListCard(props) {
-  const { url, color, title, description, tagList, timeCaption, labelCaption, mediaContent, creators } = props;
+  const { url, title, description, tagList, timeCaption, labelCaption, mediaContent, creators, itemType } = props;
 
   return (
     <div className="col text-decoration-none p-2 rk-search-result-card">
       <Link to={url} className="col text-decoration-none">
         <div className="card card-body border-0">
-          <span className={"circle me-3 mt-2 mb-2 " + color}> </span>
+          <span className={"circle me-3 mt-2 mb-2 " + itemType}> </span>
           <div className="title lh-sm">
             {title}
           </div>
@@ -84,10 +84,10 @@ function ListCard(props) {
 
 function ListBar(props) {
 
-  const { url, color, title, description, tagList, timeCaption, labelCaption, mediaContent, creators } = props;
+  const { url, title, description, tagList, timeCaption, labelCaption, mediaContent, creators, itemType } = props;
 
   return <Link className="d-flex flex-row rk-search-result" to={url}>
-    <span className={"circle me-3 mt-2 " + color}></span>
+    <span className={"circle me-3 mt-2 " + itemType}></span>
     <Col className="d-flex align-items-start flex-column col-10 overflow-hidden">
       <div className="title d-inline-block text-truncate">
         {title}
@@ -148,11 +148,9 @@ function ListDisplay(props) {
   if (!items || !items.length)
     return (<p>We could not find any matching {itemsType}s.</p>);
 
-  const colorsArray = ["green", "pink", "yellow"];
-
   const rows = gridDisplay ?
-    items.map(item => <ListCard key={item.id} {...item} color={colorsArray[item.stringScore]}/>)
-    : items.map(item => <ListBar key={item.id} {...item} color={colorsArray[item.stringScore]}/>);
+    items.map(item => <ListCard key={item.id} {...item} itemType={itemsType} />)
+    : items.map(item => <ListBar key={item.id} {...item} itemType={itemsType} />);
 
   const onPageChange = (page) => { search({ page }); };
 


### PR DESCRIPTION
We decided that each entity has a color, this will be useful when we have different entities returned by the same search results.

Green --> projects
Pink --> datasets
Yellow --> collaboration (until the tab is replaced by the iframe)

![image](https://user-images.githubusercontent.com/42647877/120499443-5610a280-c3c0-11eb-8ccf-086b377d66e8.png)

![image](https://user-images.githubusercontent.com/42647877/120499476-5d37b080-c3c0-11eb-8832-38bdf6fe27d8.png)


Closes #1376
