### PR TITLE
feat(chart)!: use global redis

### DIFF
--- a/helm-chart/renku-ui-server/requirements.lock
+++ b/helm-chart/renku-ui-server/requirements.lock
@@ -1,9 +1,6 @@
 dependencies:
-- name: redis
-  repository: https://charts.bitnami.com/bitnami
-  version: 10.7.11
 - name: certificates
   repository: https://swissdatasciencecenter.github.io/helm-charts/
   version: 0.0.1
-digest: sha256:4b8b48caa00825e471f2d379f5384d853f509ea3a9b32d3e904c9aa885bbbc59
-generated: "2022-01-26T14:46:56.715585+01:00"
+digest: sha256:405914c6b5d6eb9ba72165de7aa4b815c71b310daabfdbef79c365fc032787ae
+generated: "2022-02-16T16:25:03.784364+01:00"

--- a/helm-chart/renku-ui-server/requirements.yaml
+++ b/helm-chart/renku-ui-server/requirements.yaml
@@ -1,8 +1,4 @@
 dependencies:
-- name: redis
-  version: 10.7.11
-  repository: "https://charts.bitnami.com/bitnami"
-  condition: redis.install
 - name: certificates
   version: "0.0.1"
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"

--- a/helm-chart/renku-ui-server/templates/deployment.yaml
+++ b/helm-chart/renku-ui-server/templates/deployment.yaml
@@ -17,9 +17,8 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "ui-server.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
-        {{- if .Values.redis.install }}
-        {{ include "call-nested" (list . "redis" "redis.fullname") }}-client: "true"
-        {{- end }}
+        # The label below enables the gateway to connect to redis
+        {{ .Values.global.redis.clientLabel | toYaml | nindent 8 }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -75,25 +74,21 @@ spec:
             - name: SENTRY_DEBUG
               value: {{ .Values.sentry.debugMode | quote }}
             {{- end }}
-            {{- if .Values.redis.install }}
             - name: REDIS_HOST
-              value: {{ include "call-nested" (list . "redis" "redis.fullname") }}-master
-            - name: REDIS_PORT
-              value: "6379"
+              value: {{ .Values.global.redis.host | quote }}
+            - name: REDIS_IS_SENTINEL
+              value: {{ .Values.global.redis.sentinel.enabled | quote }}
+            - name: REDIS_MASTER_SET
+              value: {{ .Values.global.redis.sentinel.masterSet | quote }}
             - name: REDIS_DATABASE
-              value: "0"
-            - name: REDIS_PASSWORD
-              value:
-            {{ else }}
-            - name: REDIS_HOST
-              value: {{ .Values.redis.external.host | quote }}
+              value: {{ .Values.global.redis.dbIndex.uiServer | quote }}
             - name: REDIS_PORT
-              value: {{ .Values.redis.external.port | quote }}
-            - name: REDIS_DATABASE
-              value: {{ .Values.redis.external.database | default (printf "0") | quote }}
+              value: {{ .Values.global.redis.port | quote }}
             - name: REDIS_PASSWORD
-              value: {{ .Values.redis.external.password | default (printf "") | quote }}
-            {{- end }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.redis.existingSecret }}
+                  key: {{ .Values.global.redis.existingSecretPasswordKey }}
           livenessProbe:
             httpGet:
               path: /liveness

--- a/helm-chart/renku-ui-server/values.yaml
+++ b/helm-chart/renku-ui-server/values.yaml
@@ -15,6 +15,21 @@ global:
     customCAs: []
       # - secret:
 
+  ## Specify the information required to connect to a redis instance.
+  ## All the values below are required.
+  redis:
+    sentinel:
+      enabled: true
+      masterSet: mymaster
+    dbIndex:
+      uiServer: "2"
+    host: renku-redis
+    port: 26379
+    clientLabel: 
+      renku-redis-host: "true"
+    existingSecret: redis-secret
+    existingSecretPasswordKey: redis-password
+
 replicaCount: 1
 
 image:
@@ -102,28 +117,3 @@ authentication:
   id: renku-ui
   # secret: 1234abcd # do not provide any value here to use the global gateway client secret
   expirationTolerance: 10 # in seconds
