### PR TITLE
fix(client): hide download button for folders in lineage view

### DIFF
--- a/client/src/file/Lineage.present.js
+++ b/client/src/file/Lineage.present.js
@@ -262,13 +262,19 @@ class FileLineage extends Component {
       );
     }
 
-    const buttonDownload = (
-      <ExternalIconLink
-        tooltip="Download File"
-        icon={faDownload}
-        to={`${this.props.externalUrl}/-/raw/master/${this.props.path}?inline=false`}
-      />
-    );
+    const fileInfo = this.props.filesTree?.hash && this.props.gitFilePath ?
+      this.props.filesTree.hash[this.props.gitFilePath] :
+      null;
+    // Do not show the download button if it's a folder
+    const buttonDownload = fileInfo && fileInfo.type === "tree" ?
+      null :
+      (
+        <ExternalIconLink
+          tooltip="Download File"
+          icon={faDownload}
+          to={`${this.props.externalUrl}/-/raw/master/${this.props.path}?inline=false`}
+        />
+      );
 
     return <Card className="border-rk-light">
       <CardHeader className="d-flex align-items-center bg-white justify-content-between pe-3 ps-3">


### PR DESCRIPTION
As reported by @gavin-k-lee , the lineage preview shows a download button also for folders (see below). Clicking on it brings the user to a 404 page on GitLab.

This PR removes it -- that is already the case for the file preview.

![Peek 2022-06-09 08-50](https://user-images.githubusercontent.com/43481553/172882022-8039a282-de8b-455f-bf5d-ac9cd4e53807.gif)

/deploy #persist


