### PR TITLE
refactor(client): do not use formGenerator to import the dataset into an existing project (#1604)

### DIFF
--- a/client/src/dataset/addtoproject/DatasetAdd.container.js
+++ b/client/src/dataset/addtoproject/DatasetAdd.container.js
@@ -144,9 +144,8 @@ function AddDataset(props) {
       return false;
     }
     // check if the dataset project is supported
-    const projectVersion = checkTarget.result.core_compatibility_status.project_metadata_version;
     if (targetProjectVersionStatus.renkuVersionStatus === RENKU_VERSION_SCENARIOS.NEW_VERSION_REQUIRED) {
-      const backendAvailability = await props.client.checkCoreAvailability(projectVersion);
+      const backendAvailability = await props.client.checkCoreAvailability(target_metadata_version);
       if (!backendAvailability.available) {
         setCurrentStatus({ status: "errorNeedMigration", text: null });
         return false;

--- a/client/src/dataset/addtoproject/DatasetAdd.container.js
+++ b/client/src/dataset/addtoproject/DatasetAdd.container.js
@@ -24,186 +24,276 @@
  */
 
 
-import React from "react";
-import { addDatasetToProjectSchema } from "../../model/RenkuModels";
+import React, { useEffect, useState } from "react";
 import { ACCESS_LEVELS } from "../../api-client";
 import DatasetAdd from "./DatasetAdd.present";
 import { ImportStateMessage } from "../../utils/constants/Dataset";
 import { groupBy } from "../../utils/helpers/HelperFunctions";
-import _ from "lodash";
-
-let dsFormSchema = _.cloneDeep(addDatasetToProjectSchema);
 
 function AddDataset(props) {
+  const [currentStatus, setCurrentStatus] = useState(null);
+  const [importingDataset, setImportingDataset] = useState(false);
+  const [isProjectsReady, setIsProjectsReady] = useState(false);
+  const [isDatasetValid, setIsDatasetValid] = useState(null);
+  const [datasetProjectVersion, setDatasetProjectVersion] = useState(null);
+  let projectsMonitorJob = null;
 
-  if (dsFormSchema == null)
-    dsFormSchema = _.cloneDeep(addDatasetToProjectSchema);
+  useEffect(() => {
+    validateDatasetProject();
+    monitorProjectList();
+  }, []); // eslint-disable-line
 
-
-  const closeModal = () =>{
-    props.setModalOpen(false);
+  /* validate project */
+  const onProjectSelected = (value) => {
+    if (value)
+      validateProject(value, false); // validate origin only when start import
+    else
+      setCurrentStatus(null);
   };
 
-  const onCancel = (e, handlers) =>{
-    closeModal();
-    handlers.removeDraft();
-  };
+  const validateDatasetProject = async () => {
+    // check dataset has valid project url
+    setCurrentStatus({ status: "inProcess", text: "Checking Dataset..." });
+    if (!props.dataset.project || !props.dataset.project.path) {
+      setCurrentStatus({ status: "error", text: "Invalid Dataset, refresh the page to get updated values" });
+      setIsDatasetValid(false);
+      return false;
+    }
 
-  const redirectUser = (projectPath, datasetName, handlers) => {
-    handlers.setSubmitLoader({ value: false, text: "" });
-    handlers.removeDraft();
-    props.history.push({
-      pathname: `/projects/${projectPath}/datasets/${datasetName}`,
-      state: { reload: true }
-    });
-  };
+    // fetch dataset project values and check it has a valid git url
+    // TODO remove this request when dataset include httpUrlToRepo
+    let checkOrigin;
+    try {
+      const fetchDatasetProject = await props.client.getProject(props.dataset.project?.path);
+      const urlProjectOrigin = fetchDatasetProject?.data?.all?.http_url_to_repo;
+      if (!urlProjectOrigin) {
+        setCurrentStatus({ status: "error", text: "Invalid Dataset" });
+        setIsDatasetValid(false);
+        return false;
+      }
 
-  function handleJobResponse(job, monitorJob, waitedSeconds, projectPath, datasetName, handlers) {
-
-    if (job) {
-      switch (job.state) {
-        case "ENQUEUED":
-          handlers.setSubmitLoader({ value: true, text: ImportStateMessage.ENQUEUED });
-          break;
-        case "IN_PROGRESS":
-          handlers.setSubmitLoader({ value: true, text: ImportStateMessage.IN_PROGRESS });
-          break;
-        case "COMPLETED":
-          handlers.setSubmitLoader({ value: true, text: ImportStateMessage.COMPLETED });
-          clearInterval(monitorJob);
-          redirectUser(projectPath, datasetName, handlers);
-          break;
-        case "FAILED":
-          handlers.setSubmitLoader({ value: false, text: "" });
-          handlers.setServerErrors(ImportStateMessage.FAILED + job.extras.error);
-          clearInterval(monitorJob);
-          break;
-        default:
-          handlers.setSubmitLoader({ value: false, text: "" });
-          handlers.setServerErrors(ImportStateMessage.FAILED_NO_INFO);
-          clearInterval(monitorJob);
-          break;
+      // check dataset project migration status
+      checkOrigin = await props.client.checkMigration(urlProjectOrigin);
+      if (checkOrigin && checkOrigin.error !== undefined) {
+        setCurrentStatus({ status: "error", text: checkOrigin.error.reason });
+        setIsDatasetValid(false);
+        return false;
       }
     }
-    if ((waitedSeconds > 180 && job.state !== "IN_PROGRESS") || (waitedSeconds > 360 && job.state === "IN_PROGRESS")) {
-      handlers.setSubmitLoader({ value: false, text: "" });
-      handlers.setServerErrors(ImportStateMessage.TOO_LONG);
-      //here change the buttons???
-      // setTakingTooLong(true);
-      clearInterval(monitorJob);
+    catch (e) {
+      setCurrentStatus({ status: "error", text: "Invalid Dataset" });
+      setIsDatasetValid(false);
+      return false;
     }
-  }
+    setIsDatasetValid(true);
 
-  const monitorJobStatusAndHandleResponse = (job_id, projectPath, datasetName, handlers) => {
-    let cont = 0;
-    const INTERVAL = 6000;
-    let monitorJob = setInterval(() => {
-      props.client.getJobStatus(job_id, props.versionUrl)
-        .then(job => {
-          cont++;
-          if (job !== undefined) {
-            handleJobResponse(
-              job, monitorJob, cont * INTERVAL / 1000, projectPath, datasetName, handlers);
-          }
-        });
-    }, INTERVAL);
+    // check if the dataset project is supported
+    const projectVersion = checkOrigin.result.project_renku_version;
+    if (!checkOrigin.result.project_supported) {
+      setCurrentStatus({
+        status: "error",
+        text: `The dataset project version ${projectVersion} is not supported` });
+      return false;
+    }
+    setDatasetProjectVersion(projectVersion);
+    setCurrentStatus(null);
+    return projectVersion;
   };
 
-  const importDataset = (selectedProject, handlers) => {
+  const validateProject = async (project, validateOrigin) => {
+    if (!project)
+      return false;
+
+    //  start checking project
+    setCurrentStatus({ status: "checkingProject", text: null });
+    setCurrentStatus({ status: "inProcess", text: "Checking project status..." });
+    let originProjectVersion;
+    if (validateOrigin || datasetProjectVersion == null)
+      originProjectVersion = await validateDatasetProject();
+    else
+      originProjectVersion = datasetProjectVersion;
+
+    setCurrentStatus({ status: "inProcess", text: "Checking project status..." });
+    // check selected project migration status
+    const checkTarget = await props.client.checkMigration(project.value);
+    if (checkTarget && checkTarget.error !== undefined) {
+      setCurrentStatus({ status: "error", text: checkTarget.error.reason });
+      return false;
+    }
+
+    // check if the selected project doesn't need migration
+    if (checkTarget.result?.core_compatibility_status?.migration_required) {
+      setCurrentStatus({ status: "errorNeedMigration", text: null });
+      return false;
+    }
+
+    // check if dataset project version and selected project version has the same version
+    if (checkTarget.result.project_renku_version !== originProjectVersion) {
+      setCurrentStatus(
+        {
+          status: "error",
+          text: `Dataset Project version (${originProjectVersion})
+          and selected project version (${checkTarget.result.project_renku_version}) should be the same.` });
+      return false;
+    }
+    setCurrentStatus({ status: "validProject", text: "Selected Project is valid" });
+    return true;
+  };
+
+  const onSuggestionsFetchRequested = ( value, setSuggestions ) => {
+    const featured = props.projectsCoordinator.model.get("featured");
+    if (!featured.fetched || (!featured.starred.length && !featured.member.length))
+      return;
+
+    const regex = new RegExp(value, "i");
+    const searchDomain = featured.member.filter((project)=> {
+      return project.access_level >= ACCESS_LEVELS.MAINTAINER;
+    });
+
+    const hits = {};
+    const groupedSuggestions = [];
+
+    searchDomain.forEach(d => {
+      if (regex.exec(d.path_with_namespace) != null) {
+        hits[d.path_with_namespace] = {
+          "value": d.http_url_to_repo,
+          "name": d.path_with_namespace,
+          "subgroup": d.path_with_namespace.split("/")[0],
+          "id": d.id
+        };
+      }
+    });
+
+    const hitValues = Object.values(hits).sort((a, b) => (a.name > b.name) ? 1 : ((b.name > a.name) ? -1 : 0));
+    const groupedHits = groupBy(hitValues, item => item.subgroup);
+    for (var [key, val] of groupedHits) {
+      groupedSuggestions.push({
+        title: key,
+        suggestions: val
+      });
+    }
+    setCurrentStatus(null);
+    setSuggestions(groupedSuggestions);
+  };
+  /* end validate project */
+
+  /* import dataset */
+  const submitCallback = async (project) => {
+    if (!project)
+      setCurrentStatus({ status: "error", text: "Empty project" });
+
+    const isProjectValid = await validateProject(project, true);
+    if (isProjectValid) {
+      setCurrentStatus({ status: "inProcess", text: ImportStateMessage.ENQUEUED });
+      importDataset(project);
+    }
+  };
+
+  const importDataset = (selectedProject) => {
+    setImportingDataset(true);
     props.client.datasetImport(selectedProject.value, props.dataset.url, props.versionUrl)
       .then(response => {
         if (response.data.error !== undefined) {
-          handlers.setSubmitLoader({ value: false, text: "" });
-          handlers.setServerErrors(response.data.error.reason);
+          setCurrentStatus({ status: "error", text: response.data.error.reason });
+          setImportingDataset(false);
         }
         else {
           monitorJobStatusAndHandleResponse(
             response.data.result.job_id,
             selectedProject.name,
-            props.dataset.name,
-            handlers
+            props.dataset.name
           );
         }
       });
   };
 
-
-  const submitCallback = (e, mappedInputs, handlers) => {
-    handlers.setServerErrors(undefined);
-    handlers.setSubmitLoader({ value: true, text: ImportStateMessage.ENQUEUED });
-
-    const projectOptions = handlers.getFormDraftFieldProperty("project", ["options"]);
-
-    const selectedProject = projectOptions.find((project) =>
-      project.value === mappedInputs.project);
-
-    // TODO: is this what we want? Should we check that both the target and the source are up-to-date?
-    const target = selectedProject.value; // It was props.httpProjectUrl, but it's not always set
-    props.client.checkMigration(target).then((response) => {
-      if (response && response.error !== undefined) {
-        handlers.setSubmitLoader({ value: false, text: "" });
-        handlers.setServerErrors(response.error.reason);
-      }
-      else {
-        if (response.result.migration_required) {
-          handlers.setServerWarnings(selectedProject.name);
-          handlers.setSubmitLoader(false);
-        }
-        else {
-          importDataset(selectedProject, handlers);
+  const monitorJobStatusAndHandleResponse = (job_id, projectPath, datasetName) => {
+    let cont = 0;
+    const INTERVAL = 6000;
+    let monitorJob = setInterval(async () => {
+      try {
+        const job = await props.client.getJobStatus(job_id, props.versionUrl);
+        cont++;
+        if (job !== undefined) {
+          handleJobResponse(
+            job, monitorJob, cont * INTERVAL / 1000, projectPath, datasetName);
         }
       }
+      catch (e) {
+        setCurrentStatus({ status: "error", text: e.message });
+        setImportingDataset(false);
+        clearInterval(monitorJob);
+      }
+    }, INTERVAL);
+  };
+
+  function handleJobResponse(job, monitorJob, waitedSeconds, projectPath, datasetName) {
+    if (job) {
+      switch (job.state) {
+        case "ENQUEUED":
+          setCurrentStatus({ status: "inProcess", text: ImportStateMessage.ENQUEUED });
+          break;
+        case "IN_PROGRESS":
+          setCurrentStatus({ status: "inProcess", text: ImportStateMessage.IN_PROGRESS });
+          break;
+        case "COMPLETED":
+          setCurrentStatus({ status: "completed", text: ImportStateMessage.COMPLETED });
+          setImportingDataset(false);
+          clearInterval(monitorJob);
+          redirectUser(projectPath, datasetName);
+          break;
+        case "FAILED":
+          setCurrentStatus({ status: "error", text: ImportStateMessage.FAILED + job.extras.error });
+          setImportingDataset(false);
+          clearInterval(monitorJob);
+          break;
+        default:
+          setCurrentStatus({ status: "error", text: ImportStateMessage.FAILED_NO_INFO });
+          setImportingDataset(false);
+          clearInterval(monitorJob);
+          break;
+      }
+    }
+    if ((waitedSeconds > 180 && job.state !== "IN_PROGRESS") || (waitedSeconds > 360 && job.state === "IN_PROGRESS")) {
+      setCurrentStatus({ status: "error", text: ImportStateMessage.TOO_LONG });
+      setImportingDataset(false);
+      clearInterval(monitorJob);
+    }
+  }
+
+  const redirectUser = (projectPath, datasetName) => {
+    setCurrentStatus(null);
+    props.history.push({
+      pathname: `/projects/${projectPath}/datasets/${datasetName}`,
+      state: { reload: true }
     });
   };
+  /* end import dataset */
 
-  const initializeFunction = (formSchema, formHandlers) => {
-    let projectsField = formSchema.find(field => field.name === "project");
-    projectsField.customHandlers = {
-      onSuggestionsFetchRequested: ( value, reason, setSuggestions, handlers ) => {
-
-        formHandlers.setServerErrors(undefined);
-        formHandlers.setServerWarnings(undefined);
-
-        const featured = props.projectsCoordinator.model.get("featured");
-        if (!featured.fetched || (!featured.starred.length && !featured.member.length))
-          return;
-
-        const regex = new RegExp(value, "i");
-        const searchDomain = featured.member.filter((project)=> project.access_level >= ACCESS_LEVELS.MAINTAINER);
-
-        if (projectsField.options.length !== searchDomain.length) {
-          projectsField.options = searchDomain.map((project)=>({
-            "value": project.http_url_to_repo, "name": project.path_with_namespace, "id": project.id
-          }));
-        }
-
-        const hits = {};
-        const groupedSuggestions = [];
-
-        searchDomain.forEach(d => {
-          if (regex.exec(d.path_with_namespace) != null) {
-            hits[d.path_with_namespace] = {
-              "value": d.http_url_to_repo,
-              "name": d.path_with_namespace,
-              "subgroup": d.path_with_namespace.split("/")[0],
-              "id": d.id
-            };
-          }
-        });
-
-        const hitValues = Object.values(hits).sort((a, b) => (a.name > b.name) ? 1 : ((b.name > a.name) ? -1 : 0));
-        const groupedHits = groupBy(hitValues, item => item.subgroup);
-        for (var [key, val] of groupedHits) {
-          groupedSuggestions.push({
-            title: key,
-            suggestions: val
-          });
-        }
-        setSuggestions(groupedSuggestions);
-      }
-    };
+  // monitor to check when the list of projects is ready
+  const monitorProjectList = () => {
+    const INTERVAL = 2000;
+    projectsMonitorJob = setInterval(() => {
+      const featured = props.projectsCoordinator.model.get("featured");
+      const isReady = !(!featured.fetched || (!featured.starred.length && !featured.member.length));
+      setIsProjectsReady(isReady);
+      if (isReady)
+        clearInterval(projectsMonitorJob);
+    }, INTERVAL);
   };
 
+  const closeModal = () => {
+    props.setModalOpen(false);
+  };
+
+  const onCancel = () => {
+    closeModal();
+  };
+
+  const customHandlers = {
+    onSuggestionsFetchRequested,
+    onProjectSelected,
+  };
 
   return (
     <DatasetAdd
@@ -211,11 +301,12 @@ function AddDataset(props) {
       closeModal={closeModal}
       onCancel={onCancel}
       submitCallback={submitCallback}
-      addDatasetToProjectSchema={dsFormSchema}
       history={props.history}
-      initializeFunction={initializeFunction}
-      formLocation={props.formLocation}
-      model={props.model}
+      customHandlers={customHandlers}
+      currentStatus={currentStatus}
+      importingDataset={importingDataset}
+      isProjectsReady={isProjectsReady}
+      isDatasetValid={isDatasetValid}
     />
   );
 }

--- a/client/src/dataset/addtoproject/DatasetAdd.present.js
+++ b/client/src/dataset/addtoproject/DatasetAdd.present.js
@@ -29,7 +29,7 @@ import { Row, Col, Modal, ModalHeader, ModalBody } from "reactstrap";
 import { Button } from "reactstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCheck, faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
-import SelectautosuggestInput from "../../utils/components/formgenerator/fields/SelectAutosuggestInput";
+import SelectAutosuggestInput from "../../utils/components/SelectAutosuggestInput";
 import { ModalFooter } from "reactstrap/lib";
 import { Loader } from "../../utils/components/Loader";
 
@@ -100,7 +100,7 @@ function DatasetAdd(props) {
 
   let suggestionInput;
   if (props.isProjectsReady && props.isDatasetValid) {
-    suggestionInput = (<SelectautosuggestInput
+    suggestionInput = (<SelectAutosuggestInput
       existingValue={existingProject?.name || null}
       name="project"
       label="Project"

--- a/client/src/dataset/addtoproject/DatasetAdd.present.js
+++ b/client/src/dataset/addtoproject/DatasetAdd.present.js
@@ -123,7 +123,7 @@ function DatasetAdd(props) {
       <ModalHeader toggle={props.closeModal}>
         Add dataset to existing project
       </ModalHeader>
-      <ModalBody>
+      <ModalBody className={"text-break"}>
         <Row className="mb-3">
           <Col>
             <form onSubmit={onSubmit}>

--- a/client/src/dataset/addtoproject/DatasetAdd.present.js
+++ b/client/src/dataset/addtoproject/DatasetAdd.present.js
@@ -24,56 +24,119 @@
  */
 
 
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Row, Col, Modal, ModalHeader, ModalBody } from "reactstrap";
-import { FormGenerator } from "../../utils/components/formgenerator";
 import { Button } from "reactstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
+import { faCheck, faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
+import SelectautosuggestInput from "../../utils/components/formgenerator/fields/SelectAutosuggestInput";
+import { ModalFooter } from "reactstrap/lib";
+import { Loader } from "../../utils/components/Loader";
+
+function ImportDatasetStatus(status, text, existingProject, history) {
+  let statusProject = null;
+  switch (status) {
+    case "errorNeedMigration" :
+      statusProject = (
+        <div>
+          <FontAwesomeIcon icon={faExclamationTriangle} /> <strong>A new version of Renku is available.</strong>
+          <br />
+          The target project ({existingProject}) needs to be upgraded to allow
+          modification of datasets and is recommended for all projects.
+          <br />
+          <Button color="warning" onClick={() =>
+            history.push(`/projects/${existingProject}/overview/status`)}>More Info</Button>
+        </div>
+      );
+      break;
+    case "error" :
+      statusProject = <div><FontAwesomeIcon icon={faExclamationTriangle} /> {text}</div>;
+      break;
+    case "inProcess" :
+      statusProject = <div><Loader size="14" inline="true" /> {text}</div>;
+      break;
+    case "validProject" :
+      statusProject = <div><FontAwesomeIcon icon={faCheck} color={"var(--bs-success)"} /> {text}</div>;
+      break;
+    case "completed" :
+      statusProject = <div><FontAwesomeIcon icon={faCheck} color={"var(--bs-success)"} /> {text}</div>;
+      break;
+    default:
+      statusProject = null;
+  }
+  return statusProject;
+}
 
 function DatasetAdd(props) {
+  const [existingProject, setExistingProject] = useState(null);
 
-  const formatServerErrorsAndWarnings = (errorOrWarning, isError)=>{
-    const selectedProjectName = errorOrWarning;
-    if (!isError) {
-      return <div>
-        <FontAwesomeIcon icon={faExclamationTriangle} /> <strong>A new version of renku is available.</strong>
-        <br />
-        The target project ({selectedProjectName}) needs to be upgraded to allow
-        modification of datasets and is recommended for all projects.
-        <br />
-        <Button color="warning" onClick={() =>
-          props.history.push(`/projects/${selectedProjectName}/overview/status`)}>More Info</Button>
-      </div>;
-    }
-    return errorOrWarning;
-  };
+  useEffect( () => {
+    props.customHandlers.onProjectSelected(existingProject);
+  }, [existingProject]); // eslint-disable-line
 
+  const setProjectValue = value => setExistingProject(value);
+  const startImportDataset = () => props.submitCallback(existingProject);
+  const onSubmit = (e) => e.preventDefault();
+  let statusImportDataset = null;
+  if (props.currentStatus) {
+    statusImportDataset = ImportDatasetStatus(
+      props.currentStatus.status, props.currentStatus?.text || null, existingProject?.name, props.history);
+  }
+
+  /* buttons */
+  const addDatasetButton = (
+    <Button
+      color="primary"
+      disabled={props.currentStatus?.status !== "validProject" || props.importingDataset}
+      onClick={startImportDataset}>
+      Add Dataset
+    </Button>);
+
+  let closeButton = null;
+  if (props.modalOpen)
+    closeButton = <Button outline color="primary" onClick={props.closeModal}>Close</Button>;
+
+  /* end buttons */
+
+  let suggestionInput;
+  if (props.isProjectsReady && props.isDatasetValid) {
+    suggestionInput = (<SelectautosuggestInput
+      existingValue={existingProject?.name || null}
+      name="project"
+      label="Project"
+      placeholder="Select a project..."
+      customHandlers={props.customHandlers}
+      setInputs={setProjectValue}
+      options={props.options}
+      disabled={props.importingDataset || props.currentStatus?.status === "inProcess"}
+    />);
+  }
+  else if (props.isDatasetValid === null || props.isDatasetValid === false) {
+    suggestionInput = null;
+  }
+  else {
+    suggestionInput = <div><Loader size="14" inline="true" />{" "}Loading projects...</div>;
+  }
 
   return (
-    <Modal
-      isOpen={props.modalOpen}
-      toggle={props.closeModal}
-    >
+    <Modal isOpen={props.modalOpen} toggle={props.closeModal}>
       <ModalHeader toggle={props.closeModal}>
-        Add dataset to project
+        Add dataset to existing project
       </ModalHeader>
-      <ModalBody>
+      <ModalBody style={{ lineBreak: "anywhere" }}>
         <Row className="mb-3">
           <Col>
-            <FormGenerator
-              btnName={"Add Dataset"}
-              submitCallback={!props.takingTooLong ? props.submitCallback : undefined}
-              model={props.addDatasetToProjectSchema}
-              onCancel={props.onCancel}
-              formLocation={props.formLocation}
-              modelTop={props.model}
-              initializeFunction={props.initializeFunction}
-              formatServerErrorsAndWarnings={formatServerErrorsAndWarnings}
-            />
+            <form onSubmit={onSubmit}>
+              {suggestionInput}
+              {statusImportDataset}
+            </form>
           </Col>
         </Row>
       </ModalBody>
+      <ModalFooter>
+        {closeButton}
+        {addDatasetButton}
+      </ModalFooter>
     </Modal>
   );
 }

--- a/client/src/dataset/addtoproject/DatasetAdd.present.js
+++ b/client/src/dataset/addtoproject/DatasetAdd.present.js
@@ -25,13 +25,15 @@
 
 
 import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import { Row, Col, Modal, ModalHeader, ModalBody } from "reactstrap";
 import { Button } from "reactstrap";
+import { ModalFooter } from "reactstrap/lib";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCheck, faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
-import SelectAutosuggestInput from "../../utils/components/SelectAutosuggestInput";
-import { ModalFooter } from "reactstrap/lib";
+
 import { Loader } from "../../utils/components/Loader";
+import SelectAutosuggestInput from "../../utils/components/SelectAutosuggestInput";
 
 function ImportDatasetStatus(status, text, existingProject, history) {
   let statusProject = null;
@@ -39,13 +41,11 @@ function ImportDatasetStatus(status, text, existingProject, history) {
     case "errorNeedMigration" :
       statusProject = (
         <div>
-          <FontAwesomeIcon icon={faExclamationTriangle} /> <strong>A new version of Renku is available.</strong>
+          <FontAwesomeIcon icon={faExclamationTriangle} /> <strong>This project must be upgraded.</strong>
           <br />
-          The target project ({existingProject}) needs to be upgraded to allow
-          modification of datasets and is recommended for all projects.
+          The target project ({existingProject}) needs to be upgraded before datasets can be imported into it.
           <br />
-          <Button color="warning" onClick={() =>
-            history.push(`/projects/${existingProject}/overview/status`)}>More Info</Button>
+          <i className="pt-2"><Link to={`/projects/${existingProject}/overview/status`}>More info</Link></i>
         </div>
       );
       break;
@@ -123,7 +123,7 @@ function DatasetAdd(props) {
       <ModalHeader toggle={props.closeModal}>
         Add dataset to existing project
       </ModalHeader>
-      <ModalBody style={{ lineBreak: "anywhere" }}>
+      <ModalBody>
         <Row className="mb-3">
           <Col>
             <form onSubmit={onSubmit}>

--- a/client/src/model/RenkuModels.js
+++ b/client/src/model/RenkuModels.js
@@ -555,25 +555,6 @@ const datasetImportFormSchema = new Schema({
   }
 });
 
-const addDatasetToProjectSchema = new Schema({
-  project: {
-    initial: "",
-    name: "project",
-    label: "Project",
-    placeholder: "Select a project...",
-    type: FormGenerator.FieldTypes.SELECTAUTOSUGGEST,
-    options: [
-    ],
-    validators: [
-      {
-        id: "valid-option",
-        isValidFun: expression => FormGenerator.Validators.optionExists(expression),
-        alert: "Selected project is not valid"
-      }
-    ]
-  }
-});
-
 const environmentSchema = new Schema({
   fetched: { [Prop.INITIAL]: null, [Prop.MANDATORY]: true },
   fetching: { [Prop.INITIAL]: false, [Prop.MANDATORY]: true },
@@ -618,7 +599,7 @@ const formGeneratorSchema = new Schema({
 });
 
 export {
-  addDatasetToProjectSchema, datasetFormSchema, datasetImportFormSchema, environmentSchema,
+  datasetFormSchema, datasetImportFormSchema, environmentSchema,
   formGeneratorSchema, issueFormSchema, newProjectSchema, notebooksSchema, notificationsSchema,
   projectSchema, projectsSchema, statuspageSchema, userSchema
 };

--- a/client/src/project/shared/Projects.state.js
+++ b/client/src/project/shared/Projects.state.js
@@ -99,7 +99,6 @@ class ProjectsCoordinator {
           fetching: false
         }
       });
-
       return { starred: values[0], member: values[1] };
     });
   }

--- a/client/src/utils/components/SelectAutosuggestInput.js
+++ b/client/src/utils/components/SelectAutosuggestInput.js
@@ -25,13 +25,13 @@
 
 import * as React from "react";
 import { useState } from "react";
-import ValidationAlert from "./ValidationAlert";
-import HelpText from "./HelpText";
-import FormLabel from "./FormLabel";
+import ValidationAlert from "./formgenerator/fields/ValidationAlert";
+import HelpText from "./formgenerator/fields/HelpText";
+import FormLabel from "./formgenerator/fields/FormLabel";
 import { FormGroup } from "reactstrap";
 import Autosuggest from "react-autosuggest";
 
-function SelectautosuggestInput({ name, label, existingValue, alert, options,
+function SelectAutosuggestInput({ name, label, existingValue, alert, options,
   placeholder, setInputs, help, customHandlers, disabled = false, required = false }) {
   const [localValue, setLocalValue] = useState(null);
   const [suggestions, setSuggestions ] = useState([]);
@@ -143,4 +143,4 @@ function SelectautosuggestInput({ name, label, existingValue, alert, options,
   </FormGroup>;
 }
 
-export default SelectautosuggestInput;
+export default SelectAutosuggestInput;

--- a/client/src/utils/components/formgenerator/FormGenerator.present.js
+++ b/client/src/utils/components/formgenerator/FormGenerator.present.js
@@ -29,7 +29,6 @@ import TextInput from "./fields/TextInput";
 import TextareaInput from "./fields/TexAreaInput";
 import SelectInput from "./fields/SelectInput";
 import CreatorsInput from "./fields/CreatorsInput";
-import SelectautosuggestInput from "./fields/SelectAutosuggestInput";
 import CktextareaInput from "./fields/CKEditorTextArea";
 import FileUploaderInput from "./fields/FileUploaderInput";
 import KeywordsInput from "./fields/KeywordsInput";
@@ -87,7 +86,6 @@ function FormPanel({
     ImageInput,
     KeywordsInput,
     SelectInput,
-    SelectautosuggestInput,
     TextInput,
     TextareaInput,
   };

--- a/client/src/utils/components/formgenerator/README.md
+++ b/client/src/utils/components/formgenerator/README.md
@@ -15,7 +15,6 @@ Currently the form has 9 fields types:
 - File(s): used to input files, at the moment this was created to work with the core-service. Accepts local files and links (i.e dropbox). Inputs are uploaded to the core-service. Can uncompress files, display progress, errors per file, ...
 - Image: used to upload images.
 - Keywords: used to input keywords. You need to write a keyword and press enter for the keyword to be taken, you can delete keywords with a click.
-- SelectAutosuggest: this field is used inside the "add dataset to project" form, is used to suggest the user project paths where the dataset can be added.
 - Select: classic dropdown input.
 
 Field properties (shared):

--- a/client/src/utils/components/formgenerator/fields/SelectAutosuggestInput.js
+++ b/client/src/utils/components/formgenerator/fields/SelectAutosuggestInput.js
@@ -31,13 +31,12 @@ import FormLabel from "./FormLabel";
 import { FormGroup } from "reactstrap";
 import Autosuggest from "react-autosuggest";
 
-function SelectautosuggestInput({ name, label, type, value, alert, options, initial,
+function SelectautosuggestInput({ name, label, existingValue, alert, options,
   placeholder, setInputs, help, customHandlers, disabled = false, required = false }) {
-
-  const [localValue, setLocalValue] = useState("");
+  const [localValue, setLocalValue] = useState(null);
   const [suggestions, setSuggestions ] = useState([]);
 
-  const getSuggestions = (value, reason) => {
+  const getSuggestions = (value) => {
     const inputValue = value.trim().toLowerCase();
     const inputLength = inputValue.length;
 
@@ -48,47 +47,32 @@ function SelectautosuggestInput({ name, label, type, value, alert, options, init
 
   const getSuggestionValue = suggestion => suggestion;
 
-  const renderSuggestion = suggestion => (
-    <span>
-      {suggestion.name}
-    </span>
-  );
+  const renderSuggestion = suggestion => <span>{suggestion.name}</span>;
 
-  const onSuggestionSelected = (event, { method }) => {
+  const onSuggestionSelected = (event, { suggestion, method }) => {
     if (method === "enter")
       event.preventDefault();
+    setLocalValue(suggestion.name);
+    setInputs(suggestion);
+  };
+
+  const onSuggestionsFetchRequested = ({ value }) => {
+    if (customHandlers.onSuggestionsFetchRequested)
+      customHandlers.onSuggestionsFetchRequested(value, setSuggestions);
+    else
+      setSuggestions(getSuggestions(value));
   };
 
   const onChange = (event, { newValue, method }) => {
+    if (method === "enter")
+      event.preventDefault();
     if (method !== "type") {
       setLocalValue(newValue.name);
-      const artificialEvent = {
-        target: { name: name, value: newValue !== undefined ? newValue.value : "" },
-        isPersistent: () => false
-      };
-      setInputs(artificialEvent);
     }
     else {
       // If the user typed, store it as local input, otherwise set the selection
       setLocalValue(newValue);
-      const selectedOption = options.find(option => option.name === newValue );
-      const artificialEvent = {
-        target: { name: name, value: selectedOption !== undefined ? selectedOption.value : "" },
-        isPersistent: () => false
-      };
-      setInputs(artificialEvent);
     }
-
-  };
-
-  // Autosuggest will call this function every time you need to update suggestions.
-  // You already implemented this logic above, so just use it.
-  // TODO allow custom handlers for more events
-  const onSuggestionsFetchRequested = ({ value, reason }) => {
-    if (customHandlers.onSuggestionsFetchRequested)
-      customHandlers.onSuggestionsFetchRequested(value, reason, setSuggestions);
-    else
-      setSuggestions( getSuggestions(value, reason));
   };
 
   // Autosuggest will call this function every time you need to clear suggestions.
@@ -104,10 +88,12 @@ function SelectautosuggestInput({ name, label, type, value, alert, options, init
     return <strong>{section.title}</strong>;
   };
 
-  // Autosuggest will pass through all these props to the input.
+  // Allow to set existing value of it exist when load for first time the component
+  const defaultValue = localValue === null && existingValue?.length > 0 ? existingValue : localValue;
+
   const inputProps = {
     placeholder: placeholder,
-    value: localValue || "",
+    value: defaultValue || "",
     onChange: onChange,
     disabled: disabled
   };
@@ -150,6 +136,7 @@ function SelectautosuggestInput({ name, label, type, value, alert, options, init
       theme={theme}
       shouldRenderSuggestions={(v) => true}
       onSuggestionSelected={onSuggestionSelected}
+      focusInputOnSuggestionClick={false}
     />
     <HelpText content={help} />
     <ValidationAlert content={alert} />

--- a/client/src/utils/components/formgenerator/fields/index.js
+++ b/client/src/utils/components/formgenerator/fields/index.js
@@ -30,7 +30,6 @@ export default {
     TEXT_EDITOR: "cktextarea",
     FILES: "fileUploader",
     SELECT: "select",
-    SELECTAUTOSUGGEST: "selectautosuggest",
     CREATORS: "creators",
     KEYWORDS: "keywords",
     IMAGE: "image"


### PR DESCRIPTION
This PR refactors the AddDataset component to not use FormGenerator.
This PR also includes:
+ Adding loading animation if the project list is not ready
+ Validation when the dataset project does not exist
+ Validation if the version of the dataset project is not supported
+ Validation if the version of the dataset project and the selected project are not the same


![addDatasetToProject](https://user-images.githubusercontent.com/43388408/152553659-47946bb7-a2c8-4d13-ab27-0b19984e219b.gif)


# Cases to test:
- The dataset project does not exist
- The dataset project version is not supported
- The project selected needs migration
- The project selected version is not supported 
-  The project selected version and the dataset project version has a different version
- The dataset is not activated in kg

# Screenshots

**v8 dataset, v9 project**
<img width="1174" alt="image" src="https://user-images.githubusercontent.com/1196411/153164272-7b8dd37e-69b2-410e-b57b-1fe80432f446.png">

**v8 dataset, v8 project**
<img width="1174" alt="image" src="https://user-images.githubusercontent.com/1196411/153164366-1d7bfeae-4350-4a42-b3eb-905c109f8786.png">


**v4 dataset, v4 project**

<img width="1174" alt="image" src="https://user-images.githubusercontent.com/1196411/153164113-9b1332b3-5c78-404b-bbc0-e835f5ff01f6.png">



/deploy #persist