### PR TITLE
feat(client): speed up checking docker images availability

### DIFF
--- a/client/src/model/RenkuModels.js
+++ b/client/src/model/RenkuModels.js
@@ -404,6 +404,15 @@ const notebooksSchema = new Schema({
   },
   ci: {
     [Prop.SCHEMA]: new Schema({
+      image: {
+        [Prop.SCHEMA]: new Schema({
+          available: { [Prop.INITIAL]: null },
+          fetched: { [Prop.INITIAL]: null },
+          fetching: { [Prop.INITIAL]: false },
+          registryId: { [Prop.INITIAL]: null },
+          error: { [Prop.INITIAL]: null },
+        })
+      },
       pipelines: {
         [Prop.SCHEMA]: new Schema({
           list: { [Prop.INITIAL]: [] },
@@ -425,7 +434,7 @@ const notebooksSchema = new Schema({
           error: { [Prop.INITIAL]: null },
         })
       },
-      image: {
+      looping: {
         [Prop.SCHEMA]: new Schema({
           available: { [Prop.INITIAL]: null },
           fetched: { [Prop.INITIAL]: null },
@@ -435,7 +444,7 @@ const notebooksSchema = new Schema({
       },
       target: { [Prop.INITIAL]: null }, // target commit id
       type: { [Prop.INITIAL]: null }, // anonymous, pinned, logged, owner
-      stage: { [Prop.INITIAL]: null }, // starting --> pipelines --> jobs --> images
+      stage: { [Prop.INITIAL]: null }, // starting --> images --> (pipelines --> jobs -->) looping
     })
   },
   logs: {

--- a/client/src/notebooks/NotebookStart.present.js
+++ b/client/src/notebooks/NotebookStart.present.js
@@ -491,8 +491,8 @@ class StartNotebookPipelinesBadge extends Component {
     }
     else if (ci.type === NotebooksHelper.ciTypes.pinned) {
       if (ciStatus.available) {
-        color = "primary";
-        text = "pinned";
+        color = "success";
+        text = "pinned available";
       }
       else {
         color = "danger";
@@ -565,9 +565,10 @@ class StartNotebookPipelinesContent extends Component {
         <div>
           <Label>
             <p>
-              <FontAwesomeIcon icon={faExclamationTriangle} /> The image for this commit is not currently available.
+              <FontAwesomeIcon icon={faExclamationTriangle} className="text-danger" /> The
+              image for this commit is not currently available.
             </p>
-            <p>
+            <p className="mb-0">
               Since building it takes a while, consider waiting a few minutes if the commit is very recent.
               <br />Otherwise, you can either select another commit or <ExternalLink role="text" size="sm"
                 title="contact a maintainer" url={`${this.props.externalUrl}/-/project_members`} /> for
@@ -653,7 +654,8 @@ class StartNotebookPipelinesContent extends Component {
     else if (
       (ciStatus.stage === ciStages.pipelines && !ciStatus.ongoing && !ciStatus.available) ||
       (ciStatus.stage === ciStages.jobs && getCiJobStatus(ci.jobs?.target) === ciStatuses.wrong) ||
-      (ciStatus.stage === ciStages.image && !ci.available)
+      (ciStatus.stage === ciStages.image && !ci.available) ||
+      (ciStatus.stage === ciStages.looping && !ci.available)
     ) {
       const tryBuild = owner ?
         (

--- a/client/src/notebooks/Notebooks.state.js
+++ b/client/src/notebooks/Notebooks.state.js
@@ -1104,7 +1104,7 @@ class NotebooksCoordinator {
         }
       }
       else {
-        // Is we have only 1 registry, we don't need to check anything else.
+        // If we have only 1 registry, we don't need to check anything else.
         error = null;
       }
     }

--- a/client/src/notebooks/README.md
+++ b/client/src/notebooks/README.md
@@ -36,12 +36,39 @@ stateDiagram-v2
       GetJobs --> JobFail
       GetJobs --> JobRunning
 
-      JobSuccess --> GetRegistry: if no initial registry
-      JobSuccess --> GetImage
+      JobSuccess --> GetProjectImageNoEscape
+
+      GetProjectImageNoEscape --> pi_error
+      GetProjectImageNoEscape --> pi_found
       JobFail --> pi_error
       JobRunning --> GetJobs
 
       pi_found --> [*]
       pi_error --> [*]
+    }
+
+    state GetProjectImageNoEscape {
+      [*] --> no_escape_GetRegistry
+
+      no_escape_GetRegistry --> no_escape_error
+      no_escape_GetRegistry --> no_escape_Image
+
+      no_escape_Image --> no_escape_error
+      no_escape_Image --> no_escape_found
+      no_escape_Image --> no_escape_Unavailable
+      no_escape_Image --> no_escape_Jobs
+
+      no_escape_Unavailable --> no_escape_Image: if anon
+      no_escape_Jobs --> no_escape_JobSuccess
+      no_escape_Jobs --> no_escape_JobFail
+      no_escape_Jobs --> no_escape_JobRunning
+
+      no_escape_JobSuccess --> no_escape_Registry: if no initial registry
+      no_escape_JobSuccess --> no_escape_Image
+      no_escape_JobFail --> no_escape_error
+      no_escape_JobRunning --> no_escape_Jobs
+
+      no_escape_found --> [*]
+      no_escape_error --> [*]
     }
 ```

--- a/client/src/notebooks/README.md
+++ b/client/src/notebooks/README.md
@@ -1,0 +1,47 @@
+# Session Support
+
+The logic behind sessions is complex because the process of identifying if a session can be started is complicated.
+
+# Find image
+
+```mermaid
+stateDiagram-v2
+    [*] --> GetRemoteImage
+    [*] --> GetProjectImage
+
+    GetProjectImage --> Error
+    GetProjectImage --> Found
+
+    GetRemoteImage --> Error
+    GetRemoteImage --> Found
+
+    Found --> [*]
+    Error --> [*]
+
+    state GetProjectImage {
+      [*] --> GetRegistry
+
+      GetRegistry --> pi_error
+      GetRegistry --> GetImage
+      GetRegistry --> Unavailable
+
+      GetImage --> pi_error
+      GetImage --> pi_found
+      GetImage --> Unavailable
+
+      Unavailable --> GetImage: if anon
+      Unavailable --> GetPipelines
+      GetPipelines --> GetJobs
+      GetJobs --> JobSuccess
+      GetJobs --> JobFail
+      GetJobs --> JobRunning
+
+      JobSuccess --> GetRegistry: if no initial registry
+      JobSuccess --> GetImage
+      JobFail --> pi_error
+      JobRunning --> GetJobs
+
+      pi_found --> [*]
+      pi_error --> [*]
+    }
+```

--- a/e2e/cypress/integration/local/newSession.spec.ts
+++ b/e2e/cypress/integration/local/newSession.spec.ts
@@ -41,7 +41,7 @@ describe("launch sessions", () => {
 
   it("new session page - logged - success", () => {
     fixtures.userTest();
-    fixtures.newSessionPipelines().newSessionJobs().newSessionImages();
+    fixtures.newSessionImages();
     cy.visit("/projects/e2e/local-test-project/sessions/new");
     cy.wait("@getSessionImage", { timeout: 10000 });
     cy.contains("Do you want to select the branch, commit, or image?").should("be.visible");
@@ -51,7 +51,7 @@ describe("launch sessions", () => {
 
   it("new session page - logged - missing pipeline", () => {
     fixtures.userTest();
-    fixtures.newSessionPipelines(true);
+    fixtures.newSessionPipelines(true).newSessionImages(true);
     cy.visit("/projects/e2e/local-test-project/sessions/new");
     cy.wait("@getSessionPipelines", { timeout: 10000 });
     cy.contains("Hide advanced settings").should("be.visible");
@@ -86,7 +86,7 @@ describe("launch sessions", () => {
 
   it("new session page - logged - missing job", () => {
     fixtures.userTest();
-    fixtures.newSessionPipelines().newSessionJobs(true).newSessionImages();
+    fixtures.newSessionPipelines().newSessionJobs(true).newSessionImages(true);
     cy.visit("/projects/e2e/local-test-project/sessions/new");
     cy.wait("@getSessionJobs", { timeout: 10000 });
     cy.contains("Hide advanced settings").should("be.visible");
@@ -100,7 +100,7 @@ describe("launch sessions", () => {
 
   it("new session page - logged - running job", () => {
     fixtures.userTest();
-    fixtures.newSessionPipelines().newSessionJobs(false, true).newSessionImages();
+    fixtures.newSessionPipelines().newSessionJobs(false, true).newSessionImages(true);
     cy.visit("/projects/e2e/local-test-project/sessions/new");
     cy.wait("@getSessionJob", { timeout: 15000 });
     cy.contains("Hide advanced settings").should("be.visible");
@@ -114,7 +114,7 @@ describe("launch sessions", () => {
 
   it("new session page - logged - failed job", () => {
     fixtures.userTest();
-    fixtures.newSessionPipelines().newSessionJobs(false, false, true);
+    fixtures.newSessionPipelines().newSessionJobs(false, false, true).newSessionImages(true);
     cy.visit("/projects/e2e/local-test-project/sessions/new");
     cy.wait("@getSessionJobs", { timeout: 10000 });
     cy.contains("Hide advanced settings").should("be.visible");
@@ -129,9 +129,9 @@ describe("launch sessions", () => {
   it("new session page - locked project", () => {
     fixtures.projectLockStatus({ locked: true });
     fixtures.userTest();
-    fixtures.newSessionPipelines().newSessionJobs().newSessionImages();
+    fixtures.newSessionImages();
     cy.visit("/projects/e2e/local-test-project/sessions/new");
-    cy.wait("@getSessionPipelines", { timeout: 10000 });
+    cy.wait("@getSessionImage", { timeout: 10000 });
     cy.contains("Project is being modified").should("be.visible");
   });
 


### PR DESCRIPTION
This PR speeds up how we check for Docker image availability when starting a new session.
It prioritizes testing the Docker image, deferring checking pipelines and jobs -- doing it only when the image is missing.
This makes the logic in the UI similar to the one already used in renku-notebooks.

If no image is available, we either:
- [for anonymous users] notify the image is not available and keep checking for it
- [for logged users] check pipelines and jobs and provide adequate feedback -- showing quickfix buttons for users with permissions on the project

For pinned images, no big changes: we can't really check the pipelines in that case, so we just verify the image availability (without looping).

**How to test**
Ideally, the user shouldn't notice many differences. Trying to start a session and keeping the network tab open would simplify checking that we reach only the necessary APIs

/deploy renku=000-tests-ui-2_0-next #persist
fix #1742