### PR TITLE
Fix start button behavior for projects with pinned images

### DIFF
--- a/client/src/notebooks/Notebooks.container.js
+++ b/client/src/notebooks/Notebooks.container.js
@@ -439,7 +439,8 @@ class StartNotebookServer extends Component {
         const fetched = data.notebooks.fetched && data.options.fetched && data.pipelines.fetched;
         if (fetched) {
           const mainPipeline = data.pipelines.main;
-          if (mainPipeline && mainPipeline.status === "success") {
+          if (data.pipelines.type === NotebooksHelper.pipelineTypes.customImage ||
+              (mainPipeline && mainPipeline.status === "success")) {
             this.setState({ autostartReady: true });
             this.startServer();
           }

--- a/client/src/notebooks/Notebooks.present.js
+++ b/client/src/notebooks/Notebooks.present.js
@@ -1006,10 +1006,11 @@ class EnvironmentLogs extends Component {
   }
 }
 
-// This is not currently used, but keeping since it may be useful in the future.
 function pipelineAvailable(pipelines) {
   const { pipelineTypes } = NotebooksHelper;
   const mainPipeline = pipelines.main;
+
+  if (pipelines.type === pipelineTypes.customImage) return true;
 
   if (pipelines.type === pipelineTypes.logged) {
     if (mainPipeline.status === "success" || mainPipeline.status === undefined)

--- a/client/src/project/settings/ProjectSettings.present.js
+++ b/client/src/project/settings/ProjectSettings.present.js
@@ -570,7 +570,7 @@ function SessionConfigAdvanced(props) {
     (<Alert color="warning">
       <FontAwesomeIcon className="cursor-default" icon={faExclamationTriangle} color="warning" /> Fixing
       an image can yield improvements, but it can also lead to sessions not working in the expected
-      way. <a href="https://renku.readthedocs.io/en/latest/user/interactive_customizing.html">
+      way. <a href="https://renku.readthedocs.io/en/latest/user/session_customizing.html">
         Please consult the documentation
       </a> before changing this setting.
     </Alert>) :


### PR DESCRIPTION
# Test

Four cases to test:

1. Pinned image: https://renku-ci-ui-1418.dev.renku.ch/projects/cramakri/pinned-image-test (should start smoothly)
2. Slow build: https://renku-ci-ui-1418.dev.renku.ch/projects/renku-qa/slow-build (should start smoothly if image has built)
3. Slow build: https://renku-ci-ui-1418.dev.renku.ch/projects/renku-qa/slow-build (should show warning if image is building)
4. Broken build: https://renku-ci-ui-1418.dev.renku.ch/projects/renku-qa/broken-build (should show warning)

/deploy renku=ui-design-2021