### PR TITLE
feat: set page title to project or dataset title (#1881)

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -50,6 +50,7 @@
         "react-collapse": "^5.0.0",
         "react-cookie-consent": "^5.2.0",
         "react-dom": "^17.0.2",
+        "react-helmet": "^6.1.0",
         "react-js-pagination": "^3.0.2",
         "react-katex": "^2.0.2",
         "react-markdown": "^8.0.3",
@@ -2982,6 +2983,18 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8415,6 +8428,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@storybook/react/node_modules/type-fest": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.13.0.tgz",
+      "integrity": "sha512-lPfAm42MxE4/456+QyIaaVBAwgpJb6xZ8PRu09utnhPdWwcyj9vgy6Sq0Z5yNbJ21EdxB5dRU/Qg8bsyAMtlcw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@storybook/router": {
       "version": "6.4.22",
       "resolved": "https://registry.npmjs.org/@storybook/router/-/router-6.4.22.tgz",
@@ -9505,9 +9532,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "17.0.44",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.44.tgz",
-      "integrity": "sha512-Ye0nlw09GeMp2Suh8qoOv0odfgCoowfM/9MG6WeRD60Gq9wS90bdkdRtYbRkNhXOpG4H+YXGvj4wOWhAC0LJ1g==",
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.45.tgz",
+      "integrity": "sha512-YfhQ22Lah2e3CHPsb93tRwIGNiSwkuz1/blk4e6QrWS0jQzCSNbGLtOEYhPg02W0yGTTmpajp7dCTbBAMN3qsg==",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -12158,6 +12185,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/boxen/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/boxen/node_modules/wrap-ansi": {
@@ -16655,6 +16694,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/eslint-plugin-spellcheck/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/eslint-plugin-testing-library": {
       "version": "3.10.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-3.10.2.tgz",
@@ -17200,6 +17251,18 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/eslint/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint/node_modules/which": {
@@ -29907,6 +29970,20 @@
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
+    "node_modules/react-helmet": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
+      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.1.1",
+        "react-side-effect": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
+      }
+    },
     "node_modules/react-helmet-async": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-1.3.0.tgz",
@@ -30876,6 +30953,14 @@
       "dev": true,
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/react-side-effect": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.1.tgz",
+      "integrity": "sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ==",
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.0"
       }
     },
     "node_modules/react-sizeme": {
@@ -35896,10 +35981,12 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -40523,6 +40610,12 @@
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
           "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
           "dev": true
+        },
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+          "dev": true
         }
       }
     },
@@ -44352,6 +44445,14 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
           "dev": true
+        },
+        "type-fest": {
+          "version": "2.13.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.13.0.tgz",
+          "integrity": "sha512-lPfAm42MxE4/456+QyIaaVBAwgpJb6xZ8PRu09utnhPdWwcyj9vgy6Sq0Z5yNbJ21EdxB5dRU/Qg8bsyAMtlcw==",
+          "dev": true,
+          "optional": true,
+          "peer": true
         }
       }
     },
