### PR TITLE
feat(client): use new api for pinned images

### DIFF
--- a/client/src/api-client/index.js
+++ b/client/src/api-client/index.js
@@ -206,9 +206,12 @@ class APIClient {
   // REF: https://stackoverflow.com/questions/4500741/suppress-chrome-failed-to-load-resource-messages-in-console
   simpleFetch(
     url,
-    method = "GET"
+    method = "GET",
+    queryParams = null
   ) {
     const urlObject = new URL(url);
+    if (queryParams)
+      urlObject.search = new URLSearchParams(queryParams).toString();
     let headers = new Headers({
       "credentials": "same-origin",
       "X-Requested-With": "XMLHttpRequest"

--- a/client/src/api-client/notebook-servers.js
+++ b/client/src/api-client/notebook-servers.js
@@ -172,14 +172,13 @@ function addNotebookServersMethods(client) {
 
   client.getImageStatus = async (registryUrl) => {
     const headers = client.getBasicHeaders();
-    headers.append("Content-Type", "application/json");
     const url = `${client.baseUrl}/notebooks/images`;
 
     return client.clientFetch(url, {
       method: "GET",
       headers,
       queryParams: { image_url: registryUrl }
-    }).then((resp) => {
+    }, "full").then((resp) => {
       return resp.data;
     });
   };

--- a/client/src/api-client/notebook-servers.js
+++ b/client/src/api-client/notebook-servers.js
@@ -169,6 +169,20 @@ function addNotebookServersMethods(client) {
       return false;
     }
   };
+
+  client.getImageStatus = async (registryUrl) => {
+    const headers = client.getBasicHeaders();
+    headers.append("Content-Type", "application/json");
+    const url = `${client.baseUrl}/notebooks/images`;
+
+    return client.clientFetch(url, {
+      method: "GET",
+      headers,
+      queryParams: { image_url: registryUrl }
+    }).then((resp) => {
+      return resp.data;
+    });
+  };
 }
 
 export default addNotebookServersMethods;

--- a/client/src/api-client/notebook-servers.js
+++ b/client/src/api-client/notebook-servers.js
@@ -171,15 +171,17 @@ function addNotebookServersMethods(client) {
   };
 
   client.getImageStatus = async (registryUrl) => {
-    const headers = client.getBasicHeaders();
+    const queryParams = { image_url: registryUrl };
     const url = `${client.baseUrl}/notebooks/images`;
 
-    return client.clientFetch(url, {
-      method: "GET",
-      headers,
-      queryParams: { image_url: registryUrl }
-    }, "full").then((resp) => {
-      return resp.data;
+    return client.simpleFetch(url, "GET", queryParams).then((resp) => {
+      if (resp.status === 200)
+        return true;
+      else if (resp.status === 404)
+        return false;
+
+      // Throw error for any other case
+      throw new Error(`Error ${resp.status}`);
     });
   };
 }

--- a/client/src/notebooks/Notebooks.state.js
+++ b/client/src/notebooks/Notebooks.state.js
@@ -1093,16 +1093,15 @@ class NotebooksCoordinator {
     let imageObject = { fetching: true };
     this.model.setObject({ ci: { image: imageObject } });
     try {
-      const imageStatus = await this.client.getImageStatus(registryUrl);
-      if (imageStatus.available)
-        imageObject.available = true;
-      else
-        imageObject.available = false;
+      await this.client.getImageStatus(registryUrl);
+      imageObject.available = true;
       imageObject.error = null;
     }
     catch (e) {
       imageObject.available = false;
-      imageObject.error = this._getErrorMessage(e);
+      const error = this._getErrorMessage(e);
+      if (!error.includes("JSON.parse"))
+        imageObject.error = error;
     }
 
     imageObject.fetching = false;

--- a/client/src/notebooks/Notebooks.state.js
+++ b/client/src/notebooks/Notebooks.state.js
@@ -1093,15 +1093,16 @@ class NotebooksCoordinator {
     let imageObject = { fetching: true };
     this.model.setObject({ ci: { image: imageObject } });
     try {
-      await this.client.getImageStatus(registryUrl);
-      imageObject.available = true;
+      const imageAvailable = await this.client.getImageStatus(registryUrl);
+      if (imageAvailable)
+        imageObject.available = true;
+      else
+        imageObject.available = false;
       imageObject.error = null;
     }
     catch (e) {
       imageObject.available = false;
-      const error = this._getErrorMessage(e);
-      if (!error.includes("JSON.parse"))
-        imageObject.error = error;
+      imageObject.error = this._getErrorMessage(e);
     }
 
     imageObject.fetching = false;


### PR DESCRIPTION
/deploy renku-core=develop renku=tests-rp-version renku-notebooks=chore-prepare-1.6.0-release #persist

This PR changes the faulty check for the docker image availability when a project specifies a pinned image.
Instead of using the GitLab API and accessing the project registry, it uses a new renku-notebooks API `GET /notebooks/images`

![Screenshot_20220402_192201](https://user-images.githubusercontent.com/43481553/161394131-dddd63ed-8fbf-4dad-a997-a870829f7f75.png)

fix #1767