### PR TITLE
feat(client): strip dash from dataset id URLs

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -130,7 +130,7 @@ function CentralContentContainer(props) {
           p => <AddDataset
             key="addDatasetNew"
             insideProject={false}
-            identifier={`${p.match.params.identifier}`}
+            identifier={p.match.params?.identifier?.replaceAll("-", "")}
             datasets={p.datasets}
             model={props.model}
           />}
@@ -139,7 +139,7 @@ function CentralContentContainer(props) {
           p => <ShowDataset
             key="datasetPreview" {...p}
             insideProject={false}
-            identifier={`${p.match.params.identifier}`}
+            identifier={p.match.params?.identifier?.replaceAll("-", "")}
             client={props.client}
             projectsUrl="/projects"
             selectedDataset={p.match.params.datasetId}


### PR DESCRIPTION
The solution is simpler than the one suggested in the issue. We actually don't need to redirect the user since the new id is just the older one with the `-` chars stripped out.

/deploy renku=tests-new-project-form-changes #persist
fix #1819