### PR TITLE
feat: Update upload file component to adopt UX changes

### DIFF
--- a/client/src/utils/components/formgenerator/fields/FileUploaderInput.stories.tsx
+++ b/client/src/utils/components/formgenerator/fields/FileUploaderInput.stories.tsx
@@ -1,0 +1,39 @@
+/*!
+ * Copyright 2022 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as React from "react";
+import { Story } from "@storybook/react";
+import FileUploaderInput from "./FileUploaderInput";
+
+export default {
+  title: "components/FileUploaderInput",
+  component: FileUploaderInput,
+  argTypes: {
+  },
+};
+
+
+const Template: Story<any> = (args) => <FileUploaderInput {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  label: "Files",
+  required: false,
+  handlers: {
+    getFormDraftInternalValuesProperty: () => undefined
+  }
+};


### PR DESCRIPTION
This PR includes the UX changes for the file upload component.

To test it go to the form to create a new dataset:
Go to Projects -> click on a project -> click on Datasets -> click on Add a dataset.

![upload file](https://user-images.githubusercontent.com/43388408/166725566-ca5fc716-022d-4e44-836e-c7c3741f4978.gif)


Closes #1739 

/deploy renku=1811-main-menu-changes #persist