### PR TITLE
feat: show error page when gitlab is not available

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -42,6 +42,7 @@ import { Cookie, Privacy } from "./privacy";
 import { NotificationsManager, NotificationsPage } from "./notifications";
 import { StyleGuide } from "./styleguide";
 import { Url } from "./utils/url";
+import { Unavailable } from "./Maintenance";
 
 import "./App.css";
 import "react-toastify/dist/ReactToastify.css";
@@ -190,6 +191,9 @@ class App extends Component {
           <Loader />
         </section>
       );
+    }
+    else if (user.error) {
+      return (<Unavailable />);
     }
 
     return (

--- a/client/src/Maintenance.js
+++ b/client/src/Maintenance.js
@@ -25,6 +25,7 @@
 
 import React, { Component } from "react";
 import { BrowserRouter as Router, Route } from "react-router-dom";
+import { Button } from "reactstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faWrench } from "@fortawesome/free-solid-svg-icons";
 
@@ -59,4 +60,26 @@ class Maintenance extends Component {
   }
 }
 
-export { Maintenance };
+function Unavailable() {
+  const reload = () => {
+    window.location.reload();
+  };
+
+  return (
+    <main role="main" className="container-fluid">
+      <section className="jumbotron-header rounded px-3 px-sm-4 py-3 py-sm-5 text-center mb-3">
+        <h1 className="text-center text-primary">
+          <FontAwesomeIcon icon={faWrench} /> RenkuLab down
+        </h1>
+        <br />
+        <p className="text-center">Some of the resources on RenkuLab are temporarily unavailable.</p>
+        <p className="text-center">
+          Please try to <Button color="primary" size="sm" onClick={() => reload()}>reload</Button> the
+          application in a few minutes.
+        </p>
+      </section>
+    </main>
+  );
+}
+
+export { Maintenance, Unavailable };

--- a/client/src/Maintenance.js
+++ b/client/src/Maintenance.js
@@ -69,7 +69,7 @@ function Unavailable() {
     <main role="main" className="container-fluid">
       <section className="jumbotron-header rounded px-3 px-sm-4 py-3 py-sm-5 text-center mb-3">
         <h1 className="text-center text-primary">
-          <FontAwesomeIcon icon={faWrench} /> RenkuLab down
+          <FontAwesomeIcon icon={faWrench} /> RenkuLab Down
         </h1>
         <br />
         <p className="text-center">Some of the resources on RenkuLab are temporarily unavailable.</p>

--- a/client/src/model/RenkuModels.js
+++ b/client/src/model/RenkuModels.js
@@ -29,6 +29,7 @@ import FormGenerator from "../utils/formgenerator/";
 const userSchema = new Schema({
   fetched: { initial: null, mandatory: true },
   fetching: { initial: false, mandatory: true },
+  error: { initial: null, mandatory: true },
   logged: { initial: false, mandatory: true },
   data: { initial: {}, mandatory: true }
 });

--- a/client/src/user/User.state.js
+++ b/client/src/user/User.state.js
@@ -51,17 +51,19 @@ class UserCoordinator {
         const status = error.response && error.response.status ?
           error.response.status :
           "N/A";
-        // we get 401 unauthorized when the user is not logged in
-        if (error.case !== API_ERRORS.unauthorizedError) {
-          this.model.setObject({
-            fetching: false,
-            fetched: null,
-            error: status,
-            logged: false,
-            data: { $set: {} }
-          });
-        }
-        return {};
+        const errorObject = {
+          fetching: false,
+          fetched: new Date(),
+          error: null,
+          logged: false,
+          data: { $set: {} }
+        };
+        // we get 401 unauthorized when the user is not logged in, but that's not an error
+        if (error.case !== API_ERRORS.unauthorizedError)
+          errorObject.error = status;
+        this.model.setObject(errorObject);
+
+        return errorObject;
       });
   }
 }


### PR DESCRIPTION
This adds a very basic warning page when GitLab is not available.
We could try to fetch the data from StatusPage and verify if a maintenance is ongoing, and provide a better feedback to the user.

**Hot to test**: the only way is to trigger an error in the `GET /user` API.
Running telepresence to modify the `client.getUser` function in "client/src/api-client/user.js" is the easiest option.

/deploy renku=ui-design-2021
fix #805

![Screenshot_20210903_174229](https://user-images.githubusercontent.com/43481553/132032866-d34602ed-34ed-446e-81dc-6409f1ac2721.png)
