### PR TITLE
More flexible handling of status page information

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -56,9 +56,7 @@ function CentralContentContainer(props) {
       user={props.user}
       model={props.model}
       location={props.location}
-      params={props.params}
-      statuspageId={props.statuspageId}
-      statuspageModel={props.model.subModel("statuspage")} />;
+      params={props.params} />;
   }
 
   // check anonymous sessions settings
@@ -75,11 +73,10 @@ function CentralContentContainer(props) {
             user={props.user}
             client={props.client}
             model={props.model}
-            statuspageId={props.statuspageId}
             {...p} /> : null
       } />
       <Route path={Url.get(Url.pages.help)} render={
-        p => <Help key="help" {...p} statuspageId={props.statuspageId} {...props} />} />
+        p => <Help key="help" {...p} {...props} />} />
       <Route exact
         path={[Url.get(Url.pages.projects), Url.get(Url.pages.projects.starred), Url.get(Url.pages.projects.all)]}
         render={p => <ProjectList

--- a/client/src/api-client/test-samples/index.js
+++ b/client/src/api-client/test-samples/index.js
@@ -1,6 +1,7 @@
 import { issues } from "./issue-samples";
-import { projects, projectReadme, projectNotebookFile } from "./project-samples";
 import { namespaces } from "./namespaces";
+import { projects, projectReadme, projectNotebookFile } from "./project-samples";
+import { statuspage } from "./statuspage";
 import { user } from "./user";
 
-export { issues, namespaces, projects, projectReadme, projectNotebookFile, user };
+export { issues, namespaces, projects, projectReadme, projectNotebookFile, statuspage, user };

--- a/client/src/api-client/test-samples/statuspage.js
+++ b/client/src/api-client/test-samples/statuspage.js
@@ -1,0 +1,175 @@
+/* eslint-disable */
+export const statuspage = {
+  "page": {
+    "id": "q1n7m8bwwlxt",
+    "name": "illposed",
+    "url": "https://illposed.statuspage.io",
+    "time_zone": "Etc/UTC",
+    "updated_at": "2021-10-28T11:39:27.351Z"
+  },
+  "components": [
+    {
+      "id": "5wl5x0fggfqv",
+      "name": "API",
+      "status": "operational",
+      "created_at": "2020-07-17T11:09:11.216Z",
+      "updated_at": "2021-10-23T11:00:35.159Z",
+      "position": 1,
+      "description": "The API",
+      "showcase": true,
+      "start_date": null,
+      "group_id": null,
+      "page_id": "q1n7m8bwwlxt",
+      "group": false,
+      "only_show_if_degraded": false
+    },
+    {
+      "id": "y0j1kqyxj1w2",
+      "name": "KG",
+      "status": "operational",
+      "created_at": "2020-07-21T15:47:58.417Z",
+      "updated_at": "2021-10-18T11:47:00.903Z",
+      "position": 1,
+      "description": "The knowledge graph",
+      "showcase": true,
+      "start_date": null,
+      "group_id": "jdmyb79xmqh7",
+      "page_id": "q1n7m8bwwlxt",
+      "group": false,
+      "only_show_if_degraded": false
+    },
+    {
+      "id": "7cl0q594rt3g",
+      "name": "Core Service",
+      "status": "operational",
+      "created_at": "2020-07-17T11:09:11.228Z",
+      "updated_at": "2020-08-21T08:30:29.523Z",
+      "position": 2,
+      "description": "Renku core service",
+      "showcase": true,
+      "start_date": null,
+      "group_id": null,
+      "page_id": "q1n7m8bwwlxt",
+      "group": false,
+      "only_show_if_degraded": false
+    },
+    {
+      "id": "fhg73l8p4v11",
+      "name": "Loud",
+      "status": "operational",
+      "created_at": "2021-10-25T14:12:09.886Z",
+      "updated_at": "2021-10-28T10:07:38.887Z",
+      "position": 3,
+      "description": "Component to indicate if the status notification needs higher visibility.",
+      "showcase": false,
+      "start_date": "2021-10-25",
+      "group_id": null,
+      "page_id": "q1n7m8bwwlxt",
+      "group": false,
+      "only_show_if_degraded": false
+    }
+  ],
+  "incidents": [
+
+  ],
+  "scheduled_maintenances": [
+    {
+      "id": "gtny7hgjy2qx",
+      "name": "Please shut down any sessions",
+      "status": "scheduled",
+      "created_at": "2021-10-28T10:08:41.168Z",
+      "updated_at": "2021-10-28T11:39:27.342Z",
+      "monitoring_at": null,
+      "resolved_at": null,
+      "impact": "maintenance",
+      "shortlink": "https://stspg.io/yzmzx4a0600v",
+      "started_at": "2021-10-28T10:08:41.163Z",
+      "page_id": "q1n7m8bwwlxt",
+      "incident_updates": [
+        {
+          "id": "tx2twyftbxfs",
+          "status": "scheduled",
+          "body": "Shut down your sessions",
+          "incident_id": "gtny7hgjy2qx",
+          "created_at": "2021-10-28T11:39:27.340Z",
+          "updated_at": "2021-10-28T11:39:27.340Z",
+          "display_at": "2021-10-28T11:39:27.340Z",
+          "affected_components": [
+            {
+              "code": "5wl5x0fggfqv",
+              "name": "API",
+              "old_status": "operational",
+              "new_status": "operational"
+            }
+          ],
+          "deliver_notifications": true,
+          "custom_tweet": null,
+          "tweet_id": null
+        },
+        {
+          "id": "k1w8y0nt5vqf",
+          "status": "scheduled",
+          "body": "We will be undergoing scheduled maintenance during this time.",
+          "incident_id": "gtny7hgjy2qx",
+          "created_at": "2021-10-28T11:30:49.935Z",
+          "updated_at": "2021-10-28T11:30:49.935Z",
+          "display_at": "2021-10-28T11:30:49.935Z",
+          "affected_components": [
+            {
+              "code": "5wl5x0fggfqv",
+              "name": "API",
+              "old_status": "operational",
+              "new_status": "operational"
+            }
+          ],
+          "deliver_notifications": false,
+          "custom_tweet": null,
+          "tweet_id": null
+        },
+        {
+          "id": "gdsnb8wpb4w9",
+          "status": "scheduled",
+          "body": "We will be undergoing scheduled maintenance during this time.",
+          "incident_id": "gtny7hgjy2qx",
+          "created_at": "2021-10-28T10:08:41.216Z",
+          "updated_at": "2021-10-28T10:08:41.216Z",
+          "display_at": "2021-10-28T10:08:41.216Z",
+          "affected_components": [
+            {
+              "code": "fhg73l8p4v11",
+              "name": "Loud",
+              "old_status": "operational",
+              "new_status": "operational"
+            }
+          ],
+          "deliver_notifications": true,
+          "custom_tweet": null,
+          "tweet_id": null
+        }
+      ],
+      "components": [
+        {
+          "id": "5wl5x0fggfqv",
+          "name": "API",
+          "status": "operational",
+          "created_at": "2020-07-17T11:09:11.216Z",
+          "updated_at": "2021-10-23T11:00:35.159Z",
+          "position": 1,
+          "description": null,
+          "showcase": true,
+          "start_date": null,
+          "group_id": null,
+          "page_id": "q1n7m8bwwlxt",
+          "group": false,
+          "only_show_if_degraded": false
+        }
+      ],
+      "scheduled_for": "2021-11-01T08:30:00.000Z",
+      "scheduled_until": "2021-11-01T10:30:00.000Z"
+    }
+  ],
+  "status": {
+    "indicator": "none",
+    "description": "All Systems Operational"
+  }
+}

--- a/client/src/help/Help.container.js
+++ b/client/src/help/Help.container.js
@@ -40,8 +40,7 @@ function urlMap(baseUrl) {
 }
 
 function Help(props) {
-  return <HelpPresent url={urlMap(props.match.url)} statuspageId={props.statuspageId}
-    statuspageModel={props.model.subModel("statuspage")} />;
+  return <HelpPresent url={urlMap(props.match.url)} model={props.model} statuspageId={props.statuspageId} />;
 }
 
 export { Help };

--- a/client/src/help/Help.present.js
+++ b/client/src/help/Help.present.js
@@ -310,8 +310,7 @@ class HelpContent extends Component {
       />,
       <Route
         path={this.props.url.status} key="status"
-        render={props => <StatuspageDisplay key="status" statuspageId={this.props.statuspageId}
-          statuspageModel={this.props.statuspageModel} />} />,
+        render={props => <StatuspageDisplay key="status" model={this.props.model} />} />,
       <Route
         path={this.props.url.changes}
         key="changes"

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -4,19 +4,22 @@ import { connect } from "react-redux";
 import { BrowserRouter as Router, Route } from "react-router-dom";
 import "bootstrap";
 import "jquery";
+
 // Use our version of bootstrap, not the one in import 'bootstrap/dist/css/bootstrap.css';
 import "./styles/index.css";
 import "./index.css";
+
 import App from "./App";
-import { Maintenance } from "./Maintenance";
 // Disable service workers for the moment -- see below where registerServiceWorker is called
 // import registerServiceWorker from './utils/ServiceWorker';
 import APIClient from "./api-client";
-import { UserCoordinator } from "./user";
 import { LoginHelper } from "./authentication";
+import { Maintenance } from "./Maintenance";
 import { StateModel, globalSchema } from "./model";
-import { Url } from "./utils/url";
+import { pollStatuspage } from "./statuspage";
+import { UserCoordinator } from "./user";
 import { Sentry } from "./utils/sentry";
+import { Url } from "./utils/url";
 
 const configFetch = fetch("/config.json");
 const privacyFetch = fetch("/privacy-statement.md");
@@ -74,6 +77,7 @@ Promise.all([configFetch, privacyFetch]).then(valuesRead => {
     }
 
     const statuspageId = params["STATUSPAGE_ID"];
+    pollStatuspage(statuspageId, model);
 
     const VisibleApp = connect(mapStateToProps)(App);
     ReactDOM.render(
@@ -82,7 +86,7 @@ Promise.all([configFetch, privacyFetch]).then(valuesRead => {
           LoginHelper.handleLoginParams(props.history);
           return (
             <VisibleApp client={client} params={params} store={model.reduxStore} model={model}
-              statuspageId={statuspageId} location={props.location}
+              location={props.location} statuspageId={statuspageId}
             />
           );
         }} />

--- a/client/src/landing/AnonymousHome.js
+++ b/client/src/landing/AnonymousHome.js
@@ -61,8 +61,8 @@ function HomeHeader(props) {
   return <Fragment>
     <Row key="statuspage">
       <Col>
-        <StatuspageBanner siteStatusUrl={urlMap.siteStatusUrl} statuspageId={props.statuspageId}
-          statuspageModel={props.statuspageModel} />
+        <StatuspageBanner siteStatusUrl={urlMap.siteStatusUrl} model={props.model}
+          location={{ pathname: Url.get(Url.pages.landing) }} />
       </Col>
     </Row>
     <header className="px-0 pt-2 pb-4 d-flex rk-anon-home">

--- a/client/src/landing/Landing.js
+++ b/client/src/landing/Landing.js
@@ -62,8 +62,6 @@ class Home extends Component {
       user={this.props.user}
       welcomePage={atob(this.props.welcomePage)}
       urlMap={urlMap}
-      statuspageId={this.props.statuspageId}
-      statuspageModel={this.props.model.subModel("statuspage")}
       store={this.props.model.reduxStore}
     />;
   }

--- a/client/src/landing/Landing.present.js
+++ b/client/src/landing/Landing.present.js
@@ -30,7 +30,6 @@ import { Row, Col } from "reactstrap";
 import { Url } from "../utils/url";
 import { ExternalLink, InfoAlert, MarkdownTextExcerpt, ListDisplay, RenkuMarkdown,
   Loader } from "../utils/UIComponents";
-import { StatuspageBanner } from "../statuspage";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faLandmark, faPlus, faQuestion } from "@fortawesome/free-solid-svg-icons";
 
@@ -166,10 +165,6 @@ class LoggedInHome extends Component {
     return [
       <LoggedInNewVersionBanner key="new-version-banner" />,
       <Row key="username">
-        <Col xs={12}>
-          <StatuspageBanner siteStatusUrl={urlMap.siteStatusUrl} statuspageId={this.props.statuspageId}
-            statuspageModel={this.props.statuspageModel} />
-        </Col>
         <Col xs={6}>
           <h3 className="pt-4 fw-bold">{user.data.username} @ Renku</h3>
         </Col>

--- a/client/src/landing/NavBar.js
+++ b/client/src/landing/NavBar.js
@@ -40,6 +40,7 @@ import QuickNav from "../utils/quicknav";
 import { Url } from "../utils/url";
 import { NotificationsMenu } from "../notifications";
 import { LoginHelper } from "../authentication";
+import { StatuspageBanner } from "../statuspage";
 import "./NavBar.css";
 
 
@@ -252,48 +253,53 @@ class LoggedInNavBar extends Component {
   }
   render() {
     return (
-      <header className="navbar navbar-expand-lg navbar-dark rk-navbar p-0">
-        <Navbar color="primary" className="container-fluid flex-wrap flex-lg-nowrap renku-container">
-          <Link id="link-home" to="/" className="navbar-brand me-2 pb-0 pt-0">
-            <img src={logo} alt="Renku" height="50" className="d-block" />
-          </Link>
-          <NavbarToggler onClick={this.toggle} className="border-0">
-            <FontAwesomeIcon icon={faBars} id="userIcon" color="white" />
-          </NavbarToggler>
-          <Collapse isOpen={!this.state.isOpen} navbar>
-            <Nav className="navbar-nav flex-row flex-wrap ms-lg-auto">
-              <NavItem className="nav-item col-12 col-lg-auto pe-0 pe-lg-4 my-2 my-lg-0">
-                <QuickNav client={this.props.client} model={this.props.model} user={this.props.user} />
-              </NavItem>
-              <NavItem className="nav-item col-4 col-lg-auto">
-                <RenkuNavLink to="/projects" alternate={["/projects/all", "/projects/starred"]}
-                  title="Projects" id="link-projects" className="link-secondary" />
-              </NavItem>
-              <NavItem className="nav-item col-4 col-lg-auto">
-                <RenkuNavLink to="/datasets" title="Datasets" id="link-datasets" />
-              </NavItem>
-              <NavItem className="nav-item col-4 col-lg-auto pe-4">
-                <RenkuNavLink to="/sessions" title="Sessions" id="link-sessions" />
-              </NavItem>
-              <NavItem className="nav-item col-1 col-lg-auto">
-                <RenkuToolbarItemPlus currentPath={this.props.location.pathname} />
-              </NavItem>
-              <NavItem className="nav-item col-1 col-lg-auto">
-                <RenkuToolbarGitLabMenu user={this.props.user} />
-              </NavItem>
-              <NavItem className="nav-item col-1 col-lg-auto">
-                <RenkuToolbarHelpMenu />
-              </NavItem>
-              <NavItem className="nav-item col-1 col-lg-auto">
-                <RenkuToolbarNotifications {...this.props} />
-              </NavItem>
-              <NavItem className="nav-item col-1 col-lg-auto">
-                <RenkuToolbarItemUser {...this.props} />
-              </NavItem>
-            </Nav>
-          </Collapse>
-        </Navbar>
-      </header>
+      <Fragment>
+        <header className="navbar navbar-expand-lg navbar-dark rk-navbar p-0">
+          <Navbar color="primary" className="container-fluid flex-wrap flex-lg-nowrap renku-container">
+            <Link id="link-home" to="/" className="navbar-brand me-2 pb-0 pt-0">
+              <img src={logo} alt="Renku" height="50" className="d-block" />
+            </Link>
+            <NavbarToggler onClick={this.toggle} className="border-0">
+              <FontAwesomeIcon icon={faBars} id="userIcon" color="white" />
+            </NavbarToggler>
+            <Collapse isOpen={!this.state.isOpen} navbar>
+              <Nav className="navbar-nav flex-row flex-wrap ms-lg-auto">
+                <NavItem className="nav-item col-12 col-lg-auto pe-0 pe-lg-4 my-2 my-lg-0">
+                  <QuickNav client={this.props.client} model={this.props.model} user={this.props.user} />
+                </NavItem>
+                <NavItem className="nav-item col-4 col-lg-auto">
+                  <RenkuNavLink to="/projects" alternate={["/projects/all", "/projects/starred"]}
+                    title="Projects" id="link-projects" className="link-secondary" />
+                </NavItem>
+                <NavItem className="nav-item col-4 col-lg-auto">
+                  <RenkuNavLink to="/datasets" title="Datasets" id="link-datasets" />
+                </NavItem>
+                <NavItem className="nav-item col-4 col-lg-auto pe-4">
+                  <RenkuNavLink to="/sessions" title="Sessions" id="link-sessions" />
+                </NavItem>
+                <NavItem className="nav-item col-1 col-lg-auto">
+                  <RenkuToolbarItemPlus currentPath={this.props.location.pathname} />
+                </NavItem>
+                <NavItem className="nav-item col-1 col-lg-auto">
+                  <RenkuToolbarGitLabMenu user={this.props.user} />
+                </NavItem>
+                <NavItem className="nav-item col-1 col-lg-auto">
+                  <RenkuToolbarHelpMenu />
+                </NavItem>
+                <NavItem className="nav-item col-1 col-lg-auto">
+                  <RenkuToolbarNotifications {...this.props} />
+                </NavItem>
+                <NavItem className="nav-item col-1 col-lg-auto">
+                  <RenkuToolbarItemUser {...this.props} />
+                </NavItem>
+              </Nav>
+            </Collapse>
+          </Navbar>
+        </header>
+        <StatuspageBanner siteStatusUrl={Url.get(Url.pages.help.status)}
+          model={this.props.model}
+          location={this.props.location} />
+      </Fragment>
     );
   }
 }

--- a/client/src/landing/TransitionalHome.js
+++ b/client/src/landing/TransitionalHome.js
@@ -39,6 +39,7 @@ import { ExternalIconLink, RenkuNavLink } from "../utils/UIComponents";
 import { StatuspageBanner } from "../statuspage";
 import QuickNav from "../utils/quicknav";
 import { RenkuToolbarHelpMenu, RenkuToolbarNotifications } from "./NavBar";
+import { Url } from "../utils/url";
 import { WhatsNew1_0_0 as WhatsNew } from "../help/WhatsNew";
 
 import logo from "./logo.svg";
@@ -54,8 +55,8 @@ function HomeHeader(props) {
   return <Fragment>
     <Row key="statuspage">
       <Col>
-        <StatuspageBanner siteStatusUrl={urlMap.siteStatusUrl} statuspageId={props.statuspageId}
-          statuspageModel={props.statuspageModel} />
+        <StatuspageBanner siteStatusUrl={urlMap.siteStatusUrl}
+          model={props.model} location={{ pathname: Url.get(Url.pages.landing) }} />
       </Col>
     </Row>
     <header className="px-0 pt-2 pb-4 d-flex rk-anon-home">

--- a/client/src/statuspage/Statuspage.test.js
+++ b/client/src/statuspage/Statuspage.test.js
@@ -1,0 +1,66 @@
+/*!
+ * Copyright 2021 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  Statuspage.test.js
+ *  Tests for statuspage code.
+ */
+
+import React from "react";
+import ReactDOM from "react-dom";
+import { MemoryRouter } from "react-router-dom";
+
+import { statuspage as fakeStatuspage } from "../api-client/test-samples";
+import { StateModel, globalSchema } from "../model";
+import { StatuspageBanner, StatuspageDisplay } from "../statuspage";
+
+function dummyStatusSummary() {
+  return { retrieved_at: new Date(), statuspage: fakeStatuspage, error: null };
+}
+
+describe("rendering", () => {
+  const model = new StateModel(globalSchema);
+  const statusSummary = dummyStatusSummary();
+  model.subModel("statuspage").setObject(statusSummary);
+  const location = { pathname: "" };
+
+  it("renders StatuspageBanner", () => {
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    ReactDOM.render(
+      <MemoryRouter>
+        <StatuspageBanner store={model.reduxStore} model={model} location={location} />
+      </MemoryRouter>,
+      div
+    );
+  });
+
+  it("renders StatuspageDetails", () => {
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    ReactDOM.render(
+      <MemoryRouter>
+        <StatuspageDisplay store={model.reduxStore} model={model} />
+      </MemoryRouter>,
+      div
+    );
+  });
+});
+

--- a/client/src/statuspage/index.js
+++ b/client/src/statuspage/index.js
@@ -23,7 +23,7 @@
  *  Components for the displaying information from statuspage.io
  */
 
-import { StatuspageDisplay, StatuspageBanner, isStatusConfigured } from "./Statuspage.container";
-import StatuspageAPI from "./StatuspageAPI";
+import { StatuspageDisplay, StatuspageBanner } from "./Statuspage.container";
+import StatuspageAPI, { isStatusConfigured, pollStatuspage } from "./StatuspageAPI";
 
-export { StatuspageAPI, StatuspageBanner, StatuspageDisplay, isStatusConfigured };
+export { StatuspageAPI, StatuspageBanner, StatuspageDisplay, isStatusConfigured, pollStatuspage };


### PR DESCRIPTION
If requested, make status page information more visible by displaying it on all pages.

# Screenshots

**Setup in Statuspage**

![image](https://user-images.githubusercontent.com/1196411/139012056-e7c2a523-3464-419a-aee1-16cc7576bd2e.png)

**Loud maintenance on landing page**

![image](https://user-images.githubusercontent.com/1196411/139292716-8bd407cc-c9ec-4d5e-bc73-462bb72a30ee.png)

**Loud maintenance on projects page**

![image](https://user-images.githubusercontent.com/1196411/139292743-f1dd1165-a1cd-4fdc-87ff-1e220c36b456.png)

**Normal maintenance (not loud)**

![image](https://user-images.githubusercontent.com/1196411/139292458-170e9073-d991-4896-9647-2ac1e923d071.png)



# Testing

To test this feature, you need to change the configuration on statuspage.io. The easiest way to do that is to run with telepresence and pass the id for a statuspage. E.g., 

```
PR=1531  STATUSPAGE_ID="[my-statuspage-id]" ./run-telepresence.sh
```

##  Setup in Statuspage

- Create a component called 'Loud'
- Create a scheduled maintenance

If the "Loud" component is one of the affected components, then the statuspage notification will be shown on all pages of the UI, and in a larger font. Otherwise, it will only be on the landing page.

## Test in the UI

- Check that the statuspage message shows the name of the maintenance
- Check that the statuspage message shows the message of the maintenance if the maintenance is loud
- Check that the message is shown on the home page and logged-in landing page 
- Check that the message is shown on all pages if the maintenance affects the "Loud" component

Fix #1524

/deploy