### PR TITLE
fix: editing datasets without images

### DIFF
--- a/client/src/project/datasets/change/DatasetChange.container.js
+++ b/client/src/project/datasets/change/DatasetChange.container.js
@@ -244,11 +244,15 @@ function ChangeDataset(props) {
           dataset.images = images;
       }
       else {
-        dataset.images = [{
-          "content_url": mappedInputs.image.options[mappedInputs.image.selected]?.URL,
-          "position": 0,
-          "mirror_locally": true
-        }];
+        if (mappedInputs.image.options[mappedInputs.image.selected]?.URL != null) {
+          dataset.images = [
+            {
+              content_url: mappedInputs.image.options[mappedInputs.image.selected]?.URL,
+              position: 0,
+              mirror_locally: true,
+            },
+          ];
+        }
       }
     }
 


### PR DESCRIPTION
#1887 introduced an error in editing datasets that do not contain images. This PR makes dataset actions work in the following scenarios:

- Add a dataset without an image
- Add a dataset with an image
- Modify a dataset without an image
- Modify a dataset with an image

/deploy #persist