### PR TITLE
feat: highlight code syntax in markdown files

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10585,8 +10585,7 @@
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "dev": true
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
     "hex-color-regex": {
       "version": "1.1.0",
@@ -10700,6 +10699,16 @@
       "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.2.tgz",
       "integrity": "sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ==",
       "dev": true
+    },
+    "html-encoder-decoder": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/html-encoder-decoder/-/html-encoder-decoder-1.3.9.tgz",
+      "integrity": "sha512-dHv7bdOTEE69EIxXsM8Vslt+NW7QfEB5EGOC29BR14c7RQ9iHUgK76k3/aS23xNIwDg/xlZLWCSZ8lxol9bYlQ==",
+      "requires": {
+        "he": "^1.1.0",
+        "iterate-object": "^1.3.2",
+        "regex-escape": "^3.4.2"
+      }
     },
     "html-encoding-sniffer": {
       "version": "1.0.2",
@@ -11766,6 +11775,11 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz",
       "integrity": "sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA=="
+    },
+    "iterate-object": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/iterate-object/-/iterate-object-1.3.4.tgz",
+      "integrity": "sha512-4dG1D1x/7g8PwHS9aK6QV5V94+ZvyP4+d19qDv43EzImmrndysIl4prmJ1hWWIGCqrZHyaHBm6BSEWHOLnpoNw=="
     },
     "jest": {
       "version": "24.9.0",
@@ -17317,7 +17331,7 @@
       }
     },
     "reactstrap": {
-      "version": "github:SwissDataScienceCenter/reactstrap#npm-bs5-link",
+      "version": "git+ssh://git@github.com/SwissDataScienceCenter/reactstrap.git#4bf48f4c9e46916ed3da0a9b296ccbc2d02a7260",
       "from": "reactstrap@github:SwissDataScienceCenter/reactstrap#npm-bs5-link",
       "requires": {
         "@babel/runtime": "^7.12.5",
@@ -17483,6 +17497,11 @@
       "requires": {
         "@babel/runtime": "^7.8.4"
       }
+    },
+    "regex-escape": {
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/regex-escape/-/regex-escape-3.4.10.tgz",
+      "integrity": "sha512-qEqf7uzW+iYcKNLMDFnMkghhQBnGdivT6KqVQyKsyjSWnoFyooXVnxrw9dtv3AFLnD6VBGXxtZGAQNFGFTnCqA=="
     },
     "regex-not": {
       "version": "1.0.2",
@@ -18778,6 +18797,16 @@
             "decamelize": "^1.2.0"
           }
         }
+      }
+    },
+    "showdown-highlight": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/showdown-highlight/-/showdown-highlight-2.1.8.tgz",
+      "integrity": "sha512-WqrMzMPYrWEwbA03GJT8mc82QxTe91kFwvNWpEPfTgEwd/5G32d44bn5Z7zMYgOcePnXInmYClldezqHDAyGZg==",
+      "requires": {
+        "highlight.js": "^10.7.2",
+        "html-encoder-decoder": "^1.3.9",
+        "showdown": "^1.9.1"
       }
     },
     "side-channel": {

--- a/client/package.json
+++ b/client/package.json
@@ -53,6 +53,7 @@
     "redux-thunk": "^2.2.0",
     "sass": "^1.37.5",
     "showdown": "^1.9.1",
+    "showdown-highlight": "^2.1.8",
     "styled-jsx": "^3.4.5",
     "uuid": "^3.3.3",
     "xregexp": "^4.4.0",

--- a/client/src/utils/HelperFunctions.js
+++ b/client/src/utils/HelperFunctions.js
@@ -19,6 +19,7 @@
 // title.Author: Alex K. - https://stackoverflow.com/users/246342/alex-k
 // Source: https://stackoverflow.com/questions/6507056/replace-all-whitespace-characters/6507078#6507078
 import showdown from "showdown";
+import showdownHighlight from "showdown-highlight";
 import DOMPurify from "dompurify";
 import XRegExp from "xregexp";
 
@@ -166,7 +167,13 @@ function sanitizedHTMLFromMarkdown(markdown, singleLine = false) {
     replace: `<${key} $1 class="$3 ${showdownClasses[key]}" $4>`
   }));
 
-  const converter = new showdown.Converter({ ...showdownOptions, extensions: [...bindings] });
+  const converter = new showdown.Converter({
+    ...showdownOptions,
+    extensions: [
+      ...bindings,
+      showdownHighlight({ pre: true })
+    ]
+  });
   if (singleLine && markdown) {
     const lineBreakers = ["<br>", "<br />", "<br/>", "\n"];
     const breakPosition = Math.max(...lineBreakers.map(elem => markdown.indexOf(elem)));


### PR DESCRIPTION
Since we already use [highlight.js](https://www.npmjs.com/package/highlight.js) for highlighting syntax in code files, and [Showdown](https://www.npmjs.com/package/showdown) to convert Markdown to HTML, using [showdown-highlight](https://www.npmjs.com/package/showdown-highlight) allows us to highlight inline code in Markdown file with a coherent color scheme.

The library is very simple, allowing for few personalizations out of the box, but it works well as long as users specify the code language. There are other solutions but they are more complicated and they may result in a different default highlighting scheme for some languages, forcing us to create a customized common color pattern.

Example:
- New: https://renku-ci-ui-1534.dev.renku.ch/projects/lorenzo.cavazzi.tech/readme-file-dev
- Old: https://dev.renku.ch/projects/lorenzo.cavazzi.tech/readme-file-dev

![Screenshot_20211028_081930](https://user-images.githubusercontent.com/43481553/139198213-cf788b20-b100-4ebb-9006-e317a211351a.png)

/deploy
fix #1358