### PR TITLE
fix: wrong file tree display when changing to original project from fork (#1907)

### DIFF
--- a/client/src/project/Project.state.js
+++ b/client/src/project/Project.state.js
@@ -127,7 +127,7 @@ const FileTreeMixin = {
     if (oldTree.loaded === false)
       return this.initialFetchProjectFilesTree(client, openFilePath, openFolder);
 
-    if (openFolder !== undefined && oldTree.hash[openFolder].childrenLoaded === false)
+    if (openFolder !== undefined && oldTree.hash[openFolder]?.childrenLoaded === false)
       return this.deepFetchProjectFilesTree(client, openFilePath, openFolder, oldTree);
 
     return oldTree;
@@ -430,11 +430,17 @@ class ProjectCoordinator {
     this.model.setObject(value);
   }
 
+  resetFilesTree() {
+    this.set("filesTree.hash", {});
+    this.set("filesTree.loaded", false);
+  }
+
   fetchProject(client, projectPathWithNamespace) {
     const identifier = !projectPathWithNamespace ?
       this.get("metadata.id") : projectPathWithNamespace;
 
     this.setUpdating({ metadata: { exists: true } });
+    this.resetFilesTree();
     return client.getProject(identifier, { statistics: true })
       .then(resp => resp.data)
       .then(d => {

--- a/client/src/project/filestreeview/FilesTreeView.js
+++ b/client/src/project/filestreeview/FilesTreeView.js
@@ -156,7 +156,7 @@ class FilesTreeView extends Component {
       this.props.projectUrl + redirectURL;
     const toLineage = this.props.lineageUrl + redirectURL;
 
-    const tree = treeStructure.tree ?
+    const tree = treeStructure.tree && treeStructure.loaded ?
       treeStructure.tree.map((node) => {
         return <TreeNode
           key={node.path}


### PR DESCRIPTION
PR to fix wrong file tree display when changing to original project from fork.

Closes #1907 

/deploy renku-gateway=master #persist