### PR TITLE
 feat: edit project sessions settings

### DIFF
--- a/client/src/api-client/notebook-servers.js
+++ b/client/src/api-client/notebook-servers.js
@@ -69,6 +69,13 @@ function addNotebookServersMethods(client) {
       anonymous
     ).then((resp) => {
       let { data } = resp;
+
+      // ? rename defaultUrl to default_url to prevent conflicts later with project options
+      if (data && "defaultUrl" in data) {
+        data.default_url = data.defaultUrl;
+        delete data.defaultUrl;
+      }
+
       Object.keys(data).forEach(key => {
         data[key].selected = data[key].default;
       });
@@ -80,6 +87,13 @@ function addNotebookServersMethods(client) {
     const headers = client.getBasicHeaders();
     headers.append("Content-Type", "application/json");
     const url = `${client.baseUrl}/notebooks/servers`;
+
+    // ? rename default_url to legacy defaultUrl
+    if (options && options.serverOptions && "default_url" in options.serverOptions) {
+      options.serverOptions.defaultUrl = options.serverOptions.default_url;
+      delete options.serverOptions.default_url;
+    }
+
     let parameters = {
       namespace: decodeURIComponent(namespacePath),
       project: projectPath,

--- a/client/src/api-client/project.js
+++ b/client/src/api-client/project.js
@@ -388,6 +388,45 @@ function addProjectMethods(client) {
     return Promise.resolve(datasetsPromise)
       .then(datasetsContent => Promise.all(datasetsContent));
   };
+
+  /**
+   * Get project config file data
+   * @see {@link https://github.com/SwissDataScienceCenter/renku-python/blob/master/renku/service/views/config.py}
+   * @param {string} projectRepositoryUrl - external repository full url.
+   */
+  client.getProjectConfig = async (projectRepositoryUrl) => {
+    const url = `${client.baseUrl}/renku/config.show`;
+    const queryParams = { git_url: projectRepositoryUrl };
+    let headers = client.getBasicHeaders();
+    headers.append("Content-Type", "application/json");
+    headers.append("X-Requested-With", "XMLHttpRequest");
+
+    return client.clientFetch(url, {
+      method: "GET",
+      headers,
+      queryParams
+    });
+  };
+
+  /**
+   * Set project config data
+   * @see {@link https://github.com/SwissDataScienceCenter/renku-python/blob/master/renku/service/views/config.py}
+   * @param {string} projectRepositoryUrl - external repository full url.
+   * @param {object} config - config object in the form {key: value}. A null value removes the key.
+   */
+  client.setProjectConfig = async (projectRepositoryUrl, config) => {
+    const url = `${client.baseUrl}/renku/config.set`;
+    const body = { git_url: projectRepositoryUrl, config };
+    let headers = client.getBasicHeaders();
+    headers.append("Content-Type", "application/json");
+    headers.append("X-Requested-With", "XMLHttpRequest");
+
+    return client.clientFetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body)
+    });
+  };
 }
 
 

--- a/client/src/landing/NavBar.js
+++ b/client/src/landing/NavBar.js
@@ -73,9 +73,7 @@ class RenkuToolbarItemUser extends Component {
     }
     else if (!user.logged) {
       const to = Url.get(Url.pages.login.link, { pathname: location.pathname });
-      return <NavItem className="align-middle">
-        <RenkuNavLink to={to} title="Login" />
-      </NavItem>;
+      return (<RenkuNavLink to={to} title="Login" />);
     }
 
     return <UncontrolledDropdown className="nav-item dropdown">

--- a/client/src/model/RenkuModels.js
+++ b/client/src/model/RenkuModels.js
@@ -314,6 +314,17 @@ const projectGlobalSchema = new Schema({
       branch: { [Prop.INITIAL]: { name: "master" }, [Prop.MANDATORY]: true },
       commit: { [Prop.INITIAL]: { id: "latest" }, [Prop.MANDATORY]: true },
     })
+  },
+  config: {
+    [Prop.SCHEMA]: new Schema({
+      data: { [Prop.INITIAL]: {}, [Prop.MANDATORY]: true },
+      error: { [Prop.INITIAL]: {}, [Prop.MANDATORY]: true },
+      fetched: { [Prop.INITIAL]: null },
+      fetching: { [Prop.INITIAL]: false },
+
+      initial: { [Prop.INITIAL]: {} },
+      input: { [Prop.INITIAL]: {} }
+    })
   }
 });
 

