### PR TITLE
feat: hide project header in dataset view (#1984)

### DIFF
--- a/client/src/dataset/Dataset.present.js
+++ b/client/src/dataset/Dataset.present.js
@@ -40,7 +40,6 @@ import { Loader } from "../utils/components/Loader";
 import { ThrottledTooltip } from "../utils/components/Tooltip";
 import { CoreErrorAlert } from "../utils/components/errors/CoreErrorAlert";
 import { CoreError } from "../utils/components/errors/CoreErrorHelpers";
-import { ContainerWrap } from "../App";
 import EntityHeader from "../utils/components/entityHeader/EntityHeader";
 import { EntityDeleteButtonButton } from "../utils/components/entities/Buttons";
 
@@ -381,7 +380,7 @@ export default function DatasetView(props) {
     new Date(datasetDate.replace(/ /g, "T")) :
     "";
 
-  return (<ContainerWrap>
+  return (<div className={props.insideProject ? "row" : "container-xxl renku-container py-4 mt-2"}>
     <Col>
       <ErrorAfterCreation location={props.location} dataset={dataset} />
       {
@@ -471,5 +470,5 @@ export default function DatasetView(props) {
         : null
       }
     </Col>
-  </ContainerWrap>);
+  </div>);
 }

--- a/client/src/project/Project.present.js
+++ b/client/src/project/Project.present.js
@@ -885,7 +885,7 @@ function ProjectViewDatasets(props) {
         }/>
       <Route path={props.datasetUrl} render={p =>[
         <Col key="btn" md={12}>
-          <GoBackButton key="btn" label="Back to list" url={props.datasetsUrl}/>
+          <GoBackButton key="btn" label={`Back to ${props.metadata.pathWithNamespace}`} url={props.datasetsUrl}/>
         </Col>,
         props.datasetView(p, !kgDown, props.location)
       ]} />
@@ -1364,9 +1364,18 @@ class ProjectView extends Component {
             render={props => <ProjectViewHeader {...this.props} minimalistHeader={false}/>} />
           <Route path={this.props.overviewUrl}
             render={props => <ProjectViewHeader {...this.props} minimalistHeader={false}/>} />
+          <Route path={this.props.editDatasetUrl} render={() => null} />
+          <Route path={this.props.newDatasetUrl} component={() =>
+            <ProjectViewHeader {...this.props} minimalistHeader={true}/>} />
+          <Route path={this.props.datasetUrl} render={() => null} />
           <Route component={()=><ProjectViewHeader {...this.props} minimalistHeader={true}/>} />
         </Switch>
-        <ProjectNav key="nav" {...this.props} />
+        <Switch key="projectNav">
+          <Route path={this.props.newDatasetUrl} component={() => <ProjectNav key="nav" {...this.props} />} />
+          <Route path={this.props.editDatasetUrl} render={() => null} />
+          <Route path={this.props.datasetUrl} render={() => null} />
+          <Route component={() =><ProjectNav key="nav" {...this.props} />} />
+        </Switch>
         <Row key="content">
           <Switch>
             <Route exact path={this.props.baseUrl}

--- a/client/src/utils/components/TimeCaption.js
+++ b/client/src/utils/components/TimeCaption.js
@@ -45,8 +45,9 @@ function TimeCaption(
   if (!noCaption)
     className = "time-caption " + className;
 
+
   const ref = useRef(null);
-  const tooltip = showTooltip ?
+  const tooltip = showTooltip && time ?
     <ThrottledTooltip target={ref} tooltip={Time.toIsoString(time)} /> : null;
 
   return (


### PR DESCRIPTION
PR to hide the project header in the view of a project dataset and modify a dataset.

![project and dataset header](https://user-images.githubusercontent.com/43388408/185944567-2999b2b8-2441-444d-9cdf-426cad68e90c.gif)


/deploy renku-gateway=master renku=1978-styles-cards-projects-and-datasets #persist