### PR TITLE
build(server): add runAsGroup and setup telepresence 2

### DIFF
--- a/client/run-telepresence.sh
+++ b/client/run-telepresence.sh
@@ -195,10 +195,13 @@ EOF
 # suid bins need to run. Please switch the following two lines when trying to run multiple telepresence.
 # Reference: https://www.telepresence.io/reference/methods
 
-if [[ "$INJECTTCP" ]]
-then
-  # More info on the methods: https://www.telepresence.io/docs/v1/reference/methods/
-  BROWSER=none telepresence --method inject-tcp --swap-deployment ${SERVICE_NAME} --namespace ${DEV_NAMESPACE} --expose 3000:8080 --run npm start
-else
-  BROWSER=none telepresence --swap-deployment ${SERVICE_NAME} --namespace ${DEV_NAMESPACE} --expose 3000:8080 --run npm start
-fi
+# if [[ "$INJECTTCP" ]]
+# then
+#   # More info on the methods: https://www.telepresence.io/docs/v1/reference/methods/
+#   BROWSER=none telepresence --method inject-tcp --swap-deployment ${SERVICE_NAME} --namespace ${DEV_NAMESPACE} --expose 3000:8080 --run npm start
+# else
+#   BROWSER=none telepresence --swap-deployment ${SERVICE_NAME} --namespace ${DEV_NAMESPACE} --expose 3000:8080 --run npm start
+# fi
+
+echo "BROWSER=none telepresence intercept --namespace ${DEV_NAMESPACE} ${SERVICE_NAME} --port 3000:80 connect npm start"
+BROWSER=none telepresence intercept --namespace ${DEV_NAMESPACE} ${SERVICE_NAME} --port 3000:80 connect npm start

--- a/helm-chart/renku-ui-server/values.yaml
+++ b/helm-chart/renku-ui-server/values.yaml
@@ -1,0 +1,117 @@
+# Default values for ui-server.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+global:
+  ## Specify a secret that containes the certificate
+  ## if you would like to use a custom CA. The key for the secret
+  ## should have the .crt extension otherwise it is ignored. The
+  ## keys across all secrets are mounted as files in one location so
+  ## the keys across all secrets have to be unique.
+  certificates:
+    image:
+      repository: renku/certificates
+      tag: '0.0.1'
+    customCAs: []
+      # - secret:
+
+  ## Specify the information required to connect to a redis instance.
+  ## All the values below are required.
+  redis:
+    sentinel:
+      enabled: true
+      masterSet: mymaster
+    dbIndex:
+      uiServer: "2"
+    host: renku-redis
+    port: 26379
+    clientLabel:
+      renku-redis-host: "true"
+    existingSecret: redis-secret
+    existingSecretPasswordKey: redis-password
+
+replicaCount: 1
+
+image:
+  repository: renku/renku-ui-server
+  tag: "2.5.0"
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podSecurityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+
+securityContext:
+  runAsUser: 1000
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths: []
+
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+## Configure autoscaling
+autoscaling:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 5
+  cpuUtilization: 95
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+serverData:
+  url:
+  port: 8080
+  prefix: /ui-server
+
+gateway:
+  url:
+  loginSuffix: /auth/login
+  logoutSuffix: /auth/logout
+
+sentry:
+  enabled: false
+  dsn: ""
+  environment: ""
+  sampleRate: 0
+  debugMode: false
+
+authentication:
+  url:
+  id: renku-ui
+  # secret: 1234abcd # do not provide any value here to use the global gateway client secret
+  expirationTolerance: 10 # in seconds

--- a/helm-chart/renku-ui/values.yaml
+++ b/helm-chart/renku-ui/values.yaml
@@ -184,7 +184,9 @@ server:
     # If not set and create is true, a name is generated using the fullname template
     name: ""
 
-  podSecurityContext: {}
+  podSecurityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
 
   securityContext:
     runAsUser: 1000

--- a/helm-chart/renku-ui/values.yaml
+++ b/helm-chart/renku-ui/values.yaml
@@ -79,10 +79,12 @@ client:
 
   affinity: {}
 
-  podSecurityContext: {}
+  podSecurityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
 
   securityContext:
-    runAsUser: 101
+    runAsUser: 1000
     runAsNonRoot: true
     allowPrivilegeEscalation: false
 

--- a/server/README.md
+++ b/server/README.md
@@ -42,29 +42,15 @@ The second category is fully managed by the service, errors included.
 ## Developing the UI server
 
 Once you have a development instance of Renku running locally or in the cloud,
