### PR TITLE
fix: missing project display

### DIFF
--- a/client/src/dataset/Dataset.present.js
+++ b/client/src/dataset/Dataset.present.js
@@ -396,7 +396,7 @@ export default function DatasetView(props) {
     {
       //here we assume that if the dataset is only in one project
       //this one project is the current project and we don't display the list
-      (dataset.usedIn && dataset.usedIn.length > 1) && !props.insideProject ?
+      (dataset.usedIn && dataset.usedIn.length > 1) || !props.insideProject ?
         <DisplayProjects
           projects={dataset.usedIn}
           projectsUrl={props.projectsUrl}


### PR DESCRIPTION
The dataset page should show the projects a dataset is used in, even if there is just one.

<img width="1220" alt="image" src="https://user-images.githubusercontent.com/1196411/168289039-089d210a-70d5-446e-8ae1-c41baf8bdf66.png">


But the project dataset page should not (if there is just one).

<img width="1220" alt="image" src="https://user-images.githubusercontent.com/1196411/168289138-f08e30eb-c9f4-482d-ac03-c38f08c1cee7.png">

/deploy renku=000-tests-ui-2_0-next #persist