### PR TITLE
Fix a few UI glitches

### DIFF
--- a/client/src/project/Project.present.js
+++ b/client/src/project/Project.present.js
@@ -405,7 +405,8 @@ class ProjectViewHeaderOverview extends Component {
   star(event) {
     event.preventDefault();
     // do nothing if the star state is not yet loaded
-    if (this.props.starred == null) return;
+    if (this.props.starred == null && this.props.user?.logged)
+      return;
     this.setState({ updating_star: true });
     this.props.onStar().then(
       result => {
@@ -415,6 +416,7 @@ class ProjectViewHeaderOverview extends Component {
 
   render() {
     const metadata = this.props.metadata;
+    const logged = this.props.user?.logged;
 
     let starElement;
     let starText;
@@ -427,7 +429,7 @@ class ProjectViewHeaderOverview extends Component {
     }
     else {
       const starred = this.props.starred;
-      if (starred === null) {
+      if (starred == null && logged) {
         starElement = (<Loader inline size={14} />);
         starText = "";
       }
@@ -482,7 +484,7 @@ class ProjectViewHeaderOverview extends Component {
               <div id="project-stars">
                 <Button
                   className="btn-outline-rk-green btn-icon-text"
-                  disabled={this.state.updating_star || this.props.starred == null}
+                  disabled={this.state.updating_star || this.props.starred == null && logged}
                   onClick={this.star.bind(this)}>
                   {starElement} {starText} {metadata.starCount}
                 </Button>

--- a/client/src/project/list/ProjectList.container.js
+++ b/client/src/project/list/ProjectList.container.js
@@ -317,14 +317,14 @@ function ProjectList(props) {
     // Searching in own or starred projects
     if (section !== SECTION_MAP.all) {
       const newUrl = Url.get(Url.pages.projects.all, searchParams);
-      props.history.push(newUrl);
+      props.history.replace(newUrl);
       return null;
     }
     // filtering per user or group
     if (searchParams.searchIn !== SEARCH_IN_MAP.projects.value) {
       const newParams = { ...searchParams, searchIn: SEARCH_IN_MAP.projects.value };
       const newUrl = Url.get(Url.pages.projects.all, newParams);
-      props.history.push(newUrl);
+      props.history.replace(newUrl);
       return null;
     }
   }

--- a/client/src/project/list/ProjectList.container.js
+++ b/client/src/project/list/ProjectList.container.js
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+import _ from "lodash";
 import React, { useState, useEffect } from "react";
 
 import { ProjectList as ProjectListPresent } from "./ProjectList.present";
@@ -137,9 +138,9 @@ function removeDefaultParams(params, removeSection = false) {
 }
 
 /** React hook to monitor location changes and set params */
-function useLocation(props, setParams, setTargetUser) {
+function useLocation(location, params, setParams, setTargetUser) {
   useEffect(() => {
-    const newSection = getSection(props.location);
+    const newSection = getSection(location);
     let newSearchParams = getSearchParams(null, CONVERSIONS);
 
     // consider the default params when setting the new default
@@ -154,6 +155,10 @@ function useLocation(props, setParams, setTargetUser) {
     if (newSection !== SECTION_MAP.all && newParamsFull.searchIn !== SEARCH_IN_MAP.projects.value)
       newParamsFull.searchIn = SEARCH_IN_MAP.projects.value;
 
+    const newParams = { ...newParamsFull, section: newSection };
+    if (_.isEqual(newParams, params))
+      return null;
+
     setParams(p => {
       const newParams = { ...p, ...newParamsFull, section: newSection };
       // prevent extra queries when changing searchIn
@@ -162,7 +167,7 @@ function useLocation(props, setParams, setTargetUser) {
 
       return newParams;
     });
-  }, [props.location, setParams, setTargetUser]);
+  }, [location, params, setParams, setTargetUser]);
 }
 
 /** React hook to update project search results when parameters change */
@@ -301,15 +306,10 @@ function useUserProjectSearch(client, params, targetUser, setParams, setProjects
 // *** React functional components ***
 
 /**
- * Show list of projects, allowing advanced search.
- *
- * @param {object} props.location - React location object.
- * @param {object} props.history - React history object.
- * @param {object} props.client - client object.
- * @param {object} props.user - user object.
+ * Buffer component to handle anonymous users redirects.
+ * Check ProjectListRedirected for the functional component logic.
  */
 function ProjectList(props) {
-  // *** Setup ***
   // Redirect anonymous users when trying to perform an invalid search (manually modified link)
   if (!props.user.logged) {
     const section = getSection(props.location);
@@ -318,16 +318,30 @@ function ProjectList(props) {
     if (section !== SECTION_MAP.all) {
       const newUrl = Url.get(Url.pages.projects.all, searchParams);
       props.history.push(newUrl);
+      return null;
     }
     // filtering per user or group
     if (searchParams.searchIn !== SEARCH_IN_MAP.projects.value) {
       const newParams = { ...searchParams, searchIn: SEARCH_IN_MAP.projects.value };
       const newUrl = Url.get(Url.pages.projects.all, newParams);
       props.history.push(newUrl);
+      return null;
     }
   }
+  return (<ProjectListRedirected {...props} />);
+}
 
-  // Initial setup
+
+/**
+ * Show list of projects, allowing advanced search.
+ *
+ * @param {object} props.location - React location object.
+ * @param {object} props.history - React history object.
+ * @param {object} props.client - client object.
+ * @param {object} props.user - user object.
+ */
+function ProjectListRedirected(props) {
+  // *** Setup ***
   const [projects, setProjects] = useState(DEFAULT_PROJECTS);
   const [users, setUsers] = useState(DEFAULT_USERS_GROUPS);
   const [targetUser, setTargetUser] = useState(null);
@@ -338,7 +352,7 @@ function ProjectList(props) {
 
   // *** Hooks ***
   // Monitor location changes and set params
-  useLocation(props, setParams, setTargetUser);
+  useLocation(props.location, params, setParams, setTargetUser);
 
   // Get new projects when params change (ONLY when searching in projects)
   useProjectSearchParams(props.client, params, setParams, setProjects);

--- a/client/src/styles/components/_renku_search.scss
+++ b/client/src/styles/components/_renku_search.scss
@@ -130,7 +130,8 @@
 
 .rk-search-result-grid {
   display: flex;
-  margin-left: -1em;
+  margin-left: -0.5em;
+  margin-right: -0.5em;
   width: auto;
 
   .rk-search-result-grid_column {


### PR DESCRIPTION
This PR contains a few fixes. I split them in different commits so that it's easier to review the code changes separately:
1. The star button displayed an endless spinning wheel for anonymous users. Not it shows the start and it restores the behavior on click (will redirect to the login to continue)
  ![Screenshot_20220830_161208](https://user-images.githubusercontent.com/43481553/187470623-b4702dce-bd64-4dc3-8afa-53661bec5e0e.png)
2. Adjust the margins on search containers by reducing margin in equal parts on both left and right sides, instead of left only (in the screenshot, the left screen shows balanced margins, while on the right screen there is a smaller space on the left and a bigger one on the right).
  ![Screenshot_20220830_161041](https://user-images.githubusercontent.com/43481553/187471423-4ac7757e-3f17-442d-880b-cb62974b8f20.png)
3. Prevents invoking multiple times the projects API with the same parameters when reaching the projects page. This was worse in the case of anonymous users since they were also redirected, adding an extra query for their own projects that always returns empty since they can't have any own projects (in the screenshot, there are 3 queries on the right side, while only 1 on the left).
  ![Screenshot_20220830_164725](https://user-images.githubusercontent.com/43481553/187472204-f5e76198-4b0f-439e-8fc4-43cfa832df8a.png)
4. The projects page redirected anonymous users to the public projects page using `history.push`, therefore preventing any backward navigation.

/deploy renku-gateway=master #persist
fix #2014 