### PR TITLE
feat(client): improve error handling on missing pipelines

### DIFF
--- a/client/src/notebooks/NotebookStart.present.js
+++ b/client/src/notebooks/NotebookStart.present.js
@@ -42,6 +42,7 @@ import { NotebooksHelper } from "./index";
 import { ObjectStoresConfigurationButton, ObjectStoresConfigurationModal } from "./ObjectStoresConfig.present";
 import { SessionStatus } from "../utils/constants/Notebooks";
 import { Docs } from "../utils/constants/Docs";
+import { sleep } from "../utils/helpers/HelperFunctions";
 
 
 function ProjectSessionLockAlert({ lockStatus }) {
@@ -404,12 +405,14 @@ class StartNotebookPipelines extends Component {
   async reTriggerPipeline() {
     this.setState({ justTriggered: true });
     await this.props.handlers.reTriggerPipeline();
+    await sleep(5);
     this.setState({ justTriggered: false });
   }
 
   async runPipeline() {
     this.setState({ justTriggered: true });
     await this.props.handlers.runPipeline();
+    await sleep(5);
     this.setState({ justTriggered: false });
   }
 
@@ -441,7 +444,7 @@ class StartNotebookPipelines extends Component {
       <FormGroup>
         <StartNotebookPipelinesBadge {...this.props} infoButton={infoButton} />
         <Collapse isOpen={!customImage || showInfo}>
-          <StartNotebookPipelinesContent {...this.props}
+          <StartNotebookPipelinesContent {...this.props} justTriggered={this.state.justTriggered}
             buildAgain={this.reTriggerPipeline.bind(this)} tryToBuild={this.runPipeline.bind(this)} />
         </Collapse>
       </FormGroup>
@@ -648,6 +651,7 @@ class StartNotebookPipelinesContent extends Component {
       );
     }
     else if (
+      (ciStatus.stage === ciStages.pipelines && !ciStatus.ongoing && !ciStatus.available) ||
       (ciStatus.stage === ciStages.jobs && getCiJobStatus(ci.jobs?.target) === ciStatuses.wrong) ||
       (ciStatus.stage === ciStages.image && !ci.available)
     ) {

--- a/e2e/cypress/integration/local/newSession.spec.ts
+++ b/e2e/cypress/integration/local/newSession.spec.ts
@@ -49,6 +49,19 @@ describe("launch sessions", () => {
     cy.contains("Start with base image").should("not.exist");
   });
 
+  it("new session page - logged - missing pipeline", () => {
+    fixtures.userTest();
+    fixtures.newSessionPipelines(true);
+    cy.visit("/projects/e2e/local-test-project/sessions/new");
+    cy.wait("@getSessionPipelines", { timeout: 10000 });
+    cy.contains("Hide advanced settings").should("be.visible");
+    cy.contains("Start with base image").should("be.visible");
+    cy.contains("Start session").should("be.visible").should("be.disabled");
+    cy.contains("No Docker image found").should("be.visible");
+    cy.contains("building the branch image").should("be.visible");
+    cy.get(".badge").contains("not available").should("be.visible");
+  });
+
   it("new session page - anonymous - missing image", () => {
     fixtures.userNone();
     fixtures.newSessionPipelines().newSessionJobs().newSessionImages(true);

--- a/e2e/cypress/support/renkulab-fixtures/newSession.ts
+++ b/e2e/cypress/support/renkulab-fixtures/newSession.ts
@@ -24,11 +24,13 @@ import { FixturesConstructor } from "./fixtures";
 
 function NewSession<T extends FixturesConstructor>(Parent: T) {
   return class NewSessionFixtures extends Parent {
-    newSessionPipelines() {
-      const fixture = "session/ci-pipelines.json";
+    newSessionPipelines(empty = false) {
+      const data = empty ?
+        [] :
+        { fixture: "session/ci-pipelines.json" };
       cy.intercept(
         "/ui-server/api/projects/e2e%2Flocal-test-project/pipelines?sha=172a784d465a7bd45bacc165df2b64a591ac6b18",
-        { fixture }
+        data
       ).as("getSessionPipelines");
       return this;
     }


### PR DESCRIPTION
This should improve the UX when a user forks a project and something goes wrong with the pipelines.

In short:
- The pipeline API is invoked again after a short delay when it fails during a fork.
- In case of missing pipelines, the UI correctly shows the "build the branch image" button when trying to start a new session.

![Screenshot_20220407_093945](https://user-images.githubusercontent.com/43481553/162156424-dba808ca-b4e9-484e-ae1a-e8ef688e9ea8.png)

Here is an example of recovering from pipeline failures.

![Peek 2022-04-07 09-59](https://user-images.githubusercontent.com/43481553/162157042-c7185046-2c39-48a4-ac8d-b9820da4fd05.gif)

/deploy renku-core=develop renku=auto-update/renku-core-1.2.0 #persist
 