### PR TITLE
fix: add missing headers to graphql queries

### DIFF
--- a/client/src/api-client/index.js
+++ b/client/src/api-client/index.js
@@ -69,7 +69,8 @@ class APIClient {
     this.baseUrl = baseUrl;
     this.returnTypes = RETURN_TYPES;
     this.graphqlClient = new ApolloClient({
-      uri: `${baseUrl}/kg/graphql`
+      uri: `${baseUrl}/kg/graphql`,
+      headers: { "X-Requested-With": "XMLHttpRequest" }
     });
 
     addProjectMethods(this);


### PR DESCRIPTION
Adds the missing `x-requested-with` to the graphql queries.

/deploy
fix #1520