### PR TITLE
fix(client): restore projects data used by datasets

### DIFF
--- a/client/src/api-client/project.js
+++ b/client/src/api-client/project.js
@@ -153,7 +153,13 @@ function addProjectMethods(client) {
             namespace {
               fullPath
             }
-            path
+            path,
+            httpUrlToRepo,
+            userPermissions {
+              adminProject,
+              pushCode,
+              removeProject
+            }
           }
         }
       }`;

--- a/client/src/dataset/Dataset.container.js
+++ b/client/src/dataset/Dataset.container.js
@@ -27,6 +27,8 @@ export default function ShowDataset(props) {
 
   const [datasetKg, setDatasetKg] = useState();
   const [datasetFiles, setDatasetFiles] = useState();
+  const [fetchedKg, setFetchedKg] = useState(false);
+
   const dataset = useMemo(() =>
     mapDataset(props.datasets ?
       props.datasets.find(dataset => dataset.name === props.datasetId)
@@ -79,9 +81,12 @@ export default function ShowDataset(props) {
       const id = props.insideProject ? dataset.identifier : props.identifier;
       props.client.fetchDatasetFromKG(id)
         .then((datasetInfo) => {
-          if (!unmounted && datasetKg === undefined && datasetInfo !== undefined)
+          if (!unmounted && datasetKg === undefined && datasetInfo !== undefined) {
+            setFetchedKg(true);
             setDatasetKg(datasetInfo);
+          }
         }).catch(error => {
+          setFetchedKg(true);
           if (!unmounted && error.case === API_ERRORS.notFoundError)
             setFetchError({ code: 404, message: "dataset not found or missing permissions" });
           else if (!unmounted && error.case === API_ERRORS.internalServerError)
@@ -98,6 +103,7 @@ export default function ShowDataset(props) {
     dataset={dataset}
     datasets={props.datasets}
     fetchError={fetchError}
+    fetchedKg={fetchedKg}
     fileContentUrl={props.fileContentUrl}
     history={props.history}
     httpProjectUrl={props.httpProjectUrl}

--- a/client/src/dataset/Dataset.present.js
+++ b/client/src/dataset/Dataset.present.js
@@ -437,7 +437,7 @@ export default function DatasetView(props) {
         : null
     }
     {
-      dataset.insideKg === false && props.projectInsideKg === true ?
+      props.fetchedKg === true && dataset.insideKg === false && props.projectInsideKg === true ?
         <WarnAlert className="not-in-kg-warning">
           <strong>This dataset is not in the Knowledge Graph;</strong> this means that some
           operations on it are not possible.

--- a/client/src/dataset/addtoproject/DatasetAdd.container.js
+++ b/client/src/dataset/addtoproject/DatasetAdd.container.js
@@ -134,10 +134,12 @@ function AddDataset(props) {
 
     const projectOptions = handlers.getFormDraftFieldProperty("project", ["options"]);
 
-    const selectedProject = projectOptions.find((project)=>
+    const selectedProject = projectOptions.find((project) =>
       project.value === mappedInputs.project);
 
-    props.client.checkMigration(props.httpProjectUrl).then((response) => {
+    // TODO: is this what we want? Should we check that both the target and the source are up-to-date?
+    const target = selectedProject.value; // It was props.httpProjectUrl, but it's not always set
+    props.client.checkMigration(target).then((response) => {
       if (response && response.error !== undefined) {
         handlers.setSubmitLoader({ value: false, text: "" });
         handlers.setServerErrors(response.error.reason);


### PR DESCRIPTION
This fixes a bug spotted by @gavin-k-lee that prevents datasets to be added to projects.

**How to test**: look for a dataset using the dataset search, open any and click on the "Add to project" button on the top right.
The user should be able to look for a project again and import the dataset (if the target project is up-to-date).
Trying the some on dev won't work -- the user won't even be able to select a target project.

P.S. We should probably check also the source project version. That may not be straightforward in the current implementation.
I would suggest re-working a bit the "add to project" logic, removing the overcomplicated FormGenerator Autosuggest (it's half-bugged, not checking for the input data to be available and not filtering some unusable target projects), adding the required logic for checking migrations on both sides.

/deploy renku=1.0-next renku-graph=development renku-core=v1.0.2
