### PR TITLE
fix(client): show the correct session status on notebooks preview

### DIFF
--- a/client/src/file/File.present.js
+++ b/client/src/file/File.present.js
@@ -395,7 +395,7 @@ class JupyterButtonPresent extends React.Component {
       return <CheckNotebookIcon fetched={true} launchNotebookUrl={this.props.launchNotebookUrl} />;
 
     if (this.props.updating)
-      return (<span style={{ verticalAlign: "text-bottom" }}><Loader size="19" inline="true" /></span>);
+      return (<span className="ms-2 pb-1"><Loader size="19" inline="true" /></span>);
 
     return (
       <CheckNotebookStatus

--- a/client/src/file/File.test.js
+++ b/client/src/file/File.test.js
@@ -95,7 +95,7 @@ describe("rendering", () => {
       const div = document.createElement("div");
       // * fix for tooltips https://github.com/reactstrap/reactstrap/issues/773#issuecomment-357409863
       document.body.appendChild(div);
-      const branches = { all: [], fetch: () => {} };
+      const branches = { all: { standard: [] }, fetch: () => {} };
       ReactDOM.render(
         <MemoryRouter>
           <JupyterButton user={user.data} branches={branches} {...props} />

--- a/client/src/notebooks/Notebooks.present.js
+++ b/client/src/notebooks/Notebooks.present.js
@@ -2008,28 +2008,25 @@ class AutosavedDataModal extends Component {
 class CheckNotebookIcon extends Component {
   render() {
     const { fetched, notebook, location } = this.props;
-    const loader = (<span style={{ verticalAlign: "text-bottom" }}><Loader size="19" inline="true" /></span>);
+    const loader = (<span className="ms-2 pb-1"><Loader size="19" inline="true" /></span>);
     if (!fetched)
       return loader;
 
-    let tooltip, link, icon;
+    let tooltip, link, icon, aligner = null;
     if (notebook) {
       const status = NotebooksHelper.getStatus(notebook.status);
       if (status === "running") {
         tooltip = "Connect to JupyterLab";
         icon = (<JupyterIcon svgClass="svg-inline--fa fa-w-16 icon-link" />);
-        const url = `${notebook.url}lab/tree/${this.props.filePath}`;
+        const url = `${notebook.url}/lab/tree/${this.props.filePath}`;
         link = (<a href={url} role="button" target="_blank" rel="noreferrer noopener">{icon}</a>);
       }
-      else if (status === "pending") {
-        tooltip = "The session is either starting, please wait...";
-        icon = loader;
-        link = (<span>{icon}</span>);
-      }
-      else if (status === "stopping") {
-        tooltip = "The session is stopping, please wait...";
-        icon = loader;
-        link = (<span>{icon}</span>);
+      else if (status === "pending" || status === "stopping") {
+        tooltip = status === "stopping" ?
+          "The session is stopping, please wait..." :
+          "The session is starting, please wait...";
+        aligner = "pb-1";
+        link = loader;
       }
       else {
         tooltip = "Check session status";
@@ -2052,7 +2049,7 @@ class CheckNotebookIcon extends Component {
 
     return (
       <React.Fragment>
-        <span id="checkNotebookIcon">{link}</span>
+        <span id="checkNotebookIcon" className={aligner}>{link}</span>
         <ThrottledTooltip target="checkNotebookIcon" tooltip={tooltip} />
       </React.Fragment>
     );


### PR DESCRIPTION
There were a few issues with the `CheckNotebooksStatus` component, leading to different results based on a few factors (status of the sessions, user default branch already loaded when browsing the file, ...)

This should restore the previous behavior, and correct the wrong links.
With #1345, the feature will become more useful since it will be possible to identify the "correct" commit for the session instead of checking the latest

/deploy
fix #1606