### PR TITLE
feat: extend the list of extensions for code files in lineage display

### DIFF
--- a/client/src/file/Lineage.present.js
+++ b/client/src/file/Lineage.present.js
@@ -67,7 +67,14 @@ function getNodeLabel(node, NODE_COUNT, lineagesUrl) {
 function nodeToClass(node, currentNodeId, label) {
   const nodeId = node.id;
   const nodeType = node.type;
-  const FORMATS = { "py": true, "r": true, "ipynb": true };
+  // see also File.container.js > CODE_EXTENSIONS
+  const CODE_EXTENSIONS = [
+    "bat", "jl", "js", "py", "r", "rmd", "rs", "scala", "sh", "ts",
+    "c", "cc", "cxx", "cpp", "h", "hh", "hxx", "hpp", // C++
+    "f", "for", "ftn", "fpp", "f90", "f95", "f03", "f08" // Fortran
+  ];
+  const FORMATS = { "ipynb": true };
+  CODE_EXTENSIONS.forEach(e => FORMATS[e] = true);
   const nodeClasses = [];
 
   if (nodeId === currentNodeId)
@@ -79,7 +86,7 @@ function nodeToClass(node, currentNodeId, label) {
     nodeClasses.push("doubleLine");
 
   if (node.type === "Directory" || node.type === "File") {
-    if (node.location.includes(".") && FORMATS[node.location.split(".").pop()])
+    if (node.location.includes(".") && FORMATS[node.location.split(".").pop().toLowerCase()])
       nodeClasses.push("code");
     else
       nodeClasses.push("data");


### PR DESCRIPTION
# Screenshot

https://dev.renku.ch/projects/lee.gavin.k/plurilingue/files/lineage/outputs/num.txt

![image](https://user-images.githubusercontent.com/1196411/125587245-e5c8e93e-d073-4100-bc26-b098241ec11a.png)
