### PR TITLE
Route all requests to APIs through UI server

### DIFF
--- a/client/src/api-client/errors.js
+++ b/client/src/api-client/errors.js
@@ -27,8 +27,16 @@ const API_ERRORS = {
   forbiddenError: "FORBIDDEN",
   notFoundError: "NOT_FOUND",
   internalServerError: "SERVER_ERROR",
-  networkError: "NETWORK_PROBLEM"
+  networkError: "NETWORK_PROBLEM",
+  authExpired: "AUTH_EXPIRED"
 };
+
+function throwAuthError(response) {
+  let error = new APIError();
+  error.case = API_ERRORS.authExpired;
+  error.response = response;
+  return Promise.reject(error);
+}
 
 function throwErrorWithData(response, data) {
   let error;
@@ -83,4 +91,4 @@ function alertAPIErrors(error) {
   }
 }
 
-export { APIError, API_ERRORS, alertAPIErrors, throwAPIErrors };
+export { APIError, API_ERRORS, alertAPIErrors, throwAPIErrors, throwAuthError };

--- a/client/src/api-client/index.js
+++ b/client/src/api-client/index.js
@@ -60,12 +60,16 @@ const FETCH_DEFAULT = {
  * API client to query all the RenkuLab API
  */
 class APIClient {
-  constructor(baseUrl, uiserverUrl) {
-    this.baseUrl = baseUrl;
+  /**
+   * @param {string} apiUrl - base API url
+   * @param {string} uiserverUrl - UI server base url, mainly used for authentication
+   */
+  constructor(apiUrl, uiserverUrl) {
+    this.baseUrl = apiUrl;
     this.uiserverUrl = uiserverUrl;
     this.returnTypes = RETURN_TYPES;
     this.graphqlClient = new ApolloClient({
-      uri: `${baseUrl}/kg/graphql`,
+      uri: `${apiUrl}/kg/graphql`,
       headers: { "X-Requested-With": "XMLHttpRequest" }
     });
 
@@ -107,6 +111,8 @@ class APIClient {
   ) {
     return renkuFetch(url, options)
       .catch((error) => {
+        if (error.case === API_ERRORS.authExpired)
+          return this.doLogin();
         // For permission errors we send the user to login
         if (reLogin && error.case === API_ERRORS.unauthorizedError)
           return this.doLogin();

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -59,7 +59,7 @@ Promise.all([configFetch, privacyFetch]).then(valuesRead => {
     Url.setBaseUrl(params["BASE_URL"]);
 
     // create client to be passed to coordinators
-    const client = new APIClient(params.GATEWAY_URL, params.UISERVER_URL);
+    const client = new APIClient(params.UISERVER_URL + "/api", params.UISERVER_URL);
 
     // Create the global model containing the formal schema definition and the redux store
     const model = new StateModel(globalSchema);

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -23,6 +23,7 @@ const SERVER = {
   url: process.env.SERVER_URL,
   port: convertType(process.env.SERVER_PORT) || 8080,
   prefix: process.env.SERVER_PREFIX || "/ui-server",
+  logLevel: process.env.SERVER_LOG_LEVEL || "info",
 };
 
 const DEPLOYMENT = {

--- a/server/src/logger.ts
+++ b/server/src/logger.ts
@@ -22,8 +22,11 @@
 
 import winston from "winston";
 
+import config from "./config";
+
+
 const logger = winston.createLogger({
-  level: "info",
+  level: config.server.logLevel,
   format: winston.format.json(),
   defaultMeta: { service: "renku-ui-server" },
   transports: [

--- a/server/src/utils/index.ts
+++ b/server/src/utils/index.ts
@@ -43,6 +43,22 @@ function convertType(value: string, booleans = true, numbers = true): boolean | 
   return value;
 }
 
+
+/**
+ * Return target cookies if matched.
+ *
+ * @param cookies - cookies string containing all cookies
+ * @param target - target cookie name
+ * @returns value of the target cookie. Null if unmatched
+ */
+function getCookieValueByName(cookies: string, target: string): string {
+  if (!cookies || !target || cookies.length < 1 || target.length < 1)
+    return null;
+  const match = cookies.match(new RegExp("(^| )" + target + "=([^;]+)"));
+  return match ? match[2] : null;
+}
+
+
 /**
  * Simulate a sleep function.
  * @param {number} seconds - length of the sleep time span in seconds
@@ -53,4 +69,4 @@ async function sleep(seconds: number): Promise<void> {
 }
 
 
-export { convertType, sleep };
+export { convertType, getCookieValueByName, sleep };

--- a/server/tests/utils/index.test.ts
+++ b/server/tests/utils/index.test.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { convertType } from "../../src/utils/index";
+import { convertType, getCookieValueByName } from "../../src/utils/index";
 
 
 describe("Test utils functions", () => {
@@ -40,5 +40,45 @@ describe("Test utils functions", () => {
     expect(convertType("0")).toBe(0);
     expect(convertType("-12")).toBe(-12);
     expect(convertType("12", false, false)).not.toBe(12);
+  });
+
+  it("Test getCookieValueByName", async () => {
+    const target = "anon-id";
+    const values = [
+      {
+        cookies: "ui-server-session=0f2-5feef-a50B9; session=35184a0_630.XL56xeF4pmsLMI; anon-id=anon-ODvRAo6Ukj0ZE",
+        result: "anon-ODvRAo6Ukj0ZE"
+      },
+      {
+        cookies: "ui-server-session=0f2-5feef-a50B9; anon-id=anon-ODvRAo6Ukj0ZE; session=35184a0_630.XL56xeF4pmsLMI",
+        result: "anon-ODvRAo6Ukj0ZE"
+      },
+      {
+        cookies: "ui-server-session=062a726c-6737-4dae-8786-2b378a06c66c",
+        result: null
+      },
+      {
+        cookies: "anon-id=anon-aL84skoIRyaLvkhoBBwb2ZYkAXOo9IyhKEj5bDH7UPE",
+        result: "anon-aL84skoIRyaLvkhoBBwb2ZYkAXOo9IyhKEj5bDH7UPE"
+      },
+      {
+        cookies: "anon-id=anon-aL84skoIRyaLvkhoBBwb2ZYkAXOo9IyhKEj5bDH7UPE;",
+        result: "anon-aL84skoIRyaLvkhoBBwb2ZYkAXOo9IyhKEj5bDH7UPE"
+      },
+      {
+        cookies: "ui-server-session=062a726c-6737-4dae-8786-2b378a06c66c",
+        result: null
+      },
+      {
+        cookies: "",
+        result: null
+      },
+      {
+        cookies: null,
+        result: null
+      }
+    ];
+    for (const value of values)
+      expect(getCookieValueByName(value.cookies, target)).toBe(value.result);
   });
 });


### PR DESCRIPTION
This PR routes all the UI client API through the UI server.
It handles also the credentials expirations (e.g. tokens not refreshable anymore) by adding a specific header that the client reads and uses to redirect to the login page. This should happen very rarely and it's similar to the current behavior.
Should we want a different UX, we could redirect to a new UI page where we explain what happened and suggest to re-login.

P.S. Mind that the expired credentials also cause the invoked API to return a `500` message. This prevents very weird behaviors, happening when GitLab APIs respond with a `30x` code. The browser (at least Firefox) doesn't re-read the headers, causing an infinite login loop.

**How to test**
* Keep the network tab open and verify the APIs go through `<domain>/ui-server/api` instead of `<domain>/api`
* In the CI deployment, I lowered the token validity to maximum 10 minutes. Try to login, do some action, then leave the page open for >10 minutes and click on anything later. As soon as an API is invoked, the user should be redirected to the login

/deploy renku=ui1521-tests-unavailable-iframe renku-gateway=ui1521-anonid-nopath
#1521