### PR TITLE
feat(client): add migrations for anonymous users

### DIFF
--- a/client/src/api-client/migration.js
+++ b/client/src/api-client/migration.js
@@ -1,106 +1,69 @@
 export default function addMigrationMethods(client) {
 
-  // TODO: merge this with getProjectIdFromCoreService
-  client.getProjectIdFromService = async (projectUrl) => {
-    let headers = client.getBasicHeaders();
-    headers.append("Content-Type", "application/json");
-    headers.append("X-Requested-With", "XMLHttpRequest");
-
-    // If the project is in the cache, get the id from the cache
-    let projectsList = await client.clientFetch(`${client.baseUrl}/renku/cache.project_list`, {
-      method: "GET",
-      headers: headers
-    });
-
-    if (projectsList.data != null && projectsList.data.error == null) {
-      const project = projectsList.data.result.projects
-        .find(project => project.git_url === projectUrl);
-      if (project != null)
-        return project.project_id;
-    }
-
-    // Otherwise clone it and get the id
-    let project = await client.clientFetch(`${client.baseUrl}/renku/cache.project_clone`, {
-      method: "POST",
-      headers: headers,
-      body: JSON.stringify({
-        depth: 1,
-        git_url: projectUrl
-      })
-    });
-
-    if (project.data !== undefined && project.data.error !== undefined)
-      return project;
-    return project.data.result.project_id;
-  };
-
-  // TODO: switch to git_url + branch for migrations. Requires SwissDataScienceCenter/renku-python#2541
-  client.checkMigration = async (git_url, branch) => {
+  /**
+   * Check migration status of a project.
+   *
+   * @param {string} git_url - Project repository URL.
+   * @param {string} [branch] - Target branch.
+   * @returns {object} migration data.
+   */
+  client.checkMigration = async (git_url, branch = null) => {
     let headers = client.getBasicHeaders();
     headers.append("Content-Type", "application/json");
     headers.append("X-Requested-With", "XMLHttpRequest");
     const url = `${client.baseUrl}/renku/cache.migrations_check`;
-    const queryParams = { git_url, branch };
+    let queryParams = { git_url };
+    if (branch)
+      queryParams.branch = branch;
 
     return await client.clientFetch(url, {
       method: "GET",
       headers,
       queryParams
-    });
+    }).then(response => response?.data ? response.data : response);
   };
 
-  client.performMigrationCheck = async (projectId) => {
-    let headers = client.getBasicHeaders();
-    headers.append("Content-Type", "application/json");
-    headers.append("X-Requested-With", "XMLHttpRequest");
-    const url = `${client.baseUrl}/renku/cache.migrations_check`;
-    const queryParams = { project_id: projectId };
-
-    try {
-      return await client.clientFetch(url, {
-        method: "GET",
-        headers,
-        queryParams
-      });
-    }
-    catch (error) {
-      return { data: { error: { reason: error.case } } };
-    }
-  };
 
   /**
-   * Performs project migrations
+   * Migrate target project.
    *
-   * - force_template_update: set to true to update the template even
-   * if automated_template_update is not set on the template (probably not a good idea...)
-   * - skip_template_update: don't try to update the template (superseedes force_template_update)
-   * - skip_docker_update: don't try to update the Dockerfile.
-   * - skip_migrations: don't execute migrations.
+   * @param {string} git_url - Project repository URL.
+   * @param {string} [branch] - Target branch.
+   * @param {object} [options] - Migration options.
+   * @param {boolean} [options.force_template_update] - set to true to update the template even
+   *  if automated_template_update is not set on the template (usually not a good idea)
+   * @param {boolean} [options.skip_template_update] - do not update the template
+   *  (superseedes force_template_update)
+   * @param {boolean} [options.skip_docker_update] - do not update the Dockerfile.
+   * @param {boolean} [options.skip_migrations] - do not execute migrations
+   * @returns {object} migration data.
    */
