### PR TITLE
feat: open in new tab in sessions is now more visible

### DIFF
--- a/client/src/notebooks/Notebooks.present.js
+++ b/client/src/notebooks/Notebooks.present.js
@@ -145,31 +145,41 @@ function SessionInformation(props) {
   };
   const resourceList = formattedResourceList(resources);
 
+  // Create dropdown menu
+  const defaultAction = (<ExternalLink color="primary" url={url} disabled={stopping} showLinkIcon={true} title="Open" />);
+  const stopButton = (
+    <DropdownItem onClick={stop} disabled={stopping}>
+      <FontAwesomeIcon icon={faStopCircle} /> Stop
+    </DropdownItem>
+  );
+  const dropdownMenu = (
+    <ButtonWithMenu className="sessionsButton" color="primary" size="sm" default={defaultAction}>
+      {stopButton}
+    </ButtonWithMenu>
+  );
+
   return (
     <div className="d-flex flex-wrap">
       <div className="p-2 p-lg-3 text-nowrap">
-        <span className="fw-bold">Branch: </span>
+        <span className="fw-bold">Branch </span>
         <ExternalLink url={repositoryLinks.branch} title={annotations["branch"]} role="text"
           showLinkIcon={true} />
       </div>
       <div className="p-2 p-lg-3 text-nowrap">
-        <span className="fw-bold">Commit: </span>
+        <span className="fw-bold">Commit </span>
         <ExternalLink url={repositoryLinks.commit} title={annotations["commit-sha"].substring(0, 8)}
           role="text" showLinkIcon={true} />
       </div>
       <div className="p-2 p-lg-3 text-nowrap">
-        <span className="fw-bold">Resources: </span>
+        <span className="fw-bold">Resources </span>
         <span>{resourceList}</span>
       </div>
       <div className="p-2 p-lg-3 text-nowrap">
-        <span className="fw-bold">Running since: </span>
+        <span className="fw-bold">Running since </span>
         <TimeCaption noCaption={true} endPunctuation=" " time={notebook.data.started} />
       </div>
-      <div className="p-2 p-lg-3 text-nowrap">
-        <ExternalLink url={url} title="Open in new tab" role="text" showLinkIcon={true} />
-      </div>
       <div className="p-1 p-lg-2 m-auto me-1 me-lg-2">
-        <Button color="primary" onClick={stop} disabled={stopping}>Stop</Button>
+        {dropdownMenu}
       </div>
     </div>
   );

--- a/client/src/notebooks/Notebooks.present.js
+++ b/client/src/notebooks/Notebooks.present.js
@@ -145,19 +145,6 @@ function SessionInformation(props) {
   };
   const resourceList = formattedResourceList(resources);
 
-  // Create dropdown menu
-  const defaultAction = (<Button color="primary" onClick={stop} disabled={stopping}>Stop</Button>);
-  const openInNewTab = (
-    <DropdownItem href={url} target="_blank" disabled={stopping}>
-      <FontAwesomeIcon icon={faExternalLinkAlt} /> Open in new tab
-    </DropdownItem>
-  );
-  const dropdownMenu = (
-    <ButtonWithMenu className="sessionsButton" color="primary" size="sm" default={defaultAction}>
-      {openInNewTab}
-    </ButtonWithMenu>
-  );
-
   return (
     <div className="d-flex flex-wrap">
       <div className="p-2 p-lg-3 text-nowrap">
@@ -178,8 +165,11 @@ function SessionInformation(props) {
         <span className="fw-bold">Running since: </span>
         <TimeCaption noCaption={true} endPunctuation=" " time={notebook.data.started} />
       </div>
+      <div className="p-2 p-lg-3 text-nowrap">
+        <ExternalLink url={url} title="Open in new tab" role="text" showLinkIcon={true} />
+      </div>
       <div className="p-1 p-lg-2 m-auto me-1 me-lg-2">
-        {dropdownMenu}
+        <Button color="primary" onClick={stop} disabled={stopping}>Stop</Button>
       </div>
     </div>
   );


### PR DESCRIPTION
Things look like this now
![image](https://user-images.githubusercontent.com/42647877/132341580-3d8a909a-c684-4835-9b22-914ffc4bc71d.png)

I feel like there is a lot of information there and a lot has bold/underline information, i could try and clean up a bit this bar to make the actions stand out a bit more if desired.

I don't really like the icon we are using on links and i also feel it should go at the end of the text instead of at the beginning.

Closes #1400 