@@ -45133,13 +45234,12 @@
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
       "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
       "requires": {
-        "@types/react": "*",
+        "@types/react": "^17.0.41",
         "hoist-non-react-statics": "^3.3.0"
       },
       "dependencies": {
         "@types/react": {
-          "version": "18.0.0",
-          "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.0.tgz",
+          "version": "https://registry.npmjs.org/@types/react/-/react-18.0.0.tgz",
           "integrity": "sha512-7+K7zEQYu7NzOwQGLR91KwWXXDzmTFODRVizJyIALf6RfLv2GDpqpknX64pvRVILXCpXi7O/pua8NGk44dLvJw==",
           "requires": {
             "@types/prop-types": "*",
@@ -45307,9 +45407,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "17.0.44",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.44.tgz",
-      "integrity": "sha512-Ye0nlw09GeMp2Suh8qoOv0odfgCoowfM/9MG6WeRD60Gq9wS90bdkdRtYbRkNhXOpG4H+YXGvj4wOWhAC0LJ1g==",
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.45.tgz",
+      "integrity": "sha512-YfhQ22Lah2e3CHPsb93tRwIGNiSwkuz1/blk4e6QrWS0jQzCSNbGLtOEYhPg02W0yGTTmpajp7dCTbBAMN3qsg==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -45331,14 +45431,13 @@
       "integrity": "sha512-D02o3FPfqQlfu2WeEYwh3x2otYd2Dk1o8wAfsA0B1C2AJEFxE663Ozu7JzuWbznGgW248NaOF6wsqCGNq9d3qw==",
       "requires": {
         "@types/hoist-non-react-statics": "^3.3.0",
-        "@types/react": "*",
+        "@types/react": "^17.0.41",
         "hoist-non-react-statics": "^3.3.0",
         "redux": "^4.0.0"
       },
       "dependencies": {
         "@types/react": {
-          "version": "18.0.0",
-          "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.0.tgz",
+          "version": "https://registry.npmjs.org/@types/react/-/react-18.0.0.tgz",
           "integrity": "sha512-7+K7zEQYu7NzOwQGLR91KwWXXDzmTFODRVizJyIALf6RfLv2GDpqpknX64pvRVILXCpXi7O/pua8NGk44dLvJw==",
           "requires": {
             "@types/prop-types": "*",
@@ -45355,7 +45454,7 @@
       "dev": true,
       "requires": {
         "@types/history": "^4.7.11",
-        "@types/react": "*"
+        "@types/react": "^17.0.41"
       }
     },
     "@types/react-router-dom": {
@@ -47442,6 +47541,12 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        },
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+          "dev": true
         },
         "wrap-ansi": {
           "version": "7.0.0",
@@ -50982,6 +51087,12 @@
             "prelude-ls": "^1.2.1"
           }
         },
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+          "dev": true
+        },
         "which": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -51256,6 +51367,12 @@
           "requires": {
             "type-fest": "^0.20.2"
           }
+        },
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+          "dev": true
         }
       }
     },
@@ -61058,6 +61175,17 @@
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
+    "react-helmet": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
+      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
+      "requires": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.1.1",
+        "react-side-effect": "^2.1.0"
+      }
+    },
     "react-helmet-async": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-1.3.0.tgz",
@@ -61722,6 +61850,12 @@
           "dev": true
         }
       }
+    },
+    "react-side-effect": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.1.tgz",
+      "integrity": "sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ==",
+      "requires": {}
     },
     "react-sizeme": {
       "version": "3.0.2",
@@ -65544,10 +65678,12 @@
       "dev": true
     },
     "type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "type-is": {
       "version": "1.6.18",

--- a/client/package.json
+++ b/client/package.json
@@ -45,6 +45,7 @@
     "react-collapse": "^5.0.0",
     "react-cookie-consent": "^5.2.0",
     "react-dom": "^17.0.2",
+    "react-helmet": "^6.1.0",
     "react-js-pagination": "^3.0.2",
     "react-katex": "^2.0.2",
     "react-markdown": "^8.0.3",

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -24,6 +24,7 @@
  */
 
 import React, { Component, Fragment } from "react";
+import { Helmet } from "react-helmet";
 import { Route, Switch } from "react-router-dom";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
