### PR TITLE
feat(server): prevent gateway from setting anon users cookies

### DIFF
--- a/server/src/routes/apis.ts
+++ b/server/src/routes/apis.ts
@@ -74,21 +74,17 @@ const proxyMiddleware = createProxyMiddleware({
 
     // Prevent gateway from setting anon-id cookies. That's not needed in the UI anymore
     const setCookie = null ?? clientRes.headers["set-cookie"];
-    if (setCookie != null && setCookie.length) {
-      if (setCookie.length === 1) {
-        if (setCookie[0].startsWith(config.auth.cookiesAnonymousKey))
-          clientRes.headers["set-cookie"] = null;
-      }
-      else {
-        const allowedSetCookie = [];
-        for (const cookie of setCookie) {
-          if (!cookie.startsWith(config.auth.cookiesAnonymousKey))
-            allowedSetCookie.push(cookie);
-        }
-        if (allowedSetCookie.length < setCookie.length)
-          clientRes.headers["set-cookie"] = allowedSetCookie;
-      }
+    if (setCookie == null || !setCookie.length)
+      return;
+    const allowedSetCookie = [];
+    for (const cookie of setCookie) {
+      if (!cookie.startsWith(config.auth.cookiesAnonymousKey))
+        allowedSetCookie.push(cookie);
     }
+    if (!allowedSetCookie.length)
+      clientRes.headers["set-cookie"] = null;
+    else
+      clientRes.headers["set-cookie"] = allowedSetCookie;
   }
 });
 

--- a/server/src/routes/apis.ts
+++ b/server/src/routes/apis.ts
@@ -71,6 +71,24 @@ const proxyMiddleware = createProxyMiddleware({
         res.json({ error: "Invalid authentication tokens" });
       }
     }
+
+    // Prevent gateway from setting anon-id cookies. That's not needed in the UI anymore
+    const setCookie = null ?? clientRes.headers["set-cookie"];
+    if (setCookie != null && setCookie.length) {
+      if (setCookie.length === 1) {
+        if (setCookie[0].startsWith(config.auth.cookiesAnonymousKey))
+          clientRes.headers["set-cookie"] = null;
+      }
+      else {
+        const allowedSetCookie = [];
+        for (const cookie of setCookie) {
+          if (!cookie.startsWith(config.auth.cookiesAnonymousKey))
+            allowedSetCookie.push(cookie);
+        }
+        if (allowedSetCookie.length < setCookie.length)
+          clientRes.headers["set-cookie"] = allowedSetCookie;
+      }
+    }
   }
 });
 


### PR DESCRIPTION
This should prevent propagating the headers to set the anon-id related cookies from the gateway to the UI since that is managed by the UI server now.

/deploy #persist

