### PR TITLE
Add version to the job APIs URL

### DIFF
--- a/client/src/api-client/environment.js
+++ b/client/src/api-client/environment.js
@@ -21,7 +21,7 @@ function addEnvironmentMethods(client) {
    * Get the versions of the RenkuLab components.
    */
   client.getComponentsVersion = async () => {
-    const urlApi = `${client.uiserverUrl}/api/versions`;
+    const urlApi = `${client.baseUrl}/versions`;
     let headers = client.getBasicHeaders();
     headers.append("Content-Type", "application/json");
     headers.append("X-Requested-With", "XMLHttpRequest");
@@ -37,7 +37,7 @@ function addEnvironmentMethods(client) {
    * @param {string} version - target core version to test
    */
   client.checkCoreAvailability = async (version) => {
-    const urlApi = `${client.uiserverUrl}/api/renku/${version}/version`;
+    const urlApi = `${client.baseUrl}/renku/${version}/version`;
     let headers = client.getBasicHeaders();
     headers.append("Content-Type", "application/json");
     headers.append("X-Requested-With", "XMLHttpRequest");

--- a/client/src/api-client/instance.js
+++ b/client/src/api-client/instance.js
@@ -55,7 +55,7 @@ function addInstanceMethods(client) {
   };
 
   client.isValidUrlForIframe = async (url) => {
-    const response = await renkuFetch(`${client.uiserverUrl}/api/allows-iframe/${encodeURIComponent(url)}`, {
+    const response = await renkuFetch(`${client.baseUrl}/allows-iframe/${encodeURIComponent(url)}`, {
       method: "GET",
       headers: new Headers({ "Accept": "application/json" })
     });

--- a/client/src/api-client/job.js
+++ b/client/src/api-client/job.js
@@ -1,29 +1,40 @@
 
 export default function addJobMethods(client) {
 
-  client.getJobStatus = (job_id) => {
+  /**
+   * Get status for the target job in the core service
+   * @param {string} job_id - core job id
+   * @param {string} versionUrl - target core version to identify the proper jobs queue
+   */
+  client.getJobStatus = (job_id, versionUrl = null) => {
     let headers = client.getBasicHeaders();
     headers.append("Content-Type", "application/json");
     headers.append("X-Requested-With", "XMLHttpRequest");
 
-    return client.clientFetch(`${client.baseUrl}/renku/jobs/${job_id}`, {
+    const url = client.versionedCoreUrl("jobs", versionUrl);
+    return client.clientFetch(`${url}/${job_id}`, {
       method: "GET",
       headers: headers
     }).then(response => {
-      return response.data.result;
+      return response.data?.result;
     });
   };
 
-  client.getAllJobStatus = () => {
+  /**
+   * Get list of all jobs from the core service.
+   * @param {string} versionUrl - target core version to identify the proper jobs queue
+   */
+  client.getAllJobStatus = (versionUrl = null) => {
     let headers = client.getBasicHeaders();
     headers.append("Content-Type", "application/json");
     headers.append("X-Requested-With", "XMLHttpRequest");
 
-    return client.clientFetch(`${client.baseUrl}/renku/jobs`, {
+    const url = client.versionedCoreUrl("jobs", versionUrl);
+    return client.clientFetch(url, {
       method: "GET",
       headers: headers
     }).then(response => {
-      return response.data.result;
+      return response.data?.result;
     });
   };
 }

--- a/client/src/dataset/addtoproject/DatasetAdd.container.js
+++ b/client/src/dataset/addtoproject/DatasetAdd.container.js
@@ -98,7 +98,7 @@ function AddDataset(props) {
     let cont = 0;
     const INTERVAL = 6000;
     let monitorJob = setInterval(() => {
-      props.client.getJobStatus(job_id)
+      props.client.getJobStatus(job_id, props.versionUrl)
         .then(job => {
           cont++;
           if (job !== undefined) {

--- a/client/src/project/datasets/change/DatasetChange.container.js
+++ b/client/src/project/datasets/change/DatasetChange.container.js
@@ -147,7 +147,7 @@ function ChangeDataset(props) {
   }
 
   const monitorURLJobsStatuses = (datasetsJobsArray) => {
-    return props.client.getAllJobStatus()
+    return props.client.getAllJobStatus(versionUrl)
       .then(response => {
         //we set the new status and then we check if they are all finished (completed or failed)
         datasetsJobsArray.map(localJob => setNewJobStatus(localJob, response.jobs));

--- a/client/src/project/datasets/import/DatasetImport.container.js
+++ b/client/src/project/datasets/import/DatasetImport.container.js
@@ -89,7 +89,7 @@ function ImportDataset(props) {
   const monitorJobStatusAndHandleResponse = (job_id, handlers) => {
     let cont = 0;
     let monitorJob = setInterval(() => {
-      props.client.getJobStatus(job_id)
+      props.client.getJobStatus(job_id, props.migration.core.versionUrl)
         .then(job => {
           cont++;
           if (job !== undefined || cont === 50)


### PR DESCRIPTION
The URL for jobs API doesn't include the version. This causes problems when adding/editing datasets on projects with an older metadata version (specifically, the answer from the job APIs is `undefined` cause it's querying the wrong service).

**How to test**: Use an older project with metadata V8, and try to add a datasets (E.G. clone `ralf.grubenmann/test-8`)

/deploy renku=1.0-next renku-graph=development renku-core=release/v1.0.3
re SwissDataScienceCenter/renku-python#2604
