### PR TITLE
feat: refresh project header after update tags and description (#1984)

### DIFF
--- a/client/src/project/Project.state.js
+++ b/client/src/project/Project.state.js
@@ -202,14 +202,24 @@ const ProjectAttributesMixin = {
       .then(() => { this.set("metadata.pendingRefresh", true); });
   },
   setDescription(client, description) {
-    this.setUpdating({ metadata: { description: true } });
+    this.set("metadata.description", { updating: true });
     return client.setDescription(this.get("metadata.id"), description)
-      .then(() => { this.set("metadata.pendingRefresh", true); });
+      .then(() => {
+        this.set("metadata.description", description); // to refresh view
+        this.set("metadata.pendingRefresh", true);
+      });
   },
   setTags(client, tags) {
-    this.setUpdating({ metadata: { tagList: [true] } });
+    this.set("metadata.tagList.updating", true);
+    const currentTags = tags.trim();
+    const temporalTags = currentTags.length === 0 ?
+      [] : tags.split(",").map(tag => tag.trim());
+
     return client.setTags(this.get("metadata.id"), tags)
-      .then(() => { this.set("metadata.pendingRefresh", true); });
+      .then(() => {
+        this.set("metadata.tagList", temporalTags); // to refresh view
+        this.set("metadata.pendingRefresh", true);
+      });
   },
   setStars(num) {
     this.set("metadata.starCount", num);

--- a/client/src/project/datasets/ProjectDatasets.test.js
+++ b/client/src/project/datasets/ProjectDatasets.test.js
@@ -27,7 +27,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import { createMemoryHistory } from "history";
-
+import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { ACCESS_LEVELS, testClient as client } from "../../api-client";
 import { StateModel, globalSchema } from "../../model";
@@ -90,13 +90,15 @@ describe("rendering", () => {
     };
     const div = document.createElement("div");
     ReactDOM.render(
-      <MemoryRouter>
-        <AppContext.Provider value={appContext}>
-          <DatasetsListView
-            {...props}
-          />
-        </AppContext.Provider>
-      </MemoryRouter>
+      <Provider store={model.reduxStore}>
+        <MemoryRouter>
+          <AppContext.Provider value={appContext}>
+            <DatasetsListView
+              {...props}
+            />
+          </AppContext.Provider>
+        </MemoryRouter>
+      </Provider>
       , div);
   });
 

--- a/client/src/project/list/ProjectList.test.js
+++ b/client/src/project/list/ProjectList.test.js
@@ -27,6 +27,7 @@ import React from "react";
 import { MemoryRouter } from "react-router-dom";
 import { createMemoryHistory } from "history";
 import TestRenderer, { act } from "react-test-renderer";
+import { Provider } from "react-redux";
 
 import { testClient as client } from "../../api-client";
 import { generateFakeUser } from "../../user/User.test";
@@ -34,6 +35,7 @@ import { Url } from "../../utils/helpers/url";
 import { tests } from "./ProjectList.container";
 import AppContext from "../../utils/context/appContext";
 import { ProjectList } from "./";
+import { globalSchema, StateModel } from "../../model";
 
 
 describe("helper functions", () => {
@@ -117,17 +119,20 @@ describe("rendering", () => {
     params: { "TEMPLATES": templates },
     location: fakeLocation,
   };
+  const model = new StateModel(globalSchema);
 
 
   //TestRenderer
   it("Renders ProjectList for logged user", async () => {
     await act(async () => {
       TestRenderer.create(
-        <MemoryRouter>
-          <AppContext.Provider value={appContext}>
-            <ProjectList client={client} history={fakeHistory} location={fakeHistory.location} user={loggedUser} />
-          </AppContext.Provider>
-        </MemoryRouter>
+        <Provider store={model.reduxStore}>
+          <MemoryRouter>
+            <AppContext.Provider value={appContext}>
+              <ProjectList client={client} history={fakeHistory} location={fakeHistory.location} user={loggedUser} />
+            </AppContext.Provider>
+          </MemoryRouter>
+        </Provider>
       );
     });
   });
@@ -135,11 +140,13 @@ describe("rendering", () => {
   it("Renders ProjectList for anonymous user", async () => {
     await act(async () => {
       TestRenderer.create(
-        <AppContext.Provider value={appContext}>
-          <MemoryRouter>
-            <ProjectList client={client} history={fakeHistory} location={fakeHistory.location} user={anonymousUser} />
-          </MemoryRouter>
-        </AppContext.Provider>
+        <Provider store={model.reduxStore}>
+          <AppContext.Provider value={appContext}>
+            <MemoryRouter>
+              <ProjectList client={client} history={fakeHistory} location={fakeHistory.location} user={anonymousUser} />
+            </MemoryRouter>
+          </AppContext.Provider>
+        </Provider>
       );
     });
   });
@@ -154,11 +161,13 @@ describe("rendering", () => {
     // Logged users can use searchIn=users
     await act(async () => {
       rendered = TestRenderer.create(
-        <AppContext.Provider value={appContext}>
-          <MemoryRouter>
-            <ProjectList client={client} history={fakeHistory} location={fakeHistory.location} user={loggedUser} />
-          </MemoryRouter>
-        </AppContext.Provider>
+        <Provider store={model.reduxStore}>
+          <AppContext.Provider value={appContext}>
+            <MemoryRouter>
+              <ProjectList client={client} history={fakeHistory} location={fakeHistory.location} user={loggedUser} />
+            </MemoryRouter>
+          </AppContext.Provider>
+        </Provider>
       );
     });
     props = rendered.root.findByType(ProjectList).props;
@@ -169,11 +178,13 @@ describe("rendering", () => {
     // Anonymous users can't use searchIn=users, they should be redirected to searchIn=projects
     await act(async () => {
       rendered = TestRenderer.create(
-        <AppContext.Provider value={appContext}>
-          <MemoryRouter>
-            <ProjectList client={client} history={fakeHistory} location={fakeHistory.location} user={anonymousUser} />
-          </MemoryRouter>
-        </AppContext.Provider>
+        <Provider store={model.reduxStore}>
+          <AppContext.Provider value={appContext}>
+            <MemoryRouter>
+              <ProjectList client={client} history={fakeHistory} location={fakeHistory.location} user={anonymousUser} />
+            </MemoryRouter>
+          </AppContext.Provider>
+        </Provider>
       );
     });
     props = rendered.root.findByType(ProjectList).props;

--- a/client/src/utils/components/entities/Description.tsx
+++ b/client/src/utils/components/entities/Description.tsx
@@ -18,6 +18,7 @@
 
 import React, { CSSProperties } from "react";
 import { Link } from "react-router-dom";
+import { RootStateOrAny, useSelector } from "react-redux";
 
 /**
  *  renku-ui
@@ -52,6 +53,15 @@ function EntityDescription(
     minHeight: isHeightFixed ? "75px" : undefined,
     height: isHeightFixed ? "75px" : undefined,
   };
+
+  const isUpdatingValue = useSelector((state: RootStateOrAny ) => state.project.metadata.description.updating);
+  if (isUpdatingValue) {
+    return (
+      <div className="card-text text-rk-text-light" style={descriptionStyles}>
+        <small><i>Updating description...</i></small>
+      </div>
+    );
+  }
 
   return (<div className="card-text text-rk-text-light" style={descriptionStyles} data-cy="entity-description">
     {description ? description :

--- a/client/src/utils/components/entities/Description.tsx
+++ b/client/src/utils/components/entities/Description.tsx
@@ -54,7 +54,7 @@ function EntityDescription(
     height: isHeightFixed ? "75px" : undefined,
   };
 
-  const isUpdatingValue = useSelector((state: RootStateOrAny ) => state.project.metadata.description.updating);
+  const isUpdatingValue = useSelector((state: RootStateOrAny ) => state.project.metadata?.description?.updating);
   if (isUpdatingValue) {
     return (
       <div className="card-text text-rk-text-light" style={descriptionStyles}>

--- a/client/src/utils/components/entities/Tags.tsx
+++ b/client/src/utils/components/entities/Tags.tsx
@@ -18,6 +18,7 @@
 
 import React, { useRef } from "react";
 import { ThrottledTooltip } from "../Tooltip";
+import { RootStateOrAny, useSelector } from "react-redux";
 
 /**
  *  renku-ui
@@ -34,6 +35,15 @@ export interface EntityTagsProps {
 function EntityTags ({ tagList, multiline }: EntityTagsProps) {
   const ref = useRef(null);
   const multilineStyles = multiline ? "d-flex flex-wrap gap-1" : "text-truncate";
+  const isUpdatingValue = useSelector((state: RootStateOrAny ) => state.project.metadata.tagList.updating);
+  if (isUpdatingValue) {
+    return (
+      <div ref={ref} className={`tagList card-tags text-rk-text-light ${multilineStyles}`}>
+        <small><i>Updating list...</i></small>
+      </div>
+    );
+  }
+
   const tooltip = <ThrottledTooltip target={ref} tooltip={tagList?.map(tag => `#${tag}`).join(", ")} />;
   return (
     <>


### PR DESCRIPTION
PR to fresh project header after update tagList and description values.

![refresh header after update taglist and description](https://user-images.githubusercontent.com/43388408/185858884-a50fe0ff-5934-4164-9f37-b1c6bdc0d12c.gif)


/deploy renku=1978-styles-cards-projects-and-datasets  #persist