### PR TITLE
Use the new usedIn field to get dataset projects

### DIFF
--- a/client/src/dataset/Dataset.present.js
+++ b/client/src/dataset/Dataset.present.js
@@ -429,9 +429,9 @@ export default function DatasetView(props) {
     {
       //here we assume that if the dataset is only in one project
       //this one project is the current project and we don't display the list
-      (dataset.isPartOf && dataset.isPartOf.length > 1) || !props.insideProject ?
+      (dataset.usedIn && dataset.usedIn.length > 1) || !props.insideProject ?
         <DisplayProjects
-          projects={dataset.isPartOf}
+          projects={dataset.usedIn}
           projectsUrl={props.projectsUrl}
         />
         : null


### PR DESCRIPTION
# Testing

Look at the dataset view on https://dev.renku.ch and see that projects are not displayed there. Compare with the PR deployment were projects are shown.

# Screenshots

<img width="1275" alt="image" src="https://user-images.githubusercontent.com/1196411/152947328-99d60965-de5f-4530-af1c-0240c4bdeaef.png">

/deploy #persist
