### PR TITLE
refactor: derive name on dataset files when missing

### DIFF
--- a/client/src/dataset/Dataset.present.js
+++ b/client/src/dataset/Dataset.present.js
@@ -50,6 +50,25 @@ function DisplayFiles(props) {
     ( props.files[0].atLocation.startsWith("data/") ? 2 : 1 )
     : 0;
 
+  // ? This re-adds the name property on the datasets.
+  // TODO: consider refactoring FileExplorer
+  const filesWithNames = props.files.map(file => {
+    // Add the file name
+    let newFile = { ...file };
+    // Skip if it's already there
+    if (newFile.name && newFile.name.length)
+      return newFile;
+    // Skip if there is no `atLocation` property
+    if (!newFile.atLocation || !newFile.atLocation.length)
+      return newFile;
+    // Skip if it's not possible to derive it
+    const lastSlash = newFile.atLocation.lastIndexOf("/");
+    if (lastSlash === -1 || newFile.atLocation.length < lastSlash + 1)
+      return newFile;
+    newFile.name = newFile.atLocation.substring(lastSlash + 1);
+    return newFile;
+  });
+
   return <Card key="datasetDetails" className="border-rk-light mb-4">
     <CardHeader className="bg-white p-3 ps-4">Dataset files ({props.files.length})</CardHeader>
     <CardBody className="p-4 pt-3 pb-3 lh-lg pb-2">
@@ -58,7 +77,7 @@ function DisplayFiles(props) {
           <span>No files on this dataset.</span>
           :
           <FileExplorer
-            files={props.files}
+            files={filesWithNames}
             lineageUrl={props.lineagesUrl}
             insideProject={props.insideProject}
             foldersOpenOnLoad={openFolders}


### PR DESCRIPTION
This PR is an attempt to fix the broken links we would have once we won't get the `name` property for the files from the KG datasets API. We can merge it now since it still uses the `name` property when available, and it derives it from `atLocation` otherwise.

In the end I followed the suggestion in #1497 , although a cleaner solution may be desirable.
We should consider refactoring the `FileExplorer` component that has grown way too much, handling generic file trees, lineage, dataset files [...] despite the different object properties. An abstraction layer would greatly simplify handling minor changes like the current one.

/deploy
fix #1497