-
-  client.performMigration = (projectId,
-    { force_template_update = false,
-      skip_template_update = false,
-      skip_docker_update = false,
-      skip_migrations = false }
-  ) => {
+  client.migrateProject = async (git_url, branch = null, options = {
+    force_template_update: false,
+    skip_template_update: false,
+    skip_docker_update: false,
+    skip_migrations: false
+  }) => {
     let headers = client.getBasicHeaders();
     headers.append("Content-Type", "application/json");
     headers.append("X-Requested-With", "XMLHttpRequest");
+    const url = `${client.baseUrl}/renku/cache.migrate`;
+    let body = {
+      git_url,
+      force_template_update: options.force_template_update,
+      skip_template_update: options.skip_template_update,
+      skip_docker_update: options.skip_docker_update,
+      skip_migrations: options.skip_migrations
+    };
+    if (branch)
+      body.branch = branch;
 
-    return client.clientFetch(`${client.baseUrl}/renku/cache.migrate`, {
+    return await client.clientFetch(url, {
       method: "POST",
-      headers: headers,
-      body: JSON.stringify({
-        project_id: projectId,
-        force_template_update,
-        skip_template_update,
-        skip_docker_update,
-        skip_migrations
-      })
-    }).catch((error)=>
-      ({ data: { error: { reason: error.case } }
-      }));
+      headers,
+      body: JSON.stringify(body)
+    })
+      .then(response => response?.data ? response.data : response)
+      .catch(error => ({ error: { reason: error.case } }));
   };
-
 }

