### PR TITLE
fix(datasets): proper error handling when dataset add fails

### DIFF
--- a/client/src/api-client/dataset.js
+++ b/client/src/api-client/dataset.js
@@ -228,7 +228,11 @@ export default function addDatasetMethods(client) {
               "files": renkuDataset.files,
               "project_id": project_id
             })
-          });
+          }).then(response =>
+            response.data.error ?
+              { data: { error: { reason: response.data.error.reason, errorOnFileAdd: true } } }
+              : response
+          );
         } return response;
       });
   };

--- a/client/src/dataset/Dataset.present.js
+++ b/client/src/dataset/Dataset.present.js
@@ -298,7 +298,7 @@ function ErrorAfterCreation(props) {
   return props.location.state && props.location.state.errorOnCreation ?
     <Alert color="danger">
       <strong>Error on creation</strong><br/>
-      The dataset was crated but there was an error adding files to it.<br/>
+      The dataset was created, but there was an error adding files to it.<br/>
       Please {editButton} the dataset to add the missing files.
     </Alert>
     : null;

--- a/client/src/dataset/Dataset.present.js
+++ b/client/src/dataset/Dataset.present.js
@@ -287,6 +287,23 @@ function DatasetError(props) {
   );
 }
 
+function ErrorAfterCreation(props) {
+  const editButton = <Link className="float-right me-1 mb-1" id="editDatasetTooltip"
+    to={{ pathname: "modify", state: { dataset: props.dataset } }} >
+    <Button size="sm" color="danger" >
+      <FontAwesomeIcon icon={faPen} color="dark" /> Edit
+    </Button>
+  </Link>;
+
+  return props.location.state && props.location.state.errorOnCreation ?
+    <Alert color="danger">
+      <strong>Error on creation</strong><br/>
+      The dataset was crated but there was an error adding files to it.<br/>
+      Please {editButton} the dataset to add the missing files.
+    </Alert>
+    : null;
+}
+
 export default function DatasetView(props) {
 
   const [addDatasetModalOpen, setAddDatasetModalOpen] = useState(false);
@@ -307,6 +324,7 @@ export default function DatasetView(props) {
     return (<Loader />);
 
   return <Col>
+    <ErrorAfterCreation location={props.location} dataset={dataset}/>
     <Row>
       <Col md={8} sm={12}>
         {props.insideProject ?

--- a/client/src/project/Project.present.js
+++ b/client/src/project/Project.present.js
@@ -802,7 +802,7 @@ function ProjectViewDatasets(props) {
         <Col key="btn" md={12}>
           <GoBackButton key="btn" label="Back to list" url={props.datasetsUrl}/>
         </Col>,
-        props.datasetView(p, !kgDown)
+        props.datasetView(p, !kgDown, props.location)
       ]} />
       <Route exact path={props.datasetsUrl} render={p =>
         <ProjectDatasetsNav {...props} />

--- a/client/src/project/datasets/change/DatasetChange.container.js
+++ b/client/src/project/datasets/change/DatasetChange.container.js
@@ -65,7 +65,7 @@ function ChangeDataset(props) {
       titleField.help = datasetFormSchema.title.help;
       titleField.parseFun = undefined;
       image.value = {
-        options: [{ [Prop.URL]: props.dataset ? props.dataset.mediaContent : undefined }],
+        options: [{ [Prop.URL]: props.dataset ? props.dataset.mediaContent : null }],
         selected: 0
       };
     }
@@ -234,7 +234,8 @@ function ChangeDataset(props) {
             props.edit ?
               handlers.setServerErrors(
                 <div>
-                  The dataset was edited but there was an error adding uploaded files to it, please try again.
+                  Any metadata changes were successfully applied, but some uploaded files could
+                  &nbsp;not be added to the dataset. Please try adding this files again.
                   <br/><br/>
                   {response.data.error.reason}
                 </div>)

--- a/client/src/styles/bootstrap_ext/_button.scss
+++ b/client/src/styles/bootstrap_ext/_button.scss
@@ -13,6 +13,9 @@
   &:focus {
     color: $rk-white;
   }
+  &.disabled{
+    color: $rk-white;
+  }
 }
 
 .btn-outline-secondary:hover{

--- a/client/src/utils/formgenerator/fields/ImageInput.js
+++ b/client/src/utils/formgenerator/fields/ImageInput.js
@@ -272,7 +272,7 @@ function ImageInput({ name, label, value, alert, placeholder, modes,
     <Row key="row-title">
       <FormLabel className="ps-3" label={label} required={required} />
     </Row>,
-    <Row key="row-content">
+    <Row key="row-content" className="mb-3">
       <Col xs={12}>
         <div className="d-flex">
           <div className="pe-2">


### PR DESCRIPTION
When a dataset is created or edited it could happen that this succeeds but the file add function fails.

When this happens the error is not managed properly, a message is displayed making the user think that the entire operation failed.

This fix provides the user with a better picture of what happens.

1. If the dataset is created but the file add fails,  we redirect the user to the dataset and show an error message.
![image](https://user-images.githubusercontent.com/42647877/132031398-f5acbb1b-44a2-4dcc-87e1-e87a333a1059.png)

2. If the dataset is edited but the file add fails,  we show the user a message allowing them to retry on spot (no redirection necessary).
![image](https://user-images.githubusercontent.com/42647877/132031482-2366c3db-38c8-46a4-9309-7051ef42bc87.png)

### Testing
1-To make things fail: api-client/dataset.js --> line 227 make "name" become "namee" (example)
2-Add a dataset (you can see the error message), then edit a dataset (to see the error message on edit)

Closes #1077 