### PR TITLE
feat: add progress indicator when start a session (#1879)

### DIFF
--- a/client/src/notebooks/Notebooks.container.js
+++ b/client/src/notebooks/Notebooks.container.js
@@ -50,9 +50,7 @@ import ShowSessionFullscreen from "./components/SessionFullScreen";
 
 function mapSessionStateToProps(state, ownProps) {
   const notebooks = state.stateModel.notebooks.notebooks;
-  const available = notebooks.all[ownProps.target] ?
-    true :
-    false;
+  const available = !!notebooks.all[ownProps.target];
   const notebook = {
     available,
     fetched: notebooks.fetched,

--- a/client/src/notebooks/Notebooks.container.js
+++ b/client/src/notebooks/Notebooks.container.js
@@ -27,7 +27,6 @@ import {
   CheckNotebookIcon,
 } from "./Notebooks.present";
 import { StatusHelper } from "../model/Model";
-import { Loader } from "../utils/components/Loader";
 import { Url } from "../utils/helpers/url";
 import { sleep } from "../utils/helpers/HelperFunctions";
 import ShowSessionFullscreen from "./components/SessionFullScreen";
@@ -127,10 +126,6 @@ class ShowSession extends Component {
   render() {
     if (this.props.blockAnonymous && !this.userLogged)
       return <NotebooksDisabled logged={this.userLogged} />;
-
-    if (!this.model.get("notebooks.fetched"))
-      return <Loader />;
-
     return (
       <ShowSessionMapped
         target={this.target}

--- a/client/src/notebooks/Notebooks.css
+++ b/client/src/notebooks/Notebooks.css
@@ -74,3 +74,8 @@
     border-width: 1px 0 0 1px !important;
   }
 }
+
+.start-session-box {
+  max-width: 600px;
+  margin: auto;
+}

--- a/client/src/notebooks/Notebooks.present.js
+++ b/client/src/notebooks/Notebooks.present.js
@@ -749,7 +749,7 @@ const NotebookServerRowAction = memo((props) => {
       </DropdownItem>
     </Fragment>;
   }
-  if (status === SessionStatus.running) {
+  if (status === SessionStatus.running || status === SessionStatus.starting) {
     const state = scope?.filePath ? { filePath: scope?.filePath } : undefined;
     defaultAction = (
       <Link className="btn btn-outline-rk-green" to={{ pathname: props.localUrl, state }}>Open</Link>);

--- a/client/src/notebooks/Notebooks.present.js
+++ b/client/src/notebooks/Notebooks.present.js
@@ -20,12 +20,12 @@ import React, { Component, Fragment, memo, useEffect } from "react";
 import Media from "react-media";
 import { Link, useHistory } from "react-router-dom";
 import {
-  Alert, Badge, Button, Col, DropdownItem, PopoverBody, PopoverHeader, Row, UncontrolledPopover
+  Badge, Button, Col, DropdownItem, PopoverBody, PopoverHeader, Row, UncontrolledPopover
 } from "reactstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faCheckCircle, faExclamationTriangle, faExternalLinkAlt, faFileAlt,
-  faInfoCircle, faPlus, faQuestionCircle, faStopCircle, faSyncAlt, faTimesCircle
+  faInfoCircle, faPlus, faStopCircle, faSyncAlt, faTimesCircle
 } from "@fortawesome/free-solid-svg-icons";
 import _ from "lodash";
 
@@ -168,7 +168,7 @@ function SessionCommands(props) {
 }
 
 function SessionJupyter(props) {
-  const { filters, notebook, height = "800px", urlList } = props;
+  const { notebook, height = "800px", ready } = props;
   const history = useHistory();
 
   let content = null;
@@ -177,39 +177,17 @@ function SessionJupyter(props) {
     if (status === SessionStatus.running) {
       const locationFilePath = history?.location?.state?.filePath;
       const notebookUrl = locationFilePath ? `${notebook.data.url}/lab/tree/${locationFilePath}` : notebook.data.url;
-
       content = (
         <iframe id="session-iframe" title="session iframe" src={notebookUrl}
+          style={{ display: ready ? "block" : "none" }}
           width="100%" height={height} referrerPolicy="origin"
           sandbox="allow-downloads allow-forms allow-modals allow-popups allow-same-origin allow-scripts"
         />
       );
     }
-    else if (status === SessionStatus.starting || status === SessionStatus.stopping) {
+    else if (status === SessionStatus.stopping) {
       content = (<Loader />);
     }
-  }
-  else {
-    const urlNew = Url.get(Url.pages.project.session.new, {
-      namespace: filters.namespace,
-      path: filters.project,
-    });
-
-    content = (
-      <div className="p-2 p-lg-3 text-nowrap">
-        <p className="mt-2">The session you are trying to open is not available.</p>
-        <Alert color="primary">
-          <p className="mb-0">
-            <FontAwesomeIcon size="lg" icon={faQuestionCircle} />
-            {" "}You should either{" "}
-            <Link className="btn btn-primary btn-sm" to={urlNew}>start a new session</Link>
-            {" "}or{" "}
-            <Link className="btn btn-primary btn-sm" to={urlList}>check the running sessions</Link>
-            {" "}
-          </p>
-        </Alert>
-      </div>
-    );
   }
   return content;
 }

--- a/client/src/notebooks/Notebooks.test.js
+++ b/client/src/notebooks/Notebooks.test.js
@@ -35,6 +35,7 @@ import { ExpectedAnnotations } from "./Notebooks.state";
 import { StateModel, globalSchema } from "../model";
 import { ProjectCoordinator } from "../project";
 import { testClient as client } from "../api-client";
+import { Provider } from "react-redux";
 
 
 const model = new StateModel(globalSchema);
@@ -313,9 +314,11 @@ describe("rendering", () => {
     document.body.appendChild(div);
     await act(async () => {
       ReactDOM.render(
-        <MemoryRouter>
-          <ShowSession {...props} urlNewSession="new_session"/>
-        </MemoryRouter>, div);
+        <Provider store={model.reduxStore}>
+          <MemoryRouter>
+            <ShowSession {...props} urlNewSession="new_session"/>
+          </MemoryRouter>
+        </Provider>, div);
     });
   });
 

--- a/client/src/notebooks/components/ResourcesSessionModal.tsx
+++ b/client/src/notebooks/components/ResourcesSessionModal.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import React, { useState } from "react";
+import React from "react";
 
 import "./SessionModal.css";
 import { Notebook, SessionHandlers } from "./Session";
@@ -38,10 +38,11 @@ export interface ResourcesSessionModelProp {
   handlers: SessionHandlers;
   notebook: Notebook;
   defaultBranch: string;
+  setActiveTab: Function;
+  activeTab: string;
 }
 const ResourcesSessionModel =
-  ({ toggleModal, isOpen, handlers, notebook, defaultBranch }: ResourcesSessionModelProp) => {
-    const [activeTab, setActiveTab] = useState<string>(SESSION_TABS.commands);
+  ({ toggleModal, isOpen, handlers, notebook, defaultBranch, setActiveTab, activeTab }: ResourcesSessionModelProp) => {
     return (
       <Modal
         isOpen={isOpen}

--- a/client/src/notebooks/components/Session.d.ts
+++ b/client/src/notebooks/components/Session.d.ts
@@ -17,6 +17,7 @@
  */
 
 import { EntityCreator } from "../entities/Creators";
+import { SessionStatusData } from "./StartSessionProgressBar";
 
 interface NotebookAnnotations {
   [key: string]: string;
@@ -45,9 +46,7 @@ export interface Notebook {
     commits?: any;
     image: string;
     name: string;
-    status: {
-      state: string;
-    };
+    status: SessionStatusData;
     url: string;
   };
   logs: {
@@ -56,6 +55,8 @@ export interface Notebook {
     fetching: boolean;
   };
   available: boolean;
+  fetched: any;
+  fetching: any;
 }
 
 export interface ProjectMetadata {

--- a/client/src/notebooks/components/SessionFullScreen.tsx
+++ b/client/src/notebooks/components/SessionFullScreen.tsx
@@ -145,16 +145,10 @@ function ShowSessionFullscreen({ filters, notebook, urlBack, projectName, handle
   let content;
   let sessionView;
 
-  if (!notebook.fetched) {
-    content =
-      (<div className="progress-box-small progress-box-small--steps">
-        <StartSessionProgressBar toggleLogs={toggleToResourcesLogs} />
-      </div>);
-  }
-  else if (notebook.fetched && !notebook.available) {
+  if (notebook.fetched && !notebook.available) {
     content = <SessionUnavailable filters={filters} urlList={urlList} />;
   }
-  else {
+  else if (notebook.available) {
     const status = sessionStatus?.state;
     const sessionBranchKey = notebook?.data?.annotations ?
       Object.keys(notebook?.data?.annotations).find( key => key.split("/")[1] === "branch") : null;
@@ -170,6 +164,12 @@ function ShowSessionFullscreen({ filters, notebook, urlBack, projectName, handle
         ready={sessionStatus?.isTheSessionReady} filters={filters}
         notebook={notebook} urlList={urlList} height={`${iframeHeight}px`} /> :
       null;
+  }
+  else {
+    content =
+      (<div className="progress-box-small progress-box-small--steps">
+        <StartSessionProgressBar toggleLogs={toggleToResourcesLogs} />
+      </div>);
   }
 
   return (

--- a/client/src/notebooks/components/SessionFullScreen.tsx
+++ b/client/src/notebooks/components/SessionFullScreen.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import React, { useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useSelector } from "react-redux";
 import { useHistory } from "react-router-dom";
 
@@ -29,7 +29,10 @@ import { Notebook, SessionHandlers } from "./Session";
 import useWindowSize from "../../utils/helpers/UseWindowsSize";
 import { Url } from "../../utils/helpers/url";
 import { SessionStatus } from "../../utils/constants/Notebooks";
-import { SessionJupyter } from "../Notebooks.present";
+import { SESSION_TABS, SessionJupyter } from "../Notebooks.present";
+import StartSessionProgressBar, { SessionStatusData } from "./StartSessionProgressBar";
+import { AUTOSAVED_PREFIX } from "../../utils/helpers/HelperFunctions";
+import SessionUnavailable from "./SessionUnavailable";
 
 /**
  *  renku-ui
@@ -50,12 +53,14 @@ interface ShowSessionFullscreenProps {
   handlers: SessionHandlers;
 }
 function ShowSessionFullscreen({ filters, notebook, urlBack, projectName, handlers }: ShowSessionFullscreenProps) {
+  const [sessionStatus, setSessionStatus] = useState<SessionStatusData>();
 
   const [showModalAboutData, setShowModalAboutData] = useState(false);
   const toggleModalAbout = () => setShowModalAboutData(!showModalAboutData);
 
   const [showModalResourcesData, setShowModalResourcesData] = useState(false);
   const toggleModalResources = () => setShowModalResourcesData(!showModalResourcesData);
+  const [activeResourcesTab, setActiveResourcesTab] = useState<string>(SESSION_TABS.commands);
 
   const [showModalStopSession, setShowModalStopSession] = useState(false);
   const toggleStopSession = () => setShowModalStopSession(!showModalStopSession);
@@ -70,6 +75,28 @@ function ShowSessionFullscreen({ filters, notebook, urlBack, projectName, handle
     path: filters.project,
   });
 
+  const mounted = useRef(false);
+  useEffect(() => {
+    // this keeps track of the component status
+    mounted.current = true;
+    return () => { mounted.current = false; };
+  });
+
+  useEffect(() => {
+    if (!notebook.data.status)
+      return;
+    if (notebook.data.status.state === "running") {
+      setSessionStatus({ ...notebook.data.status, isTheSessionReady: false } as SessionStatusData);
+      setTimeout(() => {
+        if (mounted.current)
+          setSessionStatus({ ...notebook.data.status, isTheSessionReady: true } as SessionStatusData);
+      }, 4000); // wait 4 sec to use isTheSessionReady for session view
+    }
+    else {
+      setSessionStatus({ ...notebook.data.status, isTheSessionReady: false } as SessionStatusData);
+    }
+  }, [notebook.data.status]);
+
   // redirect immediately if the session fail
   if (history && notebook.data?.status?.state === SessionStatus.failed)
     history.push(urlList);
@@ -83,6 +110,14 @@ function ShowSessionFullscreen({ filters, notebook, urlBack, projectName, handle
 
   /* modals */
   const projectMetadata = useSelector((state: any) => state.stateModel.project?.metadata);
+  const toggleToResourcesLogs = () => {
+    setActiveResourcesTab(SESSION_TABS.logs);
+    toggleModalResources();
+  };
+  const toggleResources = () => {
+    setActiveResourcesTab(SESSION_TABS.commands);
+    toggleModalResources();
+  };
 
   const aboutModal = <AboutSessionModal
     toggleModal={toggleModalAbout}
@@ -93,9 +128,12 @@ function ShowSessionFullscreen({ filters, notebook, urlBack, projectName, handle
   const resourcesModal = <ResourcesSessionModel
     handlers={handlers}
     notebook={notebook}
-    toggleModal={toggleModalResources}
+    toggleModal={toggleResources}
     defaultBranch={filters.defaultBranch ?? "master"}
-    isOpen={showModalResourcesData}/>;
+    isOpen={showModalResourcesData}
+    activeTab={activeResourcesTab}
+    setActiveTab={setActiveResourcesTab}
+  />;
   const stopSessionModal = <StopSession
     stopNotebook={handlers.stopNotebook}
     notebook={notebook}
@@ -103,6 +141,36 @@ function ShowSessionFullscreen({ filters, notebook, urlBack, projectName, handle
     urlList={urlList}
     isOpen={showModalStopSession}/>;
   /* end Buttons */
+
+  let content;
+  let sessionView;
+
+  if (!notebook.fetched) {
+    content =
+      (<div className="progress-box-small progress-box-small--steps">
+        <StartSessionProgressBar toggleLogs={toggleToResourcesLogs} />
+      </div>);
+  }
+  else if (notebook.fetched && !notebook.available) {
+    content = <SessionUnavailable filters={filters} urlList={urlList} />;
+  }
+  else {
+    const status = sessionStatus?.state;
+    const sessionBranchKey = notebook?.data?.annotations ?
+      Object.keys(notebook?.data?.annotations).find( key => key.split("/")[1] === "branch") : null;
+    const sessionBranchValue = sessionBranchKey ? notebook?.data?.annotations[sessionBranchKey] : "";
+    const isAutoSave = sessionBranchValue.startsWith(AUTOSAVED_PREFIX);
+    content = !sessionStatus?.isTheSessionReady ?
+      (<div className="progress-box-small progress-box-small--steps">
+        <StartSessionProgressBar
+          sessionStatus={sessionStatus} isAutoSave={isAutoSave} toggleLogs={toggleToResourcesLogs} />
+      </div>) : null;
+    sessionView = status === SessionStatus.running ?
+      <SessionJupyter
+        ready={sessionStatus?.isTheSessionReady} filters={filters}
+        notebook={notebook} urlList={urlList} height={`${iframeHeight}px`} /> :
+      null;
+  }
 
   return (
     <div className="bg-white w-100">
@@ -123,7 +191,8 @@ function ShowSessionFullscreen({ filters, notebook, urlBack, projectName, handle
           </div>
         </div>
         <div ref={ref} className={`fullscreen-content w-100`}>
-          <SessionJupyter filters={filters} notebook={notebook} urlList={urlList} height={`${iframeHeight}px`} />
+          {content}
+          {sessionView}
         </div>
       </div>
       {aboutModal}

--- a/client/src/notebooks/components/SessionModal.css
+++ b/client/src/notebooks/components/SessionModal.css
@@ -1,9 +1,11 @@
 .fullscreen-header {
     height: 42px;
+    box-shadow: 0 4px 10px rgb(0 0 0 / 10%);
 }
 
 .fullscreen-content {
     height: calc(100vh - 42px);
+    background-color: var(--bs-rk-background-0);
 }
 
 .about-modal {

--- a/client/src/notebooks/components/SessionUnavailable.tsx
+++ b/client/src/notebooks/components/SessionUnavailable.tsx
@@ -1,0 +1,56 @@
+/*!
+ * Copyright 2022 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Url } from "../../utils/helpers/url";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
+import { Link } from "react-router-dom";
+import React from "react";
+import { Alert } from "../../utils/ts-wrappers";
+
+interface SessionUnavailableProps {
+  filters: {
+    namespace: string;
+    project: string;
+  };
+  urlList: string;
+}
+function SessionUnavailable({ filters, urlList }: SessionUnavailableProps) {
+  const urlNew = Url.get(Url.pages.project.session.new, {
+    namespace: filters.namespace,
+    path: filters.project,
+  });
+
+  return (
+    <div className="p-2 p-lg-3 text-nowrap container-lg">
+      <p className="mt-2">The session you are trying to open is not available.</p>
+      <Alert color="primary">
+        <p className="mb-0">
+          <FontAwesomeIcon size="lg" icon={faQuestionCircle} />
+          {" "}You should either{" "}
+          <Link className="btn btn-primary btn-sm" to={urlNew}>start a new session</Link>
+          {" "}or{" "}
+          <Link className="btn btn-primary btn-sm" to={urlList}>check the running sessions</Link>
+          {" "}
+        </p>
+      </Alert>
+    </div>
+  );
+}
+
+export default SessionUnavailable;

--- a/client/src/notebooks/components/StartSessionProgressBar.tsx
+++ b/client/src/notebooks/components/StartSessionProgressBar.tsx
@@ -1,0 +1,96 @@
+/*!
+ * Copyright 2022 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as React from "react";
+import ProgressStepsIndicator, {
+  ProgressStyle,
+  ProgressType,
+  StatusStepProgressBar,
+  StepsProgressBar
+} from "../../utils/components/progress/ProgressSteps";
+import { Button } from "../../utils/ts-wrappers";
+
+
+interface StatusDetail {
+  status: string;
+  step: string;
+}
+export interface SessionStatusData {
+  details: StatusDetail[];
+  message: string;
+  readyNumContainers: number;
+  state: string;
+  totalNumContainers: number;
+  isTheSessionReady: boolean;
+}
+interface StartSessionProgressBarProps {
+  sessionStatus?: SessionStatusData;
+  isAutoSave?: boolean;
+  toggleLogs: Function;
+}
+const StartSessionProgressBar = (
+  {
+    sessionStatus,
+    isAutoSave,
+    toggleLogs
+  }: StartSessionProgressBarProps) => {
+
+  const status = getStatusData(sessionStatus?.details, sessionStatus?.state);
+  const title = isAutoSave ? "Starting Session (continuing from autosave)" : "Starting Session";
+  const logButton = <Button onClick={toggleLogs} className="btn-outline-rk-green mt-3">Open Logs</Button>;
+
+  return (
+    <ProgressStepsIndicator
+      description="Starting the containers for your session"
+      type={ProgressType.Determinate}
+      style={ProgressStyle.Light}
+      title={title}
+      status={status}
+      moreOptions={logButton}
+    />);
+};
+
+function getStatusData(details?: StatusDetail[], state?: string): StepsProgressBar[] {
+  if (!details || !details.length) {
+    return [{
+      id: 1,
+      status: StatusStepProgressBar.EXECUTING,
+      step: "Fetching session data",
+    }];
+  }
+
+  let i = 0;
+  const steps = [];
+  details.map( (s: StatusDetail) => {
+    steps.push({
+      id: i,
+      status: s.status as StatusStepProgressBar,
+      step: s.step,
+    });
+    i++;
+  });
+
+  // add step to wait for the jupyter session  is ready
+  steps.push({
+    id: i,
+    status: state === "running" ? StatusStepProgressBar.EXECUTING : StatusStepProgressBar.WAITING,
+    step: "Connecting with your session",
+  });
+  return steps;
+}
+
+export default StartSessionProgressBar;

--- a/client/src/utils/components/progress/Progress.css
+++ b/client/src/utils/components/progress/Progress.css
@@ -148,3 +148,12 @@
         transform:  translateX(100%) scaleX(0.5);
     }
 }
+
+.progress-box-small {
+    max-width: 500px;
+    margin: auto;
+}
+
+.progress-box-small--steps {
+    padding-top: 110px;
+}

--- a/client/src/utils/components/progress/ProgressSteps.stories.tsx
+++ b/client/src/utils/components/progress/ProgressSteps.stories.tsx
@@ -1,0 +1,104 @@
+/*!
+ * Copyright 2022 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as React from "react";
+import { Story } from "@storybook/react";
+import { ProgressStyle, ProgressType } from "./Progress";
+import ProgressStepsIndicator, { ProgressStepsIndicatorProps, StepsProgressBar } from "./ProgressSteps";
+
+export default {
+  title: "components/ProgressStepsIndicator",
+  component: ProgressStepsIndicator,
+  argTypes: {
+    title: {
+      control: { type: "text" },
+      description: "Main title"
+    },
+    description: {
+      control: { type: "text" },
+      description: "subtitle",
+    },
+    style: {
+      control: { type: "radio" },
+      options: ProgressStyle,
+      description: "Style for background. Light or Dark"
+    },
+    type: {
+      control: { type: "radio" },
+      options: [ProgressType.Determinate, ProgressType.Indeterminate],
+      description: "Type of progress-bar. Indeterminate or Determinate"
+    },
+    percentage: {
+      control: {
+        type: "range",
+        min: 0,
+        max: 100,
+      },
+    },
+    message: {
+      control: {
+        type: "text"
+      },
+    },
+  },
+};
+const status = {
+  "details": [{
+    "id": 1,
+    "status": "ready",
+    "step": "Initialization"
+  }, {
+    "id": 2,
+    "status": "ready",
+    "step": "Downloading session image"
+  }, {
+    "id": 3,
+    "status": "executing",
+    "step": "Cloning and configuring the repository"
+  }, {
+    "id": 4,
+    "status": "waiting",
+    "step": "Git credentials services"
+  }, {
+    "id": 5,
+    "status": "waiting",
+    "step": "Authentication and proxying services"
+  }, {
+    "id": 6,
+    "status": "waiting",
+    "step": "Auxiliary session services"
+  }, {
+    "id": 7,
+    "status": "failed",
+    "step": "Starting session"
+  }],
+  "message": "Containers with non-ready statuses: git-proxy, git-sidecar, jupyter-server, oauth2-proxy.",
+  "readyNumContainers": 2,
+  "state": "starting",
+  "totalNumContainers": 7,
+};
+
+const Template: Story<ProgressStepsIndicatorProps> = (args) => <ProgressStepsIndicator {...args} />;
+export const Default = Template.bind({});
+Default.args = {
+  title: "Starting Session (continuing from autosave)",
+  description: "Starting the containers for your session",
+  type: ProgressType.Determinate,
+  style: ProgressStyle.Dark,
+  status: status.details as StepsProgressBar[],
+};
+

--- a/client/src/utils/components/progress/ProgressSteps.tsx
+++ b/client/src/utils/components/progress/ProgressSteps.tsx
@@ -1,0 +1,126 @@
+/*!
+ * Copyright 2022 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as React from "react";
+import "./Progress.css";
+import {
+  CheckCircleFill,
+  XCircleFill
+} from "../../ts-wrappers";
+import { Loader } from "../Loader";
+
+/**
+ *  renku-ui
+ *
+ *  Progress.tsx
+ *  Progress component
+ */
+
+// These values are actually used, but the ts compiler does not realize it
+/* eslint-disable no-unused-vars */
+export enum ProgressType {
+  Determinate = "Determinate",
+  Indeterminate = "Indeterminate",
+}
+
+export enum ProgressStyle {
+  Light = "light",
+  Dark = "dark",
+}
+
+export enum StatusStepProgressBar {
+  READY = "ready",
+  EXECUTING = "executing",
+  WAITING = "waiting",
+  FAILED = "failed"
+}
+/* eslint-enable no-unused-vars */
+
+export interface StepsProgressBar {
+  id: number;
+  status: StatusStepProgressBar;
+  step: string;
+}
+
+export interface ProgressStepsIndicatorProps {
+  /**
+   * Type of progress-bar. Indeterminate or Determinate
+   * @default Indeterminate
+   */
+  type: ProgressType;
+
+  /**
+   * Style for background. Light or Dark
+   * @default Dark
+   */
+  style: ProgressStyle;
+  title: string;
+  description: string;
+  status: StepsProgressBar[];
+  moreOptions?: React.ReactNode;
+}
+
+/**
+ * Project Visibility functional component
+ * @param {ProgressIndicatorProps} props - progress indicator options
+ */
+const ProgressStepsIndicator = (
+  {
+    style = ProgressStyle.Dark,
+    title,
+    description,
+    status,
+    moreOptions
+  }: ProgressStepsIndicatorProps) => {
+
+  const content = status.map( (s) => <ProgressStep key={`step-${s.id}`} step={s} />);
+  return (
+    <div className={`progress-box progress-box--${style}`}>
+      <h2 className="progress-title">{title}</h2>
+      <p className="pb-2">{description}</p>
+      <div className="mt-3 details-progress-box">
+        {content}
+        {moreOptions}
+      </div>
+    </div>
+  );
+};
+
+interface progressStepProps {
+  step: StepsProgressBar
+}
+function ProgressStep({ step }: progressStepProps) {
+  let content;
+  switch (step.status) {
+    case StatusStepProgressBar.EXECUTING:
+      content = <><Loader size="14" inline="true" />{step.step}</>;
+      break;
+    case StatusStepProgressBar.READY:
+      content = <><CheckCircleFill className="text-rk-green" />{step.step}</>;
+      break;
+    case StatusStepProgressBar.WAITING:
+      content = <><Loader size="14" inline="true" /><span className="text-rk-text-light">{step.step}</span></>;
+      break;
+    case StatusStepProgressBar.FAILED:
+      content = <><XCircleFill className="text-rk-danger-shadow"/>{step.step}</>;
+      break;
+  }
+
+  return <div className="d-flex gap-2 mt-2 align-items-center">{content}</div>;
+}
+
+export default ProgressStepsIndicator;

--- a/client/src/utils/helpers/HelperFunctions.js
+++ b/client/src/utils/helpers/HelperFunctions.js
@@ -423,5 +423,5 @@ export {
   capitalizeFirstLetter, generateZip, computeVisibilities,
   slugFromTitle, getActiveProjectPathWithNamespace, splitAutosavedBranches, sanitizedHTMLFromMarkdown,
   simpleHash, parseINIString, formatBytes, groupBy, gitLabUrlFromProfileUrl, isURL, verifyTitleCharacters,
-  convertUnicodeToAscii, refreshIfNecessary, sleep, toCapitalized, stylesByItemType
+  convertUnicodeToAscii, refreshIfNecessary, sleep, toCapitalized, stylesByItemType, AUTOSAVED_PREFIX
 };

--- a/client/src/utils/ts-wrappers.js
+++ b/client/src/utils/ts-wrappers.js
@@ -4,6 +4,10 @@
 import React from "react";
 
 import {
+  Accordion as WrappedAccordion,
+  AccordionItem as WrappedAccordionItem,
+  AccordionHeader as WrappedAccordionHeader,
+  AccordionBody as WrappedAccordionBody,
   Alert as WrappedAlert,
   Button as WrappedButton,
   ButtonGroup as WrappedButtonGroup,
@@ -37,6 +41,7 @@ import {
 import {
   ArrowLeft as WrappedArrowLeft,
   Briefcase as WrappedBriefcase,
+  CheckCircleFill as WrappedCheckCircleFill,
   HddStack as WrappedHddStack,
   Globe as WrappedGlobe,
   People as WrappedPeople,
@@ -46,6 +51,7 @@ import {
   Journals as WrappedJournals,
   StopCircle as WrappedStopCircle,
   InfoCircle as WrappedInfoCircle,
+  XCircleFill as WrappedXCircleFill,
 } from "react-bootstrap-icons";
 
 import { FormGroup as WrappedFormGroup, Input as WrappedInput } from "reactstrap";
@@ -227,7 +233,32 @@ function TabPane(props) {
   return <WrappedTabPane {...props} />;
 }
 
-export { Alert, Button, ButtonGroup };
+function Accordion(props) {
+  return <WrappedAccordion {...props} />;
+}
+
+function AccordionItem(props) {
+  return <WrappedAccordionItem {...props} />;
+}
+
+function AccordionHeader(props) {
+  return <WrappedAccordionHeader {...props} />;
+}
+
+function AccordionBody(props) {
+  return <WrappedAccordionBody {...props} />;
+}
+
+function CheckCircleFill(props) {
+  return <WrappedCheckCircleFill {...props} />;
+}
+
+function XCircleFill(props) {
+  return <WrappedXCircleFill {...props} />;
+}
+
+export { Accordion, AccordionItem, AccordionHeader, AccordionBody };
+export { Alert, Button, ButtonGroup, CheckCircleFill, XCircleFill };
 export { Card, CardBody, CardText, CardFooter, Col, DropdownItem };
 export { FormFeedback, FormText, Fade, Form, FormGroup, Input, Label };
 export { PopoverHeader, PopoverBody };


### PR DESCRIPTION
PR to add progress indicator when start a session.

### Testing
- Start a new session
![start a session](https://user-images.githubusercontent.com/43388408/194073040-3bc5743a-56b5-4f3e-9a12-88023c8d8c40.gif)

- Reload a session
![reload session](https://user-images.githubusercontent.com/43388408/194073103-17ec3a69-8d9f-48a2-bded-071a58abbf7a.gif)

- Unavailable session
![Screenshot 2022-10-05 at 15 38 30](https://user-images.githubusercontent.com/43388408/194074392-96301335-eb59-4a2b-83fd-dcc7f4e70160.png)

Closes #1879 

/deploy #persist renku-notebooks=feat-detailed-status-message extra-values=notebooks.amalthea.image.repository=registry.dev.renku.ch/tasko.olevski/renku-images/amalthea,notebooks.amalthea.image.tag=0.5.2-n014.h50ddcaa