### PR TITLE
feat: strip '-' from dataset identifiers

### DIFF
--- a/client/src/api-client/dataset.js
+++ b/client/src/api-client/dataset.js
@@ -14,6 +14,16 @@ function addMarqueeImageToDataset(gitUrl, dataset) {
   return dataset;
 }
 
+/**
+ * Remove dashes from the dataset identifier
+ * @param {object} dataset
+ */
+function cleanDatasetId(dataset) {
+  if (dataset.identifier)
+    dataset.identifier = dataset.identifier.replace(/-/g, "");
+  return dataset;
+}
+
 export default function addDatasetMethods(client) {
 
   client.searchDatasets = (queryParams = { query: "" }) => {
@@ -303,8 +313,11 @@ export default function addDatasetMethods(client) {
       headers,
       queryParams
     }).then((response) => {
-      if (response.data.result && response.data.result.datasets.length > 0)
-        response.data.result.datasets.map((d) => addMarqueeImageToDataset(git_url, d));
+      if (response.data.result && response.data.result.datasets.length > 0) {
+        response.data.result.datasets.map((d) =>
+          addMarqueeImageToDataset(git_url, cleanDatasetId(d))
+        );
+      }
 
       return response;
     }).catch(error => ({

--- a/e2e/cypress/support/renkulab-fixtures/datasets.ts
+++ b/e2e/cypress/support/renkulab-fixtures/datasets.ts
@@ -18,10 +18,14 @@
 
 import { FixturesConstructor } from "./fixtures";
 
+function toLegacyIdentifier(datasetId) {
+  return datasetId.slice(0, 8) + "-" + datasetId.slice(8, 12) + "-" + datasetId.slice(12, 16) +
+    "-" + datasetId.slice(16, 20) + "-" + datasetId.slice(20);
+}
+
 /**
  * Fixtures for Datasets
  */
-
 function Datasets<T extends FixturesConstructor>(Parent: T) {
   return class DatasetsFixtures extends Parent {
 
@@ -67,6 +71,20 @@ function Datasets<T extends FixturesConstructor>(Parent: T) {
         "/ui-server/api/renku/*/datasets.list?git_url=*",
         fixture
       ).as(name);
+      return this;
+    }
+
+    projectDatasetLegacyIdList(name = "datasetList", resultFile = "datasets/project-dataset-list.json") {
+      if (!this.useMockedData) return;
+      cy.fixture(resultFile).then((result) => {
+        for (const ds of result.result.datasets)
+          ds.identifier = toLegacyIdentifier(ds.identifier);
+        cy.intercept(
+          "GET",
+          "/ui-server/api/renku/*/datasets.list?git_url=*",
+          result
+        ).as(name);
+      });
       return this;
     }
 


### PR DESCRIPTION
# Testing

This PR fixes the dataset identifiers returned from the core service to match the identifiers in the KG.

To test, look at a dataset in an older project. Before this fix, the dataset is not recognized as being in the KG, since the identifiers do not match, so the dataset cannot be added to projects and there is a warning. With the fix, the dataset is found in the KG.

**Without fix**
https://dev.renku.ch/projects/cramakri/test-8-cloned/datasets/v8-dataset/

<img width="1151" alt="image" src="https://user-images.githubusercontent.com/1196411/156024823-dffccc7e-d424-43cf-b3c3-ba2c1cf07c28.png">


**With fix**
https://renku-ci-ui-1716.dev.renku.ch/projects/cramakri/test-8-cloned/datasets/v8-dataset/

<img width="1151" alt="image" src="https://user-images.githubusercontent.com/1196411/156024748-a2a801d8-9f37-4ffe-80bb-489a7933be9f.png">


Fix #1694

/deploy #persist renku=000-acceptance-tests