### PR TITLE
feat(client): support session autosaves

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -278,6 +278,7 @@
           "webhooks",
           "webpack",
           "whitespace",
+          "wip",
           "yaml",
           "zenodo"
         ]

--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -163,6 +163,7 @@
           "bool",
           "cancellable",
           "cancelled",
+          "cheatsheet",
           "checkbox",
           "ckeditor",
           "cktextarea",

--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -156,6 +156,7 @@
           "asciimath",
           "autosave",
           "autosaved",
+          "autosaves",
           "autostart",
           "autosuggest",
           "backend",

--- a/client/src/api-client/notebook-servers.js
+++ b/client/src/api-client/notebook-servers.js
@@ -17,6 +17,7 @@
  */
 
 import { FETCH_DEFAULT } from "./index";
+import { RETURN_TYPES } from "./utils";
 
 function addNotebookServersMethods(client) {
   client.getNotebookServers = (namespace, project, branch, commit, anonymous = false) => {
@@ -128,6 +129,42 @@ function addNotebookServersMethods(client) {
     }).then((resp) => {
       return resp.data;
     });
+  };
+
+  client.getProjectAutosaves = async (namespace, project) => {
+    const headers = client.getBasicHeaders();
+    headers.append("Content-Type", "application/json");
+    const projectId = encodeURIComponent(`${namespace}/${project}`); // %2F
+    const url = `${client.baseUrl}/notebooks/${projectId}/autosave`;
+
+    let response;
+    try {
+      response = await client.clientFetch(url, { method: "GET", headers });
+    }
+    catch (errorResponse) {
+      if (errorResponse?.errorData?.messages)
+        return errorResponse.errorData.messages;
+      return errorResponse;
+    }
+    return response.data;
+  };
+
+  client.deleteProjectAutosave = async (namespace, project, autosave) => {
+    const headers = client.getBasicHeaders();
+    const projectId = encodeURIComponent(`${namespace}/${project}`); // %2F
+    const autosaveSafe = encodeURIComponent(autosave);
+    const url = `${client.baseUrl}/notebooks/${projectId}/autosave/${autosaveSafe}`;
+
+    // the API doesn't return any response, hence returning `true` or `false` based on the response status
+    try {
+      const response = await client.clientFetch(url, { method: "DELETE", headers }, RETURN_TYPES.full);
+      if (response.status >= 200 && response.status < 400)
+        return true;
+      return false;
+    }
+    catch (errorResponse) {
+      return false;
+    }
   };
 }
 

--- a/client/src/file/File.container.js
+++ b/client/src/file/File.container.js
@@ -292,8 +292,7 @@ class JupyterButton extends React.Component {
       namespace: this.props.projectNamespace,
       project: this.props.projectPath,
     };
-    // TODO: plug in branch and commit coming from project page when it available
-    scope.commit = "latest";
+    // TODO: plug in branch coming from project page when it available
     scope.branch = this.getDefaultBranch();
     return scope;
   }

