### PR TITLE
fix: check if autosave commit exists in project commit list before use it

### DIFF
--- a/client/src/notebooks/Notebooks.container.js
+++ b/client/src/notebooks/Notebooks.container.js
@@ -533,7 +533,7 @@ class StartNotebookServer extends Component {
             const autosaveCommit = commits.find(commit => commit.id.startsWith(autosave.commit));
             commit = autosaveCommit;
             autosaveFound = true;
-            if (this.state.autosavesCommit !== autosaveCommit.id)
+            if (autosaveCommit && this.state.autosavesCommit !== autosaveCommit?.id)
               this.setState({ autosavesCommit: autosaveCommit.id });
           }
         }


### PR DESCRIPTION
PR to handle error where autosave commit id of autosave is used which does not exist in project commit list.

/deploy #persist
