### PR TITLE
feat(client): add activation button to datasets page

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -96,6 +96,7 @@
         "@types/node": "^17.0.21",
         "@types/react": "^17.0.41",
         "@types/react-dom": "^17.0.14",
+        "@types/react-router-dom": "^5.1.2",
         "@types/styled-components": "^5.1.25",
         "@typescript-eslint/eslint-plugin": "^5.18.0",
         "@typescript-eslint/parser": "^5.18.0",
@@ -9321,6 +9322,12 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/history": {
+      "version": "4.7.11",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
+      "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
+      "dev": true
+    },
     "node_modules/@types/hoist-non-react-statics": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
@@ -9535,6 +9542,27 @@
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-router": {
+      "version": "5.1.18",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.18.tgz",
+      "integrity": "sha512-YYknwy0D0iOwKQgz9v8nOzt2J6l4gouBmDnWqUUznltOTaon+r8US8ky8HvN0tXvc38U9m6z/t2RsVsnd1zM0g==",
+      "dev": true,
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-router-dom": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz",
+      "integrity": "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==",
+      "dev": true,
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router": "*"
       }
     },
     "node_modules/@types/react-syntax-highlighter": {
@@ -45106,6 +45134,12 @@
         "@types/unist": "*"
       }
     },
+    "@types/history": {
+      "version": "4.7.11",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
+      "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
+      "dev": true
+    },
     "@types/hoist-non-react-statics": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
@@ -45324,6 +45358,27 @@
             "csstype": "^3.0.2"
           }
         }
+      }
+    },
+    "@types/react-router": {
+      "version": "5.1.18",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.18.tgz",
+      "integrity": "sha512-YYknwy0D0iOwKQgz9v8nOzt2J6l4gouBmDnWqUUznltOTaon+r8US8ky8HvN0tXvc38U9m6z/t2RsVsnd1zM0g==",
+      "dev": true,
+      "requires": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*"
+      }
+    },
+    "@types/react-router-dom": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz",
+      "integrity": "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==",
+      "dev": true,
+      "requires": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router": "*"
       }
     },
     "@types/react-syntax-highlighter": {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -45334,7 +45334,7 @@
       "integrity": "sha512-Tr9VU9DvNoHDWlmecmcsE5ZZiUkYx+nKBzum4Oxe1K0yJVyBlfbq7H3eXjxXqJczBKqPGq3EgfTru4MgKb9+Yw==",
       "dev": true,
       "requires": {
-        "@types/react": "^17"
+        "@types/react": "^17.0.41"
       }
     },
     "@types/react-redux": {
@@ -45377,7 +45377,7 @@
       "dev": true,
       "requires": {
         "@types/history": "^4.7.11",
-        "@types/react": "*",
+        "@types/react": "^17.0.41",
         "@types/react-router": "*"
       }
     },
@@ -45386,7 +45386,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.5.tgz",
       "integrity": "sha512-VIOi9i2Oj5XsmWWoB72p3KlZoEbdRAcechJa8Ztebw7bDl2YmR+odxIqhtJGp1q2EozHs02US+gzxJ9nuf56qg==",
       "requires": {
-        "@types/react": "*"
+        "@types/react": "^17.0.41"
       }
     },
     "@types/resolve": {
@@ -45422,7 +45422,7 @@
       "dev": true,
       "requires": {
         "@types/hoist-non-react-statics": "*",
-        "@types/react": "*",
+        "@types/react": "^17.0.41",
         "csstype": "^3.0.2"
       }
     },

--- a/client/package.json
+++ b/client/package.json
@@ -102,6 +102,7 @@
     "@types/node": "^17.0.21",
     "@types/react": "^17.0.41",
     "@types/react-dom": "^17.0.14",
+    "@types/react-router-dom": "^5.1.2",
     "@types/styled-components": "^5.1.25",
     "@typescript-eslint/eslint-plugin": "^5.18.0",
     "@typescript-eslint/parser": "^5.18.0",

