### PR TITLE
fix(client): adjust session page

### DIFF
--- a/client/src/notebooks/Notebooks.present.js
+++ b/client/src/notebooks/Notebooks.present.js
@@ -103,7 +103,7 @@ function ShowSession(props) {
   });
 
   // redirect immediately if the session fail
-  if (props.history && notebook.data.status.state === SessionStatus.failed)
+  if (props.history && notebook.data?.status?.state === SessionStatus.failed)
     props.history.push(urlList);
 
   // Always add all sub-components and hide them one by one to preserve the iframe navigation where needed
@@ -152,17 +152,21 @@ function SessionInformation(props) {
   const resourceList = formattedResourceList(resources);
 
   // Create dropdown menu
+  const ready = notebook.data?.status?.state === SessionStatus.running ? true : false;
+  const stopContent = (<Fragment><FontAwesomeIcon icon={faStopCircle} /> Stop</Fragment>);
+  const stopButton = (<DropdownItem onClick={stop} disabled={stopping}>{stopContent}</DropdownItem>);
   const defaultAction = <ExternalLink color="primary" url={url} disabled={stopping} showLinkIcon={true} title="Open" />;
-  const stopButton = (
-    <DropdownItem onClick={stop} disabled={stopping}>
-      <FontAwesomeIcon icon={faStopCircle} /> Stop
-    </DropdownItem>
-  );
-  const dropdownMenu = (
-    <ButtonWithMenu className="sessionsButton" color="primary" size="sm" default={defaultAction}>
-      {stopButton}
-    </ButtonWithMenu>
-  );
+  const menu = ready ?
+    (
+      <ButtonWithMenu className="sessionsButton" color="primary" size="sm" default={defaultAction}>
+        {stopButton}
+      </ButtonWithMenu>
+    ) :
+    (
+      <Button className="sessionsButton" color="primary" size="sm" onClick={stop} disabled={stopping}>
+        {stopContent}
+      </Button>
+    );
 
   return (
     <div className="d-flex flex-wrap">
@@ -181,12 +185,10 @@ function SessionInformation(props) {
         <span>{resourceList}</span>
       </div>
       <div className="p-2 p-lg-3 text-nowrap">
-        <span className="fw-bold">Running since </span>
+        <span className="fw-bold">{ ready ? "Running since" : "Started" } </span>
         <TimeCaption noCaption={true} endPunctuation=" " time={notebook.data.started} />
       </div>
-      <div className="p-1 p-lg-2 m-auto me-1 me-lg-2">
-        {dropdownMenu}
-      </div>
+      <div className="p-1 p-lg-2 m-auto me-1 me-lg-2">{menu}</div>
     </div>
   );
 }


### PR DESCRIPTION
This fixes 2 details on the session page:
- do not show the open button when the session is not ready (fix #1796). The "Running since" label is also different until the server is actually usable -- see screenshot below.
- do not crash when the session is not available. This happened when the user tried to open a session page in the UI when the session was gone, typically a tab left open for a while.

![image](https://user-images.githubusercontent.com/43481553/163956472-8ab6d96d-84d9-4660-91f9-1875c1b35062.png)

/deploy #persist
