### PR TITLE
fix: restore columns auto width in markdown tables

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -233,3 +233,7 @@ iframe.invisible {
   height: 0;
   width: 0;
 }
+
+.word-break-normal {
+  word-break: normal !important;
+}

--- a/client/src/utils/HelperFunctions.js
+++ b/client/src/utils/HelperFunctions.js
@@ -157,7 +157,7 @@ function sanitizedHTMLFromMarkdown(markdown, singleLine = false) {
     emoji: true
   };
   const showdownClasses = {
-    table: "table"
+    table: "table word-break-normal"
   };
   // Reference: https://github.com/showdownjs/showdown/wiki/Add-default-classes-for-each-HTML-element
   const bindings = Object.keys(showdownClasses).map(key => ({


### PR DESCRIPTION
The addition of the `text-break` class on the `<RenkuMarkdown>` component ([Link](https://github.com/SwissDataScienceCenter/renku-ui/blob/713770f670468ff1675fb165c028a00050b1c4f0/client/src/utils/UIComponents.js#L476)) accidentally broke the way column width is computed in tables.
This fix restores the normal word break behavior on tables.

**How to test**
You can use the example in the reference issues. A better test would be creating on the fly a project where the README has a markdown table with 3-4 columns, where all of them contain just a (long-ish) word expect one that contains a long text.
Without the fix (i.e. on dev) the column with a single word should be very narrow, while this PR should display something more reasonable.
Here is an example from the reference issue

![Screenshot_20210922_170612](https://user-images.githubusercontent.com/43481553/134370988-752e7637-f00b-4ae8-abc5-117690b7a5e5.png)

![Screenshot_20210922_170526](https://user-images.githubusercontent.com/43481553/134371036-e165c884-e3ec-41c1-bc54-9e4145ef9cf9.png)

/deploy
fix #1496