### PR TITLE
feat(client): redirect Notebook connect button to session (#1613)

### DIFF
--- a/client/src/notebooks/NotebookStart.present.js
+++ b/client/src/notebooks/NotebookStart.present.js
@@ -1182,10 +1182,15 @@ class CheckNotebookIcon extends Component {
     if (notebook) {
       const status = notebook.status?.state;
       if (status === SessionStatus.running) {
+        const annotations = NotebooksHelper.cleanAnnotations(notebook.annotations, "renku.io");
+        const sessionUrl = Url.get(Url.pages.project.session.show, {
+          namespace: annotations["namespace"],
+          path: annotations["projectName"],
+          server: notebook.name,
+        });
         tooltip = "Connect to JupyterLab";
         icon = (<JupyterIcon svgClass="svg-inline--fa fa-w-16 icon-link" />);
-        const url = `${notebook.url}/lab/tree/${this.props.filePath}`;
-        link = (<a href={url} role="button" target="_blank" rel="noreferrer noopener">{icon}</a>);
+        link = <Link to={{ pathname: sessionUrl, state: { from: location.pathname } }} >{icon}</Link>;
       }
       else if (status === SessionStatus.starting || status === SessionStatus.stopping) {
         tooltip = status === SessionStatus.stopping ?

--- a/client/src/notebooks/NotebookStart.present.js
+++ b/client/src/notebooks/NotebookStart.present.js
@@ -1173,7 +1173,7 @@ class AutosavedDataModal extends Component {
 // * CheckNotebookIcon code * //
 class CheckNotebookIcon extends Component {
   render() {
-    const { fetched, notebook, location } = this.props;
+    const { fetched, notebook, location, filePath } = this.props;
     const loader = (<span className="ms-2 pb-1"><Loader size="19" inline="true" /></span>);
     if (!fetched)
       return loader;
@@ -1188,9 +1188,10 @@ class CheckNotebookIcon extends Component {
           path: annotations["projectName"],
           server: notebook.name,
         });
+        const state = { from: location.pathname, filePath };
         tooltip = "Connect to JupyterLab";
         icon = (<JupyterIcon svgClass="svg-inline--fa fa-w-16 icon-link" />);
-        link = <Link to={{ pathname: sessionUrl, state: { from: location.pathname } }} >{icon}</Link>;
+        link = <Link to={{ pathname: sessionUrl, state }} >{icon}</Link>;
       }
       else if (status === SessionStatus.starting || status === SessionStatus.stopping) {
         tooltip = status === SessionStatus.stopping ?

--- a/client/src/notebooks/Notebooks.present.js
+++ b/client/src/notebooks/Notebooks.present.js
@@ -18,7 +18,7 @@
 
 import React, { Component, Fragment, useState, memo } from "react";
 import Media from "react-media";
-import { Link } from "react-router-dom";
+import { Link, useHistory } from "react-router-dom";
 import {
   Alert, Badge, Button, Col, DropdownItem,
   Modal, ModalBody, ModalFooter, ModalHeader, Nav, NavItem, NavLink, PopoverBody, PopoverHeader,
@@ -329,7 +329,7 @@ function SessionCommands(props) {
 
 function SessionJupyter(props) {
   const { filters, notebook, tab, urlList } = props;
-
+  const history = useHistory();
   const invisible = tab !== SESSION_TABS.session ?
     true :
     false;
@@ -338,11 +338,14 @@ function SessionJupyter(props) {
   if (notebook.available) {
     const status = notebook.data.status.state;
     if (status === SessionStatus.running) {
+      const locationFilePath = history?.location?.state?.filePath;
+      const notebookUrl = locationFilePath ? `${notebook.data.url}/lab/tree/${locationFilePath}` : notebook.data.url;
+
       const localClass = invisible ?
         "invisible position-absolute" : // ? position-absolute prevent showing extra margins
         "";
       content = (
-        <iframe id="session-iframe" title="session iframe" src={notebook.data.url} className={localClass}
+        <iframe id="session-iframe" title="session iframe" src={notebookUrl} className={localClass}
           width="100%" height="800px" referrerPolicy="origin"
           sandbox="allow-downloads allow-forms allow-modals allow-popups allow-same-origin allow-scripts"
         />

--- a/client/src/project/Project.present.js
+++ b/client/src/project/Project.present.js
@@ -1066,34 +1066,36 @@ class ProjectViewFiles extends Component {
   }
 }
 
+const ProjectSessions = (props) => {
+  const locationFrom = props.history?.location?.state?.from;
+  const backButtonLabel = locationFrom ? "Back to notebook file" : "Back to sessions list";
+  const backUrl = locationFrom ?? props.notebookServersUrl;
 
-class ProjectSessions extends Component {
-  render() {
-    const backButton = (<GoBackButton label="Back to sessions list" url={this.props.notebookServersUrl} />);
-    return [
-      <Col key="content" xs={12}>
-        <Switch>
-          <Route exact path={this.props.notebookServersUrl}
-            render={props => <ProjectNotebookServers {...this.props} />} />
-          <Route path={this.props.launchNotebookUrl}
-            render={props => (
-              <Fragment>
-                {backButton}
-                <ProjectStartNotebookServer key="startNotebookForm" {...this.props} />
-              </Fragment>
-            )} />
-          <Route path={this.props.sessionShowUrl}
-            render={props => (
-              <Fragment>
-                {backButton}
-                <ProjectShowSession {...this.props} match={props.match} />
-              </Fragment>
-            )} />
-        </Switch>
-      </Col>
-    ];
-  }
-}
+  const backButton = (<GoBackButton label={backButtonLabel} url={backUrl} />);
+
+  return [
+    <Col key="content" xs={12}>
+      <Switch>
+        <Route exact path={props.notebookServersUrl}
+          render={p => <ProjectNotebookServers {...props} />} />
+        <Route path={props.launchNotebookUrl}
+          render={p => (
+            <Fragment>
+              {backButton}
+              <ProjectStartNotebookServer key="startNotebookForm" {...props} />
+            </Fragment>
+          )} />
+        <Route path={props.sessionShowUrl}
+          render={p => (
+            <Fragment>
+              {backButton}
+              <ProjectShowSession {...props} match={p.match} />
+            </Fragment>
+          )} />
+      </Switch>
+    </Col>
+  ];
+};
 
 function notebookWarning(userLogged, accessLevel, forkUrl, postLoginUrl, externalUrl) {
   const collaborationDocRoot = "https://renku.readthedocs.io/en/latest/how-to-guides/collaboration.html";

--- a/client/src/utils/components/Button.js
+++ b/client/src/utils/components/Button.js
@@ -87,13 +87,15 @@ function RefreshButton(props) {
  * @param {string} props.url url to go back to
  * @param {string} props.label text next to the arrow
  */
-function GoBackButton(props) {
-  const linkClasses = (props.className) ?
-    props.className + " link-rk-text text-decoration-none" :
+function GoBackButton({ className, label, url }) {
+
+  const linkClasses = (className) ?
+    className + " link-rk-text text-decoration-none" :
     "link-rk-text text-decoration-none";
+
   return <Col md={12} className="pb-4 pl-0">
-    <Link data-cy="go-back-button" className={linkClasses} to={props.url}>
-      <span className="arrow-left">  </span>{props.label}
+    <Link data-cy="go-back-button" className={linkClasses} to={url}>
+      <span className="arrow-left">  </span>{label}
     </Link>
   </Col>;
 }


### PR DESCRIPTION
This PR redirect Notebook connects button to renku session link in the same window.

![notebook connect](https://user-images.githubusercontent.com/43388408/157401039-8fb34e97-3fd8-4ac0-8ec0-146f30372b2a.gif)



### Testing
1. Launch a session with Notebooks
e.g. https://renku-ci-ui-1725.dev.renku.ch/projects/dandrea.cordoba/essm-egu-2022/sessions/new?autostart=1
2. Go to Notebook file
e.g. https://renku-ci-ui-1725.dev.renku.ch/projects/dandrea.cordoba/essm-egu-2022/files/blob/notebooks/Priestley-Taylor_equation.ipynb
3. Click in connect button, it should display the session Iframe and the link to go back to the file: 

![connect button](https://user-images.githubusercontent.com/43388408/157847089-8b1a234e-856e-4b86-ad1d-f68971dd1a46.png)


Closes #1613 

/deploy renku=000-acceptance-tests renku-notebooks=get-all-session-logs #persist