### PR TITLE
feat: new session start flow

### DIFF
--- a/client/src/notebooks/NotebookStart.present.js
+++ b/client/src/notebooks/NotebookStart.present.js
@@ -1194,19 +1194,21 @@ class ServerOptionLaunch extends Component {
       </Button>;
 
 
-    return [
-      imageStatusAlert,
-      startBaseButton,
-      " ",
-      startButtonWithMenu,
+    return <div className="d-flex flex-row-reverse">
+      <div>
+        {imageStatusAlert}
+        {startBaseButton}
+        {" "}
+        {startButtonWithMenu}
+      </div>
       <AutosavedDataModal key="modal"
         toggleModal={this.toggleModal.bind(this)}
         showModal={this.state.showModal}
         currentBranch={this.state.current}
         {...this.props}
-      />,
-      globalNotification
-    ];
+      />
+      {globalNotification}
+    </div>;
   }
 }
 

--- a/client/src/notebooks/NotebookStart.present.js
+++ b/client/src/notebooks/NotebookStart.present.js
@@ -67,12 +67,14 @@ function SessionStartSidebar(props) {
     <ProjectSessionLockAlert lockStatus={props.lockStatus} />
     <LaunchErrorAlert autosaves={props.autosaves} launchError={props.launchError} ci={props.ci} />
 
-    <p>A session gives you an environment with resources for doing work.
+    <div className="d-none d-md-block">
+      <p>A session gives you an environment with resources for doing work.
       The exact details of the available tools depends on the project.
-    </p>
+      </p>
 
-    <p>The resource settings have been set to the project defaults, but you can alter them if you wish.
-    </p>
+      <p>The resource settings have been set to the project defaults, but you can alter them if you wish.
+      </p>
+    </div>
   </>;
 }
 

