### PR TITLE
show the correct dialog when starting a session on an autosave branch 

### DIFF
--- a/client/src/notebooks/NotebookStart.present.js
+++ b/client/src/notebooks/NotebookStart.present.js
@@ -1138,11 +1138,13 @@ class ServerOptionLaunch extends Component {
   checkServer() {
     const { filters } = this.props;
     const { autosaved } = this.props.data;
+    const selectedBranchName = filters.branch.name;
+    const selectedCommitShort = filters.commit.id.substr(0, 7);
     const current = autosaved.filter(c =>
-      c.autosave.branch === filters.branch.name && c.autosave.commit === filters.commit.id.substr(0, 7));
+      c.autosave.branch === selectedBranchName && c.autosave.commit === selectedCommitShort);
     if (current.length > 0) {
       this.setState({ current: current[0] });
-      this.props.toggleShareLinkModal();
+      this.toggleModal();
     }
     else {
       this.props.handlers.startServer();


### PR DESCRIPTION
Undo a change that was introduced in #1781, which opens the wrong dialog.

Fix #1947

## Test

To test, fork this project:

https://sekhar.dev.renku.ch/projects/cramakri/test-accessing-gpus

Then, in your fork, create a branch based on `renku/autosave/cramakri/master/2f88472/2f88472` with the name `renku/autosave/{your username}/master/2f88472/2f88472`

/deploy #persist