### PR TITLE
Present estimate of migration duration

### DIFF
--- a/client/src/project/status/MigrationUtils.js
+++ b/client/src/project/status/MigrationUtils.js
@@ -34,7 +34,7 @@ function GeneralErrorMessage({ error_while, error_what, error_reason }) {
       or create an issue in {" "}
       <ExternalIconLink url="https://github.com/SwissDataScienceCenter/renku/issues" icon={faGithub} title="GitHub" />.
     </p>
-    <div><strong>Error Message</strong><pre>{error_reason}</pre></div>
+    <div><strong>Error Message</strong><pre style={{ whiteSpace: "pre-wrap" }}>{error_reason}</pre></div>
   </ErrorAlert>;
 }
 

--- a/client/src/project/status/ProjectVersionStatus.present.js
+++ b/client/src/project/status/ProjectVersionStatus.present.js
@@ -53,7 +53,8 @@ function ProjectVersionStatusBody(props) {
             loading={props.loading}
             maintainer={maintainer}
             migration={props.migration}
-            onMigrateProject={onMigrateProject} />
+            onMigrateProject={onMigrateProject}
+            statistics={props.statistics} />
         </Col></Row>
       </CardBody>
     </Card>


### PR DESCRIPTION
# Images

<img width="1018" alt="image" src="https://user-images.githubusercontent.com/1196411/147254067-a6529ba9-c725-41b4-9731-6838aec3c4ce.png">


<img width="1018" alt="image" src="https://user-images.githubusercontent.com/1196411/147253943-2314d9fe-81a9-4601-a487-0f8566d4abbd.png">

# Testing

This PR shows an estimate of the migration time **if** the user is a member of the project and the project is being updated to metadata version 9. The first restriction is because the computation requires knowing the number of commits and that information is only available if the user is a member of the project. The second restriction is because the method of estimating only works for projects migrating to metadata version 9.

Here are some projects that can be used to test:
- https://renku-ci-ui-1621.dev.renku.ch/projects/cr-migration-test/project-with-core-1-0-1-group-v2/ (no estimate shown, since project is already on metadata v. 9)
- https://renku-ci-ui-1621.dev.renku.ch/projects/cr-migration-test/test-8 (estimate shown, since project can be updated to v9 automatically)
- https://renku-ci-ui-1621.dev.renku.ch/projects/cr-migration-test/test-7 (estimate shown, since project can be updated to v9, but must be done manually)

Fix #1602

/deploy renku=1.0-next renku-graph=cli-v1 renku-core=v1.0.1