-you can [install telepresence v1](https://www.telepresence.io/docs/v1/reference/install).
+you can [install telepresence v2.4.x](https://www.telepresence.io/docs/v2.4/install).
 Clone the repository and run `npm install` (remember to re-run it every time there are
 changes on the requirements file!).
-Now you can start a development environment by using the `run-telepresence.sh` script from the `server` folder.
+Now you can start a development environment by using the `telepresence-intercept.sh`
+script from the `server` folder.
 
-The script will print some information, ask you for an admin password (required by telepresence) and then run the npm server.
-
-**TIP**: If you need to debug, you should set the environment variable `DEBUG=1`.\
-That supports also attaching external debuggers to hit breakpoints (E.G. [VScode](https://code.visualstudio.com)).
-
-```
-$ cd server
-$ npm install
-$ DEBUG=1 ./run-telepresence.sh
-```
+The script will print some information, ask you for an admin password (required by telepresence) and then start an npm server that intecepts the trafic to the ui-server.
 
 **TIP**: When you are developing, you may need to restart the server after a crash. Re-creating
-the telepresence pod each time you save a file is tedious. You could instead enable the console
-mode by setting `CONSOLE=1`. This will give you access to a console on the pods where you can
-start and stop the service manually. Keep in mind it's a bit more fragile and you may accidentally have stale services hanging on the target port.
-
-```
-$ cd server
-$ CONSOLE=1 ./run-telepresence.sh
-(tel)$ npm run dev-debug
-```
+the telepresence pod each time you save a file is tedious. You could instead use the console
+mode when the script ask you for that. This will give you access to a console on the pods where you can start and stop the service manually. Keep in mind it's a bit more fragile and you may accidentally have stale services hanging on the target port. If the debugger cannot be attached
+anymore, you should check if a pending npm process is still running: `lsof -i :9229`.

--- a/server/telepresence-intercept.sh
+++ b/server/telepresence-intercept.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+#
+# Copyright 2022 - Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+COLOR_RED="\033[0;31m"
+COLOR_RESET="\033[0m"
+
+echo -e "If you target a CI deployment, you can type the PR number"
+if [[ ! $DEV_NAMESPACE ]]
+then
+    read -p "No dev namespace found. Please specify one: " -r
+    DEV_NAMESPACE=$REPLY
+else
+    echo -e "Your current dev namespace is: ${COLOR_RED}${DEV_NAMESPACE}${COLOR_RESET}"
+    read -p "Press enter to use it, or type a different one [skip]: " -r
+    if [[ $REPLY ]]
+    then
+        DEV_NAMESPACE=$REPLY
+    fi
+fi
+if [[ ! $DEV_NAMESPACE ]]
+then
+    echo "ERROR: you need to provide a namespace"
+    exit 1
+fi
+if [[ $DEV_NAMESPACE =~ ^[0-9]+$ ]]
+then
+    DEV_NAMESPACE=renku-ci-ui-${DEV_NAMESPACE}
+    SERVICE_NAME=${DEV_NAMESPACE}-uiserver
+else
+    SERVICE_NAME=${DEV_NAMESPACE}-renku-uiserver
+fi
+
+echo -e "The service will start by default. You can switch to console mode to manually start the service."
+read -p "Do you want to use console mode? [Y/n]: " -r
+if [[ $REPLY =~ ^([yY][eE][sS]|[yY])$ ]]
+then
+    SERVICE_CONSOLE_MODE=1
+    SERVICE_CONSOLE_MODE_TEXT="on"
+else
+    SERVICE_CONSOLE_MODE=0
+    SERVICE_CONSOLE_MODE_TEXT="off"
+fi
+
+echo -e ""
+echo -e "Telepresence will start in the dev namespace ${COLOR_RED}${DEV_NAMESPACE}${COLOR_RESET}"
+echo -e "Target service: ${COLOR_RED}${SERVICE_NAME}${COLOR_RESET}"
+echo -e "Console mode: ${COLOR_RED}${SERVICE_CONSOLE_MODE_TEXT}${COLOR_RESET}"
+if [[ $SERVICE_CONSOLE_MODE == 1 ]]
+then
+    echo -e "You can start the service and wait for a debugger to attach with:"
+    echo -e "${COLOR_RED}> npm run dev-debug${COLOR_RESET}"
+fi
+echo -e "\U26A0 Please enter the sudo password when asked."
+
+if [[ $SERVICE_CONSOLE_MODE == 1 ]]
+then
+    telepresence intercept -n ${DEV_NAMESPACE} ${SERVICE_NAME} --port 8080 --mount=true -- bash
+else
+    telepresence intercept -n ${DEV_NAMESPACE} ${SERVICE_NAME} --port 8080 --mount=true -- npm run dev-debug
+fi


### PR DESCRIPTION
As a follow-up to #1794 , this PR adds the missing `runAsGroup` pod security context.
That requires moving to telepresence 2, which turned out to be easy for the server, but not straightforward for the client. There is likely something to adjust on the ports. I'll look into this later since it has already taken quite a bit of time.

/deploy renku=000-ui-server-chart #persist