### PR TITLE
fix(sessions): improvements to messagging when no image is available

### DIFF
--- a/client/src/notebooks/Notebooks.present.js
+++ b/client/src/notebooks/Notebooks.present.js
@@ -145,19 +145,6 @@ function SessionInformation(props) {
   };
   const resourceList = formattedResourceList(resources);
 
-  // Create dropdown menu
-  const defaultAction = (<Button color="primary" onClick={stop} disabled={stopping}>Stop</Button>);
-  const openInNewTab = (
-    <DropdownItem href={url} target="_blank" disabled={stopping}>
-      <FontAwesomeIcon icon={faExternalLinkAlt} /> Open in new tab
-    </DropdownItem>
-  );
-  const dropdownMenu = (
-    <ButtonWithMenu className="sessionsButton" color="primary" size="sm" default={defaultAction}>
-      {openInNewTab}
-    </ButtonWithMenu>
-  );
-
   return (
     <div className="d-flex flex-wrap">
       <div className="p-2 p-lg-3 text-nowrap">
@@ -178,8 +165,11 @@ function SessionInformation(props) {
         <span className="fw-bold">Running since: </span>
         <TimeCaption noCaption={true} endPunctuation=" " time={notebook.data.started} />
       </div>
+      <div className="p-2 p-lg-3 text-nowrap">
+        <ExternalLink url={url} title="Open in new tab" role="text" showLinkIcon={true} />
+      </div>
       <div className="p-1 p-lg-2 m-auto me-1 me-lg-2">
-        {dropdownMenu}
+        <Button color="primary" onClick={stop} disabled={stopping}>Stop</Button>
       </div>
     </div>
   );
@@ -1096,7 +1086,9 @@ class StartNotebookServer extends Component {
       <Row>
         <Col sm={12} md={10} lg={8}>
           <h3>Start a new session</h3>
-          <LaunchErrorAlert key="launch-error" launchError={this.props.launchError} />
+          <LaunchErrorAlert key="launch-error"
+            launchError={this.props.launchError}
+            pipelines={this.props.pipelines} />
           {messageOutput}
           <Form>
             <Collapse isOpen={this.state.showAdvanced}>
@@ -1109,14 +1101,18 @@ class StartNotebookServer extends Component {
 
             {show.options ?
               (<FormGroup>
-                <Button color="link" className="font-italic btn-sm" onClick={() => { this.toggleShowAdvanced(); }}>
+                <Button color="link" className="ps-0 pe-0 pt-2 font-italic btn-sm"
+                  onClick={() => { this.toggleShowAdvanced(); }}>
                   {buttonMessage}
                 </Button>
               </FormGroup>) :
               null
             }
             {show.options ?
-              <StartNotebookOptions {...this.props} /> :
+              <StartNotebookOptions
+                toggleShowAdvanced={this.toggleShowAdvanced.bind(this)}
+                showAdvanced={this.state.showAdvanced}
+                {...this.props} /> :
               !this.state.showAdvanced ?
                 <Loader /> :
                 null
@@ -1885,16 +1881,19 @@ function LaunchErrorBackendAlert({ launchError }) {
   </WarnAlert>;
 }
 
-function LaunchErrorFrontendAlert({ launchError }) {
+function LaunchErrorFrontendAlert({ launchError, pipelines }) {
+  const pipeline = pipelines.main;
+  if (pipeline && (pipeline.path || pipeline.status === "success"))
+    return null;
   return <WarnAlert timeout={0}>
     <FontAwesomeIcon icon={faExclamationTriangle} /> {launchError.errorMessage}
   </WarnAlert>;
 }
 
-function LaunchErrorAlert({ launchError }) {
+function LaunchErrorAlert({ launchError, pipelines }) {
   if (launchError == null) return null;
   return (launchError.frontendError === true) ?
-    <LaunchErrorFrontendAlert launchError={launchError} /> :
+    <LaunchErrorFrontendAlert launchError={launchError} pipelines={pipelines} /> :
     <LaunchErrorBackendAlert launchError={launchError} />;
 }
 
@@ -1938,13 +1937,23 @@ class ServerOptionLaunch extends Component {
       </Warning>;
 
     const hasImage = pipelineAvailable(this.props.pipelines);
-    const startButton = (hasImage) ?
-      <Button key="start-session" color="primary" onClick={this.checkServer}>
-        Start session
-      </Button> :
-      <Button key="start-session" color="primary" disabled={true} onClick={this.checkServer}>
-        Start session
-      </Button>;
+    const startButton = <Button key="start-session" color="primary" disabled={!hasImage} onClick={this.checkServer}>
+      Start session
+    </Button>;
+
+    const imageStatusAlert = !hasImage ? <div key="noImageAvailableWarning" className="pb-2">
+      <FontAwesomeIcon icon={faExclamationTriangle} className="text-warning"/>{" "}
+      The image for this commit is not available.{" "}
+      {this.props.showAdvanced ?
+        "Find more info about this on top."
+        : <Button color="link" className="ps-0 pe-0 font-italic"
+          onClick={() => { this.props.toggleShowAdvanced(true); }}>
+          Expand more info.
+        </Button>
+      }
+
+    </div>
+      : null;
 
     const startBaseButton = (hasImage) ?
       null :
@@ -1954,6 +1963,7 @@ class ServerOptionLaunch extends Component {
 
 
     return [
+      imageStatusAlert,
       startButton,
       " ",
       startBaseButton,

--- a/client/src/notebooks/Notebooks.present.js
+++ b/client/src/notebooks/Notebooks.present.js
@@ -1955,10 +1955,10 @@ class ServerOptionLaunch extends Component {
       <FontAwesomeIcon icon={faExclamationTriangle} className="text-warning"/>{" "}
       The image for this commit is not available.{" "}
       {this.props.showAdvanced ?
-        "Find more info about this on top."
+        <span>See the <b>Docker Image</b> section for details.</span>
         : <Button color="link" className="ps-0 pe-0 font-italic"
           onClick={() => { this.props.toggleShowAdvanced(true); }}>
-          Expand more info.
+          Click here for more info.
         </Button>
       }
 

--- a/client/src/notebooks/Notebooks.present.js
+++ b/client/src/notebooks/Notebooks.present.js
@@ -145,6 +145,19 @@ function SessionInformation(props) {
   };
   const resourceList = formattedResourceList(resources);
 
+  // Create dropdown menu
+  const defaultAction = (<Button color="primary" onClick={stop} disabled={stopping}>Stop</Button>);
+  const openInNewTab = (
+    <DropdownItem href={url} target="_blank" disabled={stopping}>
+      <FontAwesomeIcon icon={faExternalLinkAlt} /> Open in new tab
+    </DropdownItem>
+  );
+  const dropdownMenu = (
+    <ButtonWithMenu className="sessionsButton" color="primary" size="sm" default={defaultAction}>
+      {openInNewTab}
+    </ButtonWithMenu>
+  );
+
   return (
     <div className="d-flex flex-wrap">
       <div className="p-2 p-lg-3 text-nowrap">
@@ -165,11 +178,8 @@ function SessionInformation(props) {
         <span className="fw-bold">Running since: </span>
         <TimeCaption noCaption={true} endPunctuation=" " time={notebook.data.started} />
       </div>
-      <div className="p-2 p-lg-3 text-nowrap">
-        <ExternalLink url={url} title="Open in new tab" role="text" showLinkIcon={true} />
-      </div>
       <div className="p-1 p-lg-2 m-auto me-1 me-lg-2">
-        <Button color="primary" onClick={stop} disabled={stopping}>Stop</Button>
+        {dropdownMenu}
       </div>
     </div>
   );


### PR DESCRIPTION
When an image is not available but then becomes available the "no image available" sign fades.
![image](https://user-images.githubusercontent.com/42647877/132516738-3ebba370-6ed5-4c69-9255-eab14745b6c7.png)


I also added a message (because of the comment linked to the issue) to tell users the image is not available.
The message has a link to expand info on top (When it's not expanded).
![image](https://user-images.githubusercontent.com/42647877/132516562-fc15974b-3e79-45fc-9d0e-c4a2c3835aa4.png)


![image](https://user-images.githubusercontent.com/42647877/132516848-8f724338-f01d-4038-837f-f4406f35af52.png)


Closes #1448

/deploy renku=ui-design-2021