### PR TITLE
refactor: remove transient

### DIFF
--- a/client/src/model/RenkuModels.js
+++ b/client/src/model/RenkuModels.js
@@ -337,11 +337,6 @@ const projectSchema = new Schema({
       fetching: { [Prop.INITIAL]: false },
     })
   },
-  transient: {
-    [Prop.SCHEMA]: new Schema({
-      requests: { [Prop.INITIAL]: {} }
-    })
-  },
   webhook: {
     [Prop.SCHEMA]: {
       status: { [Prop.INITIAL]: null },

--- a/client/src/model/RenkuModels.js
+++ b/client/src/model/RenkuModels.js
@@ -211,11 +211,19 @@ const projectSchema = new Schema({
   },
   datasets: {
     [Prop.SCHEMA]: new Schema({
+      kg: { [Prop.INITIAL]: {
+        list: [],
+        error: {},
+        fetched: null,
+        fetching: false
+      } },
       datasets_kg: { [Prop.INITIAL]: [] },
       core: {
         [Prop.INITIAL]: {
           datasets: null,
-          error: null
+          error: null,
+          fetched: null,
+          fetching: false
         }
       }
     })

--- a/client/src/model/RenkuModels.js
+++ b/client/src/model/RenkuModels.js
@@ -211,13 +211,12 @@ const projectSchema = new Schema({
   },
   datasets: {
     [Prop.SCHEMA]: new Schema({
-      kg: { [Prop.INITIAL]: {
+      datasets_kg: { [Prop.INITIAL]: {
         list: [],
         error: {},
         fetched: null,
         fetching: false
       } },
-      datasets_kg: { [Prop.INITIAL]: [] },
       core: {
         [Prop.INITIAL]: {
           datasets: null,

--- a/client/src/model/RenkuModels.js
+++ b/client/src/model/RenkuModels.js
@@ -237,7 +237,10 @@ const projectSchema = new Schema({
   filesTree: {
     [Prop.SCHEMA]: new Schema({
       hash: { [Prop.INITIAL]: {} },
-      loaded: { [Prop.INITIAL]: false, [Prop.MANDATORY]: true }
+      loaded: { [Prop.INITIAL]: false, [Prop.MANDATORY]: true },
+      error: { [Prop.INITIAL]: null },
+      fetched: { [Prop.INITIAL]: null },
+      fetching: { [Prop.INITIAL]: false },
     })
   },
   filters: {

--- a/client/src/model/RenkuModels.js
+++ b/client/src/model/RenkuModels.js
@@ -201,7 +201,12 @@ const projectSchema = new Schema({
   },
   data: {
     [Prop.SCHEMA]: new Schema({
-      readme: { [Prop.INITIAL]: {} }
+      readme: { [Prop.INITIAL]: {
+        text: null,
+        error: {},
+        fetched: null,
+        fetching: false
+      } }
     })
   },
   datasets: {

--- a/client/src/project/Project.present.js
+++ b/client/src/project/Project.present.js
@@ -554,8 +554,8 @@ class ProjectNav extends Component {
 
 class ProjectFilesNav extends Component {
   render() {
-    const loading = isRequestPending(this.props, "filesTree");
-    const allFiles = this.props.filesTree || [];
+    const loading = this.props.filesTree.fetching === SpecialPropVal.UPDATING;
+    const allFiles = this.props.filesTree.hash || {};
     if ((loading && Object.keys(allFiles).length < 1) || this.props.filesTree === undefined)
       return <Loader />;
 

--- a/client/src/project/Project.present.js
+++ b/client/src/project/Project.present.js
@@ -72,12 +72,6 @@ function filterPaths(paths, blacklist) {
   return result;
 }
 
-function isRequestPending(props, request) {
-  const transient = props.transient || {};
-  const requests = transient.requests || {};
-  return requests[request] === SpecialPropVal.UPDATING;
-}
-
 function webhookError(props) {
   if (props == null || props === SpecialPropVal.UPDATING || props === true || props === false)
     return false;
@@ -580,7 +574,7 @@ class ProjectViewReadme extends Component {
 
   render() {
     const readmeText = this.props.readme.text;
-    const loading = isRequestPending(this.props, "readme");
+    const loading = this.props.readme.fetching === SpecialPropVal.UPDATING;
     if (loading && readmeText === "")
       return <Loader />;
 
@@ -644,6 +638,7 @@ class ProjectViewOverviewNav extends Component {
 class ProjectViewOverview extends Component {
   render() {
     const { projectCoordinator } = this.props;
+    const isLoading = projectCoordinator.get("data.readme.fetching") === SpecialPropVal.UPDATING;
     return <Col key="overview">
       <Row>
         <Col key="nav" sm={12} md={2}>
@@ -669,7 +664,7 @@ class ProjectViewOverview extends Component {
               />}
             />
             <Route exact path={this.props.overviewStatusUrl} render={props =>
-              <ProjectOverviewVersion {...this.props} isLoading={isRequestPending(this.props, "readme")} />
+              <ProjectOverviewVersion {...this.props} isLoading={isLoading} />
             } />
           </Switch>
         </Col>

--- a/client/src/project/Project.present.js
+++ b/client/src/project/Project.present.js
@@ -302,7 +302,7 @@ const ProjectSuggestActions = (props) => {
     isReadmeCommitInitial = firstCommit.id === commitsReadme.list[0].id;
   }
 
-  const isLoadingDatasets = typeof (datasets) === "string" || datasets?.datasets === null;
+  const isLoadingDatasets = datasets.fetching === SpecialPropVal.UPDATING || datasets?.datasets === null;
   let hasDatasets = !isLoadingDatasets ? datasets.datasets?.length > 0 : true;
   const isLoadingData = !commits.fetched ||
     !commitsReadme.fetched ||
@@ -826,7 +826,7 @@ function ProjectViewDatasets(props) {
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
-    const datasetsLoading = props.datasets.core === SpecialPropVal.UPDATING;
+    const datasetsLoading = props.datasets.core.fetching === SpecialPropVal.UPDATING;
     if (datasetsLoading || !props.migration.core.fetched || props.migration.core.fetching)
       return;
     props.fetchDatasets(props.location.state && props.location.state.reload);
@@ -867,7 +867,7 @@ function ProjectViewDatasets(props) {
     );
   }
 
-  const loadingDatasets = props.datasets.core === SpecialPropVal.UPDATING || props.datasets.core === undefined;
+  const loadingDatasets = props.datasets.core.fetching === SpecialPropVal.UPDATING || props.datasets.core === undefined;
   if (loadingDatasets) {
     return (
       <div>

--- a/client/src/project/Project.state.js
+++ b/client/src/project/Project.state.js
@@ -59,17 +59,17 @@ const CoreServiceProjectMixin = {
 
 const DatasetsMixin = {
   fetchProjectDatasetsFromKg(client) { //from KG
-    if (this.get("datasets.datasets_kg") === SpecialPropVal.UPDATING) return;
-    this.setUpdating({ datasets: { datasets_kg: true } });
+    if (this.get("datasets.datasets_kg.fetching") === SpecialPropVal.UPDATING) return;
+    this.setUpdating({ datasets: { datasets_kg: { fetching: true } } });
     return client.getProjectDatasetsFromKG(this.get("metadata.pathWithNamespace"))
       .then(datasets => {
-        const updatedState = { datasets_kg: { $set: datasets } };
+        const updatedState = { datasets_kg: { list: { $set: datasets }, fetching: false } };
         this.setObject({ datasets: updatedState });
         return datasets;
       })
       .catch(err => {
         const datasets = [];
-        const updatedState = { datasets_kg: { $set: datasets } };
+        const updatedState = { datasets_kg: { list: { $set: datasets }, error: { $set: err }, fetching: false } };
         this.setObject({ datasets: updatedState });
       });
   },

--- a/client/src/project/Project.state.js
+++ b/client/src/project/Project.state.js
@@ -619,13 +619,13 @@ class ProjectCoordinator {
     this.model.setUpdating({ data: { readme: { fetching: true } } });
     client.getProjectReadme(this.model.get("metadata.id"), this.model.get("metadata.defaultBranch"))
       .then(d => {
-        this.model.setObject({data: {readme: {text: d.text, error: {}}}});
+        this.model.setObject({ data: { readme: { text: d.text, error: {} } } });
       })
       .catch(error => {
         if (error.case === API_ERRORS.notFoundError)
           this.model.set("data.readme.text", "No readme file found.");
         else
-        this.model.setObject({data: {readme: {text: null, error}}});
+          this.model.setObject({ data: { readme: { text: null, error } } });
 
       })
       .finally(() => this.model.set("data.readme.fetching", false));

--- a/client/src/project/Project.state.js
+++ b/client/src/project/Project.state.js
@@ -63,13 +63,13 @@ const DatasetsMixin = {
     this.setUpdating({ datasets: { datasets_kg: true } });
     return client.getProjectDatasetsFromKG(this.get("metadata.pathWithNamespace"))
       .then(datasets => {
-        const updatedState = { datasets_kg: { $set: datasets }, transient: { requests: { datasets_kg: false } } };
+        const updatedState = { datasets_kg: { $set: datasets } };
         this.setObject({ datasets: updatedState });
         return datasets;
       })
       .catch(err => {
         const datasets = [];
-        const updatedState = { datasets_kg: { $set: datasets }, transient: { requests: { datasets_kg: false } } };
+        const updatedState = { datasets_kg: { $set: datasets } };
         this.setObject({ datasets: updatedState });
       });
   },

--- a/client/src/project/Project.state.js
+++ b/client/src/project/Project.state.js
@@ -552,7 +552,7 @@ class ProjectCoordinator {
   async fetchReadmeCommits() {
     // Do not fetch if a fetch is in progress
     if (this.get("commitsReadme.fetching") === SpecialPropVal.UPDATING) return;
-    this.model.setUpdating({ transient: { requests: { commitsReadme: true } } });
+    this.model.setUpdating({ commitsReadme: { fetching: true } } );
     const projectId = this.model.get("metadata.id");
 
     // bring only 2 commits just to validate if the user already edit the readme file
@@ -582,6 +582,9 @@ class ProjectCoordinator {
           }
         });
       }
+    }
+    finally {
+      this.model.set("commitsReadme.fetching", false);
     }
     return null;
   }

--- a/client/src/project/Project.state.js
+++ b/client/src/project/Project.state.js
@@ -611,17 +611,21 @@ class ProjectCoordinator {
 
   fetchReadme(client) {
     // Do not fetch if a fetch is in progress
-    if (this.get("transient.requests.readme") === SpecialPropVal.UPDATING) return;
+    if (this.get("data.readme.fetching") === SpecialPropVal.UPDATING) return;
 
-    this.model.setUpdating({ transient: { requests: { readme: true } } });
+    this.model.setUpdating({ data: { readme: { fetching: true } } });
     client.getProjectReadme(this.model.get("metadata.id"), this.model.get("metadata.defaultBranch"))
-      .then(d => this.model.set("data.readme.text", d.text))
+      .then(d => {
+        this.model.setObject({data: {readme: {text: d.text, error: {}}}});
+      })
       .catch(error => {
         if (error.case === API_ERRORS.notFoundError)
           this.model.set("data.readme.text", "No readme file found.");
+        else
+        this.model.setObject({data: {readme: {text: null, error}}});
 
       })
-      .finally(() => this.model.set("transient.requests.readme", false));
+      .finally(() => this.model.set("data.readme.fetching", false));
   }
 
   fetchModifiedFiles(client) {

--- a/client/src/project/datasets/DatasetsListView.js
+++ b/client/src/project/datasets/DatasetsListView.js
@@ -85,7 +85,7 @@ export default function DatasetsListView(props) {
 
   const datasets = useMemo(()=>props.datasets, [props.datasets]);
 
-  if (props.datasets_kg === SpecialPropVal.UPDATING)
+  if (props.datasets_kg.fetching === SpecialPropVal.UPDATING)
     return <Loader />;
 
   return [ <Row key="header" className="pt-2 pb-3">
@@ -101,7 +101,7 @@ export default function DatasetsListView(props) {
     <Col xs={12}>
       <DatasetList
         datasets={datasets}
-        datasets_kg={props.datasets_kg}
+        datasets_kg={props.datasets_kg.list}
         datasetsUrl={props.datasetsUrl}
         graphStatus={props.graphStatus} />
     </Col>

--- a/client/src/utils/components/FileExplorer.js
+++ b/client/src/utils/components/FileExplorer.js
@@ -4,6 +4,7 @@ import { Link } from "react-router-dom";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faFile, faFolder, faFolderOpen } from "@fortawesome/free-solid-svg-icons";
 import { Loader } from "./Loader";
+import { SpecialPropVal } from "../../model";
 
 function buildTree(parts, treeNode, jsonObj, hash, currentPath, foldersOpenOnLoad) {
   if (parts.length === 0)
@@ -198,7 +199,7 @@ function FileExplorer(props) {
     setFilesTree(filesTree);
   };
 
-  const loading = filesTree === undefined;
+  const loading = filesTree == null || filesTree.fetching === SpecialPropVal.UPDATING;
 
   if (loading)
     return <Loader />;

--- a/e2e/cypress/integration/local/project.spec.ts
+++ b/e2e/cypress/integration/local/project.spec.ts
@@ -39,6 +39,22 @@ describe("display a project", () => {
     cy.get("h1").first().should("contain.text", "local test project");
   });
 
+  it("displays the project overview page when there is no readme", () => {
+    cy.intercept(
+      "/ui-server/api/projects/*/repository/files/README.md/raw?ref=master", {
+        statusCode: 404,
+        body: {} }
+    ).as("getNoReadme");
+    cy.wait("@getNoReadme");
+    // Check that the project header is shown
+    cy.get("[data-cy='project-header']").should(
+      "contain.text",
+      "local-test-project Public"
+    );
+    // Check that the readme is shown
+    cy.contains("No readme file found").should("be.visible");
+  });
+
   it("displays project settings", () => {
     fixtures.sessionServerOptions();
     cy.visit("/projects/e2e/local-test-project/settings/sessions");


### PR DESCRIPTION
# Description

A refactoring to remove the "transient" field and standardize the structure of data in the model to use "fetching" to communicate that a fetch is in progress.

This address the first point in #1585.

/deploy renku=tests-rp-version renku-core=develop extra-values=core.sentry.enabled=true #persist