--- a/client/package.json
+++ b/client/package.json
@@ -123,6 +123,9 @@
     "styled-components": "^5.3.5",
     "typescript": "^4.5.2"
   },
+  "overrides": {
+    "@types/react": "^17.0.41"
+  },
   "browserslist": [
     ">0.2%",
     "not dead",

--- a/client/src/dataset/Dataset.present.js
+++ b/client/src/dataset/Dataset.present.js
@@ -256,8 +256,7 @@ function ErrorAfterCreation(props) {
 }
 
 function AddToProjectButton({ goToAddToProject, insideKg, locked, logged, }) {
-  if (!logged) return null;
-  const tooltip = (locked) ?
+  const tooltip = (logged && locked) ?
     <ThrottledTooltip
       target="add-dataset-to-project-button"
       tooltip="Cannot add dataset to project until project modification finishes." /> :

--- a/client/src/dataset/DatasetError.js
+++ b/client/src/dataset/DatasetError.js
@@ -15,14 +15,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { useContext } from "react";
-import { Link } from "react-router-dom";
+import React from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSearch } from "@fortawesome/free-solid-svg-icons";
 
-import { Url } from "../utils/helpers/url";
 import { ErrorAlert, InfoAlert } from "../utils/components/Alert";
-import AppContext from "../utils/context/appContext";
+import LoginAlert from "../utils/components/loginAlert/LoginAlert";
 
 /**
  *  incubator-renku-ui
@@ -32,20 +30,8 @@ import AppContext from "../utils/context/appContext";
  */
 
 function DatasetError({ fetchError, insideProject, logged }) {
-  const { location } = useContext(AppContext);
-
-  // login helper
-  let loginHelper = null;
-  if (!logged) {
-    const to = Url.get(Url.pages.login.link, { pathname: location.pathname });
-    const link = (<Link className="btn btn-primary btn-sm" to={to}>Log in</Link>);
-    loginHelper = (
-      <p className="mb-0">
-        You might need to be logged in to see this dataset.
-        Please try to {link}
-      </p>
-    );
-  }
+  const textPre = "You might need to be logged in to see this dataset. ";
+  const textPost = "and try again.";
 
   // inside project case
   if (insideProject) {
@@ -61,7 +47,7 @@ function DatasetError({ fetchError, insideProject, logged }) {
     }
     const tip = logged ?
       (<p className="mb-0">You can try to select a dataset again from the list in the previous page.</p>) :
-      loginHelper;
+      (<LoginAlert logged={logged} textPost={textPost} textPre={textPre} />);
 
     return (
       <ErrorAlert>
@@ -90,7 +76,7 @@ function DatasetError({ fetchError, insideProject, logged }) {
           </ul>
         </InfoAlert>
       ) :
-      (<InfoAlert timeout={0}>{loginHelper}</InfoAlert>);
+      (<LoginAlert logged={logged} textPost={textPost} textPre={textPre} />);
     errorDetails = (
       <div>
         <h3 data-cy="dataset-error-title">Dataset not found <FontAwesomeIcon icon={faSearch} flip="horizontal" /></h3>

--- a/client/src/dataset/addtoproject/addDatasetExistingProject.js
+++ b/client/src/dataset/addtoproject/addDatasetExistingProject.js
@@ -162,8 +162,8 @@ const AddDatasetExistingProject = (
   if (!dataset) return null;
 
   return (
-    <div className="mt-4 mx-3">
-      <form onSubmit={onSubmit} className={"mt-2"} data-cy="form-project-exist">
+    <div className="mt-4">
+      <form onSubmit={onSubmit} className="mt-2" data-cy="form-project-exist">
         {suggestionInput}
       </form>
       {addDatasetStatus}

--- a/client/src/dataset/addtoproject/addDatasetNewProject.js
+++ b/client/src/dataset/addtoproject/addDatasetNewProject.js
@@ -102,7 +102,7 @@ const AddDatasetNewProject = (
     ) : null;
 
   return (
-    <div className="mt-4 mx-3">
+    <div className="mt-4">
       {form}
       {addDatasetStatus}
       {extraInfo}

--- a/client/src/notebooks/Notebooks.container.js
+++ b/client/src/notebooks/Notebooks.container.js
@@ -80,6 +80,7 @@ class ShowSession extends Component {
     this.coordinator.reset();
     this.notifications = props.notifications;
     this.target = props.match.params.server;
+    this.userLogged = this.userModel.get("logged");
 
     if (props.scope)
       this.coordinator.setNotebookFilters(props.scope, true);
@@ -123,8 +124,8 @@ class ShowSession extends Component {
   }
 
   render() {
-    if (this.props.blockAnonymous)
-      return <NotebooksDisabled location={this.props.location} />;
+    if (this.props.blockAnonymous && !this.userLogged)
+      return <NotebooksDisabled logged={this.userLogged} />;
 
     if (!this.model.get("notebooks.fetched"))
       return <Loader />;
@@ -175,6 +176,7 @@ class Notebooks extends Component {
     this.coordinator = new NotebooksCoordinator(props.client, this.model, this.userModel);
     // temporarily reset data since notebooks model was not designed to be static
     this.coordinator.reset();
+    this.userLogged = this.userModel.get("logged");
 
     if (props.scope)
       this.coordinator.setNotebookFilters(props.scope, true);
@@ -231,8 +233,8 @@ class Notebooks extends Component {
   }
 
   render() {
-    if (this.props.blockAnonymous)
-      return <NotebooksDisabled location={this.props.location} />;
+    if (this.props.blockAnonymous && !this.userLogged)
+      return <NotebooksDisabled logged={this.userLogged} />;
 
     return <VisibleNotebooks
       handlers={this.handlers}
@@ -276,6 +278,7 @@ class StartNotebookServer extends Component {
     this.userModel = props.model.subModel("user");
     this.coordinator = new NotebooksCoordinator(props.client, this.model, this.userModel);
     this.notifications = props.notifications;
+    this.userLogged = this.userModel.get("logged");
 
     // reset data since notebooks model was not designed to be static
     this.coordinator.reset();
@@ -787,8 +790,8 @@ class StartNotebookServer extends Component {
   }
 
   render() {
-    if (this.props.blockAnonymous)
-      return <NotebooksDisabled location={this.props.location} />;
+    if (this.props.blockAnonymous && !this.userLogged)
+      return <NotebooksDisabled logged={this.userLogged} />;
 
     return <StartNotebookServerPresent
       autoStarting={this.autostart && !this.state.autostartTried}

--- a/client/src/notebooks/Notebooks.present.js
+++ b/client/src/notebooks/Notebooks.present.js
@@ -20,9 +20,7 @@ import React, { Component, Fragment, useState, memo } from "react";
 import Media from "react-media";
 import { Link, useHistory } from "react-router-dom";
 import {
-  Alert, Badge, Button, Col, DropdownItem,
-  Nav, NavItem, NavLink, PopoverBody, PopoverHeader,
-  Row, UncontrolledPopover
+  Alert, Badge, Button, Col, DropdownItem, Nav, NavItem, NavLink, PopoverBody, PopoverHeader, Row, UncontrolledPopover
 } from "reactstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
@@ -32,10 +30,16 @@ import {
 import _ from "lodash";
 
 import { NotebooksHelper } from "./index";
+import SessionCheatSheet from "./SessionCheatSheet";
+import {
+  CheckNotebookIcon, StartNotebookServer, mergeEnumOptions, ServerOptionBoolean, ServerOptionEnum,
+  ServerOptionRange
+} from "./NotebookStart.present";
 import { formatBytes, simpleHash } from "../utils/helpers/HelperFunctions";
 import Time from "../utils/helpers/Time";
-import Sizes from "../utils/constants/Media";
 import { Url } from "../utils/helpers/url";
+import Sizes from "../utils/constants/Media";
+import { Docs } from "../utils/constants/Docs";
 import { ExternalLink } from "../utils/components/ExternalLinks";
 import { ButtonWithMenu } from "../utils/components/Button";
 import { TimeCaption } from "../utils/components/TimeCaption";
@@ -43,16 +47,11 @@ import { Loader } from "../utils/components/Loader";
 import { InfoAlert, } from "../utils/components/Alert";
 import { Clipboard } from "../utils/components/Clipboard";
 import { JupyterIcon } from "../utils/components/Icon";
-import SessionCheatSheet from "./SessionCheatSheet";
-import {
-  CheckNotebookIcon, StartNotebookServer, mergeEnumOptions, ServerOptionBoolean, ServerOptionEnum,
-  ServerOptionRange
-} from "./NotebookStart.present";
-
-import "./Notebooks.css";
+import LoginAlert from "../utils/components/loginAlert/LoginAlert";
 import { EnvironmentLogs, LogDownloadButton, LogTabs, useDownloadLogs } from "../utils/components/Logs";
 import { SessionStatus } from "../utils/constants/Notebooks";
-import { Docs } from "../utils/constants/Docs";
+
+import "./Notebooks.css";
 
 
 // * Constants and helpers * //
@@ -389,26 +388,9 @@ function SessionJupyter(props) {
 
 class NotebooksDisabled extends Component {
   render() {
-    const { location } = this.props;
-
-    const to = Url.get(Url.pages.login.link, { pathname: location.pathname });
-    const info = !location ?
-      null :
-      (
-        <InfoAlert timeout={0} key="login-info">
-          <p className="mb-0">
-            <Link className="btn btn-primary btn-sm" to={to}>Log in</Link> to use
-            sessions.
-          </p>
-        </InfoAlert>
-      );
-
-    return (
-      <div>
-        <p>This Renkulab deployment doesn&apos;t allow unauthenticated users to start sessions.</p>
-        {info}
-      </div>
-    );
+    const textIntro = "This Renkulab deployment does not allow unauthenticated users to start sessions.";
+    const textPost = "to use sessions.";
+    return (<LoginAlert logged={this.props.logged} textIntro={textIntro} textPost={textPost} />);
   }
 }
 

--- a/client/src/project/new/ProjectNew.present.js
+++ b/client/src/project/new/ProjectNew.present.js
@@ -26,21 +26,15 @@
 
 import React, { Component, Fragment } from "react";
 import { Link } from "react-router-dom";
-import {
-  Alert, Button, Form,
-  FormText, ModalBody, ModalFooter, ModalHeader,
-} from "reactstrap";
+import { Button, Form, FormText, ModalBody, ModalFooter, ModalHeader } from "reactstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import {
-  faExclamationTriangle,
-} from "@fortawesome/free-solid-svg-icons";
+import { faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
 
-import "./Project.style.css";
-import { Url } from "../../utils/helpers/url";
 import { Loader } from "../../utils/components/Loader";
 import { ErrorAlert, WarnAlert } from "../../utils/components/Alert";
-import AppContext from "../../utils/context/appContext";
+import LoginAlert from "../../utils/components/loginAlert/LoginAlert";
 import FormSchema from "../../utils/components/formschema/FormSchema";
+import ProgressIndicator, { ProgressStyle, ProgressType } from "../../utils/components/progress/Progress";
 import Automated from "./components/Automated";
 import Title from "./components/Title";
 import Description from "./components/Description";
@@ -53,7 +47,9 @@ import Template from "./components/Template";
 import TemplateVariables from "./components/TemplateVariables";
 import { FormErrors, FormWarnings } from "./components/FormValidations";
 import SubmitFormButton from "./components/SubmitFormButton";
-import ProgressIndicator, { ProgressStyle, ProgressType } from "../../utils/components/progress/Progress";
+import AppContext from "../../utils/context/appContext";
+
+import "./Project.style.css";
 
 function ForkProject(props) {
   const { error, fork, forkedTitle, forking, forkUrl, namespaces, projects, toggleModal } = props;
@@ -261,20 +257,11 @@ class NewProject extends Component {
       namespaces,
       templates
     } = this.props;
-    const { location } = this.context;
+
     if (!user.logged) {
-      const to = Url.get(Url.pages.login.link, { pathname: location.pathname });
-      return (
-        <>
-          <p>Only authenticated users can create new projects.</p>
-          <Alert color="primary">
-            <p className="mb-0">
-              <Link className="btn btn-primary btn-sm" to={to}>Log in</Link> to
-              create a new project.
-            </p>
-          </Alert>
-        </>
-      );
+      const textIntro = "Only authenticated users can create new projects.";
+      const textPost = "to create a new project.";
+      return (<LoginAlert logged={user.logged} textIntro={textIntro} textPost={textPost} />);
     }
 
     const title = "New Project";

--- a/client/src/project/overview/ProjectOverview.container.js
+++ b/client/src/project/overview/ProjectOverview.container.js
@@ -158,7 +158,7 @@ class OverviewVersion extends Component {
   }
 
   componentDidMount() {
-    this.projectCoordinator.fetchProjectLockStatus();
+    this.projectCoordinator.fetchProjectLockStatus(this.props.user.logged);
   }
 
   render() {

--- a/client/src/project/settings/ProjectSettings.present.js
+++ b/client/src/project/settings/ProjectSettings.present.js
@@ -45,6 +45,7 @@ import { Loader } from "../../utils/components/Loader";
 import { WarnAlert } from "../../utils/components/Alert";
 import { CoreErrorAlert } from "../../utils/components/errors/CoreErrorAlert";
 import { ExternalLink } from "../../utils/components/ExternalLinks";
+import LoginAlert from "../../utils/components/loginAlert/LoginAlert";
 import { Docs } from "../../utils/constants/Docs";
 
 
@@ -231,7 +232,7 @@ function RepositoryUrlRow(props) {
 //** Sessions settings **//
 
 function ProjectSettingsSessions(props) {
-  const { backend, config, location, metadata, newConfig, options, setConfig, user } = props;
+  const { backend, config, metadata, newConfig, options, setConfig, user } = props;
   const { accessLevel, repositoryUrl } = metadata;
   const devAccess = accessLevel > ACCESS_LEVELS.DEVELOPER ? true : false;
   const locked = props.lockStatus?.locked ?? false;
@@ -239,11 +240,11 @@ function ProjectSettingsSessions(props) {
 
   // ? Anonymous users may have problem with notebook options, depending on the deployment
   if (!user.logged) {
-    const to = Url.get(Url.pages.login.link, { pathname: location.pathname });
+    const textIntro = "Only authenticated users can access sessions setting.";
+    const textPost = "to visualize sessions settings.";
     return (
       <SessionsDiv>
-        <p>Anonymous users cannot access sessions settings.</p>
-        <p>You can <Link className="btn btn-primary btn-sm" to={to}>Log in</Link> to see them.</p>
+        <LoginAlert logged={user.logged} textIntro={textIntro} textPost={textPost} />
       </SessionsDiv>
     );
   }

--- a/client/src/utils/components/loginAlert/LoginAlert.stories.tsx
+++ b/client/src/utils/components/loginAlert/LoginAlert.stories.tsx
@@ -25,7 +25,7 @@
 
 import * as React from "react";
 import { Story } from "@storybook/react";
-// import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router-dom";
 import LoginAlert, { LoginAlertProps } from "./LoginAlert";
 
 export default {
@@ -34,38 +34,41 @@ export default {
   argTypes: {
     logged: {
       control: { type: "boolean" },
-      description: "Whether the user is logged or not."
+      description: "Whether the user is logged or not.",
     },
     textIntro: {
       control: { type: "text" },
-      description: "Additional text to show in a paragraph outside the Alert."
+      description: "Additional text to show in a paragraph outside the Alert.",
     },
     textLogin: {
       control: { type: "text" },
-      description: "Log in button text."
+      description: "Log in button text.",
     },
     textPost: {
       control: { type: "text" },
-      description: "Text after the log in button."
+      description: "Text after the log in button.",
     },
     textPre: {
       control: { type: "text" },
-      description: "Text before the log in button."
-    }
+      description: "Text before the log in button.",
+    },
   },
 };
 
-
-const Template: Story<LoginAlertProps> = (args) => <LoginAlert {...args} />;
+const Template: Story<LoginAlertProps> = (args) => (
+  <MemoryRouter>
+    <LoginAlert {...args} />
+  </MemoryRouter>
+);
 
 export const Default = Template.bind({});
 Default.args = {
-  logged: false
+  logged: false,
 };
 
 export const Logged = Template.bind({});
 Default.args = {
-  logged: true
+  logged: true,
 };
 
 export const Complete = Template.bind({});
@@ -76,5 +79,3 @@ Default.args = {
   textPost: "Text: textPost",
   textPre: "Text: textPre",
 };
-
-// Default.decorators = [(Story => { <MemoryRouter><Story /></MemoryRouter> })]

--- a/client/src/utils/components/loginAlert/LoginAlert.stories.tsx
+++ b/client/src/utils/components/loginAlert/LoginAlert.stories.tsx
@@ -25,8 +25,10 @@
 
 import * as React from "react";
 import { Story } from "@storybook/react";
-import { MemoryRouter } from "react-router-dom";
+// import { MemoryRouter } from "react-router-dom";
 import LoginAlert, { LoginAlertProps } from "./LoginAlert";
+
+// TODO: re-enable MemoryRouter as soon as the version is compatible again
 
 export default {
   title: "components/LoginAlert",
@@ -55,11 +57,23 @@ export default {
   },
 };
 
+// const Template: Story<LoginAlertProps> = (args) => (
+//   <MemoryRouter>
+//     <LoginAlert {...args} />
+//   </MemoryRouter>
+// );
 const Template: Story<LoginAlertProps> = (args) => (
-  <MemoryRouter>
-    <LoginAlert {...args} />
-  </MemoryRouter>
+  <LoginAlert {...args} />
 );
+
+export const Complete = Template.bind({});
+Complete.args = {
+  logged: false,
+  textLogin: "log in",
+  textIntro: "You need to log in to modify workflows.",
+  textPost: " and unleash your creativity.",
+  textPre: "To unlock it, please ",
+};
 
 export const Default = Template.bind({});
 Default.args = {
@@ -67,15 +81,6 @@ Default.args = {
 };
 
 export const Logged = Template.bind({});
-Default.args = {
+Logged.args = {
   logged: true,
-};
-
-export const Complete = Template.bind({});
-Default.args = {
-  logged: true,
-  textLogin: "Text: textLogin",
-  textIntro: "Text: textIntro",
-  textPost: "Text: textPost",
-  textPre: "Text: textPre",
 };

--- a/client/src/utils/components/loginAlert/LoginAlert.stories.tsx
+++ b/client/src/utils/components/loginAlert/LoginAlert.stories.tsx
@@ -1,0 +1,80 @@
+/*!
+ * Copyright 2022 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  LoginAlert.stories.tsx
+ *  LoginAlert component storybook
+ */
+
+import * as React from "react";
+import { Story } from "@storybook/react";
+// import { MemoryRouter } from "react-router-dom";
+import LoginAlert, { LoginAlertProps } from "./LoginAlert";
+
+export default {
+  title: "components/LoginAlert",
+  component: LoginAlert,
+  argTypes: {
+    logged: {
+      control: { type: "boolean" },
+      description: "Whether the user is logged or not."
+    },
+    textIntro: {
+      control: { type: "text" },
+      description: "Additional text to show in a paragraph outside the Alert."
+    },
+    textLogin: {
+      control: { type: "text" },
+      description: "Log in button text."
+    },
+    textPost: {
+      control: { type: "text" },
+      description: "Text after the log in button."
+    },
+    textPre: {
+      control: { type: "text" },
+      description: "Text before the log in button."
+    }
+  },
+};
+
+
+const Template: Story<LoginAlertProps> = (args) => <LoginAlert {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  logged: false
+};
+
+export const Logged = Template.bind({});
+Default.args = {
+  logged: true
+};
+
+export const Complete = Template.bind({});
+Default.args = {
+  logged: true,
+  textLogin: "Text: textLogin",
+  textIntro: "Text: textIntro",
+  textPost: "Text: textPost",
+  textPre: "Text: textPre",
+};
+
+// Default.decorators = [(Story => { <MemoryRouter><Story /></MemoryRouter> })]

--- a/client/src/utils/components/loginAlert/LoginAlert.tsx
+++ b/client/src/utils/components/loginAlert/LoginAlert.tsx
@@ -1,0 +1,69 @@
+/*!
+ * Copyright 2022 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  renku-ui
+ *
+ *  LoginAlert.tsx
+ *  LoginAlert component
+ */
+
+
+import React from "react";
+import { Link, useLocation } from "react-router-dom";
+
+import { Alert } from "../../../utils/ts-wrappers";
+import { Url } from "../../helpers/url";
+
+
+export interface LoginAlertProps {
+  logged: boolean,
+  textIntro: string
+  textLogin: string
+  textPost: string
+  textPre: string
+}
+
+const LoginAlert = ({
+  logged,
+  textLogin = "Log in",
+  textIntro,
+  textPost = " to use this feature.",
+  textPre
+}: LoginAlertProps) => {
+  const location = useLocation();
+
+  // No need to show anything when the user is logged.
+  if (logged)
+    return null;
+
+  const loginUrl = Url.get(Url.pages.login.link, { pathname: location.pathname });
+  const link = (<Link className="btn btn-primary btn-sm" to={loginUrl}>{textLogin}</Link>);
+  const introElement = textIntro ? (<p>{textIntro}</p>) : null;
+
+  return (
+    <>
+      {introElement}
+      <Alert color="primary">
+        <p className="mb-0">{textPre} {link} {textPost}</p>
+      </Alert>
+    </>
+  );
+};
+
+export default LoginAlert;

--- a/e2e/cypress/integration/local/project.spec.ts
+++ b/e2e/cypress/integration/local/project.spec.ts
@@ -218,7 +218,6 @@ describe("display migration information for anon user", () => {
   it("displays required migration", () => {
     fixtures.projectMigrationRequired();
     cy.visit("/projects/e2e/local-test-project/overview/status");
-    cy.wait("@getProjectLockStatus");
     // Check that the migration suggestion is not shown
     cy.contains("Project Renku Version");
     cy.contains("This project is not compatible with the RenkuLab UI").should(


### PR DESCRIPTION
This PR adds an action button to the datasets pages making the UX more in line with logged users.
All the pages requiring anonymous users to log in now have a similar style too (see screenshots below).
P.S: the PR includes also a couple of minor bug fixes.

**Screenshots: dataset**
Logged users on the left, anonymous on the right

![Screenshot_20220530_163508](https://user-images.githubusercontent.com/43481553/171029226-10f7d5a5-0fd8-4a6a-b51a-ae653e3ea0c5.png)

![Screenshot_20220530_163614](https://user-images.githubusercontent.com/43481553/171029231-49422fff-f138-468d-ad23-7560fb42022d.png)

**Screenshots: other log-in pages**

![Screenshot_20220530_165303](https://user-images.githubusercontent.com/43481553/171029295-5f02fda2-15be-4cda-967c-660c6d8f3b50.png)

![Screenshot_20220530_165316](https://user-images.githubusercontent.com/43481553/171029313-c7bcb504-5246-482e-9cc4-eadc8978eaf6.png)

![Screenshot_20220530_170000](https://user-images.githubusercontent.com/43481553/171029322-1bf52260-0bb6-461a-8a62-9843cb3b8940.png)

![Screenshot_20220530_171149](https://user-images.githubusercontent.com/43481553/171029337-d39deae2-3a95-4513-909d-167070909c04.png)

/deploy renku=000-tests-ui-2_3_1 #persist
fix #1836