### PR TITLE
feat(client): support multiple renku-core instances

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -219,6 +219,7 @@
           "noreferrer",
           "nowrap",
           "nullable",
+          "onloadend",
           "papermill",
           "pathname",
           "pdfjs",

--- a/client/src/api-client/environment.js
+++ b/client/src/api-client/environment.js
@@ -30,6 +30,30 @@ function addEnvironmentMethods(client) {
       headers: headers
     }).then(resp => resp.data);
   };
+
+  /**
+   * Check core version availability
+   *
+   * @param {string} version - target core version to test
+   */
+  client.checkCoreAvailability = async (version) => {
+    const urlApi = `${client.uiserverUrl}/api/renku/${version}/version`;
+    let headers = client.getBasicHeaders();
+    headers.append("Content-Type", "application/json");
+    headers.append("X-Requested-With", "XMLHttpRequest");
+    const resp = await client.clientFetch(urlApi, {
+      method: "GET",
+      headers: headers
+    });
+    if (resp.error) {
+      if (resp.error.reason === "Not found")
+        return { available: false };
+      return resp;
+    }
+    if (resp.data.result?.supported_project_version)
+      return { ...resp.data.result, available: true };
+    return resp.data;
+  };
 }
 
 export default addEnvironmentMethods;

--- a/client/src/api-client/index.js
+++ b/client/src/api-client/index.js
@@ -233,6 +233,17 @@ class APIClient {
     };
     return new Headers(headers);
   }
+
+  /**
+   * Return a versioned endpoint url for the core service.
+   * @param {string} endpoint
+   * @param {string or null} version
+   * @returns string
+   */
+  versionedCoreUrl(endpoint, version) {
+    const urlAddition = version ? version : "";
+    return `${this.baseUrl}/renku${urlAddition}/${endpoint}`;
+  }
 }
 
 export default APIClient;

