### PR TITLE
feat(client): use simplified session state (#1646)

### DIFF
--- a/client/src/notebooks/NotebookStart.present.js
+++ b/client/src/notebooks/NotebookStart.present.js
@@ -41,6 +41,7 @@ import { Url } from "../utils/helpers/url";
 import Time from "../utils/helpers/Time";
 import { NotebooksHelper } from "./index";
 import { ObjectStoresConfigurationButton, ObjectStoresConfigurationModal } from "./ObjectStoresConfig.present";
+import { SessionStatus } from "../utils/constants/Notebooks";
 
 // * StartNotebookServer code * //
 function StartNotebookServer(props) {
@@ -757,8 +758,8 @@ class StartNotebookOptionsRunning extends Component {
   render() {
     const { notebook } = this.props;
 
-    const status = NotebooksHelper.getStatus(notebook.status);
-    if (status === "running") {
+    const status = notebook.status?.state;
+    if (status === SessionStatus.running) {
       const annotations = NotebooksHelper.cleanAnnotations(notebook.annotations, "renku.io");
       const localUrl = Url.get(Url.pages.project.session.show, {
         namespace: annotations["namespace"],
@@ -778,7 +779,7 @@ class StartNotebookOptionsRunning extends Component {
         </FormGroup>
       );
     }
-    else if (status === "pending" || status === "stopping") {
+    else if (status === SessionStatus.starting || status === SessionStatus.stopping) {
       return (
         <FormGroup>
           <Label>A session for this commit is starting or terminating, please wait...</Label>
@@ -1164,15 +1165,15 @@ class CheckNotebookIcon extends Component {
 
     let tooltip, link, icon, aligner = null;
     if (notebook) {
-      const status = NotebooksHelper.getStatus(notebook.status);
-      if (status === "running") {
+      const status = notebook.status?.state;
+      if (status === SessionStatus.running) {
         tooltip = "Connect to JupyterLab";
         icon = (<JupyterIcon svgClass="svg-inline--fa fa-w-16 icon-link" />);
         const url = `${notebook.url}/lab/tree/${this.props.filePath}`;
         link = (<a href={url} role="button" target="_blank" rel="noreferrer noopener">{icon}</a>);
       }
-      else if (status === "pending" || status === "stopping") {
-        tooltip = status === "stopping" ?
+      else if (status === SessionStatus.starting || status === SessionStatus.stopping) {
+        tooltip = status === SessionStatus.stopping ?
           "The session is stopping, please wait..." :
           "The session is starting, please wait...";
         aligner = "pb-1";

--- a/client/src/notebooks/Notebooks.container.js
+++ b/client/src/notebooks/Notebooks.container.js
@@ -133,6 +133,7 @@ class ShowSession extends Component {
         target={this.target}
         handlers={this.handlers}
         store={this.model.reduxStore}
+        history={this.props.history}
       />
     );
   }

--- a/client/src/notebooks/Notebooks.present.js
+++ b/client/src/notebooks/Notebooks.present.js
@@ -856,28 +856,34 @@ function getStatusObject(status, defaultImage) {
 
 class NotebooksServerRowStatus extends Component {
   render() {
-    const { status, details, uid, annotations } = this.props;
+    const { status, details, uid, annotations, startTime } = this.props;
     const data = getStatusObject(status, annotations.default_image_used);
+    const textColor = {
+      "running": "text-secondary",
+      "failed": "text-danger",
+      "starting": "text-secondary",
+      "stopping": "text-secondary",
+    };
 
-    if (status === SessionStatus.running) {
-      return <span className="time-caption font-weight-bold text-secondary">
-        {data.text} since {this.props.startTime}</span>;
-    }
+    const textStatus = status === SessionStatus.running ? `${data.text} since ${startTime}` : data.text;
 
-    const info = !details.message ?
-      (<span className="time-caption font-weight-bold text-secondary">{data.text}</span>) :
-      (<span className="time-caption font-weight-bold text-secondary">
-        {data.text}&nbsp;
-        <FontAwesomeIcon id={uid} icon={faInfoCircle} />
+    const extraInfo = details.message ?
+      (<>
+        {" "}<FontAwesomeIcon id={uid} icon={faInfoCircle} />
         <UncontrolledPopover target={uid} trigger="legacy" placement="bottom">
           <PopoverHeader>Kubernetes pod status</PopoverHeader>
           <PopoverBody>
             <span>{details.message}</span><br />
           </PopoverBody>
         </UncontrolledPopover>
-      </span>);
+      </>) : null;
 
-    return <div>{info}</div>;
+    return <>
+      <span className={`time-caption font-weight-bold ${textColor[status]}`}>
+        {textStatus}
+        {extraInfo}
+      </span>
+    </>;
   }
 }
 

--- a/client/src/notebooks/Notebooks.present.js
+++ b/client/src/notebooks/Notebooks.present.js
@@ -50,6 +50,7 @@ import {
 } from "./NotebookStart.present";
 
 import "./Notebooks.css";
+import { SessionStatus } from "../utils/constants/Notebooks";
 
 
 // * Constants and helpers * //
@@ -106,6 +107,10 @@ function ShowSession(props) {
     namespace: filters.namespace,
     path: filters.project,
   });
+
+  // redirect immediately if the session fail
+  if (props.history && notebook.data.status.state === SessionStatus.failed)
+    props.history.push(urlList);
 
   // Always add all sub-components and hide them one by one to preserve the iframe navigation where needed
   return (
@@ -331,8 +336,8 @@ function SessionJupyter(props) {
 
   let content = null;
   if (notebook.available) {
-    const status = NotebooksHelper.getStatus(notebook.data.status);
-    if (status === "running") {
+    const status = notebook.data.status.state;
+    if (status === SessionStatus.running) {
       const localClass = invisible ?
         "invisible position-absolute" : // ? position-absolute prevent showing extra margins
         "";
@@ -346,7 +351,7 @@ function SessionJupyter(props) {
     else if (invisible) {
       return null;
     }
-    else if (status === "pending" || status === "stopping") {
+    else if (status === SessionStatus.starting || status === SessionStatus.stopping) {
       content = (<Loader />);
     }
   }
@@ -549,11 +554,9 @@ class NotebookServersList extends Component {
 class NotebookServerRow extends Component {
   render() {
     const annotations = NotebooksHelper.cleanAnnotations(this.props.annotations, "renku.io");
-    const status = NotebooksHelper.getStatus(this.props.status);
+    const status = this.props.status.state;
     const details = {
-      message: this.props.status.message,
-      reason: this.props.status.reason,
-      step: this.props.status.step,
+      message: this.props.status.message
     };
     const uid = "uid_" + simpleHash(annotations["namespace"] + annotations["projectName"]
       + annotations["branch"] + annotations["commit-sha"]);
@@ -814,7 +817,7 @@ class NotebookServerRowCompact extends Component {
 
 function getStatusObject(status, defaultImage) {
   switch (status) {
-    case "running":
+    case SessionStatus.running:
       return {
         color: defaultImage ?
           "warning" :
@@ -824,19 +827,19 @@ function getStatusObject(status, defaultImage) {
           (<FontAwesomeIcon icon={faCheckCircle} size="lg" />),
         text: "Running"
       };
-    case "pending":
+    case SessionStatus.starting:
       return {
         color: "warning",
         icon: <Loader size="16" inline="true" />,
-        text: "Pending"
+        text: "Starting..."
       };
-    case "stopping":
+    case SessionStatus.stopping:
       return {
         color: "warning",
         icon: <Loader size="16" inline="true" />,
-        text: "Stopping session"
+        text: "Stopping session..."
       };
-    case "error":
+    case SessionStatus.failed:
       return {
         color: "danger",
         icon: <FontAwesomeIcon icon={faTimesCircle} size="lg" />,
@@ -855,20 +858,24 @@ class NotebooksServerRowStatus extends Component {
   render() {
     const { status, details, uid, annotations } = this.props;
     const data = getStatusObject(status, annotations.default_image_used);
-    const info = status !== "running" ?
+
+    if (status === SessionStatus.running) {
+      return <span className="time-caption font-weight-bold text-secondary">
+        {data.text} since {this.props.startTime}</span>;
+    }
+
+    const info = !details.message ?
+      (<span className="time-caption font-weight-bold text-secondary">{data.text}</span>) :
       (<span className="time-caption font-weight-bold text-secondary">
         {data.text}&nbsp;
         <FontAwesomeIcon id={uid} icon={faInfoCircle} />
         <UncontrolledPopover target={uid} trigger="legacy" placement="bottom">
           <PopoverHeader>Kubernetes pod status</PopoverHeader>
           <PopoverBody>
-            <span className="font-weight-bold">Step:</span> <span>{details.step}</span><br />
-            <span className="font-weight-bold">Reason:</span> <span>{details.reason}</span><br />
-            <span className="font-weight-bold">Message:</span> <span>{details.message}</span><br />
+            <span>{details.message}</span><br />
           </PopoverBody>
         </UncontrolledPopover>
-      </span>) :
-      (<span className="time-caption font-weight-bold text-secondary">{data.text} since {this.props.startTime}</span>);
+      </span>);
 
     return <div>{info}</div>;
   }
@@ -886,7 +893,7 @@ class NotebooksServerRowStatusIcon extends Component {
       (<span><br /><span className="font-weight-bold">Warning:</span> a fallback image was used.</span>) :
       null;
 
-    const popover = !image || status !== "running" ?
+    const popover = !image || status !== SessionStatus.running ?
       null :
       (
         <UncontrolledPopover target={id} trigger="legacy" placement="bottom">
@@ -928,7 +935,7 @@ const NotebookServerRowAction = memo((props) => {
     <FontAwesomeIcon icon={faFileAlt} /> Get logs
   </DropdownItem>);
 
-  if (status !== "stopping") {
+  if (status !== SessionStatus.stopping) {
     actions.stop = <Fragment>
       <DropdownItem divider />
       <DropdownItem onClick={() => props.stopNotebook(name)}>
@@ -936,7 +943,7 @@ const NotebookServerRowAction = memo((props) => {
       </DropdownItem>
     </Fragment>;
   }
-  if (status === "running") {
+  if (status === SessionStatus.running) {
     defaultAction = (<Link className="btn btn-secondary text-white" to={props.localUrl}>Open</Link>);
     actions.openExternal = (<DropdownItem href={props.url} target="_blank" >
       <FontAwesomeIcon icon={faExternalLinkAlt} /> Open in new tab

--- a/client/src/notebooks/Notebooks.state.js
+++ b/client/src/notebooks/Notebooks.state.js
@@ -443,11 +443,12 @@ class NotebooksCoordinator {
     return this.client.getNotebookServers(
       filters.namespace, filters.project, filters.branch, null, anonymous)
       .then(resp => {
-        let updatedNotebooks = { fetching: false, fetched: new Date() };
+        let updatedNotebooks = { fetching: false };
         // check if result is still valid
         if (!this.model.get("filters.discard")) {
           const filters = this.getQueryFilters();
           if (this.model.get("notebooks.lastParameters") === JSON.stringify(filters)) {
+            updatedNotebooks.fetched = new Date();
             const currentServers = this.model.get("notebooks.all");
             if (!(_.isEqual(resp.data, currentServers)))
               updatedNotebooks.all = { $set: resp.data };

--- a/client/src/notebooks/Notebooks.state.js
+++ b/client/src/notebooks/Notebooks.state.js
@@ -443,31 +443,18 @@ class NotebooksCoordinator {
     return this.client.getNotebookServers(
       filters.namespace, filters.project, filters.branch, null, anonymous)
       .then(resp => {
-        let updateFullObject = true;
-        let updatedNotebooks = { fetching: false };
+        let updatedNotebooks = { fetching: false, fetched: new Date() };
         // check if result is still valid
         if (!this.model.get("filters.discard")) {
           const filters = this.getQueryFilters();
           if (this.model.get("notebooks.lastParameters") === JSON.stringify(filters)) {
             const currentServers = this.model.get("notebooks.all");
-            if (_.isEqual(resp.data, currentServers)) {
-              updateFullObject = false;
-            }
-            else {
+            if (!(_.isEqual(resp.data, currentServers)))
               updatedNotebooks.all = { $set: resp.data };
-              updatedNotebooks.fetched = new Date();
-            }
           }
           // TODO: re-invoke `fetchNotebooks()` immediately if parameters are outdated
         }
-        if (updateFullObject) {
-          this.model.setObject({ notebooks: updatedNotebooks });
-        }
-        else {
-          this.model.set("notebooks.fetching", false);
-          if (this.model.get("notebooks.fetched") === null)
-            this.model.set("notebooks.fetched", new Date());
-        }
+        this.model.setObject({ notebooks: updatedNotebooks });
         return resp.data;
       })
       .catch(error => {

--- a/client/src/notebooks/Notebooks.test.js
+++ b/client/src/notebooks/Notebooks.test.js
@@ -65,46 +65,6 @@ const simplifiedGlobalOptions = {
   }
 };
 
-describe("notebook status", () => {
-  const servers = [{
-    "status": {
-      "message": null,
-      "phase": "Running",
-      "ready": true,
-      "reason": null,
-      "step": "Ready"
-    },
-    "expected": "running"
-  }, {
-    "status": {
-      "message": "containers with unready status: [notebook]",
-      "phase": "Pending",
-      "ready": false,
-      "reason": "ContainersNotReady",
-      "step": "ContainersReady"
-    },
-    "expected": "pending"
-  },
-  {
-    "status": {
-      "message": "containers with unready status: [notebook]",
-      "phase": "Pending",
-      "ready": false,
-      "reason": "ContainersNotReady",
-      "step": "ContainersReady",
-      "stopping": true,
-    },
-    "expected": "stopping"
-  }];
-
-  it("computed vs expected", () => {
-    for (let server of servers) {
-      expect(NotebooksHelper.getStatus(server)).toBe(server.expected);
-      expect(NotebooksHelper.getStatus(server.status)).toBe(server.expected);
-    }
-  });
-});
-
 describe("notebook server clean annotation", () => {
   const domain = ExpectedAnnotations.domain;
   const baseAnnotations = ExpectedAnnotations[domain].default;

--- a/client/src/project/Project.js
+++ b/client/src/project/Project.js
@@ -25,7 +25,7 @@
 
 import React, { Component } from "react";
 import { connect } from "react-redux";
-import _ from "lodash/collection";
+import _ from "lodash";
 
 import Present from "./Project.present";
 import { GraphIndexingStatus, ProjectCoordinator, MigrationStatus } from "./Project.state";

--- a/client/src/utils/constants/Notebooks.js
+++ b/client/src/utils/constants/Notebooks.js
@@ -1,0 +1,33 @@
+/*!
+ * Copyright 2022 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  utils/constants/Notebooks.js
+ *  Notebooks constants
+ */
+
+const SessionStatus = {
+  starting: "starting",
+  running: "running",
+  stopping: "stopping",
+  failed: "failed"
+};
+
+export { SessionStatus };

--- a/e2e/cypress/integration/local/home.spec.ts
+++ b/e2e/cypress/integration/local/home.spec.ts
@@ -54,15 +54,21 @@ describe("display the landing page", () => {
   });
 
   it("displays the landing page header", () => {
+    let projects;
     cy.wait("@getUser");
     cy.wait("@getProjects");
-    cy.wait("@getLastVisitedProjects");
+    cy.wait("@getLastVisitedProjects").then( result => projects = result.response.body.projects);
+
+    const findProject = (path, projects) => {
+      return projects.find( result => result.response.body.path_with_namespace === path);
+    };
 
     cy.get("h3").first().should("have.text", "e2e @ Renku");
     cy.wait(["@projectLanding", "@projectLanding", "@projectLanding", "@projectLanding"])
-      .then( (result) => {
-        const firstProject = result[0].response?.body;
-        cy.get_cy("list-card-title").first().should("have.text", firstProject.name);
+      .then( (results) => {
+        const firstProject = findProject(projects[0], results);
+        const projectData = firstProject.response?.body;
+        cy.get_cy("list-card-title").first().should("have.text", projectData.name);
       });
   });
 });


### PR DESCRIPTION
This PR is for refactoring the session status display with the changes in renku-notebooks [here](https://github.com/SwissDataScienceCenter/renku-notebooks/pull/898)

The session status changed from:
````
status: {
    message: "containers with unready status: [jupyter-server oauth2-proxy git-proxy]" // string
    phase: "Pending", // Pending, Running, Error
    ready: false
    reason: "ContainersNotReady"
    step: "Ready"
}
```` 
To:
````
status: {
   message: "Containers with non-ready statuses: git-proxy, jupyter-server, oauth2-proxy, init-certificates, git-clone." // string or undefined
   state: "starting" // starting, running, stopping, failed
}
````
![status session](https://user-images.githubusercontent.com/43388408/156799262-afd1b6f9-3af3-4a19-80ca-cfc736ead308.gif)


### Testing
Error case: https://renku-ci-ui-1718.dev.renku.ch/projects/tasko.olevski/test-failing-project-1/sessions/new?autostart=1
![error session status](https://user-images.githubusercontent.com/43388408/156801342-f48bd73b-147c-440e-886b-0ef3ffd8fe3a.gif)


Closes #1646 

/deploy renku-notebooks=simplify-session-status renku=000-acceptance-tests #persist