### PR TITLE
chore: run ca cert injection as non-root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ virtualenv
 
 # All traces of the GitLab server running locally
 /gitlab
+
+# Ignore helm charts requirements lock file
+requirements.lock

--- a/helm-chart/renku-ui/requirements.lock
+++ b/helm-chart/renku-ui/requirements.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: certificates
-  repository: https://swissdatasciencecenter.github.io/helm-charts/
-  version: 0.0.1
-digest: sha256:405914c6b5d6eb9ba72165de7aa4b815c71b310daabfdbef79c365fc032787ae
-generated: "2022-02-16T16:25:03.784364+01:00"

--- a/helm-chart/renku-ui/requirements.yaml
+++ b/helm-chart/renku-ui/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: certificates
-  version: "0.0.1"
+  version: "0.0.3"
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"

--- a/helm-chart/renku-ui/values.yaml
+++ b/helm-chart/renku-ui/values.yaml
@@ -20,7 +20,7 @@ global:
   certificates:
     image:
       repository: renku/certificates
-      tag: '0.0.1'
+      tag: '0.0.2'
     customCAs: []
       # - secret:
 

--- a/helm-chart/renku-ui/values.yaml
+++ b/helm-chart/renku-ui/values.yaml
@@ -20,7 +20,7 @@ global:
   certificates:
     image:
       repository: renku/certificates
-      tag: '0.0.2'
+      tag: "0.0.2"
     customCAs: []
       # - secret:
 


### PR DESCRIPTION
The latest certificates image and chart can run as non-root.

This is safer than what we had before.

Also the chart and image tags are not tracking each other. This is on purpose.

Lastly, the `.lock` file is not needed to be tracked in git. We always pin the requirements versions so this is not necessary to check into git and keep updating.

/deploy renku=000-ui-server-chart #persist