### PR TITLE
build(server): run ui-server as non-root user

### DIFF
--- a/helm-chart/renku-ui-server/values.yaml
+++ b/helm-chart/renku-ui-server/values.yaml
@@ -48,16 +48,12 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-podSecurityContext: {}
-  # fsGroup: 2000
+podSecurityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext:
+  allowPrivilegeEscalation: false
 
 service:
   type: ClusterIP

--- a/helm-chart/renku-ui-server/values.yaml
+++ b/helm-chart/renku-ui-server/values.yaml
@@ -50,7 +50,6 @@ serviceAccount:
 
 podSecurityContext:
   runAsUser: 1000
-  runAsGroup: 1000
 
 securityContext:
   allowPrivilegeEscalation: false


### PR DESCRIPTION
Run UI server as non-root.

To keep it coherent with the other repos, we should add also `runAsGroup: 1000`, but that creates problems with telepresence v1. I can give a quick try to telepresence v2. If that works, we could upgrade

/deploy #persist 

fix SwissDataScienceCenter/renku-notebooks#1001