--- a/client/src/dataset/Dataset.present.js
+++ b/client/src/dataset/Dataset.present.js
@@ -460,6 +460,7 @@ export default function DatasetView(props) {
     {
       props.logged ?
         <AddDataset
+          httpProjectUrl={props.httpProjectUrl}
           client={props.client}
           dataset={dataset}
           formLocation={props.location.pathname + "/add"}

--- a/client/src/dataset/addtoproject/DatasetAdd.container.js
+++ b/client/src/dataset/addtoproject/DatasetAdd.container.js
@@ -137,31 +137,21 @@ function AddDataset(props) {
     const selectedProject = projectOptions.find((project)=>
       project.value === mappedInputs.project);
 
-    props.client.getProjectIdFromService(selectedProject.value)
-      .then((response) => {
-        if (response.data && response.data.error !== undefined) {
-          handlers.setSubmitLoader({ value: false, text: "" });
-          handlers.setServerErrors(response.data.error.reason);
+    props.client.checkMigration(props.httpProjectUrl).then((response) => {
+      if (response && response.error !== undefined) {
+        handlers.setSubmitLoader({ value: false, text: "" });
+        handlers.setServerErrors(response.error.reason);
+      }
+      else {
+        if (response.result.migration_required) {
+          handlers.setServerWarnings(selectedProject.name);
+          handlers.setSubmitLoader(false);
         }
         else {
-          props.client.performMigrationCheck(response)
-            .then((response) => {
-              if (response.data && response.data.error !== undefined) {
-                handlers.setSubmitLoader({ value: false, text: "" });
-                handlers.setServerErrors(response.data.error.reason);
-              }
-              else {
-                if (response.data.result.migration_required) {
-                  handlers.setServerWarnings(selectedProject.name);
-                  handlers.setSubmitLoader(false);
-                }
-                else {
-                  importDataset(selectedProject, handlers);
-                }
-              }
-            });
+          importDataset(selectedProject, handlers);
         }
-      });
+      }
+    });
   };
 
   const initializeFunction = (formSchema, formHandlers) => {

--- a/client/src/project/Project.test.js
+++ b/client/src/project/Project.test.js
@@ -327,16 +327,6 @@ describe("rendering ProjectVersionStatus", () => {
     user: { logged: true },
   };
 
-  it("does not render if is user not logged in", () => {
-    const allProps = { ...props };
-    allProps.user.logged = false;
-    const component = TestRenderer.create(
-      <ProjectVersionStatus key="versionStatus" {...allProps} />
-    );
-    expect(component.toJSON()).toBe(null);
-    allProps.user.logged = true;
-  });
-
   it("shows bouncer if loading", () => {
     const allProps = { ...props };
     allProps.loading = true;

--- a/client/src/project/status/ProjectVersionStatus.present.js
+++ b/client/src/project/status/ProjectVersionStatus.present.js
@@ -26,11 +26,11 @@ import TemplateStatus from "./TemplateVersionStatus.present";
 import { ACCESS_LEVELS } from "../../api-client";
 
 function ProjectVersionStatusBody(props) {
+  const logged = props.user.logged;
   const maintainer = props.metadata.accessLevel >= ACCESS_LEVELS.MAINTAINER;
-  const isLogged = props.user.logged;
-  const onMigrateProject = props.onMigrateProject;
-
-  if (!isLogged) return null;
+  const onMigrateProject = async (options) => {
+    return await props.onMigrateProject(props.metadata?.httpUrl, props.metadata?.defaultBranch, options);
+  };
 
   return <Fragment>
     <Card key="renkuLabUICompatibility" className="border-rk-light mb-4">
@@ -51,6 +51,7 @@ function ProjectVersionStatusBody(props) {
           <RenkuVersionStatus
             launchNotebookUrl={props.launchNotebookUrl}
             loading={props.loading}
+            logged={logged}
             maintainer={maintainer}
             migration={props.migration}
             onMigrateProject={onMigrateProject}
@@ -66,6 +67,7 @@ function ProjectVersionStatusBody(props) {
             externalUrl={props.externalUrl}
             launchNotebookUrl={props.launchNotebookUrl}
             loading={props.loading}
+            logged={logged}
             maintainer={maintainer}
             migration={props.migration}
             onMigrateProject={onMigrateProject} />

--- a/client/src/project/status/RenkuVersionStatus.present.js
+++ b/client/src/project/status/RenkuVersionStatus.present.js
@@ -166,9 +166,9 @@ function RenkuVersionManualUpdateSection({
   </Fragment>;
 }
 
-function RenkuVersionStatusBody({ externalUrl, launchNotebookUrl, maintainer, migration, onMigrateProject,
-  statistics }) {
-
+function RenkuVersionStatusBody({
+  externalUrl, launchNotebookUrl, logged, maintainer, migration, onMigrateProject, statistics
+}) {
   let body = null;
   let updateSection = null;
 
@@ -214,11 +214,11 @@ function RenkuVersionStatusBody({ externalUrl, launchNotebookUrl, maintainer, mi
       (renkuVersionStatus === RENKU_VERSION_SCENARIOS.NEW_VERSION_NOT_REQUIRED_MANUAL)) ?
       (<MigrationInfoAlert>
         {newVersionText}
-        {updateSection}
+        {logged ? updateSection : null}
       </MigrationInfoAlert>) :
       (<MigrationWarnAlert>
         {newVersionText}
-        {updateSection}
+        {logged ? updateSection : null}
       </MigrationWarnAlert>);
   }
   return body;
@@ -247,15 +247,13 @@ function RenkuVersionStatus(props) {
 
   if (isMigrationFailure({ check_error, migration_error, migration_status })) return null;
 
-  const { externalUrl, launchNotebookUrl, maintainer, onMigrateProject,
-    statistics } = props;
+  const { externalUrl, launchNotebookUrl, logged, maintainer, migration, onMigrateProject, statistics } = props;
 
   return <div>
-    <RenkuVersionInfo migration={props.migration} />
+    <RenkuVersionInfo migration={migration} />
     <RenkuVersionStatusBody
-      externalUrl={externalUrl} launchNotebookUrl={launchNotebookUrl}
-      maintainer={maintainer} migration={props.migration}
-      onMigrateProject={onMigrateProject} statistics={statistics} />
+      externalUrl={externalUrl} launchNotebookUrl={launchNotebookUrl} logged={logged} maintainer={maintainer}
+      migration={migration} onMigrateProject={onMigrateProject} statistics={statistics} />
   </div>;
 }
 

--- a/client/src/project/status/TemplateVersionStatus.present.js
+++ b/client/src/project/status/TemplateVersionStatus.present.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import React, { useState } from "react";
+import React, { Fragment, useState } from "react";
 import { Button, Spinner, Collapse } from "reactstrap";
 
 import { ManualUpdateInstructions, MigrationSuccessAlert, MigrationWarnAlert,
@@ -43,8 +43,9 @@ function getTemplateVersionStatus({ automated_template_update, newer_template_av
 }
 
 
-function TemplateUpdateSection({ launchNotebookUrl, maintainer, projectTemplateStatus,
-  migration_status, onMigrateProject, externalUrl }) {
+function TemplateUpdateSection({
+  launchNotebookUrl, logged, maintainer, projectTemplateStatus, migration_status, onMigrateProject, externalUrl
+}) {
 
   const [isOpen, setOpen] = useState(false);
   const toggleOpen = () => setOpen(!isOpen);
@@ -75,34 +76,42 @@ function TemplateUpdateSection({ launchNotebookUrl, maintainer, projectTemplateS
       do that for you.
     </p>;
 
-  return <MigrationWarnAlert>
-    <p>
-      A new version of the <strong>project template</strong> is available.
-    </p>
-    <p>
-      If you wish to take advantage of new features, you can update to the latest version of
-      the <strong>template</strong>.
-      {/**
-       * TODO: provide more information about the template when that is possible.
-       * <ExternalLink role="text" size="sm"
-       * title="See the template repository" url={`${template_source}`} /> to learn more about
-       * the new features.
-       */}
-    </p>
-    {projectTemplateStatus === TEMPLATE_VERSION_SCENARIOS.NEW_TEMPLATE_AUTO ?
-      automaticUpdateAction : null }
-    <Button color="link" className="ps-0 mb-2 link-alert-warning text-start" onClick={toggleOpen}>
+  const UpdateActions = (
+    <Fragment>
+      <p>
+        If you wish to take advantage of new features, you can update to the latest version of
+        the <strong>template</strong>.
+        {/**
+         * TODO: provide more information about the template when that is possible.
+         * <ExternalLink role="text" size="sm"
+         * title="See the template repository" url={`${template_source}`} /> to learn more about
+         * the new features.
+         */}
+      </p>
       {
         projectTemplateStatus === TEMPLATE_VERSION_SCENARIOS.NEW_TEMPLATE_AUTO ?
-          <i>Do you prefer manual instructions?</i>
-          : <i>Automated update is not possible, but you can follow these instructions to update manually.</i>
+          automaticUpdateAction :
+          null
       }
-    </Button>
-    <Collapse isOpen={isOpen}>
-      <ManualUpdateInstructions docUrl={docUrl} launchNotebookUrl={launchNotebookUrl} />
-    </Collapse>
-  </MigrationWarnAlert>;
+      <Button color="link" className="ps-0 mb-2 link-alert-warning text-start" onClick={toggleOpen}>
+        {
+          projectTemplateStatus === TEMPLATE_VERSION_SCENARIOS.NEW_TEMPLATE_AUTO ?
+            (<i>Do you prefer manual instructions?</i>) :
+            (<i>Automated update is not possible, but you can follow these instructions to update manually.</i>)
+        }
+      </Button>
+      <Collapse isOpen={isOpen}>
+        <ManualUpdateInstructions docUrl={docUrl} launchNotebookUrl={launchNotebookUrl} />
+      </Collapse>
+    </Fragment>
+  );
 
+  return (
+    <MigrationWarnAlert>
+      <p>A new version of the <strong>project template</strong> is available.</p>
+      {logged ? UpdateActions : null}
+    </MigrationWarnAlert>
+  );
 }
 
 function TemplateSource({ template_source }) {
@@ -144,7 +153,7 @@ function TemplateVersionInfo({ check }) {
     </p>;
 }
 
-function TemplateVersionBody({ externalUrl, launchNotebookUrl, maintainer, migration }) {
+function TemplateVersionBody({ externalUrl, launchNotebookUrl, logged, maintainer, migration }) {
 
   const { onMigrateProject, migration_status } = migration;
   const { project_supported } = migration.check;
@@ -172,6 +181,7 @@ function TemplateVersionBody({ externalUrl, launchNotebookUrl, maintainer, migra
       return <TemplateUpdateSection
         externalUrl={externalUrl}
         launchNotebookUrl={launchNotebookUrl}
+        logged={logged}
         maintainer={maintainer}
         migration_status={migration_status}
         onMigrateProject={onMigrateProject}
@@ -184,7 +194,7 @@ function TemplateVersionBody({ externalUrl, launchNotebookUrl, maintainer, migra
 }
 
 function TemplateStatus(props) {
-  const { launchNotebookUrl, maintainer, externalUrl } = props;
+  const { launchNotebookUrl, logged, maintainer, externalUrl } = props;
   const { check_error } = props.migration.check;
   const { migration_status, migration_error } = props.migration;
   if (isMigrationCheckLoading(props.loading, props.migration)) return <Loader />;
@@ -192,7 +202,7 @@ function TemplateStatus(props) {
 
   return <div>
     <TemplateVersionInfo check={props.migration.check} />
-    <TemplateVersionBody externalUrl={externalUrl} launchNotebookUrl={launchNotebookUrl}
+    <TemplateVersionBody externalUrl={externalUrl} launchNotebookUrl={launchNotebookUrl} logged={logged}
       maintainer={maintainer} migration={props.migration} />
   </div>;
 }


### PR DESCRIPTION
This is a follow-up to #1507 , currently separate because it requires a backend release to remediate SwissDataScienceCenter/renku-python#2541

In short, it allows anonymous users to invoke renku-core APIs (where currently supported) by switching to using git_url + branch for migrations instead of project_id.

Anonymous users can also access project version information, getting limited access (only "up-to-date" / "outdated").
Here is the comparison

![Screenshot_20220106_155442](https://user-images.githubusercontent.com/43481553/148406226-0b47f18d-d7a8-46b4-8564-df19f230083f.png)

![Screenshot_20220106_155532](https://user-images.githubusercontent.com/43481553/148406248-f06a9ac2-5a09-45c6-9828-90b1451ded52.png)

![Screenshot_20220106_155549](https://user-images.githubusercontent.com/43481553/148406265-1194bbf0-cfa8-4784-8934-bedaba334614.png)

/deploy renku=1.0-next renku-graph=cli-v1 renku-core=0000-disbale-check-migration-optimization

re #1507