--- a/client/src/model/RenkuModels.js
+++ b/client/src/model/RenkuModels.js
@@ -336,6 +336,15 @@ const projectSchema = new Schema({
 });
 
 const notebooksSchema = new Schema({
+  autosaves: {
+    schema: {
+      list: { initial: [] },
+      error: { initial: null },
+      fetched: { initial: null },
+      fetching: { initial: false },
+      pvsSupport: { initial: null },
+    }
+  },
   notebooks: {
     schema: {
       all: { initial: {} },

--- a/client/src/notebooks/Notebooks.container.js
+++ b/client/src/notebooks/Notebooks.container.js
@@ -26,8 +26,8 @@ import {
   CheckNotebookIcon, ShowSession as ShowSessionPresent
 } from "./Notebooks.present";
 import { StatusHelper } from "../model/Model";
-import { Url } from "../utils/url";
-import { Loader } from "../utils/UIComponents";
+import { Url } from "../utils/helpers/url";
+import { Loader } from "../utils/components/Loader";
 
 
 /**

--- a/client/src/notebooks/Notebooks.container.js
+++ b/client/src/notebooks/Notebooks.container.js
@@ -26,9 +26,8 @@ import {
   CheckNotebookIcon, ShowSession as ShowSessionPresent
 } from "./Notebooks.present";
 import { StatusHelper } from "../model/Model";
-import { ProjectCoordinator } from "../project";
-import { Url } from "../utils/helpers/url";
-import { Loader } from "../utils/components/Loader";
+import { Url } from "../utils/url";
+import { Loader } from "../utils/UIComponents";
 
 
 /**
@@ -251,7 +250,7 @@ class Notebooks extends Component {
  * @param {Object} client - api-client used to query the gateway
  * @param {Object} model - global model for the ui
  * @param {Object[]} branches - Branches as returned by gitlab "/branches" API - no autosaved branches
- * @param {Object[]} commits - Commits as stored in the ProjectCoordinator
+ * @param {Object[]} commits - Commits as stored in the redux store
  * @param {Object[]} autosaved - Autosaved branches
  * @param {function} refreshBranches - Function to invoke to refresh the list of branches
  * @param {Object} scope - object containing filtering parameters
@@ -271,11 +270,9 @@ class StartNotebookServer extends Component {
     this.model = props.model.subModel("notebooks");
     this.userModel = props.model.subModel("user");
     this.coordinator = new NotebooksCoordinator(props.client, this.model, this.userModel);
-    // TODO: this should go away when moving all project content to projectCoordinator
-    this.projectModel = props.model.subModel("project");
-    this.projectCoordinator = new ProjectCoordinator(props.client, this.projectModel, props.notifications);
     this.notifications = props.notifications;
-    // temporarily reset data since notebooks model was not designed to be static
+
+    // reset data since notebooks model was not designed to be static
     this.coordinator.reset();
 
     if (props.scope)
@@ -293,6 +290,7 @@ class StartNotebookServer extends Component {
       currentSearch["commit"] :
       null;
     this.state = {
+      autosavesCommit: false,
       autostartReady: false,
       autostartTried: false,
       first: true,
@@ -303,6 +301,7 @@ class StartNotebookServer extends Component {
     };
 
     this.handlers = {
+      deleteAutosave: this.deleteAutosave.bind(this),
       refreshBranches: this.refreshBranches.bind(this),
       refreshCommits: this.refreshCommits.bind(this),
       reTriggerPipeline: this.reTriggerPipeline.bind(this),
@@ -317,11 +316,12 @@ class StartNotebookServer extends Component {
     };
   }
 
-  componentDidMount() {
+  async componentDidMount() {
     this._isMounted = true;
     if (!this.props.blockAnonymous) {
       if (!this.autostart)
         this.coordinator.startNotebookPolling();
+      this.coordinator.fetchAutosaves();
       this.refreshBranches();
     }
   }
@@ -332,17 +332,14 @@ class StartNotebookServer extends Component {
     this._isMounted = false;
   }
 
-  componentDidUpdate(previousProps) {
+  async componentDidUpdate(previousProps) {
     // TODO: temporary fix to prevent issue with component rerendered multiple times at the first url load
     if (this.state.first &&
       StatusHelper.isUpdating(previousProps.fetchingBranches) &&
       !StatusHelper.isUpdating(this.props.fetchingBranches)) {
       this.setState({ first: false });
       if (this._isMounted)
-        this.refreshBranches();
-      this.selectBranch(this.customBranch);
-
-
+        this.refreshBranches().then(r => this.selectBranchWhenReady());
     }
   }
 
@@ -357,7 +354,7 @@ class StartNotebookServer extends Component {
   setErrorInAutostart() {
     this.autostart = false;
     this.setState({
-      "starting": false,
+      starting: false,
       launchError: {
         frontendError: true,
         pipelineError: false,
@@ -372,7 +369,18 @@ class StartNotebookServer extends Component {
       if (StatusHelper.isUpdating(this.props.fetchingBranches))
         return;
       await this.props.refreshBranches();
-      if (this._isMounted && this.state.first)
+      if (this.state.first)
+        this.selectBranchWhenReady();
+    }
+  }
+
+  async selectBranchWhenReady() {
+    // Select branch only when autosaves data are available
+    if (this._isMounted) {
+      const autosavesAvailable = this.model.get("autosaves.fetched");
+      if (this.props.branches.fetching || !autosavesAvailable)
+        setTimeout(() => { this.selectBranchWhenReady(); }, 500);
+      else
         this.selectBranch(this.customBranch);
     }
   }
@@ -392,7 +400,7 @@ class StartNotebookServer extends Component {
       }
 
       // get the proper branch
-      let branchToSet;
+      let branchToSet = {};
       const { branches } = this.props;
 
       const branch = branches.filter(branch => branch.name === branchName);
@@ -404,37 +412,51 @@ class StartNotebookServer extends Component {
         branchToSet = branches[0];
       }
       else if (this.customBranch || this.customCommit) {
-        branchToSet = branches[0]; // allow form to start a new session
+        // set the error and get the first branch anyway
+        branchToSet = branches[0];
         this.setErrorInAutostart();
       }
 
-      // set branch
-      // do not retrieve the books yet, wait for the commit to be set
-      this.coordinator.setBranch(branchToSet ?? {}, !this.autostart);
-      if (!branchToSet) {
+      this.coordinator.setBranch(branchToSet);
+      this.setState({ autosavesCommit: false });
+      if (!branchToSet)
         this.coordinator.setCommit({});
-        return;
-      }
-
-      this.refreshCommits();
+      else
+        this.refreshCommits();
     }
   }
 
   async refreshCommits() {
     if (this._isMounted) {
-      if (!this.projectModel.get("commits.fetching")) {
-        const branch = this.model.get("filters.branch");
-        await this.projectCoordinator.fetchCommits({ branch: branch.name });
-      }
+      const branch = this.model.get("filters.branch");
+      await this.props.refreshCommits({ branch: branch.name });
       this.selectCommitWhenReady();
     }
   }
 
-  // TODO: ugly workaround until branches and commits will be unified in projectCoordinator
   async selectCommitWhenReady() {
+    // Ugly workaround to prevent stalling when commits.fetch was invoked somewhere else
     if (this._isMounted) {
-      if (this.projectModel.get("commits.fetching"))
-        setTimeout(() => { this.selectCommitWhenReady(); }, 100);
+      // check also if notebooks have been fetched, to be sure running sessions are not ignored
+      const notebooks = this.model.get("notebooks");
+      let delay = false;
+      // if (this.props.commits.fetching || !notebooks.fetched)
+      if (this.props.commits.fetching) {
+        delay = 500;
+      }
+      else if (!notebooks.fetched) {
+        if (notebooks.fetching) {
+          delay = 500;
+        }
+        else {
+          // this may happen with autostart
+          this.coordinator.startNotebookPolling();
+          delay = 5000;
+        }
+      }
+
+      if (delay)
+        setTimeout(() => { this.selectCommitWhenReady(); }, delay);
       else
         this.selectCommit(this.customCommit);
     }
@@ -445,8 +467,8 @@ class StartNotebookServer extends Component {
       // filter the list of commits according to the constraints
       const maximum = this.model.get("filters.displayedCommits");
       const commits = maximum && parseInt(maximum) > 0 ?
-        this.projectModel.get("commits.list").slice(0, maximum) :
-        this.projectModel.get("commits.list");
+        this.props.commits.list.slice(0, maximum) :
+        this.props.commits.list;
       let commit = commits[0];
 
       // find the proper commit or return
@@ -460,6 +482,41 @@ class StartNotebookServer extends Component {
           return;
       }
       else {
+        // check if there is an autosave for this branch, and find the corresponding commit
+        const autosaves = this.model.get("autosaves");
+        const branch = this.model.get("filters.branch");
+        let autosaveFound = false;
+        if (branch.name && autosaves.fetched && !autosaves.error && autosaves.list?.length) {
+          const autosave = autosaves.list.find(a => a.branch === branch.name);
+          if (autosave) {
+            const autosaveCommit = commits.find(commit => commit.id.startsWith(autosave.commit));
+            commit = autosaveCommit;
+            autosaveFound = true;
+            if (this.state.autosavesCommit !== autosaveCommit.id)
+              this.setState({ autosavesCommit: autosaveCommit.id });
+          }
+        }
+
+        // set a running session if any is active and valid
+        if (!autosaveFound) {
+          // verify data and sessions
+          const notebooks = this.model.get("notebooks");
+          const anyNotebook = notebooks?.all && Object.keys(notebooks.all).length ? true : false;
+          const validNotebooks = branch.name && notebooks.lastParameters.includes(branch.name) ? true : false;
+          if (anyNotebook && validNotebooks) {
+            // get the first session with a valid commit -- that should almost always be the case for running sessions
+            Object.keys(notebooks.all).find(k => {
+              const annotations = NotebooksHelper.cleanAnnotations(notebooks.all[k].annotations, "renku.io");
+              const targetCommit = commits.find(commit => commit.id === annotations["commit-sha"]);
+              if (targetCommit) {
+                commit = targetCommit;
+                return true;
+              }
+            });
+          }
+        }
+
+        // check if the current commit needs to be updated
         const oldCommit = this.model.get("filters.commit");
         if (oldCommit && oldCommit.id && oldCommit.id === commit.id)
           return;
@@ -557,6 +614,16 @@ class StartNotebookServer extends Component {
     this.coordinator.setNotebookOptions(option, value);
   }
 
+  async deleteAutosave(autosave) {
+    if (this._isMounted) {
+      const result = await this.coordinator.deleteAutosave(autosave);
+      // refresh autosaves only when no error was triggered
+      if (result)
+        this.coordinator.fetchAutosaves();
+      return result;
+    }
+  }
+
   internalStartServer() {
     // The core internal logic extracted here for re-use
     const { location, history } = this.props;
@@ -638,11 +705,11 @@ class StartNotebookServer extends Component {
     const augmentedState = {
       ...this.props.notebooks,
       data: {
+        autosaved: ownAutosaved,
+        branches: this.props.branches,
+        commits: this.props.commits.list,
         fetched: this.props.commits.fetched,
         fetching: this.props.commits.fetching,
-        commits: this.props.commits.list,
-        branches: this.props.branches,
-        autosaved: ownAutosaved
       },
       externalUrl: this.props.externalUrl
     };
@@ -657,12 +724,13 @@ class StartNotebookServer extends Component {
       return <NotebooksDisabled location={this.props.location} />;
 
     return <StartNotebookServerPresent
-      inherited={this.props}
-      message={this.props.message}
-      justStarted={this.state.starting}
       autoStarting={this.autostart && !this.state.autostartTried}
-      launchError={this.state.launchError}
+      autosavesCommit={this.state.autosavesCommit}
       ignorePipeline={this.state.ignorePipeline}
+      inherited={this.props}
+      justStarted={this.state.starting}
+      launchError={this.state.launchError}
+      message={this.props.message}
       showAdvanced={this.state.showAdvanced}
       {...this.propsToChildProps()}
     />;
@@ -708,8 +776,7 @@ class CheckNotebookStatus extends Component {
     this.model = props.model.subModel("notebooks");
     this.userModel = props.model.subModel("user");
     this.coordinator = new NotebooksCoordinator(props.client, this.model, this.userModel);
-    // TODO: this should go away when moving all project content to projectCoordinator
-    this.projectCoordinator = new ProjectCoordinator(props.client, props.model.subModel("project"));
+
     // temporarily reset data since notebooks model was not designed to be static
     this.coordinator.reset();
 
@@ -719,15 +786,10 @@ class CheckNotebookStatus extends Component {
   }
 
   async componentDidMount() {
-    // ! temporary -- ignore missing branch and get "latest" commit
     let { scope } = this.props;
-    if (!scope.branch || !scope.commit)
+    if (!scope.branch)
       return;
-    if (scope.commit === "latest") {
-      let commits = await this.projectCoordinator.fetchCommits();
-      scope.commit = commits[0];
-      this.coordinator.setNotebookFilters(scope);
-    }
+    this.coordinator.setNotebookFilters(scope);
 
     const pollingInterval = this.props.pollingInterval ?
       parseInt(this.props.pollingInterval) * 1000 :

--- a/client/src/notebooks/Notebooks.container.js
+++ b/client/src/notebooks/Notebooks.container.js
@@ -476,6 +476,8 @@ class StartNotebookServer extends Component {
         const filteredCommits = commits.filter(commit => commit.id === commitId);
         if (filteredCommits.length === 1)
           commit = filteredCommits[0];
+        else if (commitId === "latest")
+          commit = commits[0];
         else if (this.customBranch || this.customCommit)
           this.setErrorInAutostart();
         else
@@ -512,6 +514,7 @@ class StartNotebookServer extends Component {
                 commit = targetCommit;
                 return true;
               }
+              return false;
             });
           }
         }
@@ -618,8 +621,10 @@ class StartNotebookServer extends Component {
     if (this._isMounted) {
       const result = await this.coordinator.deleteAutosave(autosave);
       // refresh autosaves only when no error was triggered
-      if (result)
-        this.coordinator.fetchAutosaves();
+      if (result) {
+        await this.coordinator.fetchAutosaves();
+        this.selectCommit("latest");
+      }
       return result;
     }
   }

--- a/client/src/notebooks/Notebooks.present.js
+++ b/client/src/notebooks/Notebooks.present.js
@@ -301,17 +301,20 @@ function SessionDocs(props) {
 }
 
 function SessionCommands(props) {
-  const { tab } = props;
+  const { tab, notebook } = props;
 
   if (tab !== SESSION_TABS.commands)
     return null;
+
+  const annotations = NotebooksHelper.cleanAnnotations(notebook.data.annotations, "renku.io");
+  const branch = annotations["branch"];
 
   // ? Having a minHeight prevent losing the vertical scroll position.
   // TODO: Revisit after #1219
   return (
     <Fragment>
       <div className="p-2 p-lg-3" style={{ minHeight: 800 }}>
-        <SessionCheatSheet />
+        <SessionCheatSheet branch={branch}/>
       </div>
     </Fragment>
   );

--- a/client/src/notebooks/Notebooks.present.js
+++ b/client/src/notebooks/Notebooks.present.js
@@ -1185,7 +1185,7 @@ function AutosavesInfoAlert({ autosaves, autosavesId, currentId, deleteAutosave,
         </p>
         <p className="mb-0">
           For more options, start a session and look at the session cheatsheet,
-          which is available under this icon <FontAwesomeIcon icon={faBook} />.
+          which is available under this icon <FontAwesomeIcon className="cursor-default" icon={faBook} />.
         </p>
       </InfoAlert>
     );

--- a/client/src/notebooks/Notebooks.present.js
+++ b/client/src/notebooks/Notebooks.present.js
@@ -29,25 +29,25 @@ import {
   faBook, faCheckCircle, faCog, faCogs, faExclamationTriangle, faExternalLinkAlt, faFileAlt, faHistory,
   faInfoCircle, faLink, faQuestionCircle, faRedo, faSave, faStopCircle, faSyncAlt, faTimesCircle
 } from "@fortawesome/free-solid-svg-icons";
+import _ from "lodash";
 
-import { StatusHelper } from "../model/Model";
 import { NotebooksHelper } from "./index";
+import { StatusHelper } from "../model/Model";
 import { formatBytes, simpleHash } from "../utils/helpers/HelperFunctions";
 import Time from "../utils/helpers/Time";
 import Sizes from "../utils/constants/Media";
 import { Url } from "../utils/helpers/url";
-
-import "./Notebooks.css";
-import SessionCheatSheet from "./SessionCheatSheet";
-import _ from "lodash";
 import { ExternalLink } from "../utils/components/ExternalLinks";
 import { ButtonWithMenu } from "../utils/components/Button";
 import { TimeCaption } from "../utils/components/TimeCaption";
 import { Loader } from "../utils/components/Loader";
-import { InfoAlert, WarnAlert } from "../utils/components/Alert";
+import { InfoAlert, SuccessAlert, WarnAlert } from "../utils/components/Alert";
 import { Clipboard } from "../utils/components/Clipboard";
 import { JupyterIcon } from "../utils/components/Icon";
 import { ThrottledTooltip } from "../utils/components/Tooltip";
+import SessionCheatSheet from "./SessionCheatSheet";
+
+import "./Notebooks.css";
 
 
 // * Constants and helpers * //
@@ -1044,24 +1044,24 @@ class EnvironmentLogs extends Component {
 
 // * StartNotebookServer code * //
 function StartNotebookServer(props) {
-  const toggleShowAdvanced = props.handlers.toggleShowAdvanced;
-  const setIgnorePipeline = props.handlers.setIgnorePipeline;
+  const { deleteAutosave, setCommit, setIgnorePipeline, toggleShowAdvanced } = props.handlers;
   const { branch, commit } = props.filters;
-  const { autoStarting, pipelines, message } = props;
+  const { autosaves, autoStarting, pipelines, message } = props;
 
   if (autoStarting)
     return (<StartNotebookAutostart {...props} />);
 
   const fetching = {
+    autosaves: autosaves.fetching,
     branches: StatusHelper.isUpdating(props.fetchingBranches) ? true : false,
     pipelines: pipelines.fetching,
     commits: props.data.fetching
   };
 
   let show = {};
-  show.commits = !fetching.branches && branch.name ? true : false;
+  show.commits = !autosaves.fetching && !fetching.branches && branch.name ? true : false;
   show.pipelines = show.commits && !fetching.commits && commit && commit.id;
-  show.options = show.pipelines && pipelines.fetched;
+  show.options = show.pipelines && pipelines.fetched && autosaves.fetched;
 
   const messageOutput = message ?
     (<div key="message">{message}</div>) :
@@ -1072,44 +1072,130 @@ function StartNotebookServer(props) {
     "Hide branch, commit, and image settings" :
     "Do you want to select the branch, commit, or image?";
 
+  const advancedSelection = (
+    <Fragment>
+      <Collapse isOpen={props.showAdvanced}>
+        <AutosavesInfoAlert autosaves={autosaves} autosavesId={props.autosavesCommit}
+          currentId={props.filters.commit?.id} deleteAutosave={deleteAutosave} setCommit={setCommit} />
+        <StartNotebookBranches {...props} disabled={disabled} />
+        {show.commits ? <StartNotebookCommits {...props} disabled={disabled} /> : null}
+        {show.pipelines ? <StartNotebookPipelines {...props}
+          ignorePipeline={props.ignorePipeline}
+          setIgnorePipeline={setIgnorePipeline} /> : null}
+      </Collapse>
+      <FormGroup>
+        <Button color="link" className="ps-0 pe-0 pt-2 font-italic btn-sm"
+          onClick={() => { toggleShowAdvanced(); }}>
+          {buttonMessage}
+        </Button>
+      </FormGroup>
+    </Fragment>
+  );
+
+  const options = show.options ?
+    (<StartNotebookOptions toggleShowAdvanced={toggleShowAdvanced} showAdvanced={props.showAdvanced} {...props} />) :
+    null;
+
+  const loader = autosaves.fetching || !show.options ?
+    (
+      <div>
+        <p>Checking sessions status...</p>
+        <Loader />
+      </div>
+    ) :
+    null;
+
   return (
     <Row>
       <Col sm={12} md={10} lg={8}>
         <h3>Start a new session</h3>
-        <LaunchErrorAlert key="launch-error"
-          launchError={props.launchError}
-          pipelines={props.pipelines} />
+        <LaunchErrorAlert autosaves={autosaves} launchError={props.launchError} pipelines={props.pipelines} />
         {messageOutput}
         <Form>
-          <Collapse isOpen={props.showAdvanced}>
-            <StartNotebookBranches {...props} disabled={disabled} />
-            {show.commits ? <StartNotebookCommits {...props} disabled={disabled} /> : null}
-            {show.pipelines ? <StartNotebookPipelines {...props}
-              ignorePipeline={props.ignorePipeline}
-              setIgnorePipeline={setIgnorePipeline} /> : null}
-          </Collapse>
-
-          {show.options ?
-            (<FormGroup>
-              <Button color="link" className="ps-0 pe-0 pt-2 font-italic btn-sm"
-                onClick={() => { toggleShowAdvanced(); }}>
-                {buttonMessage}
-              </Button>
-            </FormGroup>) :
-            null
-          }
-          {show.options ?
-            <StartNotebookOptions
-              toggleShowAdvanced={toggleShowAdvanced}
-              showAdvanced={props.showAdvanced}
-              {...props} /> :
-            !props.showAdvanced ?
-              <Loader /> :
-              null
-          }
+          {advancedSelection}
+          {options}
+          {loader}
         </Form>
       </Col>
     </Row>
+  );
+}
+
+function AutosavesInfoAlert({ autosaves, autosavesId, currentId, deleteAutosave, setCommit }) {
+  const [deleteOngoing, setDeleteOngoing] = useState(false);
+  const [deleteResult, setDeleteResult] = useState(null);
+
+  // Return when autosaves data are not available
+  if (!autosaves?.fetched || autosaves?.fetching)
+    return null;
+
+  // Temporary store data when deleting autosaves to keep track of ongoing actions or failures
+  const deleteCurrentAutosave = async () => {
+    if (deleteResult != null)
+      setDeleteResult(null);
+    setDeleteOngoing(true);
+
+    // find the autosave name
+    const targetAutosave = autosaves.list.find(a => autosavesId.startsWith(a.commit));
+    const deleteOutcome = await deleteAutosave(targetAutosave.name);
+    setDeleteResult(deleteOutcome);
+    setDeleteOngoing(false);
+  };
+
+  // Manage ongoing or recently finished actions
+  if (deleteOngoing) {
+    return (
+      <InfoAlert dismissible={false} timeout={0}>
+        Deleting the autosave... <Loader size="14" inline="true" />
+      </InfoAlert>
+    );
+  }
+
+  if (deleteResult === true)
+    return (<SuccessAlert>Autosave successfully deleted.</SuccessAlert>);
+
+  if (deleteResult === false) {
+    return (
+      <WarnAlert timeout={0}>
+        <p>Could not delete the autosave.</p>
+        <p className="mb-0">
+          You might{" "}
+          <Button size="sm" color="warning" onClick={() => window.location.reload()}>refresh the page</Button>
+          {" "}and try again. The autosave may have been deleted in another session.
+        </p>
+      </WarnAlert>
+    );
+  }
+
+  // Return when there are no relevant autosaves
+  if (!currentId || !autosavesId)
+    return null;
+
+  // Show autosaves info
+  if (autosavesId === currentId) {
+    return (
+      <InfoAlert dismissible={false} timeout={0}>
+        <p>There is unsaved work left from your last session. This work will be restored.</p>
+        <p className="mb-0">
+          You can{" "}
+          <Button color="info" size="sm" onClick={() => deleteCurrentAutosave()}>delete the autosave</Button>
+          {" "}to start from the latest commit instead.
+        </p>
+      </InfoAlert>
+    );
+  }
+  return (
+    <WarnAlert dismissible={false} timeout={0}>
+      <p>
+        There is unsaved work left from your last session.<br />
+        Starting a session on a different commit will discard any unsaved work.
+      </p>
+      <p className="mb-0">
+        You can{" "}
+        <Button color="warning" size="sm" onClick={() => setCommit(autosavesId)}>restore the autosave</Button>
+        {" "}to start from there instead.
+      </p>
+    </WarnAlert>
   );
 }
 
@@ -1117,29 +1203,23 @@ function StartNotebookAutostart(props) {
   const { data, notebooks, options, pipelines } = props;
   const fetching = {
     data: data.fetched,
-    notebooks: notebooks.fetched,
     options: options.fetched,
     pipelines: pipelines.fetched
   };
-  let progress = 0;
-  let message = "Getting project data";
-  if (fetching.notebooks) {
-    message = "Checking existing sessions";
-    progress = 80;
-  }
-  else if (fetching.pipelines) {
-    message = "Checking GitLab jobs";
-    progress = 60;
-  }
-  else if (fetching.options) {
-    message = "Checking RenkuLab status";
-    progress = 40;
-  }
-  else if (fetching.data) {
-    message = "Checking project data";
-    progress = 20;
-  }
 
+  // Compute fetching status, but ignore notebooks.fetched since it may be unreliable
+  let fetched = Object.keys(fetching).filter(k => fetching[k] ? true : false);
+  if (!notebooks.fetched)
+    fetched = false;
+  const multiplier = Object.keys(fetching).length + 1;
+  let progress = fetched.length * 100 / multiplier;
+  let message = "Checking project data";
+  if (fetching.pipelines)
+    message = "Checking GitLab jobs";
+  else if (fetching.options)
+    message = "Checking RenkuLab status";
+  else if (fetching.notebooks)
+    message = "Checking existing sessions";
   return (
     <div>
       <h3>Starting session</h3>
@@ -1613,18 +1693,24 @@ class StartNotebookOptions extends Component {
     if (justStarted)
       return <Label>Starting a new session... <Loader size="14" inline="true" /></Label>;
 
-
-    const { fetched, all } = this.props.notebooks;
-    const { options } = this.props;
+    const { all, fetched } = this.props.notebooks;
+    const { filters, options } = this.props;
     if (!fetched)
       return (<Label>Verifying available sessions... <Loader size="14" inline="true" /></Label>);
 
     if (Object.keys(options.global).length === 0 || options.fetching)
       return (<Label>Loading session parameters... <Loader size="14" inline="true" /></Label>);
 
-    if (Object.keys(all).length === 1)
-      return (<StartNotebookOptionsRunning {...this.props} />);
-
+    if (Object.keys(all).length > 0) {
+      const currentCommit = filters.commit?.id;
+      const currentNotebook = Object.keys(all).find(k => {
+        const annotations = NotebooksHelper.cleanAnnotations(all[k].annotations, "renku.io");
+        if (annotations["commit-sha"] === currentCommit)
+          return true;
+      });
+      if (currentNotebook)
+        return (<StartNotebookOptionsRunning notebook={all[currentNotebook]} />);
+    }
 
     return [
       <StartNotebookServerOptions key="options" {...this.props} />,
@@ -1644,8 +1730,8 @@ function Warning(props) {
 
 class StartNotebookOptionsRunning extends Component {
   render() {
-    const { all } = this.props.notebooks;
-    const notebook = all[Object.keys(all)[0]];
+    const { notebook } = this.props;
+
     const status = NotebooksHelper.getStatus(notebook.status);
     if (status === "running") {
       const annotations = NotebooksHelper.cleanAnnotations(notebook.annotations, "renku.io");
@@ -1878,11 +1964,31 @@ function LaunchErrorFrontendAlert({ launchError, pipelines }) {
   </WarnAlert>;
 }
 
-function LaunchErrorAlert({ launchError, pipelines }) {
-  if (launchError == null) return null;
-  return (launchError.frontendError === true) ?
-    <LaunchErrorFrontendAlert launchError={launchError} pipelines={pipelines} /> :
-    <LaunchErrorBackendAlert launchError={launchError} />;
+function AutosavesErrorAlert({ autosaves }) {
+  if (autosaves.error == null)
+    return null;
+  return <WarnAlert>
+    <p>Autosaves are currently unavailable.</p>
+    <p className="mb-0">If you recently worked on the project, any previous unsaved work cannot be recovered.</p>
+  </WarnAlert>;
+}
+
+function LaunchErrorAlert({ autosaves, launchError, pipelines }) {
+  let launchErrorElement = null;
+  if (launchError != null) {
+    if (launchError.frontendError === true)
+      launchErrorElement = (<LaunchErrorFrontendAlert launchError={launchError} pipelines={pipelines} />);
+    else
+      launchErrorElement = (<LaunchErrorBackendAlert launchError={launchError} />);
+  }
+
+  let autosavesErrorElement = null;
+  if (autosaves.error != null)
+    autosavesErrorElement = (<AutosavesErrorAlert autosaves={autosaves} />);
+  return (<Fragment>
+    {launchErrorElement}
+    {autosavesErrorElement}
+  </Fragment>);
 }
 
 class ServerOptionLaunch extends Component {

--- a/client/src/notebooks/Notebooks.present.js
+++ b/client/src/notebooks/Notebooks.present.js
@@ -1707,6 +1707,7 @@ class StartNotebookOptions extends Component {
         const annotations = NotebooksHelper.cleanAnnotations(all[k].annotations, "renku.io");
         if (annotations["commit-sha"] === currentCommit)
           return true;
+        return false;
       });
       if (currentNotebook)
         return (<StartNotebookOptionsRunning notebook={all[currentNotebook]} />);

--- a/client/src/notebooks/Notebooks.present.js
+++ b/client/src/notebooks/Notebooks.present.js
@@ -1175,11 +1175,14 @@ function AutosavesInfoAlert({ autosaves, autosavesId, currentId, deleteAutosave,
   if (autosavesId === currentId) {
     return (
       <InfoAlert dismissible={false} timeout={0}>
-        <p>There is unsaved work left from your last session. This work will be restored.</p>
+        <p>
+          There is unsaved work from your last session which will be restored.
+          If you do not wish to keep it, you can{" "}
+          <Button color="info" size="sm" onClick={() => deleteCurrentAutosave()}>delete the autosave</Button>.
+        </p>
         <p className="mb-0">
-          You can{" "}
-          <Button color="info" size="sm" onClick={() => deleteCurrentAutosave()}>delete the autosave</Button>
-          {" "}to start from the latest commit instead.
+          For more options, start a session and look at the session cheatsheet,
+          which is available under this icon <FontAwesomeIcon icon={faBook} />.
         </p>
       </InfoAlert>
     );

--- a/client/src/notebooks/Notebooks.state.js
+++ b/client/src/notebooks/Notebooks.state.js
@@ -813,7 +813,7 @@ class NotebooksCoordinator {
     let autosavesData = { fetching: false, fetched: new Date() };
     if (response && response.autosaves) {
       autosavesData.error = null;
-      autosavesData.list = response.autosaves;
+      autosavesData.list = { $set: response.autosaves };
       autosavesData.pvsSupport = response.pvsSupport;
     }
     else {

--- a/client/src/notebooks/SessionCheatSheet.js
+++ b/client/src/notebooks/SessionCheatSheet.js
@@ -22,6 +22,7 @@ import React, { Fragment } from "react";
 import "./SessionCheatSheet.css";
 import { Clipboard } from "../utils/components/Clipboard";
 import { ExternalDocsLink } from "../utils/components/ExternalLinks";
+import Time from "../utils/Time";
 
 function CommandDesc({ command = "", desc = "", clipboard = true }) {
   return <div>
@@ -29,7 +30,7 @@ function CommandDesc({ command = "", desc = "", clipboard = true }) {
     {
       (clipboard === true) ? <Clipboard clipboardText={command} /> : null
     }
-    <p className="renku-info" style={{ paddingTop: "3px" }}>{desc}</p>
+    <div className="renku-info" style={{ paddingTop: "3px" }}>{desc}</div>
   </div>;
 }
 
@@ -172,30 +173,34 @@ function UndoCommit() {
   </Fragment>;
 }
 
-function Autosaves() {
-  const twoLineCommand = (<span>
-    git push --set-upstream origin your-branch-name-here
-    <br />git reset --hard origin/[default branch name]
-  </span>);
+function Autosaves({ branch }) {
+  const defaultBranchName = branch;
+  const nowString = Time.formatDateTime(new Date());
+  const nowIdString = Time.formatDateTime(new Date(), { d3FormatString: "%Y-%m-%d_%H-%M" });
+  const gitCheckoutFragment = `git checkout -b unsaved-${nowIdString}`;
+  const gitAddFragment = "git add .";
+  const gitCommitFragment = `git commit -m 'wip: save unsaved work ${nowString}'`;
+  const gitPushFragment = `git push --set-upstream origin unsaved-${nowIdString}`;
+  const twoLineCommand = `${gitCheckoutFragment};${gitAddFragment};${gitCommitFragment};${gitPushFragment}`;
   return <Fragment>
     <CommandsRow>
       <div>
         <h2>Autosave</h2>
-        <p className="mb-1">If you want to see what work was saved, you can diff the current contents:</p>
+        <b className="mb-1">To see unsaved work, diff the contents</b>
       </div>
     </CommandsRow>
     <CommandsRow>
-      <CommandDesc command="git diff HEAD^"
-        desc="Against the previous state." />
-      <CommandDesc command="git diff origin [default branch name]"
-        desc="Against the latest state of the project." />
+      <CommandDesc command="git diff HEAD"
+        desc="Diff against the previous state." />
+      <CommandDesc command={`git diff origin/${defaultBranchName}`}
+        desc="Diff against the server state." />
     </CommandsRow>
     <CommandsRow>
-      <p className="mb-1">If you want to discard the unsaved work in the running session:</p>
+      <b className="mb-1">To manage unsaved work</b>
     </CommandsRow>
     <CommandsRow>
-      <CommandDesc command="git reset --hard origin/[default branch name]"
-        desc="Return to the latest version." />
+      <CommandDesc command={`git reset --hard origin/${defaultBranchName}`}
+        desc="Discard unsaved work and return to latest version." />
       <CommandDesc command={twoLineCommand}
         desc="Keep this work around for later." />
     </CommandsRow>
@@ -225,7 +230,7 @@ function LearnMore() {
 }
 
 
-function SessionCheatSheet() {
+function SessionCheatSheet({ branch }) {
   return <div className="commands">
     <h1 className="mb-5">Renku Cheat Sheet</h1>
     <TypicalWorkflow />
@@ -234,7 +239,7 @@ function SessionCheatSheet() {
     <ManagingContents />
     <Collaboration />
     <UndoCommit />
-    <Autosaves />
+    <Autosaves branch={branch}/>
     <LearnMore />
   </div>;
 }

--- a/client/src/notebooks/SessionCheatSheet.js
+++ b/client/src/notebooks/SessionCheatSheet.js
@@ -22,7 +22,7 @@ import React, { Fragment } from "react";
 import "./SessionCheatSheet.css";
 import { Clipboard } from "../utils/components/Clipboard";
 import { ExternalDocsLink } from "../utils/components/ExternalLinks";
-import Time from "../utils/Time";
+import Time from "../utils/helpers/Time";
 
 function CommandDesc({ command = "", desc = "", clipboard = true }) {
   return <div>

--- a/client/src/notebooks/SessionCheatSheet.js
+++ b/client/src/notebooks/SessionCheatSheet.js
@@ -172,6 +172,36 @@ function UndoCommit() {
   </Fragment>;
 }
 
+function Autosaves() {
+  const twoLineCommand = (<span>
+    git push --set-upstream origin your-branch-name-here
+    <br />git reset --hard origin/[default branch name]
+  </span>);
+  return <Fragment>
+    <CommandsRow>
+      <div>
+        <h2>Autosave</h2>
+        <p className="mb-1">If you want to see what work was saved, you can diff the current contents:</p>
+      </div>
+    </CommandsRow>
+    <CommandsRow>
+      <CommandDesc command="git diff HEAD^"
+        desc="Against the previous state." />
+      <CommandDesc command="git diff origin [default branch name]"
+        desc="Against the latest state of the project." />
+    </CommandsRow>
+    <CommandsRow>
+      <p className="mb-1">If you want to discard the unsaved work in the running session:</p>
+    </CommandsRow>
+    <CommandsRow>
+      <CommandDesc command="git reset --hard origin/[default branch name]"
+        desc="Return to the latest version." />
+      <CommandDesc command={twoLineCommand}
+        desc="Keep this work around for later." />
+    </CommandsRow>
+  </Fragment>;
+}
+
 function LearnMore() {
   return <Fragment>
     <CommandsRow>
@@ -204,6 +234,7 @@ function SessionCheatSheet() {
     <ManagingContents />
     <Collaboration />
     <UndoCommit />
+    <Autosaves />
     <LearnMore />
   </div>;
 }

--- a/client/src/project/Project.js
+++ b/client/src/project/Project.js
@@ -225,6 +225,7 @@ class View extends Component {
   async fetchReadme() { return this.projectCoordinator.fetchReadme(this.props.client); }
   async fetchModifiedFiles() { return this.projectCoordinator.fetchModifiedFiles(this.props.client); }
   async fetchBranches() { return this.projectCoordinator.fetchBranches(); }
+  async fetchCommits(branch) { return this.projectCoordinator.fetchCommits({ branch }); }
   async createGraphWebhook() { return this.projectCoordinator.createGraphWebhook(this.props.client); }
   async fetchGraphWebhook() { this.projectCoordinator.fetchGraphWebhook(this.props.client, this.props.user); }
   async fetchProjectFilesTree() {
@@ -615,6 +616,9 @@ class View extends Component {
     },
     fetchBranches: () => {
       return this.projectCoordinator.fetchBranches();
+    },
+    fetchCommits: (branch = null) => {
+      return this.projectCoordinator.fetchCommits(branch);
     },
     onMigrateProject: (gitUrl, branch, options) => {
       return this.migrateProject(gitUrl, branch, options);

--- a/client/src/project/Project.present.js
+++ b/client/src/project/Project.present.js
@@ -1182,8 +1182,8 @@ class ProjectNotebookServers extends Component {
 class ProjectStartNotebookServer extends Component {
   render() {
     const {
-      branches, client, model, user, forkUrl, externalUrl, location, metadata,
-      fetchBranches, notebookServersUrl, history, blockAnonymous, notifications,
+      branches, client, commits, model, user, forkUrl, externalUrl, location, metadata,
+      fetchBranches, fetchCommits, notebookServersUrl, history, blockAnonymous, notifications,
       projectCoordinator
     } = this.props;
     const warning = notebookWarning(
@@ -1200,22 +1200,31 @@ class ProjectStartNotebookServer extends Component {
         }
       };
 
+    const scope = {
+      defaultBranch: this.props.metadata.defaultBranch,
+      namespace: this.props.metadata.namespace,
+      project: this.props.metadata.path
+    };
+
     return (
-      <StartNotebookServer client={client} model={model} history={history} location={locationEnhanced}
-        message={warning}
-        branches={branches.standard}
+      <StartNotebookServer
         autosaved={branches.autosaved}
-        fetchingBranches={branches.fetching}
-        refreshBranches={fetchBranches}
-        externalUrl={externalUrl}
-        successUrl={notebookServersUrl}
         blockAnonymous={blockAnonymous}
+        branches={branches.standard}
+        client={client}
+        commits={commits}
+        externalUrl={externalUrl}
+        fetchingBranches={branches.fetching}
+        history={history}
+        location={locationEnhanced}
+        message={warning}
+        model={model}
         notebooks={projectCoordinator.model.baseModel.get("notebooks")}
         notifications={notifications}
-        commits={projectCoordinator.get("commits")}
-        projectCoordinator={projectCoordinator}
-        scope={{ namespace: this.props.metadata.namespace, project: this.props.metadata.path,
-          defaultBranch: this.props.metadata.defaultBranch }}
+        refreshBranches={fetchBranches}
+        refreshCommits={fetchCommits}
+        scope={scope}
+        successUrl={notebookServersUrl}
         user={this.props.user}
       />
     );

--- a/client/src/project/Project.state.js
+++ b/client/src/project/Project.state.js
@@ -262,8 +262,10 @@ const RepoMixin = {
 
     return standard;
   },
-  async fetchCommits(customFilters = null) {
-    const projectId = this.model.get("metadata.id");
+  async fetchCommits(customFilters = null, customProjectId = null) {
+    const projectId = customProjectId ?
+      customProjectId :
+      this.model.get("metadata.id");
     if (!projectId)
       return {};
     const branch = customFilters ?
@@ -271,6 +273,9 @@ const RepoMixin = {
       this.model.get("filters.branch.name");
 
     // start fetching
+    const alreadyFetching = this.model.get("commits.fetching");
+    if (alreadyFetching)
+      return {};
     this.model.set("commits.fetching", true);
     let response = null, date = null, commits = [], error = null;
     try {
@@ -294,8 +299,7 @@ const RepoMixin = {
         this.notifications.addWarning(
           this.notifications.Topics.PROJECT_API,
           "There was an error while fetching the project commits.",
-          null, null, [],
-            `Error for branch "${branch}" on project "${projectName}": ${errorMex}`
+          null, null, [], `Error for branch "${branch}" on project "${projectName}": ${errorMex}`
         );
       }
     }


### PR DESCRIPTION
This PR implements most of the changes from #1345 , except the visual changes to the commits info in the dropdown menu.
There are a few additional changes to simplify selecting an already running session for a target branch.

In short, these are the changes:
* Get and delete autosaves.
* Select new session commit based on autosaves and running sessions.
* Update CheckNotebookStatus component to support per-branch sessions.

**How to test**
Start a session on any project (possibly from last - 1 or -2 commit), do some work, and stop the session.
You should now have an autosave. If you try to start a session again, you should see some info when trying to select a branch/commit (P.S. this is silent unless you click on "select branch/commit/..." -- see screenshots below).
Notice that the older commits should be selected when
- No session is running, but the autosave is detected.
- The session is already running (take priority over the last commit)
- File preview on notebooks should also detect running sessions form older commits

**Screenshots**
* Autosave content available
![Screenshot_20220117_154255](https://user-images.githubusercontent.com/43481553/149918903-90e4f789-3c97-4377-a7bc-e670fac71681.png)

* User trying to start from another commit
![Screenshot_20220117_154313](https://user-images.githubusercontent.com/43481553/149918960-19487279-8cd5-44b2-b510-8d8cf9e481fc.png)

* Error on delete --> we don't get any info about the error, but it may (rarely) happen if the user has already "consumed" the autosave in another tab and left this open 
![Screenshot_20220117_134806](https://user-images.githubusercontent.com/43481553/149919016-9ab1dba1-8580-46a8-a999-d19cd8c9a99f.png)



/deploy renku=1.0-next renku-graph=cli-v1 renku-core=0000-disbale-check-migration-optimization
fix #1345, #789