### PR TITLE
feat: Add cancel datasets search (#1352)

### DIFF
--- a/client/src/dataset/list/DatasetList.container.js
+++ b/client/src/dataset/list/DatasetList.container.js
@@ -31,6 +31,7 @@ class List extends Component {
     super(props);
     this.model = new DatasetListModel(props.client);
     this.handlers = {
+      onCancelSearch: this.onCancelSearch.bind(this),
       onSearchQueryChange: this.onSearchQueryChange.bind(this),
       onSearchSubmit: this.onSearchSubmit.bind(this),
       onOrderByDropdownToggle: this.onOrderByDropdownToggle.bind(this),
@@ -165,6 +166,11 @@ class List extends Component {
     this.model.resetBeforeNewSearch();
     this.model.performSearch();
     this.pushNewSearchToHistory();
+  }
+
+  onCancelSearch(e) {
+    e.preventDefault();
+    this.model.cancelSearch();
   }
 
   mapStateToProps(ownProps) {

--- a/client/src/dataset/list/DatasetList.present.js
+++ b/client/src/dataset/list/DatasetList.present.js
@@ -82,8 +82,8 @@ function OrderByDropdown(props) {
 class DatasetSearchForm extends Component {
 
   render() {
-    return <Row className="justify-content-lg-between justify-content-md-center pb-2">
-      <Col md={12} className="pb-2">
+    return <Row className="justify-content-lg-between justify-content-md-center">
+      <Col md={12}>
         <Form key="form" inline onSubmit={this.props.handlers.onSearchSubmit}
           className="row row-cols-lg-auto justify-content-start g-1 pb-2">
           <Col className="col-auto w-25 d-inline-block">
@@ -153,7 +153,7 @@ class DatasetSearchForm extends Component {
             </Card>
           </UncontrolledCollapse>
         </Col>
-        <Col className="d-flex justify-content-end">
+        <Col className="d-flex pt-4">
           <Button color="rk-white" id="displayButton" onClick={() => this.props.onGridDisplayToggle()}>
             {
               this.props.gridDisplay ?

--- a/client/src/dataset/list/DatasetList.present.js
+++ b/client/src/dataset/list/DatasetList.present.js
@@ -22,7 +22,15 @@ import { Row, Col, Alert, Card, CardBody } from "reactstrap";
 import { Button, Form, FormText, Input, Label, InputGroup, UncontrolledCollapse } from "reactstrap";
 import { DropdownToggle, DropdownMenu, DropdownItem } from "reactstrap";
 import { MarkdownTextExcerpt, ListDisplay, Loader } from "../../utils/UIComponents";
-import { faCheck, faSortAmountUp, faSortAmountDown, faSearch, faBars, faTh } from "@fortawesome/free-solid-svg-icons";
+import {
+  faCheck,
+  faSortAmountUp,
+  faSortAmountDown,
+  faSearch,
+  faBars,
+  faTh,
+  faStop
+} from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { ButtonDropdown } from "reactstrap/lib";
 
@@ -83,6 +91,7 @@ class DatasetSearchForm extends Component {
               <Input type="text"
                 name="searchQuery"
                 id="searchQuery"
+                disabled={this.props.loading}
                 placeholder={"Search... "}
                 value={decodeURIComponent(this.props.searchQuery) || ""}
                 onChange={this.props.handlers.onSearchQueryChange}
@@ -99,19 +108,14 @@ class DatasetSearchForm extends Component {
             orderSearchAsc={this.props.orderSearchAsc}
           />
           <Col className="col-auto">
-            <Button color="rk-white" id="searchButton" onClick={this.props.handlers.onSearchSubmit}>
-              <FontAwesomeIcon icon={faSearch} />
-            </Button>
-          </Col>
-          <Col className="col-auto">
-            <Button color="rk-white" id="displayButton"
-              onClick={() => this.props.onGridDisplayToggle()}>
-              {
-                this.props.gridDisplay ?
-                  <FontAwesomeIcon icon={faBars} /> :
-                  <FontAwesomeIcon icon={faTh} />
-              }
-            </Button>
+            { this.props.loading ?
+              <Button color="rk-white" id="cancelButton" onClick={this.props.handlers.onCancelSearch}>
+                <FontAwesomeIcon icon={faStop}/>
+              </Button> :
+              <Button color="rk-white" id="searchButton" onClick={this.props.handlers.onSearchSubmit}>
+                <FontAwesomeIcon icon={faSearch}/>
+              </Button>
+            }
           </Col>
         </Form>
         <Col sm={12}>
@@ -148,6 +152,14 @@ class DatasetSearchForm extends Component {
               </CardBody>
             </Card>
           </UncontrolledCollapse>
+        </Col>
+        <Col className="d-flex justify-content-end">
+          <Button color="rk-white" id="displayButton" onClick={() => this.props.onGridDisplayToggle()}>
+            {
+              this.props.gridDisplay ?
+                <FontAwesomeIcon icon={faBars} /> : <FontAwesomeIcon icon={faTh} />
+            }
+          </Button>
         </Col>
       </Col>
     </Row>;
@@ -216,6 +228,7 @@ function DatasetsSearch(props) {
       <div className="pb-2 rk-search-bar">
         <DatasetSearchForm
           searchQuery={props.searchQuery}
+          loading={loading}
           handlers={props.handlers}
           errorMessage={props.errorMessage}
           orderByValuesMap={props.orderByValuesMap}

--- a/client/src/dataset/list/DatasetList.state.js
+++ b/client/src/dataset/list/DatasetList.state.js
@@ -147,7 +147,7 @@ class DatasetListModel extends StateModel {
       page: this.get("currentPage"),
     };
     return this.client.searchDatasets(searchParams)
-      .then( async response => {
+      .then( response => {
         const currentSearchId = this.get("searchId");
         if (currentSearchId !== searchId) return;
         this.manageResponse(response);

--- a/client/src/dataset/list/DatasetList.state.js
+++ b/client/src/dataset/list/DatasetList.state.js
@@ -119,6 +119,7 @@ class DatasetListModel extends StateModel {
   }
 
   manageResponse(response) {
+    if (!this.get("loading")) return;
     const { pagination } = response;
     const newData = {
       datasets: { $set: response.data },
@@ -155,6 +156,11 @@ class DatasetListModel extends StateModel {
         newData.initialized = false;
         this.setObject(newData);
       });
+  }
+
+  cancelSearch() {
+    // set that is not loading or waiting for results
+    this.set("loading", false);
   }
 }
 

--- a/client/src/dataset/list/DatasetList.state.js
+++ b/client/src/dataset/list/DatasetList.state.js
@@ -24,6 +24,7 @@
  */
 
 import { Schema, StateKind, StateModel } from "../../model/Model";
+import uuid from "uuid/v4";
 
 const orderByValuesMap = {
   TITLE: "title",
@@ -135,6 +136,9 @@ class DatasetListModel extends StateModel {
 
   performSearch() {
     if (this.get("loading")) return;
+
+    const searchId = uuid();
+    this.set("searchId", searchId);
     this.set("loading", true);
     const searchParams = {
       query: this.get("query") === "" ? "*" : this.get("query"),
@@ -143,7 +147,11 @@ class DatasetListModel extends StateModel {
       page: this.get("currentPage"),
     };
     return this.client.searchDatasets(searchParams)
-      .then(response => this.manageResponse(response))
+      .then( async response => {
+        const currentSearchId = this.get("searchId");
+        if (currentSearchId !== searchId) return;
+        this.manageResponse(response);
+      })
       .catch((error) => {
         let newData = {};
         if (error.response && error.response.status === 400 && this.get("initialized") === false)

--- a/client/src/model/RenkuModels.js
+++ b/client/src/model/RenkuModels.js
@@ -65,6 +65,7 @@ const forkDisplaySchema = new Schema({
   displayId: { initial: "", mandatory: false },
   slug: { initial: "", mandatory: true },
   loading: { initial: false, mandatory: false },
+  searchId: { initial: "", mandatory: false },
   errors: { initial: [], mandatory: false },
 
   statuses: { initial: [] },


### PR DESCRIPTION
Added cancellation of dataset search when a search is already in progress, which prevents the input from being used for new searches when a new one is still running. The user can cancel the current one.
Included searchId to show only the results of the current search.

/deploy renku=ui1337-uiserver-values