-
-# ui-server dedicate redis
-redis:
-  # if you don't install a local redis instance, fill in the `external` variables (database and password optional)
-  install: true
-  external:
-    host:
-    port:
-    database:
-    password:
-
-  nameOverride: ui-server-redis
-
-  cluster:
-    enabled: false
-
-  usePassword: false
-
-  master:
-    persistence:
-      enabled: false
-
-  networkPolicy:
-    enabled: true
-    allowExternal: false

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -63,6 +63,8 @@ const REDIS = {
   port: convertType(process.env.REDIS_PORT) || 6379,
   database: process.env.REDIS_DATABASE || "0",
   password: process.env.REDIS_PASSWORD || null,
+  isSentinel: (process.env.REDIS_IS_SENTINEL || "false") == "true",
+  masterSet: process.env.REDIS_MASTER_SET || "mymaster",
 };
 
 const ROUTES = {

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -63,7 +63,7 @@ const REDIS = {
   port: convertType(process.env.REDIS_PORT) || 6379,
   database: process.env.REDIS_DATABASE || "0",
   password: process.env.REDIS_PASSWORD || null,
-  isSentinel: (process.env.REDIS_IS_SENTINEL || "false") == "true",
+  isSentinel: convertType(process.env.REDIS_IS_SENTINEL) || false,
   masterSet: process.env.REDIS_MASTER_SET || "mymaster",
 };
 

--- a/server/src/storage/RedisStorage.ts
+++ b/server/src/storage/RedisStorage.ts
@@ -28,7 +28,7 @@ class RedisStorage implements Storage {
     host: string = config.redis.host,
     port: number = config.redis.port as number,
     password: string = config.redis.password,
-    isSentinel: boolean = config.redis.isSentinel,
+    isSentinel: boolean = config.redis.isSentinel as boolean,
     masterSet: string = config.redis.masterSet,
   ) {
     // configure redis
@@ -40,15 +40,15 @@ class RedisStorage implements Storage {
           10000;
       },
     };
-    if (isSentinel){
+    if (isSentinel) {
       redisConfig.sentinels = [
         { host, port },
       ];
       redisConfig.name = masterSet;
-      if (password) {
+      if (password)
         redisConfig.sentinelPassword = password;
-      }
-    } else {
+    }
+    else {
       redisConfig.host = host;
       redisConfig.port = port;
     }

--- a/server/src/storage/RedisStorage.ts
+++ b/server/src/storage/RedisStorage.ts
@@ -27,12 +27,12 @@ class RedisStorage implements Storage {
   constructor(
     host: string = config.redis.host,
     port: number = config.redis.port as number,
-    password: string = config.redis.password
+    password: string = config.redis.password,
+    isSentinel: boolean = config.redis.isSentinel,
+    masterSet: string = config.redis.masterSet,
   ) {
     // configure redis
     const redisConfig: Redis.RedisOptions = {
-      host,
-      port,
       lazyConnect: true,
       retryStrategy: (times) => {
         return times > 5 ?
@@ -40,6 +40,18 @@ class RedisStorage implements Storage {
           10000;
       },
     };
+    if (isSentinel){
+      redisConfig.sentinels = [
+        { host, port },
+      ];
+      redisConfig.name = masterSet;
+      if (password) {
+        redisConfig.sentinelPassword = password;
+      }
+    } else {
+      redisConfig.host = host;
+      redisConfig.port = port;
+    }
     if (password)
       redisConfig.password = password;
     try {


### PR DESCRIPTION
Hopefully I did this right. It is really cool that you use typescript in the ui server. I did not know this.

With this change everything the ui server needs is specified in the global redis section. So if someone brings their own redis then they do not install the redis chart bundled with renku but they fill out all stuff in global.redis. If people use the included redis then they can stick with the defaults and everything should work. If they change the defaults then the global.redis section and regular redis section need to be compatible and some values between the two will be duplicated.

**THIS IS A BREAKING CHANGE FOR THE HELM CHART**

/deploy #persist

~Please add any comments on the helm chart and its organization in the parent PR in the renku repo at https://github.com/SwissDataScienceCenter/renku/pull/2483. That way we can all agree on the any potential changes to the helm chart.~