### PR TITLE
build: nginx configuration

### DIFF
--- a/client/nginx.vh.default.conf
+++ b/client/nginx.vh.default.conf
@@ -38,4 +38,14 @@ server {
     location / {
          try_files $uri $uri/ /index.html;
     }
+
+    location ~* .(?:css|js)$ {
+      expires 7d;
+      add_header Cache-Control "public";
+    }
+
+    location ~* .(?:jpg|png|svg)$ {
+      expires 7d;
+      add_header Cache-Control "public";
+    }
 }

--- a/client/nginx.vh.default.conf
+++ b/client/nginx.vh.default.conf
@@ -48,4 +48,12 @@ server {
       expires 7d;
       add_header Cache-Control "public";
     }
+
+    location /config.json {
+      add_header Cache-Control "no-cache, max-age=-1";
+    }
+
+    location /manifest.json {
+      add_header Cache-Control "no-cache, max-age=-1";
+    }
 }

--- a/client/nginx.vh.default.conf
+++ b/client/nginx.vh.default.conf
@@ -7,6 +7,9 @@ charset utf-8;
 # client_max_body_size ${CLIENT_MAX_BODY_SIZE}k;
 # reset_timedout_connection on;
 
+gzip on;
+gzip_vary on;
+gzip_proxied any;
 gzip_types
     text/css
     text/javascript

--- a/server/src/routes/apis.ts
+++ b/server/src/routes/apis.ts
@@ -34,6 +34,8 @@ const proxyMiddleware = createProxyMiddleware({
   // set gateway as target
   target: config.deployment.gatewayUrl,
   changeOrigin: true,
+  proxyTimeout: 600000,
+  timeout: 600000,
   pathRewrite: (path): string => {
     // remove basic ui-server routing
     const rewrittenPath = path.substring((config.server.prefix + config.routes.api).length);


### PR DESCRIPTION
* gzip proxied requests
* provide cache-control information for css, js, and, images
* turn off caching for config.json

Fix #1908 #1876

# Testing

**Compression**

Make a request for content (e.g., HTML) specifying that compression is allowed.

```
curl -H "Accept-Encoding: gzip" -i https://renku-ci-ui-1914.dev.renku.ch | head -n 10
```

You should see the following headers included in the response:

```
vary: Accept-Encoding
content-encoding: gzip
```

Compare with renkulab.io:
```
curl -H "Accept-Encoding: gzip" -i https://renkulab.io | head -n 10
```

**Cache control**

Request css, images, and js and see that cache-control headers are returned:

```
curl -I https://renku-ci-ui-1914.dev.renku.ch/static/css/main.31d541f2.chunk.css
```

```
curl -I https://renku-ci-ui-1914.dev.renku.ch/android-chrome-192x192.png
```

```
curl -I https://renku-ci-ui-1914.dev.renku.ch/main.b1a79a05ad246d1f14b3-4f12af5.chunk.js
```

You should see `cache-control` headers in the response. 

Compare with renkulab.io

```
curl -I https://renkulab.io/static/css/main.31d541f2.chunk.css
```

```
curl -I https://renkulab.io/android-chrome-192x192.png
```

```
curl -I https://renkulab.io/2.e7b53cb2366c4f6152b7-01e6d07.chunk.js
```

**config.json**

```
curl -I https://renku-ci-ui-1914.dev.renku.ch/config.json
```

You should see the following headers included in the response:

```
cache-control: no-cache, max-age=-1
```

The `config.json` file is small and only requested when renkulab is initially requested or reloaded, so it is infrequent and should not impose a performance penalty. 

Compare with renkulab.io:

```
curl -I https://renkulab.io/config.json
```


/deploy #persist