### PR TITLE
feat: simplified launch of environments

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -153,6 +153,7 @@
           "ascii",
           "autosave",
           "autosaved",
+          "autostart",
           "autosuggest",
           "backend",
           "bool",

--- a/client/src/api-client/notebook-servers.js
+++ b/client/src/api-client/notebook-servers.js
@@ -108,8 +108,11 @@ function addNotebookServersMethods(client) {
       method: "POST",
       headers,
       body: JSON.stringify(parameters)
-    }).then((resp) => {
+    }).then(resp => {
       return resp.data;
+    }).catch(error => {
+      if (error.errorData && error.errorData.messages && error.errorData.messages.error)
+        throw new Error(error.errorData.messages.error);
     });
   };
 

--- a/client/src/notebooks/Notebooks.test.js
+++ b/client/src/notebooks/Notebooks.test.js
@@ -370,6 +370,7 @@ describe("rendering", () => {
       model,
       branches: [],
       autosaved: [],
+      location: fakeLocation,
       refreshBranches: () => { },
     };
 

--- a/client/src/project/Project.js
+++ b/client/src/project/Project.js
@@ -355,6 +355,7 @@ class View extends Component {
       mrOverviewUrl: `${baseUrl}/pending`,
       mrUrl: `${baseUrl}/pending/:mrIid`,
       launchNotebookUrl: `${baseUrl}/sessions/new`,
+      sessionAutostartUrl: `${baseUrl}/sessions/new?autostart=1`,
       notebookServersUrl: `${baseUrl}/sessions`,
       sessionShowUrl: `${baseUrl}/sessions/show/:server`
     };

--- a/client/src/project/Project.present.js
+++ b/client/src/project/Project.present.js
@@ -33,8 +33,8 @@ import {
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faStar as faStarRegular } from "@fortawesome/free-regular-svg-icons";
 import {
-  faCodeBranch, faExclamationTriangle, faUserFriends, faGlobe, faInfoCircle, faLock, faSearch,
-  faStar as faStarSolid
+  faCodeBranch, faExclamationTriangle, faGlobe, faInfoCircle, faLock, faPlay, faSearch,
+  faStar as faStarSolid, faUserFriends
 } from "@fortawesome/free-solid-svg-icons";
 import qs from "query-string";
 
@@ -330,6 +330,7 @@ class ProjectViewHeaderOverview extends Component {
                 gitlabIDEUrl={gitlabIDEUrl}
                 userLogged={this.props.user.logged} />
             </ButtonGroup>
+            <StartSessionButton {...this.props} />
           </Col>
           <Col className="text-rk-text order-1 order-md-2">
             <span>{this.props.core.path_with_namespace}{forkedFrom}</span>
@@ -348,6 +349,25 @@ class ProjectViewHeaderOverview extends Component {
       </Fragment>
     );
   }
+}
+
+function StartSessionButton(props) {
+  const { launchNotebookUrl, sessionAutostartUrl } = props;
+
+  const defaultAction = (
+    <Link className="btn btn-primary btn-sm" to={sessionAutostartUrl}>
+      <FontAwesomeIcon className="me-1" icon={faPlay} /> Start
+    </Link>
+  );
+  return (
+    <ButtonGroup size="sm" className="ms-1">
+      <ButtonWithMenu className="sessionsButton" size="sm" default={defaultAction} color="primary">
+        <DropdownItem>
+          <Link className="text-decoration-none" to={launchNotebookUrl}>Start with options</Link>
+        </DropdownItem>
+      </ButtonWithMenu>
+    </ButtonGroup>
+  );
 }
 
 class ProjectViewHeader extends Component {

--- a/client/src/project/settings/ProjectSettings.present.js
+++ b/client/src/project/settings/ProjectSettings.present.js
@@ -436,7 +436,7 @@ function SessionsOptionReset(props) {
   const { disabled, onChange, option } = props;
   return (
     <Fragment>
-      <Button disabled={disabled} id={`${option}_reset`} color="outline-primary" size="sm"
+      <Button disabled={disabled} id={`${option}_reset`} color="" size="sm"
         className="border-0" onClick={(event) => onChange(event, null, true)}>
         <FontAwesomeIcon icon={faTimesCircle} />
       </Button>
@@ -691,7 +691,7 @@ function SessionPinnedImage(props) {
   else {
     const edit = devAccess ?
       (<Fragment>
-        <Button disabled={disabled} id="advanced_image_add" color="outline-primary" size="sm"
+        <Button disabled={disabled} id="advanced_image_add" color="" size="sm"
           className="border-0" onClick={toggleModifyString}>
           <FontAwesomeIcon icon={faEdit} />
         </Button>

--- a/client/src/utils/url/Url.js
+++ b/client/src/utils/url/Url.js
@@ -326,6 +326,12 @@ const Url = {
             "/projects/group/subgroup/path/sessions/new",
           ]
         ),
+        autostart: new UrlRule(
+          projectPageUrlBuilder("/sessions/new?autostart=1"), ["namespace", "path"], null, [
+            "/projects/namespace/path/sessions/new?autostart=1",
+            "/projects/group/subgroup/path/sessions/new?autostart=1",
+          ]
+        ),
         show: new UrlRule(
           projectSessionUrlBuilder(), ["namespace", "path", "server"], null, [
             "/projects/namespace/path/sessions/show/server-id",


### PR DESCRIPTION
This PR adds a quick-start button on the project header to quickly start a new session from the latest commit on the default branch and connect to it directly.
It doesn't consider autosaves or currently running sessions _yet_, but that will come soon with #1345 , significantly improving the experience when users push new commits and then try to start another session.

P.S. The button in the header looks misaligned on smaller screens, but the header is going to change significantly with #1385

![Screenshot_20210624_184601](https://user-images.githubusercontent.com/43481553/123302880-7514d700-d51d-11eb-944d-098a9e1186ce.png)

![Screenshot_20210624_184625](https://user-images.githubusercontent.com/43481553/123302854-6d553280-d51d-11eb-9e3d-162f68e78fa5.png)

/deploy renku=ui-design-2021-startbutton
fix #1152 