### PR TITLE
fix(server): use the correct redis namespace

### DIFF
--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -71,7 +71,7 @@ const AUTHENTICATION = {
 const REDIS = {
   host: process.env.REDIS_HOST || "localhost",
   port: convertType(process.env.REDIS_PORT) || 6379,
-  database: parseInt(process.env.REDIS_DATABASE || "0"),
+  database: convertType(process.env.REDIS_DATABASE) || 0,
   password: process.env.REDIS_PASSWORD || null,
   isSentinel: convertType(process.env.REDIS_IS_SENTINEL) || false,
   masterSet: process.env.REDIS_MASTER_SET || "mymaster",

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -71,7 +71,7 @@ const AUTHENTICATION = {
 const REDIS = {
   host: process.env.REDIS_HOST || "localhost",
   port: convertType(process.env.REDIS_PORT) || 6379,
-  database: process.env.REDIS_DATABASE || "0",
+  database: parseInt(process.env.REDIS_DATABASE || "0"),
   password: process.env.REDIS_PASSWORD || null,
   isSentinel: convertType(process.env.REDIS_IS_SENTINEL) || false,
   masterSet: process.env.REDIS_MASTER_SET || "mymaster",

--- a/server/src/storage/RedisStorage.ts
+++ b/server/src/storage/RedisStorage.ts
@@ -30,11 +30,12 @@ class RedisStorage implements Storage {
     password: string = config.redis.password,
     isSentinel: boolean = config.redis.isSentinel as boolean,
     masterSet: string = config.redis.masterSet,
+    db: number = config.redis.database as number,
   ) {
     // configure redis
     const redisConfig: Redis.RedisOptions = {
       lazyConnect: true,
-      db: config.redis.database,
+      db,
       retryStrategy: (times) => {
         return times > 5 ?
           null :

--- a/server/src/storage/RedisStorage.ts
+++ b/server/src/storage/RedisStorage.ts
@@ -34,6 +34,7 @@ class RedisStorage implements Storage {
     // configure redis
     const redisConfig: Redis.RedisOptions = {
       lazyConnect: true,
+      db: config.redis.database,
       retryStrategy: (times) => {
         return times > 5 ?
           null :


### PR DESCRIPTION
The ui server was defaulting to using the `0` redis namespace which is reserved for the gateway.

This has not caused issues as far as I know because the likelihood of collisions is low.

But it is better to use a dedicated redis namespace for the ui-server and not put keys in the gateway's namespace.

/deploy #persist