@@ -72,6 +73,9 @@ function CentralContentContainer(props) {
 
   return <div className="container-xxl pt-4 mt-2 renku-container">
     <AppContext.Provider value={appContext}>
+      <Helmet>
+        <title>Reproducible Data Science | Open Research | Renku</title>
+      </Helmet>
       <Switch>
         <Route exact path="/login" render={
           p => <Login key="login" {...p} {...props} />} />

--- a/client/src/dataset/Dataset.present.js
+++ b/client/src/dataset/Dataset.present.js
@@ -17,6 +17,7 @@
  */
 
 import React, { useState } from "react";
+import { Helmet } from "react-helmet";
 import {
   Button, Card, CardBody, CardHeader, Col, DropdownItem, DropdownMenu, DropdownToggle, Row,
   Table, UncontrolledButtonDropdown, Badge
@@ -334,8 +335,20 @@ export default function DatasetView(props) {
       props.history.push(addDatasetUrl);
   };
 
+  const datasetTitle = dataset.title || dataset.name;
+  const datasetDesc = dataset.description;
+  const pageTitle = datasetDesc ?
+    `${datasetTitle} • Dataset • ${datasetDesc}` :
+    `${datasetTitle} • Dataset`;
+
   return <Col>
     <ErrorAfterCreation location={props.location} dataset={dataset} />
+    {
+      props.insideProject ? null :
+        <Helmet>
+          <title>{pageTitle}</title>
+        </Helmet>
+    }
     <Row>
       <Col md={8} sm={12}>
         {props.insideProject ?

--- a/client/src/project/Project.present.js
+++ b/client/src/project/Project.present.js
@@ -25,6 +25,7 @@
 
 
 import React, { Component, Fragment, useState, useEffect } from "react";
+import { Helmet } from "react-helmet";
 import { Link, Route, Switch } from "react-router-dom";
 import {
   Alert, Badge, Button, ButtonGroup, Card, CardBody, CardHeader, Col, DropdownItem,
@@ -1376,8 +1377,17 @@ class ProjectView extends Component {
           location={this.props.location} />
       );
     }
+    const projectTitle = this.props.metadata.title;
+    const projectPath = this.props.metadata.pathWithNamespace;
+    const projectDesc = this.props.metadata.description;
+    const pageTitle = projectDesc ?
+      `${projectTitle} • Project • ${projectPath} • ${projectDesc}` :
+      `${projectTitle} • Project • ${projectPath}`;
 
     return [
+      <Helmet key="page-title">
+        <title>{pageTitle}</title>
+      </Helmet>,
       <Switch key="projectHeader">
         <Route exact path={this.props.baseUrl}
           render={props => <ProjectViewHeader {...this.props} minimalistHeader={false}/>} />

--- a/e2e/cypress/integration/local/datasets.spec.ts
+++ b/e2e/cypress/integration/local/datasets.spec.ts
@@ -55,6 +55,8 @@ describe("display a dataset", () => {
     cy.get_cy("list-card-title").contains(datasetName).click();
     cy.wait("@getDatasetById")
       .its("response.body").then( dataset => {
+        // Check that the title is correct
+        cy.get("title").first().should("contain.text", "abcd • Dataset • Dataset for testing purposes");
         // the dataset title is displayed
         cy.get_cy("dataset-title").should("contain.text", dataset?.title);
         // files are displayed

--- a/e2e/cypress/integration/local/project.spec.ts
+++ b/e2e/cypress/integration/local/project.spec.ts
@@ -29,6 +29,7 @@ describe("display a project", () => {
   });
 
   it("displays the project overview page", () => {
+    cy.wait("@getProject");
     cy.wait("@getReadme");
     // Check that the project header is shown
     cy.get("[data-cy='project-header']").should(
@@ -37,6 +38,9 @@ describe("display a project", () => {
     );
     // Check that the readme is shown
     cy.get("h1").first().should("contain.text", "local test project");
+
+    // Check that the title is correct
+    cy.get("title").first().should("contain.text", "local-test-project • Project • e2e/local-test-project");
   });
 
   it("displays project settings", () => {


### PR DESCRIPTION
Introduces changes to set the title tag as a user navigates through Renku.

- On a project page, the title tag is the title of the project 
- On a dataset page, the title tag is the title of the dataset
- Otherwise, the title tag is "Reproducible Data Science | Open Research | Renku"

closes #1881 

**Project**
<img width="927" alt="image" src="https://user-images.githubusercontent.com/1196411/173108961-9a90b78a-5d74-4518-9894-0146d53b0eee.png">

**Dataset**
<img width="927" alt="image" src="https://user-images.githubusercontent.com/1196411/173109026-599322f9-efb3-4087-8a6f-ad1116d42dc2.png">

/deploy renku=tests-ui-2.5.0 #persist