### PR TITLE
Correctly set forked information

### DIFF
--- a/client/src/project/Project.state.js
+++ b/client/src/project/Project.state.js
@@ -461,7 +461,7 @@ class ProjectCoordinator {
 
     this.model.setObject({ metadata,
       filters: filtersObject,
-      forkedFromProject,
+      forkedFromProject: { $set: forkedFromProject },
       statistics: statsObject
     });
     return metadata;


### PR DESCRIPTION
Forked information is now correctly set when navigating to a new project.

# Testing

Go to 
- https://renku-ci-ui-1633.dev.renku.ch/projects/lorenzo.cavazzi.tech/covid-19-forecast
Click on the "forked from" link

See that the fork information is correctly displayed.

<img width="1056" alt="image" src="https://user-images.githubusercontent.com/1196411/148548468-01278fe2-e192-4707-9ff1-e08aebe91615.png">

Compare with the description in #1625

Fix #1625

/deploy renku=0000-project-version renku-graph=cli-v1 renku-core=v1.0.1