### PR TITLE
fix: do not show renkulab down when the users auth token has expired

### DIFF
--- a/client/src/api-client/index.js
+++ b/client/src/api-client/index.js
@@ -111,8 +111,10 @@ class APIClient {
   ) {
     return renkuFetch(url, options)
       .catch((error) => {
-        if (error.case === API_ERRORS.authExpired)
-          return this.doLogin();
+        if (error.case === API_ERRORS.authExpired) {
+          this.doLogin();
+          return Promise.reject(error);
+        }
         // For permission errors we send the user to login
         if (reLogin && error.case === API_ERRORS.unauthorizedError)
           return this.doLogin();

--- a/client/src/user/User.state.js
+++ b/client/src/user/User.state.js
@@ -59,7 +59,7 @@ class UserCoordinator {
           data: { $set: {} }
         };
         // we get 401 unauthorized when the user is not logged in, but that's not an error
-        if (error.case !== API_ERRORS.unauthorizedError)
+        if (error.case !== API_ERRORS.unauthorizedError && error.case !== API_ERRORS.authExpired)
           errorObject.error = status;
         this.model.setObject(errorObject);
 


### PR DESCRIPTION
# Description

The fact that the server response was caused by an expired token was getting lost, so it was not possible to handle the error correctly at higher levels. This has been fixed.

Testing: Log into the Keycloak admin console and set the *SSO Session Idle* and *Client Session Idle* values to something very short (like 1 min). This will provoke more frequent auth token expirations, and you will be redirected to login, but you should not see the "RenklabDown" warning.

<img width="583" alt="image" src="https://user-images.githubusercontent.com/1196411/162941129-456f7fd7-dc65-4c0e-aff8-aecf89d6e309.png">

Fix #1759

/deploy renku=auto-update/renku-core-1.2.1 #persist