--- a/client/src/notebooks/NotebookStart.present.js
+++ b/client/src/notebooks/NotebookStart.present.js
@@ -113,16 +113,16 @@ function StartNotebookServer(props) {
   const cloudStorageAvailable = s3MountsConfig?.enabled ?? false;
 
   const advancedSelection = (
-    <Fragment>
-      {show.ci ? <StartNotebookPipelines {...props}
+    <>
+      {<StartNotebookPipelines {...props}
         ignorePipeline={props.ignorePipeline}
-        setIgnorePipeline={setIgnorePipeline} /> : null}
+        setIgnorePipeline={setIgnorePipeline} />}
       <AutosavesInfoAlert autosaves={autosaves} autosavesId={props.autosavesCommit}
         currentId={props.filters.commit?.id} deleteAutosave={deleteAutosave} setCommit={setCommit} />
       <StartNotebookBranches {...props} disabled={disabled} />
       {show.commits ? <StartNotebookCommits {...props} disabled={disabled} /> : null}
       {cloudStorageAvailable ?
-        <Fragment>
+        <>
           <ObjectStoresConfigurationButton
             objectStoresConfiguration={objectStoresConfiguration}
             toggleShowObjectStoresConfigModal={toggleShowObjectStoresConfigModal} />
@@ -131,10 +131,10 @@ function StartNotebookServer(props) {
             showObjectStoreModal={showObjectStoreModal}
             toggleShowObjectStoresConfigModal={toggleShowObjectStoresConfigModal}
             setObjectStoresConfiguration={props.handlers.setObjectStoresConfiguration} />
-        </Fragment> :
+        </> :
         null
       }
-    </Fragment>
+    </>
   );
 
   const options = show.options ?
@@ -299,7 +299,7 @@ class StartNotebookBranches extends Component {
     }
     else if (branches.length === 0) {
       content = (
-        <React.Fragment>
+        <FormGroup>
           <Label>A commit is necessary to start a session.</Label>
           <InfoAlert timeout={0}>
             <p>You can still do one of the following:</p>
@@ -315,7 +315,7 @@ class StartNotebookBranches extends Component {
               </li>
             </ul>
           </InfoAlert>
-        </React.Fragment>
+        </FormGroup>
       );
     }
     else {
@@ -955,11 +955,11 @@ class StartNotebookServerOptions extends Component {
           const options = mergeEnumOptions(globalOptions, projectOptions, key);
           serverOption["options"] = options;
           const separator = options.length === 1 ? null : (<br />);
-          optionContent = (<Fragment>
+          optionContent = (<FormGroup className="field-group">
             <Label className="me-2">{serverOption.displayName}</Label>
             {separator}<ServerOptionEnum {...serverOption} onChange={onChange} />
             {warning}
-          </Fragment>);
+          </FormGroup>);
         }
         else if (serverOption.type === "int" || serverOption.type === "float") {
           const step = serverOption.type === "int" ?

--- a/client/src/notebooks/NotebookStart.present.js
+++ b/client/src/notebooks/NotebookStart.present.js
@@ -79,7 +79,8 @@ function SessionStartSidebar(props) {
 }
 
 function StartNotebookAdvancedOptions(props) {
-  const { autosaves, showObjectStoreModal } = props;
+  const { autosaves, showObjectStoreModal, justStarted } = props;
+  if (justStarted) return null;
   const { objectStoresConfiguration } = props.filters;
   const { deleteAutosave, setCommit, setIgnorePipeline, toggleShowObjectStoresConfigModal } = props.handlers;
   const s3MountsConfig = props.options.global.cloudstorage?.s3;

--- a/client/src/notebooks/NotebookStart.present.js
+++ b/client/src/notebooks/NotebookStart.present.js
@@ -114,13 +114,13 @@ function StartNotebookServer(props) {
 
   const advancedSelection = (
     <Fragment>
+      {show.ci ? <StartNotebookPipelines {...props}
+        ignorePipeline={props.ignorePipeline}
+        setIgnorePipeline={setIgnorePipeline} /> : null}
       <AutosavesInfoAlert autosaves={autosaves} autosavesId={props.autosavesCommit}
         currentId={props.filters.commit?.id} deleteAutosave={deleteAutosave} setCommit={setCommit} />
       <StartNotebookBranches {...props} disabled={disabled} />
       {show.commits ? <StartNotebookCommits {...props} disabled={disabled} /> : null}
-      {show.ci ? <StartNotebookPipelines {...props}
-        ignorePipeline={props.ignorePipeline}
-        setIgnorePipeline={setIgnorePipeline} /> : null}
       {cloudStorageAvailable ?
         <Fragment>
           <ObjectStoresConfigurationButton

--- a/client/src/notebooks/NotebookStart.present.js
+++ b/client/src/notebooks/NotebookStart.present.js
@@ -66,7 +66,6 @@ function SessionStartSidebar(props) {
     <p>On the project<br /><b>{props.pathWithNamespace}</b></p>
     <ProjectSessionLockAlert lockStatus={props.lockStatus} />
     <LaunchErrorAlert autosaves={props.autosaves} launchError={props.launchError} ci={props.ci} />
-    {props.messageOutput}
 
     <p>A session gives you an environment with resources for doing work.
       The exact details of the available tools depends on the project.
@@ -169,10 +168,11 @@ function StartNotebookServer(props) {
       <Col sm={12} md={3}>
         <SessionStartSidebar autosaves={autosaves} ci={props.ci}
           launchError={props.launchError} lockStatus={props.lockStatus}
-          messageOutput={messageOutput} pathWithNamespace={pathWithNamespace} />
+          pathWithNamespace={pathWithNamespace} />
       </Col>
       <Col sm={12} md={9} lg={7}>
         <Form className="form-rk-green">
+          {messageOutput}
           <StartNotebookAdvancedOptions {...props}
             disabled={disabled}
             show={show} />

--- a/client/src/notebooks/NotebookStart.present.js
+++ b/client/src/notebooks/NotebookStart.present.js
@@ -167,12 +167,12 @@ function StartNotebookServer(props) {
 
   return (
     <Row>
-      <Col sm={12} md={3}>
+      <Col sm={12} md={3} lg={4}>
         <SessionStartSidebar autosaves={autosaves} ci={props.ci}
           launchError={props.launchError} lockStatus={props.lockStatus}
           pathWithNamespace={pathWithNamespace} />
       </Col>
-      <Col sm={12} md={9} lg={7}>
+      <Col sm={12} md={9} lg={8}>
         <Form className="form-rk-green">
           {messageOutput}
           <StartNotebookAdvancedOptions {...props}

--- a/client/src/notebooks/NotebookStart.present.js
+++ b/client/src/notebooks/NotebookStart.present.js
@@ -1160,12 +1160,15 @@ class ServerOptionLaunch extends Component {
       </Button>;
 
 
-    return <div className="d-flex flex-row-reverse">
-      <div>
-        {imageStatusAlert}
-        {startBaseButton}
-        {" "}
-        {startButtonWithMenu}
+    return <div>
+      {imageStatusAlert}
+      <div className="d-flex flex-row-reverse">
+        <div>
+          {startButtonWithMenu}
+        </div>
+        <div>
+          {startBaseButton} &nbsp;
+        </div>
       </div>
       <AutosavedDataModal key="modal"
         toggleModal={this.toggleModal.bind(this)}

--- a/client/src/notebooks/NotebookStart.present.js
+++ b/client/src/notebooks/NotebookStart.present.js
@@ -63,7 +63,7 @@ function ProjectSessionLockAlert({ lockStatus }) {
 function SessionStartSidebar(props) {
   return <>
     <h2>Start session</h2>
-    <p>On the project<br /><b>{props.pathWithNamespace}</b></p>
+    <p>On the project<br /><b className="text-break">{props.pathWithNamespace}</b></p>
     <ProjectSessionLockAlert lockStatus={props.lockStatus} />
     <LaunchErrorAlert autosaves={props.autosaves} launchError={props.launchError} ci={props.ci} />
 

--- a/client/src/notebooks/Notebooks.container.js
+++ b/client/src/notebooks/Notebooks.container.js
@@ -308,7 +308,6 @@ class StartNotebookServer extends Component {
       first: true,
       ignorePipeline: null,
       launchError: null,
-      showAdvanced: false,
       showObjectStoreModal: false,
       starting: false,
       commitDelay: false, // used in setCommitWhenReady
@@ -331,7 +330,6 @@ class StartNotebookServer extends Component {
       startServer: this.startServer.bind(this),
       setObjectStoresConfiguration: this.setObjectStoresConfiguration.bind(this),
       toggleMergedBranches: this.toggleMergedBranches.bind(this),
-      toggleShowAdvanced: this.toggleShowAdvanced.bind(this),
       toggleShowObjectStoresConfigModal: this.toggleShowObjectStoresConfigModal.bind(this)
     };
   }
@@ -362,10 +360,6 @@ class StartNotebookServer extends Component {
       if (this._isMounted)
         this.refreshBranches().then(r => this.selectBranchWhenReady());
     }
-  }
-
-  toggleShowAdvanced() {
-    this.setState({ showAdvanced: !this.state.showAdvanced });
   }
 
   toggleShowObjectStoresConfigModal() {
@@ -573,7 +567,7 @@ class StartNotebookServer extends Component {
     if (this._isMounted) {
       const { accessLevel, user } = this.props;
       await this.coordinator.fetchNotebookOptions(); // TODO: this should not be here
-      const callback = () => { this.setState({ showAdvanced: true }); };
+      const callback = () => { };
       const owner = accessLevel >= ACCESS_LEVELS.DEVELOPER;
       await this.coordinator.fetchOrPollCi(force, user.logged, owner, callback);
       this.triggerAutoStart();
@@ -644,7 +638,6 @@ class StartNotebookServer extends Component {
               autostartReady: true,
               autostartTried: true,
               launchError: { frontendError: true, pipelineError: true, errorMessage },
-              showAdvanced: true,
               starting: false
             });
           }
@@ -816,7 +809,6 @@ class StartNotebookServer extends Component {
       launchError={this.state.launchError}
       lockStatus={this.props.lockStatus}
       message={this.props.message}
-      showAdvanced={this.state.showAdvanced}
       {...this.propsToChildProps()}
     />;
   }

--- a/client/src/notebooks/Notebooks.present.js
+++ b/client/src/notebooks/Notebooks.present.js
@@ -96,19 +96,21 @@ function ShowSession(props) {
     return handlers.fetchLogs(notebook.data.name);
   };
 
-  const urlList = Url.get(Url.pages.project.session, {
+  const urlList = Url.get(Url.pages.sessions);
+  const urlProject = Url.get(Url.pages.project.base, {
     namespace: filters.namespace,
     path: filters.project,
   });
 
   // redirect immediately if the session fail
   if (props.history && notebook.data?.status?.state === SessionStatus.failed)
-    props.history.push(urlList);
+    props.history.push(urlProject);
 
   // Always add all sub-components and hide them one by one to preserve the iframe navigation where needed
   return (
     <div className="bg-white">
-      <SessionInformation notebook={notebook} stopNotebook={handlers.stopNotebook} urlList={urlList} />
+      <SessionInformation notebook={notebook} stopNotebook={handlers.stopNotebook}
+        urlProject={urlProject} />
       <div className="d-lg-flex">
         <SessionNavbar fetchLogs={fetchLogs} setTab={setTab} tab={tab} />
         <div className={`border sessions-iframe-border w-100`}>
@@ -123,14 +125,14 @@ function ShowSession(props) {
 }
 
 function SessionInformation(props) {
-  const { notebook, stopNotebook, urlList } = props;
+  const { notebook, stopNotebook, urlProject } = props;
 
   const [stopping, setStopping] = useState(false);
 
   const stop = async () => {
     setStopping(true);
     // ? no need to handle the error here since we use the notifications at container level
-    const success = await stopNotebook(notebook.data.name, urlList);
+    const success = await stopNotebook(notebook.data.name, urlProject);
     if (success !== false)
       return;
     setStopping(false);

--- a/client/src/notebooks/components/LaunchErrorAlert.tsx
+++ b/client/src/notebooks/components/LaunchErrorAlert.tsx
@@ -1,0 +1,92 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+import { WarnAlert } from "../../utils/components/Alert";
+import { NotebooksHelper } from "../index";
+
+interface LaunchErrorProps {
+  launchError: {
+    frontendError: boolean;
+    errorMessage: string;
+    pipelineError: boolean;
+  };
+}
+
+interface AutosavesProps {
+  autosaves: { error: object | null };
+}
+
+interface CiProps extends LaunchErrorProps {
+  ci: object;
+}
+
+interface CiStatus {
+  available: boolean;
+}
+
+interface LaunchErrorAlertProps extends AutosavesProps, CiProps {}
+
+function LaunchErrorBackendAlert({ launchError }: LaunchErrorProps) {
+  return (
+    <WarnAlert>
+      The attempt to start a session failed with the following error:
+      <div>
+        <code>{launchError}</code>
+      </div>
+      This could be an intermittent issue, so you should try a second time, and
+      the session will hopefully start. If the problem persists, you can{" "}
+      <Link to="/help">contact us for assistance</Link>.
+    </WarnAlert>
+  );
+}
+
+function LaunchErrorFrontendAlert({ launchError, ci }: CiProps) {
+  const ciStatus = NotebooksHelper.checkCiStatus(ci) as CiStatus;
+  if (launchError.pipelineError && ciStatus.available) return null;
+  return <WarnAlert>{launchError.errorMessage}</WarnAlert>;
+}
+
+function AutosavesErrorAlert({ autosaves }: AutosavesProps) {
+  if (autosaves.error == null) return null;
+  return (
+    <WarnAlert>
+      <p>Autosaves are currently unavailable.</p>
+      <p className="mb-0">
+        If you recently worked on the project, any previous unsaved work cannot
+        be recovered.
+      </p>
+    </WarnAlert>
+  );
+}
+
+function LaunchErrorAlert({
+  autosaves,
+  launchError,
+  ci,
+}: LaunchErrorAlertProps) {
+  let launchErrorElement = null;
+  if (launchError != null) {
+    if (launchError.frontendError === true) {
+      launchErrorElement = (
+        <LaunchErrorFrontendAlert launchError={launchError} ci={ci} />
+      );
+    }
+    else {
+      launchErrorElement = (
+        <LaunchErrorBackendAlert launchError={launchError} />
+      );
+    }
+  }
+
+  let autosavesErrorElement = null;
+  if (autosaves.error != null)
+    autosavesErrorElement = <AutosavesErrorAlert autosaves={autosaves} />;
+  return (
+    <>
+      {launchErrorElement}
+      {autosavesErrorElement}
+    </>
+  );
+}
+
+export default LaunchErrorAlert;

--- a/client/src/project/Project.present.js
+++ b/client/src/project/Project.present.js
@@ -580,6 +580,9 @@ class ProjectNav extends Component {
             <NavItem>
               <RenkuNavLink exact={false} to={this.props.datasetsUrl} title="Datasets" />
             </NavItem>
+            <NavItem>
+              <RenkuNavLink exact={false} to={this.props.notebookServersUrl} title="Sessions" />
+            </NavItem>
             <NavItem className="pe-0">
               <RenkuNavLink exact={false} to={this.props.settingsUrl} title="Settings" />
             </NavItem>
@@ -1084,7 +1087,10 @@ const ProjectSessions = (props) => {
     <Col key="content" xs={12}>
       <Switch>
         <Route exact path={props.notebookServersUrl}
-          render={p => <ProjectNotebookServers {...props} />} />
+          render={p => <>
+            {backButton}
+            <ProjectNotebookServers {...props} />
+          </>} />
         <Route path={props.launchNotebookUrl}
           render={p => (
             <Fragment>

--- a/client/src/project/Project.present.js
+++ b/client/src/project/Project.present.js
@@ -580,9 +580,6 @@ class ProjectNav extends Component {
             <NavItem>
               <RenkuNavLink exact={false} to={this.props.datasetsUrl} title="Datasets" />
             </NavItem>
-            <NavItem>
-              <RenkuNavLink exact={false} to={this.props.notebookServersUrl} title="Sessions" />
-            </NavItem>
             <NavItem className="pe-0">
               <RenkuNavLink exact={false} to={this.props.settingsUrl} title="Settings" />
             </NavItem>
@@ -1078,8 +1075,8 @@ const ProjectSessions = (props) => {
   const locationFrom = props.history?.location?.state?.from;
   const filePath = props.history?.location?.state?.filePath;
   const backNotebookLabel = filePath ? `Back to ${filePath}` : "Back to notebook file";
-  const backButtonLabel = locationFrom ? backNotebookLabel : "Back to sessions list";
-  const backUrl = locationFrom ?? props.notebookServersUrl;
+  const backButtonLabel = locationFrom ? backNotebookLabel : `Back to ${props.metadata.pathWithNamespace}`;
+  const backUrl = locationFrom ?? props.baseUrl;
 
   const backButton = (<GoBackButton label={backButtonLabel} url={backUrl} />);
 
@@ -1405,9 +1402,14 @@ class ProjectView extends Component {
             render={props => <ProjectViewHeader {...this.props} minimalistHeader={false}/>} />
           <Route path={this.props.overviewUrl}
             render={props => <ProjectViewHeader {...this.props} minimalistHeader={false}/>} />
+          <Route path={this.props.notebookServersUrl}
+            render={() => null} />
           <Route component={()=><ProjectViewHeader {...this.props} minimalistHeader={true}/>} />
         </Switch>
-        <ProjectNav key="nav" {...this.props} />
+        <Switch key="projectNav">
+          <Route path={this.props.notebookServersUrl} render={() => null} />
+          <Route component={() =><ProjectNav key="nav" {...this.props} />} />
+        </Switch>
         <Row key="content">
           <Switch>
             <Route exact path={this.props.baseUrl}

--- a/client/src/styles/components/_renku_form.scss
+++ b/client/src/styles/components/_renku_form.scss
@@ -13,7 +13,7 @@
 }
 
 .field-group {
-  margin-bottom: 33px !important;
+  margin-bottom: 24px !important;
 }
 
 .form-label {
@@ -63,10 +63,6 @@
   border: 1px solid var(--bs-danger);
   box-sizing: border-box;
   box-shadow: 0 0 6px var(--bs-rk-danger-shadow);
-}
-
-.field-group {
-  margin-bottom: 33px;
 }
 
 .inlineSubmit {

--- a/e2e/cypress.json
+++ b/e2e/cypress.json
@@ -3,6 +3,7 @@
   "defaultCommandTimeout": 6000,
   "baseUrl": "https://dev.renku.ch/",
   "experimentalStudio": true,
+  "chromeWebSecurity": false,
   "env": {
     "GITLAB_PROVIDER": "dev.renku.ch",
     "USER": "",

--- a/e2e/cypress/integration/local/newSession.spec.ts
+++ b/e2e/cypress/integration/local/newSession.spec.ts
@@ -34,9 +34,8 @@ describe("launch sessions", () => {
     fixtures.newSessionImages();
     cy.visit("/projects/e2e/local-test-project/sessions/new");
     cy.wait("@getSessionImage", { timeout: 10000 });
-    cy.contains("Do you want to select the branch, commit, or image?").should("be.visible");
-    cy.contains("Start session").should("be.visible").should("be.enabled");
-    cy.contains("Start with base image").should("not.exist");
+    cy.get("form").contains("Start session").should("be.visible").should("be.enabled");
+    cy.get("form").contains("Start with base image").should("not.exist");
   });
 
   it("new session page - logged - success", () => {
@@ -44,9 +43,8 @@ describe("launch sessions", () => {
     fixtures.newSessionImages();
     cy.visit("/projects/e2e/local-test-project/sessions/new");
     cy.wait("@getSessionImage", { timeout: 10000 });
-    cy.contains("Do you want to select the branch, commit, or image?").should("be.visible");
-    cy.contains("Start session").should("be.visible").should("be.enabled");
-    cy.contains("Start with base image").should("not.exist");
+    cy.get("form").contains("Start session").should("be.visible").should("be.enabled");
+    cy.get("form").contains("Start with base image").should("not.exist");
   });
 
   it("new session page - logged - missing pipeline", () => {
@@ -54,9 +52,8 @@ describe("launch sessions", () => {
     fixtures.newSessionPipelines(true).newSessionImages(true);
     cy.visit("/projects/e2e/local-test-project/sessions/new");
     cy.wait("@getSessionPipelines", { timeout: 10000 });
-    cy.contains("Hide advanced settings").should("be.visible");
-    cy.contains("Start with base image").should("be.visible");
-    cy.contains("Start session").should("be.visible").should("be.disabled");
+    cy.get("form").contains("Start with base image").should("be.visible");
+    cy.get("form").contains("Start session").should("be.visible").should("be.disabled");
     cy.contains("No Docker image found").should("be.visible");
     cy.contains("building the branch image").should("be.visible");
     cy.get(".badge").contains("not available").should("be.visible");
@@ -67,9 +64,8 @@ describe("launch sessions", () => {
     fixtures.newSessionPipelines().newSessionJobs().newSessionImages(true);
     cy.visit("/projects/e2e/local-test-project/sessions/new");
     cy.wait("@getSessionImage", { timeout: 10000 });
-    cy.contains("Hide advanced settings").should("be.visible");
-    cy.contains("Start with base image").should("be.visible");
-    cy.contains("Start session").should("be.visible").should("be.disabled");
+    cy.get("form").contains("Start with base image").should("be.visible");
+    cy.get("form").contains("Start session").should("be.visible").should("be.disabled");
     cy.get(".badge").contains("not available").should("be.visible");
   });
 
@@ -78,9 +74,8 @@ describe("launch sessions", () => {
     fixtures.newSessionPipelines().newSessionJobs().newSessionImages(true);
     cy.visit("/projects/e2e/local-test-project/sessions/new");
     cy.wait("@getSessionImage", { timeout: 10000 });
-    cy.contains("Hide advanced settings").should("be.visible");
-    cy.contains("Start with base image").should("be.visible");
-    cy.contains("Start session").should("be.visible").should("be.disabled");
+    cy.get("form").contains("Start with base image").should("be.visible");
+    cy.get("form").contains("Start session").should("be.visible").should("be.disabled");
     cy.get(".badge").contains("not available").should("be.visible");
   });
 
@@ -89,9 +84,8 @@ describe("launch sessions", () => {
     fixtures.newSessionPipelines().newSessionJobs(true).newSessionImages(true);
     cy.visit("/projects/e2e/local-test-project/sessions/new");
     cy.wait("@getSessionJobs", { timeout: 10000 });
-    cy.contains("Hide advanced settings").should("be.visible");
-    cy.contains("Start with base image").should("be.visible");
-    cy.contains("Start session").should("be.visible").should("be.disabled");
+    cy.get("form").contains("Start with base image").should("be.visible");
+    cy.get("form").contains("Start session").should("be.visible").should("be.disabled");
     cy.get(".badge").contains("not available").should("be.visible");
     cy.get("#image_build").should("be.visible");
     cy.get("#image_build_again").should("not.exist");
@@ -103,9 +97,8 @@ describe("launch sessions", () => {
     fixtures.newSessionPipelines().newSessionJobs(false, true).newSessionImages(true);
     cy.visit("/projects/e2e/local-test-project/sessions/new");
     cy.wait("@getSessionJob", { timeout: 15000 });
-    cy.contains("Hide advanced settings").should("be.visible");
-    cy.contains("Start with base image").should("be.visible");
-    cy.contains("Start session").should("be.visible").should("be.disabled");
+    cy.get("form").contains("Start with base image").should("be.visible");
+    cy.get("form").contains("Start session").should("be.visible").should("be.disabled");
     cy.get(".badge").contains("building").should("be.visible");
     cy.get("#image_build").should("not.exist");
     cy.get("#image_build_again").should("not.exist");
@@ -117,9 +110,8 @@ describe("launch sessions", () => {
     fixtures.newSessionPipelines().newSessionJobs(false, false, true).newSessionImages(true);
     cy.visit("/projects/e2e/local-test-project/sessions/new");
     cy.wait("@getSessionJobs", { timeout: 10000 });
-    cy.contains("Hide advanced settings").should("be.visible");
-    cy.contains("Start with base image").should("be.visible");
-    cy.contains("Start session").should("be.visible").should("be.disabled");
+    cy.get("form").contains("Start with base image").should("be.visible");
+    cy.get("form").contains("Start session").should("be.visible").should("be.disabled");
     cy.get(".badge").contains("not available").should("be.visible");
     cy.get("#image_build").should("not.exist");
     cy.get("#image_build_again").should("be.visible");
@@ -132,9 +124,6 @@ describe("launch sessions", () => {
     fixtures.newSessionPipelines().newSessionJobs().newSessionImages();
     cy.visit("/projects/e2e/local-test-project/sessions/new");
     cy.wait("@getSessionImage", { timeout: 10000 });
-    cy.contains(
-      "Do you want to select the branch, commit, or image, or configure cloud storage?"
-    ).should("be.visible").click();
     cy.contains("Configure Cloud Storage").should("be.visible").click();
     cy.contains("Object Store Configuration").should("be.visible");
   });


### PR DESCRIPTION
Develop a new session start flow with more emphasis on the session and less on the project.

![image](https://user-images.githubusercontent.com/1196411/185408279-f8213990-4ac7-4083-9c1f-7bc03e254a60.png)

# Testing

Try starting sessions with and without options and see that the interaction is smooth.

I'm still not sure about the behavior after closing a session -- currently, the user gets taken back to the main project page. I think that feels better than going to watch the session shut down, since you usually do not care, but we can discuss this.

/deploy renku=ui-tests-2.8.0 renku-gateway=master #persist
Fix #1990