### PR TITLE
chore(chart): modify security context

### DIFF
--- a/helm-chart/renku-ui-server/values.yaml
+++ b/helm-chart/renku-ui-server/values.yaml
@@ -48,10 +48,11 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-podSecurityContext:
-  runAsUser: 1000
+podSecurityContext: {}
 
 securityContext:
+  runAsUser: 1000
+  runAsNonRoot: true
   allowPrivilegeEscalation: false
 
 service:

--- a/helm-chart/renku-ui/templates/deployment-template.yaml
+++ b/helm-chart/renku-ui/templates/deployment-template.yaml
@@ -106,6 +106,8 @@ spec:
             periodSeconds: 30
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
@@ -118,6 +120,8 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.pullSecrets }}

--- a/helm-chart/renku-ui/values.yaml
+++ b/helm-chart/renku-ui/values.yaml
@@ -51,6 +51,13 @@ tolerations: []
 
 affinity: {}
 
+podSecurityContext: {}
+
+securityContext:
+  runAsUser: 101
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+
 welcomePage:
   text: |
     ## Welcome to Renku!


### PR DESCRIPTION
This does a few things:
- Changes the security context defaults in the values file for the server so that the "global" pod-level security context is not set but rather the container-level security context is used. We cannot set the global security context for the whole pod because it interferes with the certificates container which needs elevated permissions
- Adds a security context to the nginx server in the ui client component, this already ran as non root which is great but it still does not hurt to make the security context modifiable through the helm chart and not have it hardcoded.

/deploy #persist