### PR TITLE
1.2.1 bugfix

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -13,6 +13,7 @@ on:
     - server/**
     - helm-chart/**
     - .github/workflows/**
+    - chartpress.yaml
 
 jobs:
   cleanup-previous-runs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## [1.2.1](https://github.com/SwissDataScienceCenter/renku-ui/compare/1.2.0...1.2.1) (2021-11-29)
+
+### Bug Fixes
+
+* adjust the build pipeline to prevent showing version update popups when unnecessary ([#1594](https://github.com/SwissDataScienceCenter/renku-ui/issues/1594))
+
 ## [1.2.0](https://github.com/SwissDataScienceCenter/renku-ui/compare/1.1.0...1.2.0) (2021-11-26)
 
 ### Features

--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -18,6 +18,8 @@ charts:
           - client
           - server
           - helm-chart
+          - .github
+          - "."
         buildArgs:
           SHORT_SHA: "{LAST_COMMIT}"
   - name: helm-chart/renku-ui-server
@@ -39,5 +41,7 @@ charts:
           - client
           - server
           - helm-chart
+          - .github
+          - "."
         buildArgs:
           SHORT_SHA: "{LAST_COMMIT}"

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "renku-ui",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "renku-ui",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "dependencies": {
     "@babel/helper-regex": "^7.10.5",

--- a/helm-chart/renku-ui-server/Chart.yaml
+++ b/helm-chart/renku-ui-server/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: "1.0"
 description: A Helm chart for the Renku UI Server
 name: renku-ui-server
 icon: https://github.com/SwissDataScienceCenter/renku-sphinx-theme/raw/master/renku_sphinx_theme/static/favicon.png
-version: 1.2.0
+version: 1.2.1

--- a/helm-chart/renku-ui-server/values.yaml
+++ b/helm-chart/renku-ui-server/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: renku/renku-ui-server
-  tag: "1.2.0"
+  tag: "1.2.1"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/helm-chart/renku-ui/Chart.yaml
+++ b/helm-chart/renku-ui/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.0'
 description: A Helm chart for the Renku UI
 name: renku-ui
 icon: https://github.com/SwissDataScienceCenter/renku-sphinx-theme/raw/master/renku_sphinx_theme/static/favicon.png
-version: 1.2.0
+version: 1.2.1

--- a/helm-chart/renku-ui/values.yaml
+++ b/helm-chart/renku-ui/values.yaml
@@ -16,7 +16,7 @@ replicaCount: 1
 
 image:
   repository: renku/renku-ui
-  tag: "1.2.0"
+  tag: "1.2.1"
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "renku-ui-server",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "renku-ui-server",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Server for renku API",
   "private": true,
   "main": "dist/index.js",


### PR DESCRIPTION
Bugfix release to prevent accidentally showing the "new version" banner after a release where the last commit didn't touch an "essential" file (i.e. not in the server, client, or helm_chart folder).


![Screenshot_20211129_161244](https://user-images.githubusercontent.com/43481553/143905777-88278c58-6726-4687-bd2a-dacb91ae2b35.png)
 