### PR TITLE
fix(design): small fixes to the UI design

### DIFF
--- a/client/src/dataset/Dataset.present.js
+++ b/client/src/dataset/Dataset.present.js
@@ -158,7 +158,7 @@ function DisplayInfoTable(props) {
     <tbody className="text-rk-text">
       { source ?
         <tr>
-          <td className="text-dark fw-bold col-sm-2">
+          <td className="text-dark fw-bold" style={{ "width": "120px" }}>
             Source
           </td>
           <td>
@@ -168,7 +168,7 @@ function DisplayInfoTable(props) {
         : null
       }
       { authors ? <tr>
-        <td className="text-dark fw-bold col-sm-2">
+        <td className="text-dark fw-bold col-auto">
           Author(s)
         </td>
         <td>
@@ -179,7 +179,7 @@ function DisplayInfoTable(props) {
       }
       { datasetDate ?
         <tr>
-          <td className="text-dark fw-bold col-sm-2">
+          <td className="text-dark fw-bold col-auto">
             {datasetPublished ? "Published on " : "Created on "}
           </td>
           <td>
@@ -189,7 +189,7 @@ function DisplayInfoTable(props) {
         : null
       }
       { keywords ? <tr>
-        <td className="text-dark fw-bold col-sm-2">
+        <td className="text-dark fw-bold col-auto">
           Keywords
         </td>
         <td>
@@ -322,14 +322,14 @@ export default function DatasetView(props) {
       <Col md={4} sm={12} className="d-flex flex-col justify-content-end mb-auto">
         { props.logged ?
           <Button disabled={dataset.insideKg === false}
-            className="float-right mb-1 me-1" size="sm" color="primary" onClick={() => setAddDatasetModalOpen(true)}>
+            className="float-right mb-1 me-1" size="sm" color="secondary" onClick={() => setAddDatasetModalOpen(true)}>
             <FontAwesomeIcon icon={faPlus} color="dark" /> Add to project
           </Button>
           : null}
         { props.insideProject && props.maintainer ?
           <Link className="float-right me-1 mb-1" id="editDatasetTooltip"
             to={{ pathname: "modify", state: { dataset: dataset } }} >
-            <Button size="sm" color="primary" >
+            <Button size="sm" color="secondary" >
               <FontAwesomeIcon icon={faPen} color="dark" />
             </Button>
           </Link>
@@ -337,7 +337,7 @@ export default function DatasetView(props) {
         }
         { props.insideProject && props.maintainer ?
           <UncontrolledButtonDropdown size="sm" className="float-right mb-1">
-            <DropdownToggle caret color="primary" className="removeArrow">
+            <DropdownToggle caret color="secondary" className="removeArrow">
               <FontAwesomeIcon icon={faEllipsisV} color="dark" />
             </DropdownToggle>
             <DropdownMenu>

--- a/client/src/dataset/list/DatasetList.present.js
+++ b/client/src/dataset/list/DatasetList.present.js
@@ -21,7 +21,7 @@ import { Route, Switch } from "react-router-dom";
 import { Row, Col, Alert, Card, CardBody } from "reactstrap";
 import { Button, Form, FormText, Input, Label, InputGroup, UncontrolledCollapse } from "reactstrap";
 import { DropdownToggle, DropdownMenu, DropdownItem } from "reactstrap";
-import { MarkdownTextExcerpt, ListDisplay } from "../../utils/UIComponents";
+import { MarkdownTextExcerpt, ListDisplay, Loader } from "../../utils/UIComponents";
 import { faCheck, faSortAmountUp, faSortAmountDown, faSearch, faBars, faTh } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { ButtonDropdown } from "reactstrap/lib";
@@ -160,6 +160,8 @@ class DatasetsRows extends Component {
     const datasetsUrl = this.props.datasetsUrl;
 
     const { currentPage, perPage, search, totalItems, gridDisplay } = this.props;
+
+    if (this.props.loading) return <Loader />;
 
     const datasetItems = datasets.map(dataset => {
       const projectsCount = dataset.projectsCount > 1

--- a/client/src/help/Help.present.js
+++ b/client/src/help/Help.present.js
@@ -70,18 +70,18 @@ class HelpGetting extends Component {
       </div>,
       <div key="main1" className="d-flex mb-3 flex-wrap">
         <div className="me-4" style={{ flex: "0 1", flexBasis }}>
-          <h2>
+          <h3>
             <ExternalIconLink url="https://renku.discourse.group" icon={faDiscourse} title="Forum" />
-          </h2>
+          </h3>
           <p>
             We maintain a <ExternalDocsLink url="https://renku.discourse.group" title="help forum" /> for
             discussion about Renku. This is a good place to ask questions and find answers.
           </p>
         </div>
         <div className="me-4" style={{ flex: "0 1", flexBasis }}>
-          <h2>
+          <h3>
             <ExternalIconLink url="https://gitter.im/SwissDataScienceCenter/renku" icon={faGitter} title="Gitter" />
-          </h2>
+          </h3>
           <p>
             Want to reach out to the development team live? Contact us on{" "}
             <ExternalDocsLink url="https://gitter.im/SwissDataScienceCenter/renku" title="Gitter" />, we would be happy
@@ -89,13 +89,13 @@ class HelpGetting extends Component {
           </p>
         </div>
         <div className="me-4" style={{ flex: "0 1", flexBasis }}>
-          <h2>
+          <h3>
             <ExternalIconLink
               url="https://github.com/SwissDataScienceCenter/renku"
               icon={faGithub}
               title="GitHub"
             />
-          </h2>
+          </h3>
           <p>
             Renku is open source and being developed on{" "}
             <ExternalDocsLink url="https://github.com/SwissDataScienceCenter/renku" title="GitHub" />. This is the best
@@ -113,30 +113,30 @@ class HelpDocumentation extends Component {
     return (
       <Row>
         <Col md={8}>
-          <h2>
+          <h3>
             <ExternalDocsLink url="https://renku.readthedocs.io/en/latest/tutorials/01_firststeps.html"
               title="Tutorial" />
-          </h2>
+          </h3>
           <p>
             If you are here for the first time or you are not sure how to use Renku, we recommend you
             to go through our {" "}
             <ExternalDocsLink url="https://renku.readthedocs.io/en/latest/tutorials/01_firststeps.html"
               title="tutorial" />.
           </p>
-          <h2>
+          <h3>
             <ExternalDocsLink url="https://renku.readthedocs.io/en/latest/"
               title="Renku" />
-          </h2>
+          </h3>
           <p>
             The <ExternalDocsLink url="https://renku.readthedocs.io/en/latest/"
               title="Renku project documentation" /> explains Renku as a whole. It describes
             the parts that make it up, how they fit together, and how to use Renku in your
             data-science projects to work more effectively.
           </p>
-          <h2>
+          <h3>
             <ExternalDocsLink url="https://renku-python.readthedocs.io/en/latest/"
               title="Renku CLI" />
-          </h2>
+          </h3>
           <p>
             The <ExternalDocsLink url="https://renku-python.readthedocs.io/en/latest/"
               title="command-line-interface (CLI) documentation" /> details the commands of the
@@ -153,7 +153,7 @@ class HelpFeatures extends Component {
     return (
       <Row>
         <Col md={8}>
-          <h2>Features</h2>
+          <h3>Features</h3>
           <p>
             Renku consists of a collection of services, including a web-based user interface and a command-line client,
             exploiting in a coherent setup the joint features of:
@@ -242,15 +242,12 @@ class HelpContent extends Component {
 class Help extends Component {
   render() {
     return [
-      <Row key="header">
-        <Col md={8}>
-          <h1>Using Renku</h1>
+      <Row key="header" className="pt-2 pb-3">
+        <Col className="d-flex mb-2 justify-content-between">
+          <h2>Using Renku</h2>
         </Col>
       </Row>,
-      <Row key="spacePre">
-        <Col>&nbsp;</Col>
-      </Row>,
-      <Row key="nav">
+      <Row key="nav" className="pb-2">
         <Col>
           <HelpNav {...this.props} />
         </Col>

--- a/client/src/notebooks/Notebooks.present.js
+++ b/client/src/notebooks/Notebooks.present.js
@@ -668,7 +668,7 @@ class NotebookServerRowFull extends Component {
     </span>);
 
     return (
-      <div className="d-flex flex-row rk-search-result rk-search-result-100 cursor-auto">
+      <div className="d-flex flex-row rk-search-result rk-search-result-100 cursor-auto overflow-visible">
         <span className={this.props.standalone ? "me-3 mt-2" : "me-3 mt-1"}>{icon}</span>
         <Col className="d-flex align-items-start flex-column col-10 overflow-hidden">
           <div className="project d-inline-block text-truncate">

--- a/client/src/project/Project.css
+++ b/client/src/project/Project.css
@@ -6,9 +6,13 @@ Button.alert-link {
 
 .warningLabel {
   display: inline;
-  color: #ffc107;
+  color: #f0c800;
   margin-right: 0.3em;
-  font-size: 0.8em;
+  font-size: 0.75em;
+}
+.warningLabel > svg {
+  vertical-align: top;
+  margin-top: 0.20rem;
 }
 
 .selected-dataset{

--- a/client/src/statuspage/Statuspage.present.js
+++ b/client/src/statuspage/Statuspage.present.js
@@ -236,7 +236,7 @@ function StatuspageDisplay(props) {
     return <Loader />;
   return <Row>
     <Col md={8}>
-      <h2>RenkuLab Status</h2>
+      <h3>RenkuLab Status</h3>
       <MaintenanceSummaryDetails statuspage={summary.statuspage} />
       <SiteStatusDetails statuspage={summary.statuspage} />
       <br />

--- a/client/src/styles/bootstrap_ext/_button.scss
+++ b/client/src/styles/bootstrap_ext/_button.scss
@@ -61,28 +61,11 @@
   }
 }
 
-// .btn-rk-white-dark-active.active{
-//   background-color: $rk-hover;
-//   color: $dark;
-//   border-color: #E4E7EA;
-// }
-
-.btn-outline-primary.border-light:hover{
-  background-color: $light;
-  //not sure if this border color looks good
-  border-color:$primary !important;
-  color: $primary
-}
-
-.btn-group{
-  .btn-outline-primary {
-      background-color: white;
-    &:hover {
-      background-color: $primary;
-    }
-  }
-  
-  .btn-outline-primary.active {
+.btn-outline-primary{
+  background-color: white;
+  color: $primary;
+  &.active{
     background-color: $primary;
+    color: white;
   }
 }

--- a/client/src/utils/UIComponents.js
+++ b/client/src/utils/UIComponents.js
@@ -201,7 +201,7 @@ class Pagination extends Component {
       itemClass={"page-item"}
       linkClass={"page-link"}
       activeClass={"page-item active"}
-      hideFirstLastPages={true}
+      hideFirstLastPages={false}
       hideDisabled={true}
     />;
   }

--- a/client/src/utils/UIComponents.js
+++ b/client/src/utils/UIComponents.js
@@ -198,12 +198,10 @@ class Pagination extends Component {
       innerClass={className}
 
       // Some defaults for the styling
-      prevPageText={"Previous"}
-      nextPageText={"Next"}
       itemClass={"page-item"}
       linkClass={"page-link"}
       activeClass={"page-item active"}
-      hideFirstLastPages={false}
+      hideFirstLastPages={true}
       hideDisabled={true}
     />;
   }


### PR DESCRIPTION
change to text size in help page

![image](https://user-images.githubusercontent.com/42647877/121532409-98109880-c9ff-11eb-9dc4-54f262693de9.png)

fix to menu in environments
![image](https://user-images.githubusercontent.com/42647877/121532656-d73ee980-c9ff-11eb-8fee-10d63ce2f3f0.png)

![image](https://user-images.githubusercontent.com/42647877/121532735-ecb41380-c9ff-11eb-8f25-a812dc98afe0.png)

Pagination now looks like:
![image](https://user-images.githubusercontent.com/42647877/121534162-423cf000-ca01-11eb-9d0f-f2c74f4de807.png)

Warning sign style:
before
![image](https://user-images.githubusercontent.com/42647877/121536169-1d497c80-ca03-11eb-8041-f105b53c1a57.png)

after
![image](https://user-images.githubusercontent.com/42647877/121536029-fc812700-ca02-11eb-9caf-9cdc3453e786.png)

Dataset details table has less spacing 
before
![image](https://user-images.githubusercontent.com/42647877/121536697-9648d400-ca03-11eb-99c7-5601004a8099.png)

after
![image](https://user-images.githubusercontent.com/42647877/121536569-79140580-ca03-11eb-9d08-dc6c0702c72f.png)

Action buttons in datasets are now green
![image](https://user-images.githubusercontent.com/42647877/121537102-ecb61280-ca03-11eb-9e59-678edf913c97.png)

![image](https://user-images.githubusercontent.com/42647877/121537155-f8a1d480-ca03-11eb-8058-f550e04fb287.png)

/deploy renku=ui-design-2021

Closes #1367 