### PR TITLE
feat: use new notebook server error response format

### DIFF
--- a/client/src/api-client/notebook-servers.js
+++ b/client/src/api-client/notebook-servers.js
@@ -118,8 +118,8 @@ function addNotebookServersMethods(client) {
     }).then(resp => {
       return resp.data;
     }).catch(error => {
-      if (error.errorData && error.errorData.messages && error.errorData.messages.error) {
-        const err = new Error(error.errorData.messages.error);
+      if (error.errorData && error.errorData.error && error.errorData.error.message) {
+        const err = new Error(error.errorData.error.message);
         err.cause = error;
         throw err;
       }
@@ -151,8 +151,9 @@ function addNotebookServersMethods(client) {
       response = await client.clientFetch(url, { method: "GET", headers });
     }
     catch (errorResponse) {
-      if (errorResponse?.errorData?.messages)
-        return errorResponse.errorData.messages;
+      if (errorResponse?.errorData?.error?.message)
+        return errorResponse.errorData.error.message;
+
       return errorResponse;
     }
     return response.data;


### PR DESCRIPTION
Use new notebook server error format
rel https://github.com/SwissDataScienceCenter/renku-notebooks/pull/849

### testing
Start a session in which the branch does not exist, you should be able to see the error message in the alert and in the error notification
![error notebook](https://user-images.githubusercontent.com/43388408/183890273-84fcf79a-8421-4269-8bbe-e9df8e60e723.gif)


/deploy renku-notebooks=feat-standardize-error-messages #persist