### PR TITLE
fix: prevent values duplication for session enum

### DIFF
--- a/client/src/notebooks/Notebooks.container.js
+++ b/client/src/notebooks/Notebooks.container.js
@@ -477,7 +477,7 @@ class StartNotebookServer extends Component {
   setServerOptionFromEvent(option, event, providedValue = null) {
     const target = event.target.type.toLowerCase();
     let value = providedValue;
-    if (!providedValue != null) {
+    if (!providedValue && providedValue !== 0) {
       if (target === "button")
         value = event.target.textContent;
 


### PR DESCRIPTION
A previous fix introduced a worse bug that shows duplicate values whenever a user picks a non-stringy value in a session enumeration. This PR fixes it.
Thank you @gavin-k-lee for reposting it!

/deploy renku=ui-design-2021
fix #1436