--- a/client/src/notebooks/Notebooks.present.js
+++ b/client/src/notebooks/Notebooks.present.js
@@ -1634,22 +1634,23 @@ class StartNotebookServerOptions extends Component {
           case "enum": {
             const options = mergeEnumOptions(globalOptions, projectOptions, key);
             serverOption["options"] = options;
-            return <FormGroup key={key} className={serverOption.options.length === 1 ? "mb-0" : ""}>
+            const separator = options.length === 1 ? null : (<br />);
+            return <FormGroup key={key}>
               <Label className="me-2">{serverOption.displayName}</Label>
-              <ServerOptionEnum {...serverOption} onChange={onChange} />
+              {separator}<ServerOptionEnum {...serverOption} onChange={onChange} />
               {warning}
             </FormGroup>;
           }
           case "int":
             return <FormGroup key={key}>
               <Label className="me-2">{`${serverOption.displayName}: ${serverOption.selected}`}</Label>
-              <ServerOptionRange step={1} {...serverOption} onChange={onChange} />
+              <br /><ServerOptionRange step={1} {...serverOption} onChange={onChange} />
             </FormGroup>;
 
           case "float":
             return <FormGroup key={key}>
               <Label className="me-2">{`${serverOption.displayName}: ${serverOption.selected}`}</Label>
-              <ServerOptionRange step={0.01} {...serverOption} onChange={onChange} />
+              <br /><ServerOptionRange step={0.01} {...serverOption} onChange={onChange} />
             </FormGroup>;
 
           case "boolean":
@@ -1691,17 +1692,13 @@ class StartNotebookServerOptions extends Component {
 
 class ServerOptionEnum extends Component {
   render() {
-    const { selected } = this.props;
+    const { disabled, selected } = this.props;
     let { options } = this.props;
 
     if (selected && options && options.length && !options.includes(selected))
       options = options.concat(selected);
-    if (options.length === 1) {
-      const color = this.props.selected ?
-        "primary" :
-        "light";
-      return (<Badge color={color}>{this.props.options[0]}</Badge>);
-    }
+    if (options.length === 1)
+      return (<Badge color="primary">{this.props.options[0]}</Badge>);
 
     return (
       <ButtonGroup>
@@ -1712,10 +1709,10 @@ class ServerOptionEnum extends Component {
               "danger" :
               "primary";
           }
-          const size = this.props.size ? this.props.size : "sm";
+          const size = this.props.size ? this.props.size : null;
           return (
             <Button
-              key={optionName} color={color} size={size}
+              key={optionName} color={color} size={size} disabled={disabled}
               onClick={event => this.props.onChange(event, optionName)}>{optionName}</Button>
           );
         })}
@@ -1726,11 +1723,12 @@ class ServerOptionEnum extends Component {
 
 class ServerOptionBoolean extends Component {
   render() {
+    const { disabled } = this.props;
     // The double negation solves an annoying problem happening when checked=undefined
     // https://stackoverflow.com/a/39709700/1303090
     const selected = !!this.props.selected;
     return (<div className="form-check form-switch d-inline-block">
-      <Input type="switch" id={this.props.id} label={this.props.displayName}
+      <Input type="switch" id={this.props.id} label={this.props.displayName} disabled={disabled}
         checked={selected} onChange={this.props.onChange} className="form-check-input rounded-pill"/>
       <Label check htmlFor={this.props.id}>{this.props.displayName}</Label>
     </div>
@@ -1740,6 +1738,7 @@ class ServerOptionBoolean extends Component {
 
 class ServerOptionRange extends Component {
   render() {
+    const { disabled } = this.props;
     return (
       <Input
         type="range"
@@ -1749,6 +1748,7 @@ class ServerOptionRange extends Component {
         min={this.props.range[0]}
         max={this.props.range[1]}
         step={this.props.step}
+        disabled={disabled}
       />
     );
   }

--- a/client/src/notebooks/Notebooks.present.js
+++ b/client/src/notebooks/Notebooks.present.js
@@ -1591,8 +1591,8 @@ class StartNotebookOptionsRunning extends Component {
  */
 function mergeEnumOptions(globalOptions, projectOptions, key) {
   let options = globalOptions[key].options;
-  // defaultUrl can extend the existing options, but not the other ones
-  if (key === "defaultUrl"
+  // default_url can extend the existing options, but not the other ones
+  if (key === "default_url"
     && Object.keys(projectOptions).indexOf(key) >= 0
     && globalOptions[key].options.indexOf(projectOptions[key]) === -1)
     options = [...globalOptions[key].options, projectOptions[key]];
@@ -1635,20 +1635,20 @@ class StartNotebookServerOptions extends Component {
             const options = mergeEnumOptions(globalOptions, projectOptions, key);
             serverOption["options"] = options;
             return <FormGroup key={key} className={serverOption.options.length === 1 ? "mb-0" : ""}>
-              <Label>{serverOption.displayName}</Label>
+              <Label className="me-2">{serverOption.displayName}</Label>
               <ServerOptionEnum {...serverOption} onChange={onChange} />
               {warning}
             </FormGroup>;
           }
           case "int":
             return <FormGroup key={key}>
-              <Label>{`${serverOption.displayName}: ${serverOption.selected}`}</Label>
+              <Label className="me-2">{`${serverOption.displayName}: ${serverOption.selected}`}</Label>
               <ServerOptionRange step={1} {...serverOption} onChange={onChange} />
             </FormGroup>;
 
           case "float":
             return <FormGroup key={key}>
-              <Label>{`${serverOption.displayName}: ${serverOption.selected}`}</Label>
+              <Label className="me-2">{`${serverOption.displayName}: ${serverOption.selected}`}</Label>
               <ServerOptionRange step={0.01} {...serverOption} onChange={onChange} />
             </FormGroup>;
 
@@ -1696,23 +1696,30 @@ class ServerOptionEnum extends Component {
 
     if (selected && options && options.length && !options.includes(selected))
       options = options.concat(selected);
-    if (options.length === 1)
-      return (<label>: {this.props.selected}</label>);
+    if (options.length === 1) {
+      const color = this.props.selected ?
+        "primary" :
+        "light";
+      return (<Badge color={color}>{this.props.options[0]}</Badge>);
+    }
 
     return (
-      <div>
-        <ButtonGroup>
-          {options.map((optionName, i) => {
-            const color = optionName === selected ? "primary" : "outline-primary";
-            return (
-              <Button
-                color={color}
-                key={optionName}
-                onClick={event => this.props.onChange(event, optionName)}>{optionName}</Button>
-            );
-          })}
-        </ButtonGroup>
-      </div>
+      <ButtonGroup>
+        {options.map((optionName, i) => {
+          let color = "outline-primary";
+          if (optionName === selected) {
+            color = this.props.warning != null && this.props.warning === optionName ?
+              "danger" :
+              "primary";
+          }
+          const size = this.props.size ? this.props.size : "sm";
+          return (
+            <Button
+              key={optionName} color={color} size={size}
+              onClick={event => this.props.onChange(event, optionName)}>{optionName}</Button>
+          );
+        })}
+      </ButtonGroup>
     );
   }
 }
@@ -1722,7 +1729,7 @@ class ServerOptionBoolean extends Component {
     // The double negation solves an annoying problem happening when checked=undefined
     // https://stackoverflow.com/a/39709700/1303090
     const selected = !!this.props.selected;
-    return (<div className="form-check form-switch">
+    return (<div className="form-check form-switch d-inline-block">
       <Input type="switch" id={this.props.id} label={this.props.displayName}
         checked={selected} onChange={this.props.onChange} className="form-check-input rounded-pill"/>
       <Label check htmlFor={this.props.id}>{this.props.displayName}</Label>
@@ -1906,4 +1913,7 @@ class CheckNotebookIcon extends Component {
   }
 }
 
-export { CheckNotebookIcon, Notebooks, NotebooksDisabled, ShowSession, StartNotebookServer, mergeEnumOptions };
+export {
+  CheckNotebookIcon, Notebooks, NotebooksDisabled, ServerOptionBoolean, ServerOptionEnum, ServerOptionRange,
+  ShowSession, StartNotebookServer, mergeEnumOptions
+};

--- a/client/src/notebooks/Notebooks.state.js
+++ b/client/src/notebooks/Notebooks.state.js
@@ -42,6 +42,8 @@ const VALID_SETTINGS = [
   "image"
 ];
 
+const SESSIONS_PREFIX = "interactive.";
+
 const ExpectedAnnotations = {
   domain: "renku.io",
   "renku.io": {
@@ -110,10 +112,92 @@ const NotebooksHelper = {
   },
 
   /**
+   * Get options and default values from notebooks and project options
+   *
+   * @param {object} notebooksOptions - notebook options as return by the "GET server_options" API.
+   * @param {object} projectOptions - project options as returned by the "GET config.show" API.
+   * @param {string} [projectPrefix] - project option key prefix used by config to identify session options.
+   */
+  getProjectDefault: (notebooksOptions, projectOptions, projectPrefix = SESSIONS_PREFIX) => {
+    let returnObject = {};
+    if (!notebooksOptions || !projectOptions)
+      return returnObject;
+
+    // Conversion helper
+    const convert = (value) => {
+      // return boolean
+      if (value === true || value === false)
+        return value;
+
+      // convert stringy boolean
+      if (value && value.toLowerCase() === "true")
+        return true;
+
+      else if (value && value.toLowerCase() === "false")
+        return false;
+
+      // convert stringy number
+      else if (!isNaN(value))
+        return parseFloat(value);
+
+      return value;
+    };
+
+    // Define options
+    const sortedOptions = Object.keys(notebooksOptions)
+      .sort((a, b) => parseInt(notebooksOptions[a].order) - parseInt(notebooksOptions[b].order));
+    let unknownOptions = [];
+
+    // Get RenkuLab defaults
+    let globalDefaults = [...sortedOptions].reduce((defaults, option) => {
+      if ("default" in notebooksOptions[option])
+        defaults[option] = notebooksOptions[option].default;
+      return defaults;
+    }, {});
+
+    // Overwrite renku defaults
+    if (projectOptions && projectOptions.default && Object.keys(projectOptions.default)) {
+      for (const [key, value] of Object.entries(projectOptions.default)) {
+        if (key.startsWith(projectPrefix)) {
+          const option = key.substring(projectPrefix.length);
+          if (!sortedOptions.includes(option))
+            unknownOptions.push(option);
+          globalDefaults[option] = convert(value);
+        }
+      }
+    }
+
+    // Get project defaults
+    let projectDefaults = [];
+    if (projectOptions && projectOptions.config && Object.keys(projectOptions.config)) {
+      for (const [key, value] of Object.entries(projectOptions.config)) {
+        if (key.startsWith(projectPrefix)) {
+          const option = key.substring(projectPrefix.length);
+          if (!sortedOptions.includes(option))
+            unknownOptions.push(option);
+          projectDefaults[option] = convert(value);
+        }
+      }
+    }
+
+    return {
+      defaults: {
+        global: globalDefaults,
+        project: projectDefaults
+      },
+      options: {
+        known: sortedOptions,
+        unknown: unknownOptions
+      }
+    };
+  },
+
+  /**
    * Parse project options raw data from the .ini file to a JS object
    *
    * @param {string} data - raw file content
    */
+  // TODO: use the getProjectDefault function after switching to the "GET config.show" API
   parseProjectOptions: (data) => {
     let projectOptions = {};
 
@@ -132,10 +216,10 @@ const NotebooksHelper = {
       parsedOptions = parsedData[RENKU_INI_SECTION_LEGACY];
     if (parsedOptions) {
       Object.keys(parsedOptions).forEach(parsedOption => {
-        // treat "default_url" as "defaultUrl" to allow name consistency in the the .ini file
+        // treat "defaultUrl" as "default_url" to allow name consistency in the the .ini file
         let option = parsedOption;
-        if (parsedOption === "default_url")
-          option = "defaultUrl";
+        if (parsedOption === "defaultUrl")
+          option = "default_url";
 
         // convert boolean and numbers
         let value = parsedOptions[parsedOption];
@@ -165,8 +249,8 @@ const NotebooksHelper = {
    * @param {string} currentValue - current project option value
    */
   checkOptionValidity: (globalOptions, currentOption, currentValue) => {
-    // defaultUrl is a special case and any string will fit
-    if (currentOption === "defaultUrl") {
+    // default_url is a special case and any string will fit
+    if (currentOption === "default_url") {
       if (typeof currentValue === "string")
         return true;
       return false;
@@ -217,7 +301,8 @@ const NotebooksHelper = {
   },
 
   pipelineTypes: PIPELINE_TYPES,
-  validSettings: VALID_SETTINGS
+  validSettings: VALID_SETTINGS,
+  sessionConfigPrefix: SESSIONS_PREFIX
 };
 
 class NotebooksCoordinator {
@@ -361,8 +446,9 @@ class NotebooksCoordinator {
       });
   }
 
-  async fetchNotebookOptions() {
-    await this.fetchProjectOptions();
+  async fetchNotebookOptions(skip = false) {
+    if (!skip)
+      await this.fetchProjectOptions();
     const oldData = this.model.get("options.global");
     if (Object.keys(oldData).length !== 0)
       return;
@@ -381,6 +467,7 @@ class NotebooksCoordinator {
       });
   }
 
+  // TODO: switch to the "GET config.show" API. Adapt (or remove) also the following setDefaultOptions function
   async fetchProjectOptions() {
     // prepare query data and reset warnings
     const filters = this.getQueryFilters();

--- a/client/src/project/Project.js
+++ b/client/src/project/Project.js
@@ -66,6 +66,7 @@ const subRoutes = {
   data: "files/data",
   workflows: "files/workflows",
   settings: "settings",
+  settingsSessions: "settings/sessions",
   environments: "environments",
   environmentNew: "environments/new",
   showSession: "environments/show/:server"
@@ -350,6 +351,7 @@ class View extends Component {
       dataUrl: `${filesUrl}/data`,
       workflowsUrl: `${filesUrl}/workflows`,
       settingsUrl: `${baseUrl}/settings`,
+      settingsSessionsUrl: `${baseUrl}/settings/sessions`,
       mrOverviewUrl: `${baseUrl}/pending`,
       mrUrl: `${baseUrl}/pending/:mrIid`,
       launchNotebookUrl: `${baseUrl}/environments/new`,
@@ -745,4 +747,4 @@ function withProjectMapped(MappingComponent, features = [], passProps = true) {
 
 
 export default { View };
-export { GraphIndexingStatus, splitProjectSubRoute, mapProjectFeatures, withProjectMapped, MigrationStatus };
+export { GraphIndexingStatus, MigrationStatus, mapProjectFeatures, splitProjectSubRoute, withProjectMapped };

--- a/client/src/project/Project.present.js
+++ b/client/src/project/Project.present.js
@@ -27,25 +27,24 @@
 import React, { Component, Fragment, useState, useEffect } from "react";
 import { Link, NavLink, Route, Switch } from "react-router-dom";
 import {
-  Alert, Button, ButtonGroup, Card, CardBody, CardHeader, Col, DropdownItem, Form, FormGroup,
-  FormText, Input, Label, Row, Table, Nav, NavItem, UncontrolledTooltip, Modal, Badge,
-  NavLink as ReactNavLink
+  Alert, Badge, Button, ButtonGroup, Card, CardBody, CardHeader, Col, DropdownItem,
+  Row, Modal, Nav, NavLink as ReactNavLink, NavItem, UncontrolledTooltip
 } from "reactstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faStar as faStarRegular } from "@fortawesome/free-regular-svg-icons";
 import {
   faCodeBranch, faExclamationTriangle, faUserFriends, faGlobe, faInfoCircle, faLock, faSearch,
-  faStar as faStarSolid,
+  faStar as faStarSolid
 } from "@fortawesome/free-solid-svg-icons";
+import qs from "query-string";
 
 import {
-  Clipboard, ExternalLink, Loader, RenkuNavLink, TimeCaption,
-  ButtonWithMenu, InfoAlert, GoBackButton, RenkuMarkdown,
+  ExternalLink, Loader, RenkuNavLink, TimeCaption, ButtonWithMenu, InfoAlert, GoBackButton, RenkuMarkdown
 } from "../utils/UIComponents";
 import { Url } from "../utils/url";
 import { SpecialPropVal } from "../model/Model";
-import { ProjectAvatarEdit, ProjectTags, ProjectTagList } from "./shared";
-import { ShowSession, Notebooks, StartNotebookServer } from "../notebooks";
+import { ProjectTagList } from "./shared";
+import { Notebooks, ShowSession, StartNotebookServer } from "../notebooks";
 import Issue from "../collaboration/issue/Issue";
 import {
   CollaborationList, collaborationListTypeMap, itemsStateMap
@@ -57,8 +56,7 @@ import ProjectVersionStatus from "./status/ProjectVersionStatus.present";
 import { NamespaceProjects } from "../namespace";
 import { ProjectOverviewCommits, ProjectOverviewStats } from "./overview";
 import { ForkProject } from "./new";
-import qs from "query-string";
-
+import { ProjectSettingsGeneral, ProjectSettingsNav, ProjectSettingsSessions } from "./settings";
 
 import "./Project.css";
 
@@ -486,15 +484,16 @@ class ProjectViewOverviewNav extends Component {
           <RenkuNavLink to={this.props.baseUrl} title="Description" />
         </NavItem>
         <NavItem>
-          <RenkuNavLink to={`${this.props.statsUrl}`} title="Stats" />
+          <RenkuNavLink to={this.props.statsUrl} title="Stats" />
         </NavItem>
         <NavItem>
-          <RenkuNavLink to={`${this.props.overviewCommitsUrl}`} title="Commits" />
+          <RenkuNavLink to={this.props.overviewCommitsUrl} title="Commits" />
         </NavItem>
         <NavItem>
-          <RenkuNavLink to={`${this.props.overviewStatusUrl}`} title="Status" />
+          <RenkuNavLink to={this.props.overviewStatusUrl} title="Status" />
         </NavItem>
-      </Nav>);
+      </Nav>
+    );
   }
 }
 
@@ -1075,164 +1074,30 @@ class ProjectStartNotebookServer extends Component {
   }
 }
 
-function RepositoryUrlRow(props) {
-  return (
-    <tr>
-      <th scope="row">{props.urlType}</th>
-      <td>{props.url}</td>
-      <td style={{ width: 1 }}><Clipboard clipboardText={props.url} /></td>
-    </tr>
-  );
-}
-
-class RepositoryUrls extends Component {
-  render() {
-    return (
-      <div>
-        <Label className="font-weight-bold">Repository URL</Label>
-        <Table size="sm">
-          <tbody>
-            <RepositoryUrlRow urlType="SSH" url={this.props.system.ssh_url} />
-            <RepositoryUrlRow urlType="HTTP" url={this.props.system.http_url} />
-          </tbody>
-        </Table>
-      </div>
-    );
-  }
-}
-
-function CommandRow(props) {
-  return (
-    <tr>
-      <th scope="row">{props.application}</th>
-      <td>
-        <code>{props.command}</code>
-      </td>
-      <td style={{ width: 1 }}><Clipboard clipboardText={props.command} /></td>
-    </tr>
-  );
-}
-
-function GitCloneCmd(props) {
-  const [cmdOpen, setCmdOpen] = useState(false);
-  const { externalUrl, projectPath } = props;
-  const gitClone = `git clone ${externalUrl}.git && cd ${projectPath} && git lfs install --local --force`;
-  const gitHooksInstall = "renku githooks install"; // eslint-disable-line
-  return (cmdOpen) ?
-    <div className="mt-3">
-      <p style={{ fontSize: "smaller" }} className="font-italic">
-        If the <b>renku</b> command is not available, you can clone a project using Git.
-      </p>
-      <Table style={{ fontSize: "smaller" }} size="sm" className="mb-0" borderless={true}>
-        <tbody>
-          <tr>
-            <th scope="row">Git<sup>*</sup></th>
-            <td>
-              <code>{gitClone}</code>
-              <div className="mt-2 mb-0">
-                If you want to work with the repo using renku, {" "}
-                you need to run the following after the <code>git clone</code> completes:
-              </div>
-            </td>
-            <td style={{ width: 1 }}><Clipboard clipboardText={gitClone} /></td>
-          </tr>
-          <tr>
-            <th scope="row"></th>
-            <td>
-              <code>{gitHooksInstall}</code>
-            </td>
-            <td style={{ width: 1 }}><Clipboard clipboardText={gitHooksInstall} /></td>
-          </tr>
-        </tbody>
-      </Table>
-      <Button style={{ fontSize: "smaller" }} color="link" onClick={() => setCmdOpen(false)}>
-        Hide git command
-      </Button>
-    </div> :
-    <Button color="link" style={{ fontSize: "smaller" }} className="font-italic"
-      onClick={() => setCmdOpen(true)}>
-      Do not have renku?
-    </Button>;
-}
-
-
-class RepositoryClone extends Component {
-  render() {
-    const { externalUrl } = this.props;
-    const renkuClone = `renku clone ${externalUrl}.git`;
-    return (
-      <div>
-        <Label className="font-weight-bold">Clone commands</Label>
-        <Table size="sm" className="mb-0">
-          <tbody>
-            <CommandRow application="Renku" command={renkuClone} />
-          </tbody>
-        </Table>
-        <GitCloneCmd externalUrl={externalUrl} projectPath={this.props.core.project_path} />
-      </div>
-    );
-  }
-}
-
-class ProjectDescription extends Component {
-  constructor(props) {
-    super(props);
-    this.state = ProjectDescription.getDerivedStateFromProps(props, {});
-    this.onValueChange = this.handleChange.bind(this);
-    this.onSubmit = this.handleSubmit.bind(this);
-  }
-
-  static getDerivedStateFromProps(nextProps, prevState) {
-    const update = { value: nextProps.core.description };
-    return { ...update, ...prevState };
-  }
-
-  handleChange(e) { this.setState({ value: e.target.value }); }
-
-  handleSubmit(e) { e.preventDefault(); this.props.onProjectDescriptionChange(this.state.value); }
-
-  render() {
-    const inputField = this.props.settingsReadOnly ?
-      <Input id="projectDescription" readOnly value={this.state.value} /> :
-      <Input id="projectDescription" onChange={this.onValueChange}
-        value={this.state.value === null ? "" : this.state.value} />;
-    let submit = (this.props.core.description !== this.state.value) ?
-      <Button className="mb-3 updateProjectSettings" color="primary">Update</Button> :
-      <span></span>;
-    return <Form onSubmit={this.onSubmit}>
-      <FormGroup>
-        <Label for="projectDescription">Project Description</Label>
-        {inputField}
-        <FormText>A short description for the project</FormText>
-      </FormGroup>
-      {submit}
-    </Form>;
-  }
-}
-
 function ProjectSettings(props) {
-  return <Col key="settings" xs={12}>
-    <Row>
-      <Col xs={12} lg={6}>
-        <ProjectTags
-          tag_list={props.system.tag_list}
-          onProjectTagsChange={props.onProjectTagsChange}
-          settingsReadOnly={props.settingsReadOnly} />
-        <ProjectDescription {...props} />
-      </Col>
-      <Col xs={12} lg={6}>
-        <RepositoryClone {...props} />
-        <RepositoryUrls {...props} />
-      </Col>
-    </Row>
-    <Row>
-      <Col xs={12} lg={6}>
-        <ProjectAvatarEdit externalUrl={props.externalUrl}
-          avatarUrl={props.core.avatar_url} onAvatarChange={props.onAvatarChange}
-          settingsReadOnly={props.settingsReadOnly} />
-      </Col>
-    </Row>
-  </Col>;
+  return (
+    <Col key="settings">
+      <Row>
+        <Col key="nav" sm={12} md={2}>
+          <ProjectSettingsNav {...props} />
+        </Col>
+        <Col key="content" sm={12} md={10}>
+          <Switch>
+            <Route exact path={props.settingsUrl}
+              render={renderProps => {
+                return <ProjectSettingsGeneral {...props} />;
+              }}
+            />
+            <Route exact path={props.settingsSessionsUrl}
+              render={renderProps => {
+                return <ProjectSettingsSessions {...props} />;
+              }}
+            />
+          </Switch>
+        </Col>
+      </Row>
+    </Col>
+  );
 }
 
 class ProjectViewNotFound extends Component {

--- a/client/src/project/Project.state.js
+++ b/client/src/project/Project.state.js
@@ -535,6 +535,25 @@ class ProjectCoordinator {
     });
     return commits;
   }
+
+  async fetchProjectConfig(repositoryUrl) {
+    let configObject = {
+      error: { $set: {} },
+      fetching: true,
+    };
+    this.model.setObject({ config: configObject });
+    const response = await this.client.getProjectConfig(repositoryUrl);
+    configObject.fetching = false;
+    configObject.fetched = new Date();
+    if (response.data && response.data.error) {
+      configObject.error = response.data.error;
+      this.model.setObject({ config: configObject });
+      return response.data.error;
+    }
+    configObject.data = { $set: response.data.result };
+    this.model.setObject({ config: configObject });
+    return response.data.result;
+  }
 }
 
 export { ProjectModel, GraphIndexingStatus, ProjectCoordinator, MigrationStatus };

--- a/client/src/project/settings/ProjectSettings.container.js
+++ b/client/src/project/settings/ProjectSettings.container.js
@@ -1,0 +1,158 @@
+/*!
+ * Copyright 2021 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  ProjectSettings.container.js
+ *  Project settings container components.
+ */
+
+import React, { Component, useState } from "react";
+import { connect } from "react-redux";
+
+import { ProjectSettingsSessions as ProjectSettingsSessionsPresent } from "./ProjectSettings.present";
+import { NotebooksCoordinator } from "../../notebooks";
+import { refreshIfNecessary } from "../../utils/HelperFunctions";
+
+/**
+ * Mapper component for ProjectSettingsSessions.
+ *
+ * @param {Object} props.projectCoordinator - project coordinator
+ * @param {Object} props.model - model object
+ * @param {Object} props.location - react location object
+ * @param {object} props.client - client object
+ */
+class ProjectSettingsSessionsMapper extends Component {
+  constructor(props) {
+    super(props);
+    this.model = props.model;
+    this.projectCoordinator = props.projectCoordinator;
+
+    // add notebooks coordinator
+    const notebooksModel = props.model.subModel("notebooks");
+    const userModel = props.model.subModel("user");
+    this.notebooksCoordinator = new NotebooksCoordinator(props.client, notebooksModel, userModel);
+
+    // add handlers
+    this.handlers = {
+      refreshConfig: this.refreshConfig.bind(this)
+    };
+  }
+
+  componentDidMount() {
+    // Refresh project configuration for logged user
+    if (!this.model.get("user.logged"))
+      return null;
+    const currentConfig = this.model.get("project.config");
+    refreshIfNecessary(
+      currentConfig.fetching, currentConfig.fetched, () => { this.refreshConfig(); }
+    );
+    const currentOptions = this.model.get("notebooks.options");
+    refreshIfNecessary(
+      currentOptions.fetching, currentOptions.fetched, () => { this.refreshOptions(); }
+    );
+
+    this.refreshOptions();
+  }
+
+  async refreshConfig(repositoryUrl = null) {
+    const url = repositoryUrl ?
+      repositoryUrl :
+      this.props.externalUrl;
+    return await this.projectCoordinator.fetchProjectConfig(url);
+  }
+
+  refreshOptions() {
+    return this.notebooksCoordinator.fetchNotebookOptions(true);
+  }
+
+  mapStateToProps(state, ownProps) {
+    return {
+      options: state.notebooks.options,
+      metadata: state.project.metadata,
+      config: state.project.config,
+      user: state.user
+    };
+  }
+  render() {
+    const ProjectSettingsSessionsConnected = connect(this.mapStateToProps.bind(this))(ProjectSettingsSessions);
+    return (
+      <ProjectSettingsSessionsConnected
+        projectCoordinator={this.projectCoordinator}
+        store={this.model.reduxStore}
+        handlers={this.handlers}
+        location={this.props.location}
+        client={this.props.client}
+        repositoryUrl={this.props.externalUrl}
+      />
+    );
+  }
+}
+
+/**
+ * Component to manage project level sessions settings.
+ */
+function ProjectSettingsSessions(props) {
+  const { client, config, handlers, location, metadata, options, repositoryUrl, user } = props;
+
+  const pristineNewConfig = {
+    updating: false,
+    keyName: null,
+    value: null,
+    updated: false,
+    error: null
+  };
+  const [newConfig, setNewConfig] = useState({ ...pristineNewConfig });
+
+  // Set target project config value
+  const setConfig = async (key, value, keyName) => {
+    setNewConfig({ ...pristineNewConfig, keyName, updating: true });
+    try {
+      const config = { [key]: value };
+      const response = await client.setProjectConfig(repositoryUrl, config);
+      if (response.data.error) {
+        setNewConfig({ ...newConfig, updating: false, keyName, error: response.data.error.reason });
+      }
+      else {
+        const value = response.data.result.config[Object.keys(response.data.result.config)[0]];
+        setNewConfig({ ...newConfig, updating: false, updated: true, keyName, value });
+      }
+    }
+    catch (error) {
+      setNewConfig({ ...newConfig, keyName, error: error.message });
+    }
+    finally {
+      await handlers.refreshConfig();
+    }
+  };
+
+  return (
+    <ProjectSettingsSessionsPresent
+      config={config}
+      location={location}
+      metadata={metadata}
+      newConfig={newConfig}
+      options={options}
+      setConfig={setConfig}
+      user={user}
+    />
+  );
+}
+
+export { ProjectSettingsSessionsMapper as ProjectSettingsSessions };

--- a/client/src/project/settings/ProjectSettings.container.js
+++ b/client/src/project/settings/ProjectSettings.container.js
@@ -122,7 +122,7 @@ function ProjectSettingsSessions(props) {
 
   // Set target project config value
   const setConfig = async (key, value, keyName) => {
-    setNewConfig({ ...pristineNewConfig, keyName, updating: true });
+    setNewConfig({ ...pristineNewConfig, keyName, updating: true, error: null });
     try {
       const config = { [key]: value };
       const response = await client.setProjectConfig(repositoryUrl, config);
@@ -131,7 +131,7 @@ function ProjectSettingsSessions(props) {
       }
       else {
         const value = response.data.result.config[Object.keys(response.data.result.config)[0]];
-        setNewConfig({ ...newConfig, updating: false, updated: true, keyName, value });
+        setNewConfig({ ...newConfig, updating: false, updated: true, error: null, keyName, value });
       }
     }
     catch (error) {

--- a/client/src/project/settings/ProjectSettings.present.js
+++ b/client/src/project/settings/ProjectSettings.present.js
@@ -1,0 +1,521 @@
+/*!
+ * Copyright 2021 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  ProjectSettings.present.js
+ *  Project settings presentational components.
+ */
+
+import React, { Component, Fragment, useState } from "react";
+import { Link } from "react-router-dom";
+import {
+  Alert, Button, Col, Collapse, Form, FormGroup,
+  FormText, Input, Label, Row, Table, Nav, NavItem, UncontrolledTooltip
+} from "reactstrap";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  faExclamationTriangle, faInfoCircle, faTimesCircle
+} from "@fortawesome/free-solid-svg-icons";
+
+import { ACCESS_LEVELS } from "../../api-client";
+import { ProjectAvatarEdit, ProjectTags, } from "../shared";
+import { NotebooksHelper, ServerOptionBoolean, ServerOptionEnum, ServerOptionRange } from "../../notebooks";
+import { Clipboard, Loader, RenkuNavLink } from "../../utils/UIComponents";
+import { Url } from "../../utils/url";
+
+
+//** Navigation **//
+
+function ProjectSettingsNav(props) {
+  return (
+    <Nav className="flex-column nav-light">
+      <NavItem>
+        <RenkuNavLink to={props.settingsUrl} title="General" />
+      </NavItem>
+      <NavItem>
+        <RenkuNavLink to={props.settingsSessionsUrl} title="Sessions" />
+      </NavItem>
+    </Nav>
+  );
+}
+
+
+//** General settings **//
+
+function ProjectSettingsGeneral(props) {
+  return (
+    <Fragment>
+      <Row className="mt-2">
+        <Col xs={12} lg={6}>
+          <ProjectTags
+            tag_list={props.system.tag_list}
+            onProjectTagsChange={props.onProjectTagsChange}
+            settingsReadOnly={props.settingsReadOnly} />
+          <ProjectDescription {...props} />
+        </Col>
+        <Col xs={12} lg={6}>
+          <RepositoryClone {...props} />
+          <RepositoryUrls {...props} />
+        </Col>
+      </Row>
+      <Row>
+        <Col xs={12}>
+          <ProjectAvatarEdit externalUrl={props.externalUrl}
+            avatarUrl={props.core.avatar_url} onAvatarChange={props.onAvatarChange}
+            settingsReadOnly={props.settingsReadOnly} />
+        </Col>
+      </Row>
+    </Fragment>
+  );
+}
+
+class RepositoryClone extends Component {
+  render() {
+    const { externalUrl } = this.props;
+    const renkuClone = `renku clone ${externalUrl}.git`;
+    return (
+      <div className="mb-3">
+        <Label className="font-weight-bold">Clone commands</Label>
+        <Table size="sm" className="mb-0">
+          <tbody>
+            <CommandRow application="Renku" command={renkuClone} />
+          </tbody>
+        </Table>
+        <GitCloneCmd externalUrl={externalUrl} projectPath={this.props.core.project_path} />
+      </div>
+    );
+  }
+}
+
+function GitCloneCmd(props) {
+  const [cmdOpen, setCmdOpen] = useState(false);
+  const { externalUrl, projectPath } = props;
+  const gitClone = `git clone ${externalUrl}.git && cd ${projectPath} && git lfs install --local --force`;
+  const gitHooksInstall = "renku githooks install"; // eslint-disable-line
+  return (cmdOpen) ?
+    <div className="mt-3">
+      <p style={{ fontSize: "smaller" }} className="font-italic">
+        If the <b>renku</b> command is not available, you can clone a project using Git.
+      </p>
+      <Table style={{ fontSize: "smaller" }} size="sm" className="mb-0" borderless={true}>
+        <tbody>
+          <tr>
+            <th scope="row">Git<sup>*</sup></th>
+            <td>
+              <code>{gitClone}</code>
+              <div className="mt-2 mb-0">
+                If you want to work with the repo using renku, {" "}
+                you need to run the following after the <code>git clone</code> completes:
+              </div>
+            </td>
+            <td style={{ width: 1 }}><Clipboard clipboardText={gitClone} /></td>
+          </tr>
+          <tr>
+            <th scope="row"></th>
+            <td>
+              <code>{gitHooksInstall}</code>
+            </td>
+            <td style={{ width: 1 }}><Clipboard clipboardText={gitHooksInstall} /></td>
+          </tr>
+        </tbody>
+      </Table>
+      <Button style={{ fontSize: "smaller" }} color="link" onClick={() => setCmdOpen(false)}>
+        Hide git command
+      </Button>
+    </div> :
+    <Button color="link" style={{ fontSize: "smaller" }} className="font-italic"
+      onClick={() => setCmdOpen(true)}>
+      Do not have renku?
+    </Button>;
+}
+
+class ProjectDescription extends Component {
+  constructor(props) {
+    super(props);
+    this.state = ProjectDescription.getDerivedStateFromProps(props, {});
+    this.onValueChange = this.handleChange.bind(this);
+    this.onSubmit = this.handleSubmit.bind(this);
+  }
+
+  static getDerivedStateFromProps(nextProps, prevState) {
+    const update = { value: nextProps.core.description };
+    return { ...update, ...prevState };
+  }
+
+  handleChange(e) { this.setState({ value: e.target.value }); }
+
+  handleSubmit(e) { e.preventDefault(); this.props.onProjectDescriptionChange(this.state.value); }
+
+  render() {
+    const inputField = this.props.settingsReadOnly ?
+      <Input id="projectDescription" readOnly value={this.state.value} /> :
+      <Input id="projectDescription" onChange={this.onValueChange}
+        value={this.state.value === null ? "" : this.state.value} />;
+    let submit = (this.props.core.description !== this.state.value) ?
+      <Button className="mb-3 updateProjectSettings" color="primary">Update</Button> :
+      <span></span>;
+    return <Form onSubmit={this.onSubmit}>
+      <FormGroup>
+        <Label for="projectDescription">Project Description</Label>
+        {inputField}
+        <FormText>A short description for the project</FormText>
+      </FormGroup>
+      {submit}
+    </Form>;
+  }
+}
+
+function CommandRow(props) {
+  return (
+    <tr>
+      <th scope="row">{props.application}</th>
+      <td>
+        <code>{props.command}</code>
+      </td>
+      <td style={{ width: 1 }}><Clipboard clipboardText={props.command} /></td>
+    </tr>
+  );
+}
+
+class RepositoryUrls extends Component {
+  render() {
+    return (
+      <div className="mb-3">
+        <Label className="font-weight-bold">Repository URL</Label>
+        <Table size="sm">
+          <tbody>
+            <RepositoryUrlRow urlType="SSH" url={this.props.system.ssh_url} />
+            <RepositoryUrlRow urlType="HTTP" url={this.props.system.http_url} />
+          </tbody>
+        </Table>
+      </div>
+    );
+  }
+}
+
+function RepositoryUrlRow(props) {
+  return (
+    <tr>
+      <th scope="row">{props.urlType}</th>
+      <td>{props.url}</td>
+      <td style={{ width: 1 }}><Clipboard clipboardText={props.url} /></td>
+    </tr>
+  );
+}
+
+
+//** Sessions settings **//
+
+function ProjectSettingsSessions(props) {
+  const { config, location, metadata, newConfig, options, setConfig, user } = props;
+  const { accessLevel } = metadata;
+  const devAccess = accessLevel > ACCESS_LEVELS.DEVELOPER ? true : false;
+
+  // ? Anonymous users may have problem with notebook options, depending on the deployment
+  if (!user.logged) {
+    const to = Url.get(Url.pages.login.link, { pathname: location.pathname });
+    return (
+      <SessionsDiv>
+        <p>Anonymous users cannot access sessions settings.</p>
+        <p>You can <Link className="btn btn-primary btn-sm" to={to}>Log in</Link> to see them.</p>
+      </SessionsDiv>
+    );
+  }
+
+  // Handle ongoing operations
+  if (config.fetching || options.fetching)
+    return (<SessionsDiv><Loader /></SessionsDiv>);
+
+  if (newConfig.updating)
+    return (<SessionsDiv><NewConfigStatus {...newConfig} /></SessionsDiv>);
+
+  // Handle errors
+  if (config.error && config.error.code)
+    return (<SessionsDiv><SessionConfigError config={config} /></SessionsDiv>);
+
+  // ? this prevents early rendering when hitting the sessions page on the url bar directly
+  const globalOptions = options.global;
+  if (!Object.keys(options.global).length)
+    return null;
+
+  // Get metadata and create the visual elements for every option
+  const projectData = NotebooksHelper.getProjectDefault(
+    options.global ? options.global : {},
+    config.data ? config.data : {}
+  );
+
+  const knownOptions = (
+    <SessionConfigKnown availableOptions={projectData.options} defaults={projectData.defaults}
+      devAccess={devAccess} globalOptions={globalOptions} setConfig={setConfig}
+    />
+  );
+
+  const unknownOptions = (
+    <SessionConfigUnknown devAccess={devAccess} defaults={projectData.defaults.project}
+      options={projectData.options.unknown} setConfig={setConfig}
+    />
+  );
+
+  // Information based on user's access level
+  const text = devAccess ?
+    (<p>
+      Any change will be permanently saved in the project options and used as default.
+      <br /> Mind that users can still manually modify any option before starting a session.
+    </p>) :
+    (<p>Settings can be changed only by developers and maintainers.</p>);
+
+  return (
+    <SessionsDiv>
+      <NewConfigStatus {...newConfig} />
+      {text}
+      {knownOptions}
+      {unknownOptions}
+    </SessionsDiv>
+  );
+}
+
+function SessionConfigKnown(props) {
+  const { availableOptions, defaults, devAccess, globalOptions, setConfig } = props;
+
+  return availableOptions.known.map(option => {
+    return (
+      <SessionsElement key={option}
+        option={option} // key cannot be accessed as a property, hence the duplication here
+        globalDefault={defaults.global[option]}
+        projectDefault={defaults.project[option]}
+        rendering={globalOptions[option]}
+        setConfig={setConfig}
+        devAccess={devAccess}
+        configPrefix={NotebooksHelper.sessionConfigPrefix}
+      />
+    );
+  });
+}
+
+function SessionConfigUnknown(props) {
+  const { defaults, devAccess, options, setConfig } = props;
+
+  const [showUnknown, setShowUnknown] = useState(false);
+  const toggleShowUnknown = () => setShowUnknown(!showUnknown);
+
+  const resetValue = (option) => {
+    const configKey = `${NotebooksHelper.sessionConfigPrefix}${option}`;
+    setConfig(configKey, null, option);
+  };
+
+  // Don't show anything when there are no unknown settings
+  if (!options || !options.length)
+    return null;
+
+  // Create option elements
+  const unknownOptions = options.map(option => {
+    const value = defaults[option];
+
+    const reset = devAccess ?
+      (<SessionsOptionReset onChange={() => resetValue(option)} option={option} />) :
+      null;
+
+    return (
+      <FormGroup key={option}>
+        <Label>{option}: {value}</Label> {reset}
+      </FormGroup>
+    );
+  });
+
+  // Collapse unknown values by default
+  return (
+    <Fragment>
+      <Collapse isOpen={showUnknown}>
+        <h4>Unrecognized settings</h4>
+        <p>
+          The following settings are stored in the project configuration but they are not
+          supported in this RenkuLab deployment.
+        </p>
+        {unknownOptions}
+      </Collapse>
+      <Button color="link" className="font-italic btn-sm" onClick={toggleShowUnknown}>
+        [{showUnknown ? "Hide " : "Show "} unrecognized settings]
+      </Button>
+    </Fragment>
+  );
+}
+
+function SessionConfigError(props) {
+  const { config } = props;
+
+  const [showError, setShowError] = useState(false);
+  const toggleShowError = () => setShowError(!showError);
+
+  return (
+    <Alert color="danger">
+      <h3>Error</h3>
+      <p>We could not access the project settings.</p>
+
+      <Collapse isOpen={showError}>
+        <code>{config.error.reason ? config.error.reason : `Error code ${config.error.code}`}</code>
+      </Collapse>
+      <Button color="link" className="font-italic btn-sm" onClick={toggleShowError}>
+        [{showError ? "Hide details" : "Show details"} info]
+      </Button>
+    </Alert>
+  );
+}
+
+function NewConfigStatus(props) {
+  const { error, keyName, updated, updating, value } = props;
+
+  if (updating) {
+    return (<div><span>Updating {keyName}, please wait... <Loader size="14" inline="true" /></span></div>);
+  }
+  else if (error) {
+    return (
+      <Alert color="danger">
+        <FontAwesomeIcon icon={faExclamationTriangle} /> Error occurred
+        while updating &quot;{keyName}&quot;: {error}
+      </Alert>
+    );
+  }
+  else if (updated) {
+    const text = value == null ?
+      "unset." :
+      (<span>updated to <code>{value}</code></span>);
+    return (<Alert color="info"><FontAwesomeIcon icon={faInfoCircle} /> &quot;{keyName}&quot; {text}</Alert>);
+  }
+
+  return null;
+}
+
+function SessionsDiv(props) {
+  return (
+    <div className="mt-2">
+      <h3>Sessions settings</h3>
+      {props.children}
+    </div>
+  );
+}
+
+function SessionsOptionReset(props) {
+  const { onChange, option } = props;
+  return (
+    <Fragment>
+      <Button id={`${option}_reset`} color="outline-primary" size="sm" className="border-0"
+        onClick={(event) => onChange(event, null, true)}>
+        <FontAwesomeIcon icon={faTimesCircle} />
+      </Button>
+      <UncontrolledTooltip key="tooltip" placement="top" target={`${option}_reset`}>
+        Reset value
+      </UncontrolledTooltip>
+    </Fragment>
+  );
+}
+
+function SessionsElement(props) {
+  const { configPrefix, devAccess, globalDefault, option, projectDefault, rendering, setConfig } = props;
+
+  // Compatibility layer to re-use the notebooks presentation components
+  const onChange = (event, providedValue, reset = false) => {
+    if (!devAccess)
+      return null;
+
+    // get the correct value
+    let value;
+    if (reset) {
+      value = null;
+    }
+    else if (providedValue != null) {
+      value = providedValue;
+    }
+    else {
+      const target = event.target.type.toLowerCase();
+      if (target === "button")
+        value = event.target.textContent;
+
+      else if (target === "checkbox")
+        value = event.target.checked.toString();
+
+      else
+        value = event.target.value;
+    }
+
+    const configKey = `${configPrefix}${option}`;
+    setConfig(configKey, value, rendering.displayName);
+  };
+
+  // Provide default info when nothing is selected
+  const info = projectDefault != null ?
+    null :
+    (<Fragment>
+      <span id={`${option}_info`}><FontAwesomeIcon className="cursor-default" icon={faInfoCircle} /></span>
+      <UncontrolledTooltip key="tooltip" placement="top" target={`${option}_info`}>
+        Default RenkuLab value: <code className="text-white">{rendering.default.toString()}</code>
+      </UncontrolledTooltip>
+    </Fragment>);
+
+  // Add reset button
+  const reset = devAccess && projectDefault != null ?
+    (<SessionsOptionReset onChange={onChange} option={option} />) :
+    null;
+
+  // Render proper type
+  if (rendering.type === "enum") {
+    let warning = projectDefault && !rendering.options.includes(projectDefault) && option !== "default_url" ?
+      (<Fragment>
+        <span id={`${option}_warn`} className="text-danger">
+          <FontAwesomeIcon className="cursor-default" icon={faExclamationTriangle} color="danger" />
+        </span>
+        <UncontrolledTooltip key="tooltip" placement="top" target={`${option}_warn`}>
+          Unsupported value on RenkuLab.
+          { devAccess ? " Consider changing it." : "" }
+        </UncontrolledTooltip>
+      </Fragment>) :
+      null;
+
+    return (
+      <FormGroup>
+        <Label className="me-2">{rendering.displayName} {info} {warning}</Label>
+        <ServerOptionEnum {...rendering} selected={projectDefault} onChange={onChange}
+          warning={warning ? projectDefault : null} />
+        {reset}
+      </FormGroup>
+    );
+  }
+  else if (rendering.type === "boolean") {
+    return (
+      <FormGroup>
+        <ServerOptionBoolean {...rendering} selected={projectDefault} onChange={onChange} />
+        {reset}
+      </FormGroup>
+    );
+  }
+  else if (rendering.type === "float" || rendering.type === "int") {
+    const step = rendering.type === "float" ?
+      0.01 :
+      1;
+    return (
+      <FormGroup>
+        <Label className="me-2">{`${rendering.displayName}: ${projectDefault || globalDefault}`}</Label>
+        <ServerOptionRange step={step} {...rendering} selected={projectDefault} onChange={onChange} />
+        {reset}
+      </FormGroup>
+    );
+  }
+}
+
+export { ProjectSettingsGeneral, ProjectSettingsNav, ProjectSettingsSessions };

--- a/client/src/project/settings/ProjectSettings.present.js
+++ b/client/src/project/settings/ProjectSettings.present.js
@@ -31,7 +31,7 @@ import {
 } from "reactstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
-  faCheck, faEdit, faExclamationTriangle, faInfoCircle, faTrash, faTimesCircle
+  faCheck, faEdit, faExclamationTriangle, faTrash, faTimesCircle
 } from "@fortawesome/free-solid-svg-icons";
 
 import { ACCESS_LEVELS } from "../../api-client";
@@ -296,7 +296,7 @@ function SessionConfigKnown(props) {
 
   const elementsList = availableOptions.known.map(option => {
     return (
-      <Col key={option} xs={12} lg={6}>
+      <Col key={option} xs={12} lg={6} xl={5}>
         <SessionsElement
           configPrefix={NotebooksHelper.sessionConfigPrefix}
           devAccess={devAccess}
@@ -408,7 +408,7 @@ function NewConfigStatus(props) {
     const text = value == null ?
       "unset." :
       (<span>updated to <code>{value}</code></span>);
-    return (<Alert color="info"><FontAwesomeIcon icon={faInfoCircle} /> &quot;{keyName}&quot; {text}</Alert>);
+    return (<Alert color="info">&quot;{keyName}&quot; {text}</Alert>);
   }
 
   return null;
@@ -443,6 +443,10 @@ function SessionsElement(props) {
     configPrefix, devAccess, disabled, globalDefault, option, projectDefault, rendering, setConfig
   } = props;
 
+  // temporary save the new value to highlight the correct option while updating
+  const [newValue, setNewValue] = useState(null);
+  const [newValueApplied, setNewValueApplied] = useState(false);
+
   // Compatibility layer to re-use the notebooks presentation components
   const onChange = (event, providedValue, reset = false) => {
     if (!devAccess)
@@ -468,6 +472,8 @@ function SessionsElement(props) {
         value = event.target.value.toString();
     }
 
+    setNewValue(value);
+    setNewValueApplied(true);
     const configKey = `${configPrefix}${option}`;
     setConfig(configKey, value, rendering.displayName);
   };
@@ -475,10 +481,7 @@ function SessionsElement(props) {
   // Provide default info when nothing is selected
   let info = projectDefault != null ?
     null :
-    (<FormText>
-      <FontAwesomeIcon className="cursor-default" icon={faInfoCircle} /> Default RenkuLab
-      value: <code>{rendering.default.toString()}</code>
-    </FormText>);
+    (<FormText>Default value: <code>{rendering.default.toString()}</code></FormText>);
 
   // Add reset button
   const reset = devAccess && projectDefault != null ?
@@ -497,19 +500,20 @@ function SessionsElement(props) {
       </FormText>);
     }
     else if (rendering.options.length === 1) {
-      info = (<FormText>
-        <FontAwesomeIcon className="cursor-default" icon={faInfoCircle} /> RenkuLab does not
-        allow changing this.
-      </FormText>);
+      info = (<FormText>RenkuLab does not allow changing this.</FormText>);
     }
+
+    const labelLoader = newValueApplied ?
+      (<Loader size="14" inline="true" />) :
+      null;
 
     const separator = rendering.options.length === 1 ? null : (<br />);
     return (
       <FormGroup>
-        <Label className="me-2">{rendering.displayName}</Label>
+        <Label className="me-2">{rendering.displayName} {labelLoader}</Label>
         {separator}
-        <ServerOptionEnum {...rendering} selected={projectDefault} onChange={onChange}
-          warning={warning ? projectDefault : null} disabled={disabled} />
+        <ServerOptionEnum {...rendering} selected={newValueApplied ? newValue : projectDefault}
+          onChange={onChange} warning={warning ? projectDefault : null} disabled={disabled} />
         {reset}
         {info ? (<Fragment><br />{info}</Fragment>) : null}
       </FormGroup>
@@ -518,8 +522,8 @@ function SessionsElement(props) {
   else if (rendering.type === "boolean") {
     return (
       <FormGroup>
-        <ServerOptionBoolean {...rendering} selected={projectDefault} onChange={onChange}
-          disabled={disabled} />
+        <ServerOptionBoolean {...rendering} selected={newValueApplied ? newValue : projectDefault}
+          onChange={onChange} disabled={disabled} />
         {reset}
       </FormGroup>
     );
@@ -531,8 +535,8 @@ function SessionsElement(props) {
     return (
       <FormGroup>
         <Label className="me-2">{`${rendering.displayName}: ${projectDefault || globalDefault}`}</Label>
-        <br /><ServerOptionRange step={step} {...rendering} selected={projectDefault} disabled={disabled}
-          onChange={onChange} />
+        <br /><ServerOptionRange step={step} {...rendering} selected={newValueApplied ? newValue : projectDefault}
+          disabled={disabled} onChange={onChange} />
         {reset}
       </FormGroup>
     );

--- a/client/src/project/settings/ProjectSettings.present.js
+++ b/client/src/project/settings/ProjectSettings.present.js
@@ -440,18 +440,18 @@ function SessionsElement(props) {
       value = null;
     }
     else if (providedValue != null) {
-      value = providedValue;
+      value = providedValue.toString();
     }
     else {
       const target = event.target.type.toLowerCase();
       if (target === "button")
-        value = event.target.textContent;
+        value = event.target.textContent.toString();
 
       else if (target === "checkbox")
         value = event.target.checked.toString();
 
       else
-        value = event.target.value;
+        value = event.target.value.toString();
     }
 
     const configKey = `${configPrefix}${option}`;

--- a/client/src/project/settings/ProjectSettings.present.js
+++ b/client/src/project/settings/ProjectSettings.present.js
@@ -275,10 +275,7 @@ function ProjectSettingsSessions(props) {
 
   // Information based on user's access level
   const text = devAccess ?
-    (<p>
-      Any change will be permanently saved in the project options and used as default.
-      <br /> Mind that users can still manually modify any option before starting a session.
-    </p>) :
+    null :
     (<p>Settings can be changed only by developers and maintainers.</p>);
 
   return (
@@ -405,7 +402,7 @@ function NewConfigStatus(props) {
 function SessionsDiv(props) {
   return (
     <div className="mt-2">
-      <h3>Sessions settings</h3>
+      <h3>Session settings</h3>
       {props.children}
     </div>
   );

--- a/client/src/project/settings/ProjectSettings.present.js
+++ b/client/src/project/settings/ProjectSettings.present.js
@@ -446,23 +446,27 @@ function SessionsElement(props) {
       value = null;
     }
     else if (providedValue != null) {
-      value = providedValue.toString();
+      value = providedValue;
     }
     else {
       const target = event.target.type.toLowerCase();
       if (target === "button")
-        value = event.target.textContent.toString();
+        value = event.target.textContent;
 
       else if (target === "checkbox")
-        value = event.target.checked.toString();
+        value = event.target.checked;
 
       else
-        value = event.target.value.toString();
+        value = event.target.value;
     }
 
     setNewValue(value);
     setNewValueApplied(true);
     const configKey = `${configPrefix}${option}`;
+    // ? stringify non null values to prevent API errors
+    value = value === null ?
+      value :
+      value.toString();
     setConfig(configKey, value, rendering.displayName);
   };
 

--- a/client/src/project/settings/ProjectSettings.present.js
+++ b/client/src/project/settings/ProjectSettings.present.js
@@ -227,6 +227,7 @@ function ProjectSettingsSessions(props) {
   const { config, location, metadata, newConfig, options, setConfig, user } = props;
   const { accessLevel } = metadata;
   const devAccess = accessLevel > ACCESS_LEVELS.DEVELOPER ? true : false;
+  const disabled = !devAccess || newConfig.updating;
 
   // ? Anonymous users may have problem with notebook options, depending on the deployment
   if (!user.logged) {
@@ -259,19 +260,19 @@ function ProjectSettingsSessions(props) {
 
   const knownOptions = (
     <SessionConfigKnown availableOptions={projectData.options} defaults={projectData.defaults}
-      devAccess={devAccess} globalOptions={globalOptions} setConfig={setConfig} disabled={newConfig.updating}
+      devAccess={devAccess} globalOptions={globalOptions} setConfig={setConfig} disabled={disabled}
     />
   );
 
   const advancedOptions = (
     <SessionConfigAdvanced devAccess={devAccess} defaults={projectData.defaults.project}
-      options={projectData.options.unknown} setConfig={setConfig} disabled={newConfig.updating}
+      options={projectData.options.unknown} setConfig={setConfig} disabled={disabled}
     />
   );
 
   const unknownOptions = (
     <SessionConfigUnknown devAccess={devAccess} defaults={projectData.defaults.project}
-      options={projectData.options.unknown} setConfig={setConfig} disabled={newConfig.updating}
+      options={projectData.options.unknown} setConfig={setConfig} disabled={disabled}
     />
   );
 
@@ -387,28 +388,15 @@ function SessionConfigError(props) {
 }
 
 function NewConfigStatus(props) {
-  const { error, keyName, updated, updating, value } = props;
+  const { error, keyName } = props;
 
-  if (updating) {
-    return (
-      <Alert color="info">
-        <span>Updating {keyName}, please wait... <Loader size="14" inline="true" /></span>
-      </Alert>
-    );
-  }
-  else if (error) {
+  if (error) {
     return (
       <Alert color="danger">
         <FontAwesomeIcon icon={faExclamationTriangle} /> Error occurred
         while updating &quot;{keyName}&quot;: {error}
       </Alert>
     );
-  }
-  else if (updated) {
-    const text = value == null ?
-      "unset." :
-      (<span>updated to <code>{value}</code></span>);
-    return (<Alert color="info">&quot;{keyName}&quot; {text}</Alert>);
   }
 
   return null;
@@ -555,8 +543,11 @@ function SessionConfigAdvanced(props) {
 
   const warningMessage = devAccess ?
     (<Alert color="warning">
-      <FontAwesomeIcon className="cursor-default" icon={faExclamationTriangle} color="warning" /> Changing
-      the following settings may lead to corrupted sessions.
+      <FontAwesomeIcon className="cursor-default" icon={faExclamationTriangle} color="warning" /> Fixing
+      an image can yield improvements, but it can also lead to sessions not working in the expected
+      way. <a href="https://renku.readthedocs.io/en/latest/user/interactive_customizing.html">
+        Please consult the documentation
+      </a> before changing this setting.
     </Alert>) :
     null;
   return (

--- a/client/src/project/settings/ProjectSettings.test.js
+++ b/client/src/project/settings/ProjectSettings.test.js
@@ -1,0 +1,85 @@
+/*!
+ * Copyright 2021 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  ProjectSettings.test.js
+ *  Tests for project settings.
+ */
+
+import React from "react";
+import { act } from "react-dom/test-utils";
+import ReactDOM from "react-dom";
+import { MemoryRouter } from "react-router-dom";
+
+import { ProjectSettingsGeneral, ProjectSettingsNav, ProjectSettingsSessions } from "./index";
+import { testClient as client } from "../../api-client";
+import { StateModel, globalSchema } from "../../model";
+
+
+const model = new StateModel(globalSchema);
+const fakeLocation = { pathname: "" };
+
+describe("rendering", () => {
+  it("renders ProjectSettingsNav", async () => {
+    const props = {
+      settingsUrl: "",
+      settingsSessionsUrl: ""
+    };
+
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    await act(async () => {
+      ReactDOM.render(<MemoryRouter>
+        <ProjectSettingsNav {...props} />
+      </MemoryRouter>, div);
+    });
+  });
+
+  it("renders ProjectSettingsGeneral", async () => {
+    const props = {
+      core: {},
+      system: {}
+    };
+
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    await act(async () => {
+      ReactDOM.render(<MemoryRouter>
+        <ProjectSettingsGeneral {...props} />
+      </MemoryRouter>, div);
+    });
+  });
+
+  it("renders ProjectSettingsSessions", async () => {
+    const props = {
+      client,
+      location: fakeLocation,
+      model
+    };
+
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    await act(async () => {
+      ReactDOM.render(<MemoryRouter>
+        <ProjectSettingsSessions {...props} />
+      </MemoryRouter>, div);
+    });
+  });
+});

--- a/client/src/project/settings/index.js
+++ b/client/src/project/settings/index.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2018 - Swiss Data Science Center (SDSC)
+ * Copyright 2021 - Swiss Data Science Center (SDSC)
  * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
  * Eidgenössische Technische Hochschule Zürich (ETHZ).
  *
@@ -17,19 +17,13 @@
  */
 
 /**
- *  renku-ui
+ * renku-ui
  *
- * Components for interacting with the notebook server (renku-notebooks)
+ * Components for project settings
  *
  */
 
-import { CheckNotebookStatus, Notebooks, ShowSession, StartNotebookServer } from "./Notebooks.container";
-import { NotebooksCoordinator, NotebooksHelper } from "./Notebooks.state";
-import {
-  CheckNotebookIcon, NotebooksDisabled, ServerOptionBoolean, ServerOptionEnum, ServerOptionRange
-} from "./Notebooks.present";
+import { ProjectSettingsSessions } from "./ProjectSettings.container";
+import { ProjectSettingsGeneral, ProjectSettingsNav } from "./ProjectSettings.present";
 
-export {
-  CheckNotebookIcon, CheckNotebookStatus, Notebooks, NotebooksCoordinator, NotebooksDisabled, NotebooksHelper,
-  ServerOptionBoolean, ServerOptionEnum, ServerOptionRange, ShowSession, StartNotebookServer
-};
+export { ProjectSettingsGeneral, ProjectSettingsNav, ProjectSettingsSessions };

--- a/client/src/project/shared/ProjectAvatar.container.js
+++ b/client/src/project/shared/ProjectAvatar.container.js
@@ -79,7 +79,7 @@ function ProjectAvatarEdit({ avatarUrl, onAvatarChange, externalUrl, settingsRea
   }, [value.selected]);
   const maxSize = 200 * 1024; // 200KB
   // format: image/png, image/jpeg, image/gif, image/tiff
-  return <div>
+  return <div className="mb-3">
     <div>Project Avatar</div>
     <ImageInput name="project-avatar"
       value={value}


### PR DESCRIPTION
_INFO: ready to review, but the `pinned image` is still missing and will be added soon_


The project settings are now split in 2 pages, where `General` contains the previous settings and `Sessions` allows the logged users to:
* Check the project and RenkuLab options and default values
* Allor user with > developer permissions to change the options according to the values supported on RenkuLab

**Changes/discrepancies with the original issue**
- Change multiple values and confirm later: I tried using different colors to distinguish current settings vs yet-to-be-applied changes. The result was very confusing. I opted for applying any change directly on click. The UX looks much easier, even though we may get extra commits.
- Set arbitrary values: I tried to add an "unlock values" option to allow the user to set any values for all the options. That was very confusing and there is no added value since all the invalid values are later discarded when launching a new session. If we want to provide an interface for setting any custom option, we should do that in a separate tab (in `General` on a new `Advanced` tab) with a simple interface without any validation.

**How to test**: pick a project and go to "Settings --> Sessions". Try to change values and start a new session.
This sample projects also contains a few "wrong" settings
https://renku-ci-ui-1386.dev.renku.ch/projects/lorenzo.cavazzi.tech/project-config/settings/sessions

![image](https://user-images.githubusercontent.com/43481553/121390814-07c64b00-c94e-11eb-8b06-8140c953fb8e.png)

/deploy renku=ui-design-test
fix #1114