### PR TITLE
minor: allow telepresence against the dev/renku deployment

### DIFF
--- a/server/run-telepresence.sh
+++ b/server/run-telepresence.sh
@@ -67,7 +67,12 @@ else
   else
     echo "Exchanging k8s deployments for the following context/namespace: ${CURRENT_CONTEXT}/${DEV_NAMESPACE}"
   fi
-  SERVICE_NAME=${DEV_NAMESPACE}-renku-uiserver
+  if [[ ! $SERVICE_NAME ]]
+  then
+    SERVICE_NAME=${DEV_NAMESPACE}-renku-uiserver
+  else
+    echo "Exchanging k8s deployments for the following service name: ${SERVICE_NAME}"
+  fi
 fi
 
 


### PR DESCRIPTION
Minor fix to telepresence script which only worked on ci-deployments, but not the main dev deployment.