### PR TITLE
build: keep the values.client structure

### DIFF
--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -13,7 +13,7 @@ charts:
         contextPath: client/
         # Dockerfile path relative to chartpress.yaml
         dockerfilePath: client/Dockerfile
-        valuesPath: client.image
+        valuesPath: image
         paths:
           - client
           - e2e

--- a/helm-chart/renku-ui/templates/NOTES.txt
+++ b/helm-chart/renku-ui/templates/NOTES.txt
@@ -1,18 +1,18 @@
 1. Get the application URL by running these commands:
-{{- if .Values.client.ingress.enabled }}
-{{- range .Values.client.ingress.hosts }}
-  http{{ if $.Values.client.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.client.ingress.path }}
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
 {{- end }}
-{{- else if contains "NodePort" .Values.client.service.type }}
+{{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "ui.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.client.service.type }}
+{{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get svc -w {{ template "ui.fullname" . }}'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "ui.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo http://$SERVICE_IP:{{ .Values.client.service.port }}
-{{- else if contains "ClusterIP" .Values.client.service.type }}
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "ui.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://localhost:3000 to use your application"
   kubectl port-forward $POD_NAME 3000:80

--- a/helm-chart/renku-ui/templates/ui-client-deployment-template.yaml
+++ b/helm-chart/renku-ui/templates/ui-client-deployment-template.yaml
@@ -9,7 +9,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  replicas: {{ .Values.client.replicaCount }}
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       app: {{ .appName }}
@@ -20,24 +20,24 @@ spec:
         app: {{ .appName }}
         release: {{ .Release.Name }}
     spec:
-      {{- if and .Values.client.privacy.enabled .Values.client.privacy.page.enabled }}
+      {{- if and .Values.privacy.enabled .Values.privacy.page.enabled }}
       volumes:
         - name: privacy
           configMap:
-            name: {{ .Values.client.privacy.page.configMapName | default (printf "%s-privacy-sample" (include "ui.fullname" .)) | quote }}
+            name: {{ .Values.privacy.page.configMapName | default (printf "%s-privacy-sample" (include "ui.fullname" .)) | quote }}
             items:
-            - key: {{ .Values.client.privacy.page.configMapKey | default (printf "privacy_statement") | quote }}
+            - key: {{ .Values.privacy.page.configMapKey | default (printf "privacy_statement") | quote }}
               path: statement.md
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: {{ .imageName }}
-          imagePullPolicy: {{ .Values.client.image.pullPolicy }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: {{ .Values.client.service.port }}
+              containerPort: {{ .Values.service.port }}
               protocol: TCP
-          {{- if and .Values.client.privacy.enabled .Values.client.privacy.page.enabled }}
+          {{- if and .Values.privacy.enabled .Values.privacy.page.enabled }}
           volumeMounts:
             - mountPath: /config-privacy
               name: privacy
@@ -48,34 +48,34 @@ spec:
             - name: GATEWAY_URL
               value: {{ .Values.gatewayUrl | default (printf "%s://%s/api" (include "ui.protocol" .) .Values.global.renku.domain) | quote }}
             - name: UISERVER_URL
-              value: {{ .Values.client.uiserverUrl | default (printf "%s://%s/ui-server" (include "ui.protocol" .) .Values.global.renku.domain) | quote }}
+              value: {{ .Values.uiserverUrl | default (printf "%s://%s/ui-server" (include "ui.protocol" .) .Values.global.renku.domain) | quote }}
             - name: WELCOME_PAGE
-              value: {{ .Values.client.welcomePage.text | b64enc | quote }}
-            {{- if .Values.client.statuspage }}
+              value: {{ .Values.welcomePage.text | b64enc | quote }}
+            {{- if .Values.statuspage }}
             - name: STATUSPAGE_ID
-              value: {{ .Values.client.statuspage.id | quote }}
+              value: {{ .Values.statuspage.id | quote }}
             {{- end }}
-            {{- if .Values.client.sentry.enabled }}
+            {{- if .Values.sentry.enabled }}
             - name: SENTRY_URL
-              value: {{ .Values.client.sentry.dsn | quote }}
+              value: {{ .Values.sentry.dsn | quote }}
             - name: SENTRY_NAMESPACE
-              value: {{ .Values.client.sentry.environment | default (printf "%s" .Release.Namespace) | quote }}
+              value: {{ .Values.sentry.environment | default (printf "%s" .Release.Namespace) | quote }}
             - name: SENTRY_SAMPLE_RATE
-              value: {{ .Values.client.sentry.sampleRate | quote }}
+              value: {{ .Values.sentry.sampleRate | quote }}
             {{- end }}
-            {{- if .Values.client.maintenance }}
+            {{- if .Values.maintenance }}
             - name: MAINTENANCE
-              value: {{ .Values.client.maintenance | default (printf "false") | quote }}
+              value: {{ .Values.maintenance | default (printf "false") | quote }}
             {{- end }}
             - name: ANONYMOUS_SESSIONS
               value: {{ .Values.global.anonymousSessions.enabled | default (printf "false") | quote }}
             - name: PRIVACY_ENABLED
-              value: {{ .Values.client.privacy.enabled | quote }}
-            {{- if .Values.client.privacy.enabled }}
+              value: {{ .Values.privacy.enabled | quote }}
+            {{- if .Values.privacy.enabled }}
             - name: PRIVACY_BANNER_CONTENT
-              value: {{ .Values.client.privacy.banner.content | default (printf "") | b64enc | quote }}
+              value: {{ .Values.privacy.banner.content | default (printf "") | b64enc | quote }}
             - name: PRIVACY_BANNER_LAYOUT
-              value: {{ toJson .Values.client.privacy.banner.layout | default (printf "") | quote }}
+              value: {{ toJson .Values.privacy.banner.layout | default (printf "") | quote }}
             {{ else }}
             - name: PRIVACY_BANNER_CONTENT
               value: ""
@@ -83,15 +83,15 @@ spec:
               value: "{}"
             {{- end }}
             - name: TEMPLATES
-              value: {{ toJson .Values.client.templates | quote }}
+              value: {{ toJson .Values.templates | quote }}
             - name: PREVIEW_THRESHOLD
-              value: {{ toJson .Values.client.previewSizeThreshold | quote }}
+              value: {{ toJson .Values.previewSizeThreshold | quote }}
             - name: UPLOAD_THRESHOLD
-              value: {{ toJson .Values.client.uploadSizeThreshold | quote }}
+              value: {{ toJson .Values.uploadSizeThreshold | quote }}
             - name: UI_VERSION
               value: {{ .Chart.Version | quote }}
             - name: HOMEPAGE
-              value: {{ toJson .Values.client.homepage | quote }}
+              value: {{ toJson .Values.homepage | quote }}
           livenessProbe:
             httpGet:
               path: /
@@ -105,26 +105,26 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 30
           resources:
-{{ toYaml .Values.client.resources | indent 12 }}
+{{ toYaml .Values.resources | indent 12 }}
           securityContext:
-            {{- toYaml .Values.client.securityContext | nindent 12 }}
-    {{- with .Values.client.nodeSelector }}
+            {{- toYaml .Values.securityContext | nindent 12 }}
+    {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.client.affinity }}
+    {{- with .Values.affinity }}
       affinity:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.client.tolerations }}
+    {{- with .Values.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
       securityContext:
-        {{- toYaml .Values.client.podSecurityContext | nindent 8 }}
-      {{- if .Values.client.image.pullSecrets }}
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
-      {{- range .Values.client.image.pullSecrets }}
+      {{- range .Values.image.pullSecrets }}
         - name: {{ . }}
       {{- end}}
       {{- end }}

--- a/helm-chart/renku-ui/templates/ui-client-deployment.yaml
+++ b/helm-chart/renku-ui/templates/ui-client-deployment.yaml
@@ -1,10 +1,10 @@
 {{- $fullName := include "ui.fullname" . -}}
 {{- $appName := include "ui.name" . -}}
-{{- $imageName := (print .Values.client.image.repository ":" .Values.client.image.tag) -}}
+{{- $imageName := (print .Values.image.repository ":" .Values.image.tag) -}}
 {{- include "ui-client-deployment-template" (merge (dict "deploymentName" $fullName "appName" $appName "imageName" $imageName) .) }}
 ---
-{{- if .Values.client.canary.enabled }}
-{{- $imageName := (print .Values.client.canary.image.repository ":" .Values.client.canary.image.tag) -}}
+{{- if .Values.canary.enabled }}
+{{- $imageName := (print .Values.canary.image.repository ":" .Values.canary.image.tag) -}}
 {{- $canaryValues := dict "deploymentName" (print $fullName "-canary") "appName" (print $appName "-canary") "imageName" $imageName -}}
 {{- include "ui-client-deployment-template" (merge $canaryValues .) }}
 {{- end }}

--- a/helm-chart/renku-ui/templates/ui-client-ingress.yaml
+++ b/helm-chart/renku-ui/templates/ui-client-ingress.yaml
@@ -1,7 +1,7 @@
-{{- if .Values.client.ingress.enabled -}}
+{{- if .Values.ingress.enabled -}}
 {{- $fullName := include "ui.fullname" . -}}
-{{- $servicePort := .Values.client.service.port -}}
-{{- $ingressPath := .Values.client.ingress.path -}}
+{{- $servicePort := .Values.service.port -}}
+{{- $ingressPath := .Values.ingress.path -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -11,14 +11,14 @@ metadata:
     chart: {{ template "ui.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{- with .Values.client.ingress.annotations }}
+{{- with .Values.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-{{- if .Values.client.ingress.tls }}
+{{- if .Values.ingress.tls }}
   tls:
-  {{- range .Values.client.ingress.tls }}
+  {{- range .Values.ingress.tls }}
     - hosts:
       {{- range .hosts }}
         - {{ . }}
@@ -27,7 +27,7 @@ spec:
   {{- end }}
 {{- end }}
   rules:
-  {{- range .Values.client.ingress.hosts }}
+  {{- range .Values.ingress.hosts }}
     - host: {{ . }}
       http:
         paths:
@@ -41,7 +41,7 @@ spec:
   {{- end }}
 {{- end }}
 ---
-{{- if .Values.client.canary.enabled }}
+{{- if .Values.canary.enabled }}
 {{- $fullName := include "ui.fullname" . -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/helm-chart/renku-ui/templates/ui-client-service.yaml
+++ b/helm-chart/renku-ui/templates/ui-client-service.yaml
@@ -8,9 +8,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  type: {{ .Values.client.service.type }}
+  type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.client.service.port }}
+    - port: {{ .Values.service.port }}
       targetPort: 8080
       protocol: TCP
       name: http
@@ -18,7 +18,7 @@ spec:
     app: {{ template "ui.name" . }}
     release: {{ .Release.Name }}
 ---
-{{- if .Values.client.canary.enabled }}
+{{- if .Values.canary.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -29,9 +29,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  type: {{ .Values.client.service.type }}
+  type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.client.service.port }}
+    - port: {{ .Values.service.port }}
       targetPort: 8080
       protocol: TCP
       name: http

--- a/helm-chart/renku-ui/values.yaml
+++ b/helm-chart/renku-ui/values.yaml
@@ -39,131 +39,130 @@ global:
     existingSecret: redis-secret
     existingSecretPasswordKey: redis-password
 
-client: 
-  replicaCount: 1
+replicaCount: 1
 
+image:
+  repository: renku/renku-ui
+  tag: "2.5.0"
+  pullPolicy: IfNotPresent
+
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  # pullSecrets:
+  #   - myRegistrKeySecretName
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+podSecurityContext: {}
+
+securityContext:
+  runAsUser: 101
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+
+welcomePage:
+  text: |
+    ## Welcome to Renku!
+    Renku is software for collaborative data science. With Renku you can share code and data,
+    discuss problems and solutions, and coordinate data-science projects.
+
+templates:
+  custom: true
+  repositories:
+    - url: https://github.com/SwissDataScienceCenter/renku-project-template
+      ref: 0.1.15
+      name: Renku
+
+# This defines the threshold for automatically showing a preview when browsing projects' files.
+# Above the soft limit, the user receives a warning. Above the hard limit, no preview is available.
+previewSizeThreshold:
+  soft: 1048576 # 1MB
+  hard: 10485760 # 10MB
+
+# This defines the threshold for displaying a message when a user is trying to upload a large file
+# so that they know it's not necessary to wait for this. There is only hard limit for now.
+uploadSizeThreshold:
+  soft: 104857600 # 100MB
+
+# Any string here, other than 'false', will enable the maintenance page and be added on it as an info.
+# Setting 'true' will display a standard message embedded in maintenace page.
+maintenance: false
+
+sentry:
+  enabled: false
+  dsn: ""
+  environment: ""
+  sampleRate: 0 # number between 0 and 1. (e.g., to send 20% of transactions, set 0.2.)
+
+# If you want to enable the privacy page, please create also a configMap and set its name in the
+# privacy.page.configMapName value. As a reference, you can use the sample configMap generated when
+# enabling the feature.
+privacy:
+  enabled: false
+  page:
+    enabled: false
+    #configMapName: privacy-page
+    #configMapKey: privacy_statement
+  banner:
+    content: |
+      This website requires cookies in order to ensure basic functionality. By clicking
+      or navigating the site, you consent to the use of cookies in accordance with
+      our <u><a class="text-white" href="/privacy">Privacy Policy</a></u>.
+    layout:
+      cookieName: RenkuLabPrivacy
+      disableStyles: true
+      containerClasses: fixed-bottom p-3 bg-dark
+      contentClasses: text-white small
+      buttonClasses: btn btn-sm btn-light me-2
+      buttonWrapperClasses: mt-2
+## If you maintain a statuspage.io page for the status of your RenkuLab instance, put the id for it here.
+statuspage:
+  id: ""
+
+homepage:
+  custom:
+    # If you want to enable a custom content on the homepage, you can enable it and provide content here
+    enabled: false
+    main:
+      contentMd: |
+        # Welcome to RenkuLab
+      backgroundImage:
+        url: ""
+  # The default is to show the tutorial from the docs, but can also link to an
+  # internal project
+  tutorialLink: https://renku.readthedocs.io/en/latest/tutorials/01_firststeps.html
+  # Projects to highlight on the homepage
+  projects: []
+canary:
+  enabled: false
   image:
     repository: renku/renku-ui
-    tag: "2.5.0"
-    pullPolicy: IfNotPresent
-
-    ## Optionally specify an array of imagePullSecrets.
-    ## Secrets must be manually created in the namespace.
-    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-    ##
-    # pullSecrets:
-    #   - myRegistrKeySecretName
-
-  service:
-    type: ClusterIP
-    port: 80
-
-  ingress:
-    enabled: false
-
-  resources: {}
-    # We usually recommend not to specify default resources and to leave this as a conscious
-    # choice for the user. This also increases chances charts run on environments with little
-    # resources, such as Minikube. If you do want to specify resources, uncomment the following
-    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-    # limits:
-    #  cpu: 100m
-    #  memory: 128Mi
-    # requests:
-    #  cpu: 100m
-    #  memory: 128Mi
-
-  nodeSelector: {}
-
-  tolerations: []
-
-  affinity: {}
-
-  podSecurityContext: {}
-
-  securityContext:
-    runAsUser: 101
-    runAsNonRoot: true
-    allowPrivilegeEscalation: false
-
-  welcomePage:
-    text: |
-      ## Welcome to Renku!
-      Renku is software for collaborative data science. With Renku you can share code and data,
-      discuss problems and solutions, and coordinate data-science projects.
-
-  templates:
-    custom: true
-    repositories:
-      - url: https://github.com/SwissDataScienceCenter/renku-project-template
-        ref: 0.1.15
-        name: Renku
-
-  # This defines the threshold for automatically showing a preview when browsing projects' files.
-  # Above the soft limit, the user receives a warning. Above the hard limit, no preview is available.
-  previewSizeThreshold:
-    soft: 1048576 # 1MB
-    hard: 10485760 # 10MB
-
-  # This defines the threshold for displaying a message when a user is trying to upload a large file
-  # so that they know it's not necessary to wait for this. There is only hard limit for now.
-  uploadSizeThreshold:
-    soft: 104857600 # 100MB
-
-  # Any string here, other than 'false', will enable the maintenance page and be added on it as an info.
-  # Setting 'true' will display a standard message embedded in maintenace page.
-  maintenance: false
-
-  sentry:
-    enabled: false
-    dsn: ""
-    environment: ""
-    sampleRate: 0 # number between 0 and 1. (e.g., to send 20% of transactions, set 0.2.)
-
-  # If you want to enable the privacy page, please create also a configMap and set its name in the
-  # privacy.page.configMapName value. As a reference, you can use the sample configMap generated when
-  # enabling the feature.
-  privacy:
-    enabled: false
-    page:
-      enabled: false
-      #configMapName: privacy-page
-      #configMapKey: privacy_statement
-    banner:
-      content: |
-        This website requires cookies in order to ensure basic functionality. By clicking
-        or navigating the site, you consent to the use of cookies in accordance with
-        our <u><a class="text-white" href="/privacy">Privacy Policy</a></u>.
-      layout:
-        cookieName: RenkuLabPrivacy
-        disableStyles: true
-        containerClasses: fixed-bottom p-3 bg-dark
-        contentClasses: text-white small
-        buttonClasses: btn btn-sm btn-light me-2
-        buttonWrapperClasses: mt-2
-  ## If you maintain a statuspage.io page for the status of your RenkuLab instance, put the id for it here.
-  statuspage:
-    id: ""
-
-  homepage:
-    custom:
-      # If you want to enable a custom content on the homepage, you can enable it and provide content here
-      enabled: false
-      main:
-        contentMd: |
-          # Welcome to RenkuLab
-        backgroundImage:
-          url: ""
-    # The default is to show the tutorial from the docs, but can also link to an
-    # internal project
-    tutorialLink: https://renku.readthedocs.io/en/latest/tutorials/01_firststeps.html
-    # Projects to highlight on the homepage
-    projects: []
-  canary:
-    enabled: false
-    image:
-      repository: renku/renku-ui
-      tag: "0.11.16"
+    tag: "0.11.16"
 
 server:
   replicaCount: 1


### PR DESCRIPTION
Changes to keep the `ui` values under `ui` instead of moving to `ui.client`
I personally would keep the current structure cause it's cleaner, but this will prevent introducing a breaking change for admins.

/deploy renku=ui1901-unify-ui-charts #persist
