### PR TITLE
refactor: Rearrange session menu options (#1545)

### DIFF
--- a/client/src/notebooks/Notebooks.present.js
+++ b/client/src/notebooks/Notebooks.present.js
@@ -918,10 +918,12 @@ const NotebookServerRowAction = memo((props) => {
     actions.openExternal = (<DropdownItem href={props.url} target="_blank" >
       <FontAwesomeIcon icon={faExternalLinkAlt} /> Open in new tab
     </DropdownItem>);
-    actions.stop = (
+    actions.stop = <Fragment>
+      <DropdownItem divider />
       <DropdownItem onClick={() => props.stopNotebook(name)}>
         <FontAwesomeIcon icon={faStopCircle} /> Stop
-      </DropdownItem>);
+      </DropdownItem>
+    </Fragment>;
   }
   else {
     const classes = { color: "secondary", className: "text-nowrap" };
@@ -932,7 +934,6 @@ const NotebookServerRowAction = memo((props) => {
     <ButtonWithMenu className="sessionsButton" size="sm" default={defaultAction} color="secondary">
       {actions.openExternal}
       {actions.logs}
-      { status === "running" ? <DropdownItem divider /> : null }
       {actions.stop}
     </ButtonWithMenu>
   );

--- a/client/src/notebooks/Notebooks.present.js
+++ b/client/src/notebooks/Notebooks.present.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import React, { Component, Fragment, useState } from "react";
+import React, { Component, Fragment, useState, memo } from "react";
 import Media from "react-media";
 import { Link } from "react-router-dom";
 import {
@@ -43,6 +43,7 @@ import { Url } from "../utils/url";
 
 import "./Notebooks.css";
 import SessionCheatSheet from "./SessionCheatSheet";
+import _ from "lodash";
 
 
 // * Constants and helpers * //
@@ -900,42 +901,43 @@ class NotebookServerRowProject extends Component {
   }
 }
 
-class NotebookServerRowAction extends Component {
-  render() {
-    const { status, name } = this.props;
-    const actions = {
-      connect: null,
-      stop: null,
-      logs: null
-    };
-    let defaultAction = null;
-    actions.logs = (<DropdownItem onClick={() => this.props.toggleLogs(name)} color="secondary">
-      <FontAwesomeIcon icon={faFileAlt} /> Get logs
-    </DropdownItem>);
+const NotebookServerRowAction = memo((props) => {
+  const { status, name } = props;
+  const actions = {
+    connect: null,
+    stop: null,
+    logs: null
+  };
+  let defaultAction = null;
+  actions.logs = (<DropdownItem onClick={() => props.toggleLogs(name)} color="secondary">
+    <FontAwesomeIcon icon={faFileAlt} /> Get logs
+  </DropdownItem>);
 
-    if (status === "running") {
-      defaultAction = (<Link className="btn btn-secondary text-white" to={this.props.localUrl}>Open</Link>);
-      actions.openExternal = (<DropdownItem href={this.props.url} target="_blank" >
-        <FontAwesomeIcon icon={faExternalLinkAlt} /> Open in new tab
-      </DropdownItem>);
-      actions.stop = (<DropdownItem onClick={() => this.props.stopNotebook(name)}>
+  if (status === "running") {
+    defaultAction = (<Link className="btn btn-secondary text-white" to={props.localUrl}>Open</Link>);
+    actions.openExternal = (<DropdownItem href={props.url} target="_blank" >
+      <FontAwesomeIcon icon={faExternalLinkAlt} /> Open in new tab
+    </DropdownItem>);
+    actions.stop = (
+      <DropdownItem onClick={() => props.stopNotebook(name)}>
         <FontAwesomeIcon icon={faStopCircle} /> Stop
       </DropdownItem>);
-    }
-    else {
-      const classes = { color: "secondary", className: "text-nowrap" };
-      defaultAction = (<Button {...classes} onClick={() => this.props.toggleLogs(name)}>Get logs</Button>);
-    }
-
-    return (
-      <ButtonWithMenu className="sessionsButton" size="sm" default={defaultAction} color="secondary">
-        {actions.openExternal}
-        {actions.stop}
-        {actions.logs}
-      </ButtonWithMenu>
-    );
   }
-}
+  else {
+    const classes = { color: "secondary", className: "text-nowrap" };
+    defaultAction = (<Button {...classes} onClick={() => props.toggleLogs(name)}>Get logs</Button>);
+  }
+
+  return (
+    <ButtonWithMenu className="sessionsButton" size="sm" default={defaultAction} color="secondary">
+      {actions.openExternal}
+      {actions.logs}
+      { status === "running" ? <DropdownItem divider /> : null }
+      {actions.stop}
+    </ButtonWithMenu>
+  );
+}, _.isEqual);
+NotebookServerRowAction.displayName = "NotebookServerRowAction";
 
 /**
  * Simple environment logs container


### PR DESCRIPTION
- Move the stop option to the end of the list to avoid click problems.

- Refactor the NotebookServerRowAction component to be a functional component and use memo to avoid rendering that component if the props have not changed and it is already rendered, the component was rendered for each session state request.

Fix #1545

/deploy renku=ui1337-uiserver-values
