### PR TITLE
fix: prevent duplication of falsy options

### DIFF
--- a/client/src/notebooks/Notebooks.container.js
+++ b/client/src/notebooks/Notebooks.container.js
@@ -451,7 +451,7 @@ class StartNotebookServer extends Component {
   setServerOptionFromEvent(option, event, providedValue = null) {
     const target = event.target.type.toLowerCase();
     let value = providedValue;
-    if (!providedValue && providedValue !== 0) {
+    if (!providedValue != null) {
       if (target === "button")
         value = event.target.textContent;
 

--- a/client/src/notebooks/Notebooks.container.js
+++ b/client/src/notebooks/Notebooks.container.js
@@ -451,7 +451,7 @@ class StartNotebookServer extends Component {
   setServerOptionFromEvent(option, event, providedValue = null) {
     const target = event.target.type.toLowerCase();
     let value = providedValue;
-    if (!providedValue) {
+    if (!providedValue && providedValue !== 0) {
       if (target === "button")
         value = event.target.textContent;
 


### PR DESCRIPTION
Remove the duplication on notebooks options that could be tested to false.
That may happen when receiving the number `0` as one of the possible values.

![Screenshot_20210628_152245](https://user-images.githubusercontent.com/43481553/123644304-8b74a880-d825-11eb-858d-135024fe7777.png)

**How to test**: This would require a deployment with GPUs. One way to manually fake it would be to add the following code before the `return data;` at line 82 in the file "client/src/api-client/notebook-servers.js" 
```
data = {
  ...data, gpu_request: {
    "default": 0,
    "displayName": "Number of GPUs",
    "options": [
      0,
      1,
      2
    ],
    "order": 5,
    "type": "enum"
  }
};
```

/deploy renku=ui-design-2021
fix #1122