### PR TITLE
fix(client): adjust checking project lock status

### DIFF
--- a/client/src/api-client/project.js
+++ b/client/src/api-client/project.js
@@ -462,7 +462,6 @@ function addProjectMethods(client) {
    * @param {string} projectRepositoryUrl - external repository full url.
    * @param {string} [versionUrl] - project version url.
    */
-  /* eslint-enable max-len */
   client.getProjectLockStatus = async (projectRepositoryUrl, versionUrl = null) => {
     const url = client.versionedCoreUrl("project.lock_status", versionUrl);
     const queryParams = { git_url: projectRepositoryUrl };

--- a/client/src/project/Project.js
+++ b/client/src/project/Project.js
@@ -257,7 +257,7 @@ class View extends Component {
   }
 
   async fetchProjectLockStatus() {
-    return await this.projectCoordinator.fetchProjectLockStatus();
+    return await this.projectCoordinator.fetchProjectLockStatus(this.props.user.logged);
   }
 
   async fetchAll() {
@@ -278,7 +278,6 @@ class View extends Component {
       const migrationData = await this.fetchMigrationCheck(gitUrl, defaultBranch);
       const projectVersion = migrationData.core_compatibility_status?.project_metadata_version;
       await this.checkCoreAvailability(projectVersion);
-      await this.fetchProjectLockStatus();
       this.fetchProjectDatasets();
     }
   }
@@ -606,9 +605,9 @@ class View extends Component {
     },
     fetchDatasets: (forceReFetch) => {
       this.fetchProjectDatasetsFromKg();
-      this.fetchProjectDatasets(forceReFetch);
-      // Also check if the project is locked
-      this.fetchProjectLockStatus();
+      this.fetchProjectDatasets(forceReFetch).then(() => {
+        this.fetchProjectLockStatus();
+      });
     },
     setOpenFolder: (filePath) => {
       this.setProjectOpenFolder(filePath);

--- a/e2e/cypress/integration/local/project.spec.ts
+++ b/e2e/cypress/integration/local/project.spec.ts
@@ -157,7 +157,7 @@ describe("display lock status", () => {
 
   it("displays messages for locked project", () => {
     fixtures.projectLockStatus({ locked: true });
-    cy.visit("/projects/e2e/local-test-project/");
+    cy.visit("/projects/e2e/local-test-project/datasets");
     cy.wait("@getProject");
     cy.wait("@getProjectLockStatus");
     cy.contains("currently being modified").should("be.visible");
@@ -165,13 +165,15 @@ describe("display lock status", () => {
 
   it("displays error when the API fails", () => {
     fixtures.projectLockStatus({ locked: true, error: true });
-    cy.visit("/projects/e2e/local-test-project/");
+    cy.visit("/projects/e2e/local-test-project/datasets");
+    cy.wait("@getProjectLockStatus");
     cy.contains("cannot verify status").should("be.visible");
   });
 
   it("displays error when the legacy API fails", () => {
     fixtures.projectLockStatus({ locked: true, legacyError: true });
-    cy.visit("/projects/e2e/local-test-project/");
+    cy.visit("/projects/e2e/local-test-project/datasets");
+    cy.wait("@getProjectLockStatus");
     cy.contains("cannot verify status").should("be.visible");
   });
 });


### PR DESCRIPTION
The lock status should not show errors anymore for anonymous users, and we don't fetch it when non-necessary.

/deploy renku=000-tests-ui-2_0-next #persist
fix #1858