### PR TITLE
fix: send dataset current image url when updating the dataset (#1861)

### DIFF
--- a/client/src/project/datasets/change/DatasetChange.container.js
+++ b/client/src/project/datasets/change/DatasetChange.container.js
@@ -236,18 +236,22 @@ function ChangeDataset(props) {
     dataset.keywords = mappedInputs.keywords;
     dataset.creators = mappedInputs.creators.map(creator => getCreator(creator));
 
-    if (mappedInputs.image.options.length && mappedInputs.image.selected) {
-      const images = await uploadDatasetImages(mappedInputs.image, handlers);
-      if (images)
-        dataset.images = images;
+    if (mappedInputs.image.options.length) {
+      const imageSelected = mappedInputs.image.options[mappedInputs.image.selected];
+      if (imageSelected.STOCK === false) {
+        const images = await uploadDatasetImages(mappedInputs.image, handlers);
+        if (images)
+          dataset.images = images;
+      }
+      else {
+        dataset.images = [{
+          "content_url": mappedInputs.image.options[mappedInputs.image.selected]?.URL,
+          "position": 0,
+          "mirror_locally": true
+        }];
+      }
     }
-    else if (mappedInputs.image.options.length && !mappedInputs.image.selected && mappedInputs.image.options[0]?.URL) {
-      dataset.images = [{
-        "content_url": mappedInputs.image.options[0]?.URL,
-        "position": 0,
-        "mirror_locally": true
-      }];
-    }
+
     props.client.postDataset(props.httpProjectUrl, dataset, props.defaultBranch, props.edit, versionUrl)
       .then(response => {
         if (response.data.error !== undefined) {

--- a/client/src/project/datasets/change/DatasetChange.container.js
+++ b/client/src/project/datasets/change/DatasetChange.container.js
@@ -241,7 +241,13 @@ function ChangeDataset(props) {
       if (images)
         dataset.images = images;
     }
-
+    else if (mappedInputs.image.options.length && !mappedInputs.image.selected && mappedInputs.image.options[0]?.URL) {
+      dataset.images = [{
+        "content_url": mappedInputs.image.options[0]?.URL,
+        "position": 0,
+        "mirror_locally": true
+      }];
+    }
     props.client.postDataset(props.httpProjectUrl, dataset, props.defaultBranch, props.edit, versionUrl)
       .then(response => {
         if (response.data.error !== undefined) {


### PR DESCRIPTION
PR to send the url of the current image when updating the dataset so as not to delete the existing image.
Currently the endpoint for updating a dataset requests the url of the current image from the dataset to keep that image, otherwise it deletes the image. This is a workaround for this case, but the API should not delete the image if it is not included in the dataset object when updating a dataset.

closes #1861 

/deploy #persist