### PR TITLE
feat(project): title and slug in search result

### DIFF
--- a/client/src/project/list/ProjectList.present.js
+++ b/client/src/project/list/ProjectList.present.js
@@ -91,7 +91,8 @@ function ProjectListRows(props) {
       id: project.id,
       url: url,
       itemType: "project",
-      title: project.path_with_namespace,
+      title: project.name,
+      slug: project.path_with_namespace,
       description: project.description ?
         <Fragment>
           <MarkdownTextExcerpt markdownText={project.description} singleLine={gridDisplay ? false : true}

--- a/client/src/styles/components/_renku_search.scss
+++ b/client/src/styles/components/_renku_search.scss
@@ -58,6 +58,9 @@
 
   .title{
     font-size: 24px;
+    .slug{
+      font-size: 14px;
+    }
   }
 
   .description{

--- a/client/src/utils/List.js
+++ b/client/src/utils/List.js
@@ -37,7 +37,7 @@ import { ProjectTagList } from "../project/shared/ProjectTag.container";
  * @param itemType type of the item being rendered, the color of the circle depends on this.
  */
 function ListCard(props) {
-  const { url, title, description, tagList, timeCaption, labelCaption, mediaContent, creators, itemType } = props;
+  const { url, title, description, tagList, timeCaption, labelCaption, mediaContent, creators, itemType, slug } = props;
 
   return (
     <div className="col text-decoration-none p-2 rk-search-result-card">
@@ -47,6 +47,15 @@ function ListCard(props) {
           <div className="title lh-sm">
             {title}
           </div>
+          {
+            slug ?
+              <div className="card-text creators text-rk-text mt-1">
+                <small style={{ display: "block" }} className="font-weight-light">
+                  {slug}
+                </small>
+              </div>
+              : null
+          }
           {
             creators ?
               <div className="card-text creators text-truncate text-rk-text mt-1">
@@ -85,13 +94,20 @@ function ListCard(props) {
 
 function ListBar(props) {
 
-  const { url, title, description, tagList, timeCaption, labelCaption, mediaContent, creators, itemType } = props;
+  const { url, title, description, tagList, timeCaption, labelCaption, mediaContent, creators, itemType, slug } = props;
 
   return <Link className="d-flex flex-row rk-search-result" to={url}>
     <span className={"circle me-3 mt-2 " + itemType}></span>
     <Col className="d-flex align-items-start flex-column col-10 overflow-hidden">
       <div className="title d-inline-block text-truncate">
         {title}
+        {
+          slug ?
+            <span className="slug font-weight-light text-rk-text ms-2">
+              {slug}
+            </span>
+            : null
+        }
       </div>
       {
         creators ?


### PR DESCRIPTION
Rok asked me to do this change... instead of slug we display the project title inside the search result. The slug is displayed but smaller.

![image](https://user-images.githubusercontent.com/42647877/122786430-98891900-d2b4-11eb-849e-4b074a2289f6.png)

![image](https://user-images.githubusercontent.com/42647877/122786508-ac347f80-d2b4-11eb-96dd-1d35fa99cbab.png)

Possible changes:
- Make description and slug the same size
- In case there is space in the card put the slug under the title

/deploy renku=ui-design-2021