--- a/client/src/api-client/project.js
+++ b/client/src/api-client/project.js
@@ -385,10 +385,11 @@ function addProjectMethods(client) {
    * Get project config file data
    * @see {@link https://github.com/SwissDataScienceCenter/renku-python/blob/master/renku/service/views/config.py}
    * @param {string} projectRepositoryUrl - external repository full url.
-   * @param {string} branch - target branch.
+   * @param {string} [versionUrl] - project version url.
+   * @param {string} [branch] - target branch.
    */
-  client.getProjectConfig = async (projectRepositoryUrl, branch = null) => {
-    const url = `${client.baseUrl}/renku/config.show`;
+  client.getProjectConfig = async (projectRepositoryUrl, versionUrl = null, branch = null) => {
+    const url = client.versionedCoreUrl("config.show", versionUrl);
     let queryParams = { git_url: projectRepositoryUrl };
     if (branch)
       queryParams.branch = branch;
@@ -408,10 +409,14 @@ function addProjectMethods(client) {
    * @see {@link https://github.com/SwissDataScienceCenter/renku-python/blob/master/renku/service/views/config.py}
    * @param {string} projectRepositoryUrl - external repository full url.
    * @param {object} config - config object in the form {key: value}. A null value removes the key.
+   * @param {string} [versionUrl] - project version url.
+   * @param {string} [branch] - target branch.
    */
-  client.setProjectConfig = async (projectRepositoryUrl, config) => {
-    const url = `${client.baseUrl}/renku/config.set`;
-    const body = { git_url: projectRepositoryUrl, config };
+  client.setProjectConfig = async (projectRepositoryUrl, config, versionUrl = null, branch = null) => {
+    const url = client.versionedCoreUrl("config.set", versionUrl);
+    let body = { git_url: projectRepositoryUrl, config };
+    if (branch)
+      body.branch = branch;
     let headers = client.getBasicHeaders();
     headers.append("Content-Type", "application/json");
     headers.append("X-Requested-With", "XMLHttpRequest");

--- a/client/src/dataset/Dataset.present.js
+++ b/client/src/dataset/Dataset.present.js
@@ -55,7 +55,7 @@ function DisplayFiles(props) {
   }
 
   let openFolders = props.files.length > 0 ?
-    ( props.files[0].atLocation.startsWith("data/") ? 2 : 1 )
+    (props.files[0].atLocation.startsWith("data/") ? 2 : 1)
     : 0;
 
   // ? This re-adds the name property on the datasets.
@@ -177,14 +177,14 @@ function DisplayInfoTable(props) {
     : null;
 
   const keywords = dataset.keywords && dataset.keywords.length > 0 ?
-    dataset.keywords.map(keyword=>
+    dataset.keywords.map(keyword =>
       <span key={keyword}><Badge color="rk-text">{keyword}</Badge>&nbsp;</span>)
     : null;
 
   // eslint-disable-next-line
   return <Table className="mb-4 table-borderless" size="sm">
     <tbody className="text-rk-text">
-      { source ?
+      {source ?
         <tr>
           <td className="text-dark fw-bold" style={{ "width": "120px" }}>
             Source
@@ -195,7 +195,7 @@ function DisplayInfoTable(props) {
         </tr>
         : null
       }
-      { authors ? <tr>
+      {authors ? <tr>
         <td className="text-dark fw-bold col-auto">
           Author(s)
         </td>
@@ -205,7 +205,7 @@ function DisplayInfoTable(props) {
       </tr>
         : null
       }
-      { datasetDate ?
+      {datasetDate ?
         <tr>
           <td className="text-dark fw-bold col-auto">
             {datasetPublished ? "Published on " : "Created on "}
@@ -216,7 +216,7 @@ function DisplayInfoTable(props) {
         </tr>
         : null
       }
-      { keywords ? <tr>
+      {keywords ? <tr>
         <td className="text-dark fw-bold col-auto">
           Keywords
         </td>
@@ -325,8 +325,8 @@ function ErrorAfterCreation(props) {
 
   return props.location.state && props.location.state.errorOnCreation ?
     <ErrorAlert>
-      <strong>Error on creation</strong><br/>
-      The dataset was created, but there was an error adding files to it.<br/>
+      <strong>Error on creation</strong><br />
+      The dataset was created, but there was an error adding files to it.<br />
       Please {editButton} the dataset to add the missing files.
     </ErrorAlert>
     : null;
@@ -338,21 +338,23 @@ export default function DatasetView(props) {
   const [deleteDatasetModalOpen, setDeleteDatasetModalOpen] = useState(false);
   const dataset = props.dataset;
 
-  if (!_.isEmpty(props.fetchError) && dataset === undefined) {
-    return (
-      <DatasetError
-        fetchError={props.fetchError}
-        insideProject={props.insideProject}
-        location={props.location}
-        logged={props.logged} />
-    );
+  if (dataset === undefined) {
+    if (!_.isEmpty(props.fetchError)) {
+      return (
+        <DatasetError
+          fetchError={props.fetchError}
+          insideProject={props.insideProject}
+          location={props.location}
+          logged={props.logged} />
+      );
+    }
+
+    if (props.loadingDatasets || !props.insideProject)
+      return <Loader />;
   }
 
-  if (dataset === undefined)
-    return (<Loader />);
-
   return <Col>
-    <ErrorAfterCreation location={props.location} dataset={dataset}/>
+    <ErrorAfterCreation location={props.location} dataset={dataset} />
     <Row>
       <Col md={8} sm={12}>
         {props.insideProject ?
@@ -366,13 +368,13 @@ export default function DatasetView(props) {
         }
       </Col>
       <Col md={4} sm={12} className="d-flex flex-col justify-content-end mb-auto">
-        { props.logged ?
+        {props.logged ?
           <Button disabled={dataset.insideKg === false}
             className="float-right mb-1 me-1" size="sm" color="secondary" onClick={() => setAddDatasetModalOpen(true)}>
             <FontAwesomeIcon icon={faPlus} color="dark" /> Add to project
           </Button>
           : null}
-        { props.insideProject && props.maintainer ?
+        {props.insideProject && props.maintainer ?
           <Link className="float-right me-1 mb-1" id="editDatasetTooltip"
             to={{ pathname: "modify", state: { dataset: dataset } }} >
             <Button size="sm" color="secondary" >
@@ -381,7 +383,7 @@ export default function DatasetView(props) {
           </Link>
           : null
         }
-        { props.insideProject && props.maintainer ?
+        {props.insideProject && props.maintainer ?
           <UncontrolledButtonDropdown size="sm" className="float-right mb-1">
             <DropdownToggle caret color="secondary" className="removeArrow">
               <FontAwesomeIcon icon={faEllipsisV} color="dark" />
@@ -397,12 +399,12 @@ export default function DatasetView(props) {
       </Col>
     </Row>
     <div className="d-flex">
-      { dataset.mediaContent ?
+      {dataset.mediaContent ?
         <div className="flex-shrink-0 pe-3" style={{ width: "120px" }}>
           <img src={dataset.mediaContent} className=" rounded" alt=""
-            style={{ objectFit: "cover", width: "100%", height: "90px" }}/>
+            style={{ objectFit: "cover", width: "100%", height: "90px" }} />
         </div>
-        : null }
+        : null}
       <div className="flex-grow-1">
         <DisplayInfoTable
           dataset={dataset}
@@ -458,28 +460,30 @@ export default function DatasetView(props) {
     {
       props.logged ?
         <AddDataset
-          dataset={dataset}
-          modalOpen={addDatasetModalOpen}
-          setModalOpen={setAddDatasetModalOpen}
-          projectsCoordinator={new ProjectsCoordinator(props.client, props.model.subModel("projects"))}
-          model={props.model}
-          history={props.history}
           client={props.client}
-          user={props.user}
+          dataset={dataset}
           formLocation={props.location.pathname + "/add"}
+          history={props.history}
+          modalOpen={addDatasetModalOpen}
+          model={props.model}
+          projectsCoordinator={new ProjectsCoordinator(props.client, props.model.subModel("projects"))}
+          setModalOpen={setAddDatasetModalOpen}
+          user={props.user}
+          versionUrl={props.migration.core.versionUrl}
         />
         : null
     }
-    { props.insideProject && props.maintainer ?
+    {props.insideProject && props.maintainer ?
       <DeleteDataset
-        dataset={dataset}
-        modalOpen={deleteDatasetModalOpen}
-        setModalOpen={setDeleteDatasetModalOpen}
-        httpProjectUrl={props.httpProjectUrl}
-        projectPathWithNamespace={props.projectPathWithNamespace}
-        history={props.history}
         client={props.client}
+        dataset={dataset}
+        history={props.history}
+        httpProjectUrl={props.httpProjectUrl}
+        modalOpen={deleteDatasetModalOpen}
+        projectPathWithNamespace={props.projectPathWithNamespace}
+        setModalOpen={setDeleteDatasetModalOpen}
         user={props.user}
+        versionUrl={props.migration.core.versionUrl}
       />
       : null
     }

--- a/client/src/dataset/Datasets.test.js
+++ b/client/src/dataset/Datasets.test.js
@@ -45,6 +45,18 @@ describe("Dataset functions", () => {
     pathname: "/projects",
     search: "?page=1"
   });
+  const migration = { core: { versionUrl: "" } };
+  const datasets = [{
+    "title": "Test dataset title",
+    "identifier": "79215657-4319-4fcf-82b9-58267f2a1db8",
+    "name": "test-dataset-name",
+    "created_at": "2021-06-04 04:20:24.287936+00:00",
+    "creators": [{
+      "name": "First, Creator",
+      "email": null,
+      "affiliation": "Some Affiliation",
+    }]
+  }];
 
   it("renders datasets list view without crashing", async () => {
     const div = document.createElement("div");
@@ -53,9 +65,10 @@ describe("Dataset functions", () => {
         <MemoryRouter>
           <DatasetList key="datasets"
             client={client}
-            model={model}
             history={fakeHistory}
             location={fakeHistory.location}
+            migration={migration}
+            model={model}
           />
         </MemoryRouter>
         , div);
@@ -68,13 +81,17 @@ describe("Dataset functions", () => {
       ReactDOM.render(
         <MemoryRouter>
           <ShowDataset
-            insideProject={false}
-            identifier={"79215657-4319-4fcf-82b9-58267f2a1db8"}
             client={client}
-            projectsUrl="/projects"
-            selectedDataset={"79215657-4319-4fcf-82b9-58267f2a1db8"}
+            datasets={datasets}
+            datasetId="test-dataset-name"
+            identifier="79215657-4319-4fcf-82b9-58267f2a1db8"
+            insideProject={false}
+            location={fakeHistory.location}
             logged={true}
+            migration={migration}
             model={model}
+            projectsUrl="/projects"
+            selectedDataset="79215657-4319-4fcf-82b9-58267f2a1db8"
           />
         </MemoryRouter>
         , div);

--- a/client/src/dataset/addtoproject/DatasetAdd.container.js
+++ b/client/src/dataset/addtoproject/DatasetAdd.container.js
@@ -110,7 +110,7 @@ function AddDataset(props) {
   };
 
   const importDataset = (selectedProject, handlers) => {
-    props.client.datasetImport(selectedProject.value, props.dataset.url)
+    props.client.datasetImport(selectedProject.value, props.dataset.url, props.versionUrl)
       .then(response => {
         if (response.data.error !== undefined) {
           handlers.setSubmitLoader({ value: false, text: "" });

--- a/client/src/model/GlobalSchema.js
+++ b/client/src/model/GlobalSchema.js
@@ -26,7 +26,7 @@
 import { Schema, PropertyName as Prop } from "./index";
 import {
   environmentSchema, formGeneratorSchema, newProjectSchema, notebooksSchema, notificationsSchema,
-  projectsSchema, projectGlobalSchema, statuspageSchema, userSchema
+  projectsSchema, projectSchema, statuspageSchema, userSchema
 } from "./RenkuModels";
 
 const globalSchema = new Schema({
@@ -35,7 +35,7 @@ const globalSchema = new Schema({
   newProject: { [Prop.SCHEMA]: newProjectSchema },
   notebooks: { [Prop.SCHEMA]: notebooksSchema },
   notifications: { [Prop.SCHEMA]: notificationsSchema },
-  project: { [Prop.SCHEMA]: projectGlobalSchema },
+  project: { [Prop.SCHEMA]: projectSchema },
   projects: { [Prop.SCHEMA]: projectsSchema },
   statuspage: { [Prop.SCHEMA]: statuspageSchema },
   user: { [Prop.SCHEMA]: userSchema },

--- a/client/src/model/RenkuModels.js
+++ b/client/src/model/RenkuModels.js
@@ -59,33 +59,6 @@ const projectsSchema = new Schema({
   }
 });
 
-const metaSchema = new Schema({
-  id: { initial: "", mandatory: false },
-  projectNamespace: { initial: {}, mandatory: false },
-  visibility: { initial: "public", mandatory: true },
-  optoutKg: { initial: false, mandatory: false }, // eslint-disable-line
-});
-
-const forkDisplaySchema = new Schema({
-  title: { initial: "", mandatory: true },
-  description: { initial: "", mandatory: true },
-  displayId: { initial: "", mandatory: false },
-  slug: { initial: "", mandatory: true },
-  loading: { initial: false, mandatory: false },
-  searchId: { initial: "", mandatory: false },
-  errors: { initial: [], mandatory: false },
-
-  statuses: { initial: [] },
-  namespaces: { initial: [] },
-  namespaceGroup: { initial: null },
-  namespacesFetched: { initial: false }
-});
-
-const forkProjectSchema = new Schema({
-  meta: { schema: metaSchema, mandatory: true },
-  display: { schema: forkDisplaySchema, mandatory: true }
-});
-
 const newProjectSchema = new Schema({
   config: {
     [Prop.SCHEMA]: new Schema({
@@ -186,16 +159,7 @@ const newProjectSchema = new Schema({
   }
 });
 
-const projectStatisticsSchema = new Schema({
-  commit_count: { [Prop.INITIAL]: null },
-  storage_size: { [Prop.INITIAL]: null },
-  repository_size: { [Prop.INITIAL]: null },
-  wiki_size: { [Prop.INITIAL]: null },
-  lfs_objects_size: { [Prop.INITIAL]: null },
-  job_artifacts_size: { [Prop.INITIAL]: null }
-});
-
-const projectGlobalSchema = new Schema({
+const projectSchema = new Schema({
   branches: {
     [Prop.SCHEMA]: new Schema({
       standard: { [Prop.INITIAL]: [], [Prop.MANDATORY]: true },
@@ -331,8 +295,16 @@ const projectGlobalSchema = new Schema({
   },
   statistics: {
     [Prop.SCHEMA]: new Schema({
-      data: { schema: projectStatisticsSchema },
-
+      data: {
+        schema: new Schema({
+          commit_count: { [Prop.INITIAL]: null },
+          storage_size: { [Prop.INITIAL]: null },
+          repository_size: { [Prop.INITIAL]: null },
+          wiki_size: { [Prop.INITIAL]: null },
+          lfs_objects_size: { [Prop.INITIAL]: null },
+          job_artifacts_size: { [Prop.INITIAL]: null }
+        })
+      },
       fetched: { [Prop.INITIAL]: null },
       fetching: { [Prop.INITIAL]: false },
     })
@@ -621,7 +593,7 @@ const formGeneratorSchema = new Schema({
 });
 
 export {
-  userSchema, metaSchema, newProjectSchema, forkProjectSchema, notebooksSchema,
-  projectsSchema, datasetFormSchema, issueFormSchema, datasetImportFormSchema, projectGlobalSchema,
-  addDatasetToProjectSchema, statuspageSchema, notificationsSchema, formGeneratorSchema, environmentSchema
+  addDatasetToProjectSchema, datasetFormSchema, datasetImportFormSchema, environmentSchema,
+  formGeneratorSchema, issueFormSchema, newProjectSchema, notebooksSchema, notificationsSchema,
+  projectSchema, projectsSchema, statuspageSchema, userSchema
 };

--- a/client/src/model/RenkuModels.js
+++ b/client/src/model/RenkuModels.js
@@ -262,34 +262,44 @@ const projectSchema = new Schema({
   },
   migration: {
     [Prop.SCHEMA]: new Schema({
-      check: { [Prop.INITIAL]: {
-        core_renku_version: undefined,
-        project_supported: undefined,
-        project_renku_version: undefined,
-        core_compatibility_status: {
-          project_metadata_version: undefined,
-          migration_required: undefined,
-          current_metadata_version: undefined
+      check: {
+        [Prop.INITIAL]: {
+          core_renku_version: undefined,
+          project_supported: undefined,
+          project_renku_version: undefined,
+          core_compatibility_status: {
+            project_metadata_version: undefined,
+            migration_required: undefined,
+            current_metadata_version: undefined
+          },
+          dockerfile_renku_status: {
+            latest_renku_version: undefined,
+            dockerfile_renku_version: undefined,
+            automated_dockerfile_update: undefined,
+            newer_renku_available: undefined
+          },
+          template_status: {
+            newer_template_available: undefined,
+            template_id: undefined,
+            automated_template_update: undefined,
+            template_ref: undefined,
+            project_template_version: undefined,
+            template_source: undefined,
+            latest_template_version: undefined
+          }
         },
-        dockerfile_renku_status: {
-          latest_renku_version: undefined,
-          dockerfile_renku_version: undefined,
-          automated_dockerfile_update: undefined,
-          newer_renku_available: undefined
-        },
-        template_status: {
-          newer_template_available: undefined,
-          template_id: undefined,
-          automated_template_update: undefined,
-          template_ref: undefined,
-          project_template_version: undefined,
-          template_source: undefined,
-          latest_template_version: undefined
-        }
+        migrating: { [Prop.INITIAL]: false },
+        migration_status: { [Prop.INITIAL]: null },
+        migration_error: { [Prop.INITIAL]: null },
       },
-      migrating: { [Prop.INITIAL]: false },
-      migration_status: { [Prop.INITIAL]: null },
-      migration_error: { [Prop.INITIAL]: null },
+      core: {
+        [Prop.SCHEMA]: new Schema({
+          versionUrl: { [Prop.INITIAL]: null, [Prop.MANDATORY]: true },
+          backendAvailable: { [Prop.INITIAL]: null, [Prop.MANDATORY]: true },
+
+          fetched: { [Prop.INITIAL]: null, [Prop.MANDATORY]: true },
+          fetching: { [Prop.INITIAL]: false, [Prop.MANDATORY]: true },
+        })
       }
     })
   },
@@ -560,6 +570,12 @@ const environmentSchema = new Schema({
   fetching: { [Prop.INITIAL]: false, [Prop.MANDATORY]: true },
   data: { [Prop.INITIAL]: {}, [Prop.MANDATORY]: true },
   timeout: { [Prop.INITIAL]: null, [Prop.MANDATORY]: true },
+  coreVersions: {
+    [Prop.SCHEMA]: new Schema({
+      available: { [Prop.INITIAL]: {}, [Prop.MANDATORY]: true },
+      unavailable: { [Prop.INITIAL]: {}, [Prop.MANDATORY]: true },
+    })
+  },
 });
 
 /**

--- a/client/src/model/index.js
+++ b/client/src/model/index.js
@@ -25,9 +25,9 @@
 
 import { PropertyName, Schema, StateModel, StateKind, SubModel, SpecialPropVal, StatusHelper } from "./Model";
 import { globalSchema } from "./GlobalSchema";
-import { projectGlobalSchema, formGeneratorSchema } from "./RenkuModels";
+import { formGeneratorSchema, projectSchema } from "./RenkuModels";
 
 export {
-  globalSchema, Schema, StateModel, StateKind, SubModel, SpecialPropVal, StatusHelper, projectGlobalSchema,
-  PropertyName, formGeneratorSchema
+  formGeneratorSchema, globalSchema, projectSchema, PropertyName, Schema, SpecialPropVal, StateKind,
+  StateModel, StatusHelper, SubModel
 };

--- a/client/src/project/Project.state.js
+++ b/client/src/project/Project.state.js
@@ -24,7 +24,7 @@
  */
 
 import { ACCESS_LEVELS, API_ERRORS } from "../api-client";
-import { SpecialPropVal, projectGlobalSchema } from "../model";
+import { SpecialPropVal, projectSchema } from "../model";
 import { splitAutosavedBranches } from "../utils/HelperFunctions";
 
 
@@ -371,7 +371,7 @@ class ProjectCoordinator {
   }
 
   resetProject() {
-    const emptyModel = projectGlobalSchema.createInitialized();
+    const emptyModel = projectSchema.createInitialized();
     this.model.baseModel.setObject({
       [this.model.baseModelPath]: { $set: emptyModel }
     });
@@ -412,7 +412,7 @@ class ProjectCoordinator {
     if (!data) {
       metadata = {
         $set: {
-          ...projectGlobalSchema.createInitialized().metadata,
+          ...projectSchema.createInitialized().metadata,
           exists: false,
           fetched: new Date(),
           fetching: false
@@ -421,13 +421,13 @@ class ProjectCoordinator {
       forkedFromProject = {};
       statsObject = {
         $set: {
-          ...projectGlobalSchema.createInitialized().statistics,
+          ...projectSchema.createInitialized().statistics,
           fetched: new Date(),
           fetching: false
         }
       };
       filtersObject = {
-        ...projectGlobalSchema.createInitialized().filters,
+        ...projectSchema.createInitialized().filters,
         fetched: new Date(),
         fetching: false
       };
@@ -440,7 +440,7 @@ class ProjectCoordinator {
       if (statistics) {
         const stats = data.all && data.all.statistics ?
           data.all.statistics :
-          projectGlobalSchema.createInitialized().statistics.data;
+          projectSchema.createInitialized().statistics.data;
         statsObject = {
           data: { $set: stats },
           fetched: new Date(),
@@ -449,8 +449,9 @@ class ProjectCoordinator {
       }
 
       // set filters
-      const filtersData = data.filters ? data.filters :
-        projectGlobalSchema.createInitialized().filters.data;
+      const filtersData = data.filters ?
+        data.filters :
+        projectSchema.createInitialized().filters.data;
       filtersObject = {
         branch: { $set: filtersData.branch },
         commit: { $set: filtersData.commit },
@@ -614,7 +615,7 @@ class ProjectCoordinator {
     const resp = await this.client.getProject(pathWithNamespace, { statistics: true });
     const stats = resp.data.all.statistics ?
       resp.data.all.statistics :
-      projectGlobalSchema.createInitialized().statistics.data;
+      projectSchema.createInitialized().statistics.data;
     const statsObject = {
       fetching: false,
       fetched: new Date(),

--- a/client/src/project/Project.test.js
+++ b/client/src/project/Project.test.js
@@ -30,7 +30,7 @@ import { MemoryRouter } from "react-router-dom";
 import TestRenderer, { act } from "react-test-renderer";
 import { createMemoryHistory } from "history";
 
-import { StateModel, globalSchema, projectGlobalSchema, SpecialPropVal } from "../model";
+import { StateModel, globalSchema, projectSchema, SpecialPropVal } from "../model";
 import Project, { mapProjectFeatures, withProjectMapped } from "./Project";
 import { filterPaths } from "./Project.present";
 import { OverviewCommitsBody } from "./overview/ProjectOverview.present";
@@ -226,7 +226,7 @@ describe("rendering ProjectSuggestActions", () => {
   const projectCoordinator = new ProjectCoordinator(client, model.subModel("project"));
 
   const props = {
-    ...projectGlobalSchema,
+    ...projectSchema,
     projectCoordinator,
     model: {},
     fetchDatasets: () => {},

--- a/client/src/project/datasets/ProjectDatasets.test.js
+++ b/client/src/project/datasets/ProjectDatasets.test.js
@@ -45,6 +45,7 @@ describe("rendering", () => {
     initialEntries: ["/"],
     initialIndex: 0,
   });
+  const migration = { core: { versionUrl: "" } };
 
   fakeHistory.push({
     pathname: "/projects/namespace/project-name/datasets/new"
@@ -74,9 +75,10 @@ describe("rendering", () => {
           "affiliation": "Some Affiliation",
         }]
       }],
-      visibility: { accessLevel: ACCESS_LEVELS.MAINTAINER },
       graphStatus: false,
-      user: loggedUser
+      migration,
+      user: loggedUser,
+      visibility: { accessLevel: ACCESS_LEVELS.MAINTAINER }
     };
     const div = document.createElement("div");
     ReactDOM.render(
@@ -94,13 +96,14 @@ describe("rendering", () => {
     ReactDOM.render(
       <MemoryRouter>
         <ChangeDataset
-          edit={false}
-          maintainer={ACCESS_LEVELS.maintainer}
           client={client}
-          model={model}
-          user={loggedUser}
+          edit={false}
           location={fakeHistory}
+          maintainer={ACCESS_LEVELS.maintainer}
+          migration={migration}
+          model={model}
           params={{ UPLOAD_THRESHOLD: { soft: 104857600 } }}
+          user={loggedUser}
         />
       </MemoryRouter>
       , div);
@@ -112,12 +115,13 @@ describe("rendering", () => {
     ReactDOM.render(
       <MemoryRouter>
         <DatasetImport
-          edit={false}
-          maintainer={ACCESS_LEVELS.maintainer}
           client={client}
+          edit={false}
+          location={fakeHistory}
+          maintainer={ACCESS_LEVELS.maintainer}
+          migration={migration}
           model={model}
           user={loggedUser}
-          location={fakeHistory}
         />
       </MemoryRouter>
       , div);

--- a/client/src/project/datasets/change/DatasetChange.container.js
+++ b/client/src/project/datasets/change/DatasetChange.container.js
@@ -50,6 +50,7 @@ function ChangeDataset(props) {
     , undefined, datasetFiles)
   , [props.datasets, props.datasetId, datasetFiles]);
   const [initialized, setInitialized] = useState(false);
+  const versionUrl = props.migration.core.versionUrl;
 
   const initializeFunction = (formSchema) => {
     let titleField = formSchema.find(field => field.name === "title");
@@ -190,7 +191,7 @@ function ChangeDataset(props) {
     if (!image.options) return images;
     if (!image.options[image.selected].FILE) return images;
     const selectedFile = image.options[image.selected];
-    images = await props.client.uploadSingleFile(selectedFile.FILE)
+    images = await props.client.uploadSingleFile(selectedFile.FILE, false, versionUrl)
       .then((response) => {
         if (response.data.error !== undefined) {
           handlers.setSubmitLoader({ value: false, text: "" });
@@ -232,7 +233,7 @@ function ChangeDataset(props) {
 
     dataset.images = await uploadDatasetImages(mappedInputs.image, handlers);
 
-    props.client.postDataset(props.httpProjectUrl, dataset, props.defaultBranch, props.edit)
+    props.client.postDataset(props.httpProjectUrl, dataset, props.defaultBranch, props.edit, versionUrl)
       .then(response => {
         if (response.data.error !== undefined) {
           handlers.setSubmitLoader({ value: false, text: "" });
@@ -315,7 +316,7 @@ function ChangeDataset(props) {
     let unmounted = false;
     if (props.edit) {
       if (!initialized && dataset !== undefined) {
-        props.client.fetchDatasetFilesFromCoreService(dataset.name, props.httpProjectUrl)
+        props.client.fetchDatasetFilesFromCoreService(dataset.name, props.httpProjectUrl, versionUrl)
           .then(response => {
             if (!unmounted && datasetFiles === undefined) {
               if (response.data.result) {
@@ -368,20 +369,20 @@ function ChangeDataset(props) {
       ];
       dsFormSchema.keywords.value = dsFormSchema.keywords.initial;
     }
-  }, [props, initialized, dataset, datasetFiles,
-    setDatasetFiles, props.client]);
+  }, [props, initialized, dataset, datasetFiles, versionUrl, setDatasetFiles, props.client]);
 
   return <DatasetChange
-    initialized={initialized}
-    datasetFormSchema={dsFormSchema}
     accessLevel={props.accessLevel}
-    submitCallback={submitCallback}
-    onCancel={onCancel}
-    overviewCommitsUrl={props.overviewCommitsUrl}
+    datasetFormSchema={dsFormSchema}
     edit={props.edit}
-    model={props.model}
     formLocation={formLocation}
     initializeFunction={initializeFunction}
+    initialized={initialized}
+    model={props.model}
+    onCancel={onCancel}
+    overviewCommitsUrl={props.overviewCommitsUrl}
+    submitCallback={submitCallback}
+    versionUrl={versionUrl}
   />;
 }
 export default ChangeDataset;

--- a/client/src/project/datasets/change/DatasetChange.present.js
+++ b/client/src/project/datasets/change/DatasetChange.present.js
@@ -92,16 +92,17 @@ function DatasetChange(props) {
   const edit = props.edit;
 
   return <FormGenerator
-    title={edit ? "Modify Dataset" : undefined}
     btnName={edit ? "Modify Dataset" : "Create Dataset"}
-    submitCallback={props.submitCallback}
-    model={props.datasetFormSchema}
-    onCancel={props.onCancel}
     edit={edit}
-    modelTop={props.model}
     formLocation={props.formLocation}
-    initializeFunction={props.initializeFunction}
     formatServerErrorsAndWarnings={formatServerErrorsAndWarnings}
+    initializeFunction={props.initializeFunction}
+    model={props.datasetFormSchema}
+    modelTop={props.model}
+    onCancel={props.onCancel}
+    submitCallback={props.submitCallback}
+    title={edit ? "Modify Dataset" : undefined}
+    versionUrl={props.versionUrl}
   />;
 }
 

--- a/client/src/project/datasets/delete/DeleteDataset.container.js
+++ b/client/src/project/datasets/delete/DeleteDataset.container.js
@@ -46,7 +46,7 @@ function DeleteDataset(props) {
     setServerErrors(undefined);
     setSubmitLoader(true);
     setSubmitLoaderText("Deleting dataset...");
-    props.client.deleteDataset(props.httpProjectUrl, props.dataset.name)
+    props.client.deleteDataset(props.httpProjectUrl, props.dataset.name, props.versionUrl)
       .then(response => {
         if (response.data.error !== undefined) {
           setSubmitLoader(false);

--- a/client/src/project/datasets/delete/DeleteDataset.present.js
+++ b/client/src/project/datasets/delete/DeleteDataset.present.js
@@ -50,15 +50,16 @@ function DeleteDatasetPresent(props) {
           <FormText color="primary">
             <Loader size="16" inline="true" margin="2" />
             {props.submitLoader.text}
+            <br />
           </FormText>
           : null
         }
         <Button type="submit" onClick={props.deleteDataset}
-          disabled={props.submitLoader.value} className="float-right mt-1" color="primary">
-          Delete Dataset
+          disabled={props.submitLoader.value} className="float-right mt-1" color="secondary">
+          Delete dataset
         </Button>
-        <Button disabled={props.submitLoader.value} className="float-right mt-1 me-1"
-          color="secondary" onClick={props.closeModal}>
+        <Button disabled={props.submitLoader.value} className="float-right mt-1 ms-2"
+          color="primary" onClick={props.closeModal}>
           Cancel
         </Button>
       </Fragment>

--- a/client/src/project/datasets/import/DatasetImport.container.js
+++ b/client/src/project/datasets/import/DatasetImport.container.js
@@ -102,7 +102,7 @@ function ImportDataset(props) {
     handlers.setServerErrors(undefined);
     handlers.setServerWarnings(undefined);
     handlers.setSubmitLoader({ value: true, text: ImportStateMessage.ENQUEUED });
-    props.client.datasetImport(props.httpProjectUrl, mappedInputs.uri)
+    props.client.datasetImport(props.httpProjectUrl, mappedInputs.uri, props.migration.core.versionUrl)
       .then(response => {
         if (response.data.error !== undefined) {
           handlers.setSubmitLoader({ value: false, text: "" });

--- a/client/src/project/status/RenkuLabCompatibilityStatus.present.js
+++ b/client/src/project/status/RenkuLabCompatibilityStatus.present.js
@@ -40,7 +40,7 @@ function RenkuLabVersionInfo({ core_compatibility_status }) {
   </p>;
 }
 
-function RenkuLabCompatibilityBody({ project_supported, migration_required }) {
+function RenkuLabCompatibilityBody({ backendAvailable, migration_required, project_supported }) {
   if (project_supported === false) {
     return <MigrationWarnAlert>
       This project appears to be using an experimental version of Renku.&nbsp;<br /><br />
@@ -50,6 +50,16 @@ function RenkuLabCompatibilityBody({ project_supported, migration_required }) {
   }
   if (migration_required === false)
     return <MigrationSuccessAlert>This project and the RenkuLab UI are compatible.</MigrationSuccessAlert>;
+  if (backendAvailable) {
+    return (
+      <MigrationWarnAlert>
+        <p>
+          This project is compatible with the RenkuLab UI, but upgrading to the
+          latest <b>renku version</b> is highly recommended.
+        </p>
+      </MigrationWarnAlert>
+    );
+  }
   return <MigrationWarnAlert>
     <p>
       This project is not compatible with the RenkuLab UI.
@@ -71,6 +81,7 @@ function RenkuLabCompatibilityStatus({ loading, migration }) {
 
   const { migration_status, migration_error } = migration;
   const { check_error, project_supported } = migration.check;
+  const { backendAvailable } = migration.core;
   const migrationErrorProps = { check_error, migration_error, migration_status };
   if (isMigrationFailure(migrationErrorProps))
     return <ShowMigrationFailure {...migrationErrorProps} />;
@@ -81,8 +92,9 @@ function RenkuLabCompatibilityStatus({ loading, migration }) {
   return <div>
     <RenkuLabVersionInfo core_compatibility_status={core_compatibility_status} />
     <RenkuLabCompatibilityBody
-      project_supported={project_supported}
+      backendAvailable={backendAvailable}
       migration_required={migration_required}
+      project_supported={project_supported}
     />
   </div>;
 }

--- a/client/src/project/status/RenkuLabCompatibilityStatus.present.js
+++ b/client/src/project/status/RenkuLabCompatibilityStatus.present.js
@@ -63,7 +63,7 @@ function RenkuLabCompatibilityBody({ project_supported, migration_required }) {
 
 /**
  * Show the RenkuLab compatibility status.
- * @param {object} props {migration: projectGlobalSchema.migration, loading: bool}
+ * @param {object} props {migration: projectSchema.migration, loading: bool}
  * @returns Component
  */
 function RenkuLabCompatibilityStatus({ loading, migration }) {

--- a/client/src/project/status/RenkuVersionStatus.present.js
+++ b/client/src/project/status/RenkuVersionStatus.present.js
@@ -63,7 +63,9 @@ function MigrationTimeEstimate({ current_metadata_version, project_metadata_vers
   </span>;
 }
 
-function UpdateInfo({ current_metadata_version, project_metadata_version, renkuVersionStatus, statistics }) {
+function UpdateInfo({
+  backendAvailable, current_metadata_version, project_metadata_version, renkuVersionStatus, statistics
+}) {
   if (updateNotRequired(renkuVersionStatus)) {
     return <p>
       If you wish to take advantage of new features, you can update to the latest version of{" "}
@@ -72,10 +74,16 @@ function UpdateInfo({ current_metadata_version, project_metadata_version, renkuV
         project_metadata_version={project_metadata_version} statistics={statistics} />
     </p>;
   }
-  return <p>An update is necessary to work with datasets from the UI. {" "}
-    <MigrationTimeEstimate current_metadata_version={current_metadata_version}
-      project_metadata_version={project_metadata_version} statistics={statistics} />
-  </p>;
+  const updateMessage = backendAvailable ?
+    null :
+    (<span>An update is necessary to work with datasets from the UI.<br /></span>);
+  return (
+    <p>
+      {updateMessage}
+      <MigrationTimeEstimate current_metadata_version={current_metadata_version}
+        project_metadata_version={project_metadata_version} statistics={statistics} />
+    </p>)
+  ;
 }
 
 function AutoUpdateButton({ externalUrl, maintainer, migration_status, onMigrateProject, renkuVersionStatus }) {
@@ -103,9 +111,10 @@ function AutoUpdateButton({ externalUrl, maintainer, migration_status, onMigrate
 const docUrl = "https://renku.readthedocs.io/en/latest/how-to-guides/upgrading-renku.html" +
 "#upgrading-your-image-to-use-the-latest-renku-cli-version";
 
-function RenkuVersionAutomaticUpdateSection(
-  { current_metadata_version, externalUrl, launchNotebookUrl, maintainer,
-    migration_status, onMigrateProject, project_metadata_version, renkuVersionStatus, statistics }) {
+function RenkuVersionAutomaticUpdateSection({
+  backendAvailable, current_metadata_version, externalUrl, launchNotebookUrl, maintainer,
+  migration_status, onMigrateProject, project_metadata_version, renkuVersionStatus, statistics
+}) {
   const linkClassName = updateNotRequired(renkuVersionStatus) ?
     "" :
     "link-alert-warning";
@@ -113,8 +122,9 @@ function RenkuVersionAutomaticUpdateSection(
   const toggleOpen = () => setOpen(!isOpen);
 
   return <Fragment>
-    <UpdateInfo current_metadata_version={current_metadata_version} project_metadata_version={project_metadata_version}
-      renkuVersionStatus={renkuVersionStatus} statistics={statistics} />
+    <UpdateInfo backendAvailable={backendAvailable} current_metadata_version={current_metadata_version}
+      project_metadata_version={project_metadata_version} renkuVersionStatus={renkuVersionStatus}
+      statistics={statistics} />
     <AutoUpdateButton externalUrl={externalUrl} maintainer={maintainer}
       migration_status={migration_status} onMigrateProject={onMigrateProject}
       renkuVersionStatus={renkuVersionStatus} />
@@ -130,8 +140,10 @@ function RenkuVersionAutomaticUpdateSection(
   </Fragment>;
 }
 
-function RenkuVersionManualUpdateSection({ current_metadata_version, launchNotebookUrl,
-  project_metadata_version, renkuVersionStatus, statistics }) {
+function RenkuVersionManualUpdateSection({
+  backendAvailable, current_metadata_version, launchNotebookUrl, project_metadata_version, renkuVersionStatus,
+  statistics
+}) {
   const [isOpen, setOpen] = useState(false);
   const toggleOpen = () => setOpen(!isOpen);
 
@@ -140,8 +152,9 @@ function RenkuVersionManualUpdateSection({ current_metadata_version, launchNoteb
     "" :
     "link-alert-warning";
   return <Fragment>
-    <UpdateInfo current_metadata_version={current_metadata_version} project_metadata_version={project_metadata_version}
-      renkuVersionStatus={renkuVersionStatus} statistics={statistics} />
+    <UpdateInfo backendAvailable={backendAvailable} current_metadata_version={current_metadata_version}
+      project_metadata_version={project_metadata_version} renkuVersionStatus={renkuVersionStatus}
+      statistics={statistics} />
     <UpdateSection>
       <Button color="link" className={`ps-0 mb-2 ${linkClassName} text-start`} onClick={toggleOpen}>
         <i>Automated update is not possible, but you can follow these instructions to update manually.</i>
@@ -161,12 +174,13 @@ function RenkuVersionStatusBody({ externalUrl, launchNotebookUrl, maintainer, mi
 
   const renkuVersionStatus = migrationCheckToRenkuVersionStatus(migration.check);
   const { migration_status } = migration;
+  const { backendAvailable } = migration.core;
   const current_metadata_version = migration?.check?.core_compatibility_status?.current_metadata_version;
   const project_metadata_version = migration?.check?.core_compatibility_status?.project_metadata_version;
-  const updateProps = { current_metadata_version, externalUrl, launchNotebookUrl,
-    maintainer, migration_status, onMigrateProject, project_metadata_version,
-    renkuVersionStatus, statistics };
-
+  const updateProps = {
+    backendAvailable, current_metadata_version, externalUrl, launchNotebookUrl, maintainer, migration_status,
+    onMigrateProject, project_metadata_version, renkuVersionStatus, statistics
+  };
 
   switch (renkuVersionStatus) {
     case RENKU_VERSION_SCENARIOS.PROJECT_NOT_SUPPORTED :

--- a/client/src/utils/formgenerator/FormGenerator.container.js
+++ b/client/src/utils/formgenerator/FormGenerator.container.js
@@ -147,14 +147,15 @@ class FormGenerator extends Component {
     const [inputs, setInputs, setSubmit] = useForm(this.props.submitCallback, this.handlers, draft);
     return (<VisibleFormGenerator
       {...this.props}
-      locationHash={this.locationHash}
-      store={this.model.reduxStore}
       handlers={this.handlers}
-      modelValues={this.getDraft()}
       inputs={inputs}
+      loading={this.getDraft() === undefined}
+      locationHash={this.locationHash}
+      modelValues={this.getDraft()}
       setInputs={setInputs}
       setSubmit={setSubmit}
-      loading={this.getDraft() === undefined}
+      store={this.model.reduxStore}
+      versionUrl={this.props.versionUrl ? this.props.versionUrl : ""}
     />);
   }
 }

--- a/client/src/utils/formgenerator/FormGenerator.present.js
+++ b/client/src/utils/formgenerator/FormGenerator.present.js
@@ -68,8 +68,10 @@ function SubmitButtonGroup(props) {
   </Fragment>;
 }
 
-function FormPanel({ title, btnName, submitCallback, formLocation, onCancel, edit, handlers,
-  formatServerErrorsAndWarnings, draft, loading, inputs, setInputs, setSubmit }) {
+function FormPanel({
+  btnName, draft, edit, formLocation, formatServerErrorsAndWarnings, handlers, inputs, loading,
+  onCancel, setInputs, setSubmit, submitCallback, title, versionUrl
+}) {
 
   const submitLoader = draft?.submitLoader;
   const hideButtons = draft?.hideButtons;
@@ -79,22 +81,31 @@ function FormPanel({ title, btnName, submitCallback, formLocation, onCancel, edi
   const disableAll = draft?.disableAll;
 
   const Components = {
-    TextInput,
-    TextareaInput,
     CktextareaInput,
+    CreatorsInput,
     FileUploaderInput,
+    ImageInput,
+    KeywordsInput,
     SelectInput,
     SelectautosuggestInput,
-    CreatorsInput,
-    KeywordsInput,
-    ImageInput
+    TextInput,
+    TextareaInput,
   };
 
   const renderInput = input => {
     const Component = Components[capitalize(input.type) + "Input"];
-    return <Component key={input.name} value={input.value}
-      disabled={(submitLoader && submitLoader.value ) || (input.edit === false && edit) || disableAll}
-      setInputs={setInputs} {...input} handlers={handlers} formLocation={formLocation}/>;
+    const disabled = (submitLoader && submitLoader.value) || (input.edit === false && edit) || disableAll;
+    return (
+      <Component {...input}
+        disabled={disabled}
+        formLocation={formLocation}
+        handlers={handlers}
+        key={input.name}
+        setInputs={setInputs}
+        value={input.value}
+        versionUrl={versionUrl}
+      />
+    );
   };
 
   const extractErrorsAndWarnings = (errorOrWarning, isError) => {

--- a/client/src/utils/formgenerator/fields/FileUploaderInput.js
+++ b/client/src/utils/formgenerator/fields/FileUploaderInput.js
@@ -93,9 +93,10 @@ function getFileObject(name, path, size, id, error, alias, controller, uncompres
   };
 }
 
-function FileUploaderInput({ name, label, alert, value, setInputs, help, disabled = false,
-  uploadFileFunction, required = false, internalValues, handlers, formLocation, notifyFunction, uploadThresholdSoft }) {
-
+function FileUploaderInput({
+  alert, disabled = false, formLocation, handlers, help, internalValues, label, name, notifyFunction,
+  required = false, setInputs, uploadFileFunction, uploadThresholdSoft, value, versionUrl
+}) {
 
   //send value as an already built tree/hash to display and
   // delete from the files/paths /data/dataset-name so i can check if the file is there or not
@@ -351,7 +352,7 @@ function FileUploaderInput({ name, label, alert, value, setInputs, help, disable
         }
       }
     };
-    uploadFileFunction(file, file.file_uncompress, setFileProgress,
+    uploadFileFunction(versionUrl, file, file.file_uncompress, setFileProgress,
       thenCallback, onErrorCallback, setController);
   };
 

--- a/client/src/utils/url/Url.js
+++ b/client/src/utils/url/Url.js
@@ -339,6 +339,32 @@ const Url = {
             "/projects/group/subgroup/path/sessions/show/server-id",
           ]
         )
+      },
+      overview: {
+        base: new UrlRule(
+          projectPageUrlBuilder(""), ["namespace", "path"], null, [
+            "/projects/namespace/path",
+            "/projects/group/subgroup/path",
+          ]
+        ),
+        stats: new UrlRule(
+          projectPageUrlBuilder("/overview/stats"), ["namespace", "path"], null, [
+            "/projects/namespace/path/overview/stats",
+            "/projects/group/subgroup/path/overview/stats",
+          ]
+        ),
+        commits: new UrlRule(
+          projectPageUrlBuilder("/overview/commits"), ["namespace", "path"], null, [
+            "/projects/namespace/path/overview/commits",
+            "/projects/group/subgroup/path/overview/commits",
+          ]
+        ),
+        status: new UrlRule(
+          projectPageUrlBuilder("/overview/status"), ["namespace", "path"], null, [
+            "/projects/namespace/path/overview/status",
+            "/projects/group/subgroup/path/overview/status",
+          ]
+        )
       }
     },
     sessions: {


### PR DESCRIPTION
This PR introduces support for simultaneous renku-core instances.
When browsing a project, some operations are blocked until the project version is assessed, and the core APIs invocation is delayed and properly routed. For each new project version, the backend availability is checked and cached for further re-use when browsing other projects on the same version.

Mind that this PR contains a few tangential changes -- minor fixes/improvements made on the fly when adapting the code.

/deploy renku=1.0-next renku-graph=cli-v1 renku-core=2507-lock-status-endpoint
fix #1507