### PR TITLE
fix: Order maintenance by schedule date asc

### DIFF
--- a/client/src/statuspage/Statuspage.present.js
+++ b/client/src/statuspage/Statuspage.present.js
@@ -118,8 +118,7 @@ function SiteStatusLanding(props) {
  * @param {array} maintenances
  */
 function sortedMaintenances(maintenances) {
-  maintenances.sort((a, b) => a.scheduled_for < b.scheduled_for);
-  return maintenances;
+  return maintenances.sort((a, b) => new Date(a.scheduled_for) > new Date(b.scheduled_for));
 }
 
 function maintenanceTimeFragment(first) {

--- a/client/src/statuspage/Statuspage.present.js
+++ b/client/src/statuspage/Statuspage.present.js
@@ -118,7 +118,11 @@ function SiteStatusLanding(props) {
  * @param {array} maintenances
  */
 function sortedMaintenances(maintenances) {
-  return maintenances.sort((a, b) => new Date(a.scheduled_for) > new Date(b.scheduled_for));
+  return maintenances.sort((a, b) => {
+    return (new Date(a.scheduled_for) < new Date(b.scheduled_for)) ?
+      -1 :
+      1;
+  });
 }
 
 function maintenanceTimeFragment(first) {


### PR DESCRIPTION
Added sorting by schedule date in the maintenance summary.

Tested in Chrome, Safari and Firefox browsers.

Closes #1609 

/deploy ui.statuspage=lhwy5ln8yrnn