### PR TITLE
feat: add env variables in start session form

### DIFF
--- a/client/src/api-client/notebook-servers.js
+++ b/client/src/api-client/notebook-servers.js
@@ -84,7 +84,7 @@ function addNotebookServersMethods(client) {
     });
   };
 
-  client.startNotebook = (namespacePath, projectPath, branchName, commitId, image, options) => {
+  client.startNotebook = (namespacePath, projectPath, branchName, commitId, image, options, env_variables = {}) => {
     const headers = client.getBasicHeaders();
     headers.append("Content-Type", "application/json");
     const url = `${client.baseUrl}/notebooks/servers`;
@@ -106,6 +106,7 @@ function addNotebookServersMethods(client) {
       commit_sha: commitId,
       branch: branchName,
       notebook,
+      environment_variables: env_variables,
       ...options
     };
     if (image)

--- a/client/src/api-client/utils.js
+++ b/client/src/api-client/utils.js
@@ -79,4 +79,15 @@ function fetchJson(...args) {
   return fetch(...args).then(response => response.json());
 }
 
-export { fetchJson, renkuFetch, AUTH_HEADER, RETURN_TYPES };
+function formatEnvironmentVariables(variables) {
+  const env_variables = {};
+  if (variables?.length > 0) {
+    variables.map( variable => {
+      if (variable.key && variable.value)
+        env_variables[variable.key] = variable.value;
+    });
+  }
+  return env_variables;
+}
+
+export { fetchJson, renkuFetch, formatEnvironmentVariables, AUTH_HEADER, RETURN_TYPES };

--- a/client/src/model/RenkuModels.js
+++ b/client/src/model/RenkuModels.js
@@ -364,6 +364,8 @@ const projectSchema = new Schema({
   },
 });
 
+const DEFAULT_ENV_VARIABLES = [{ key: "", value: "" }];
+
 const notebooksSchema = new Schema({
   autosaves: {
     schema: {
@@ -391,7 +393,7 @@ const notebooksSchema = new Schema({
       commit: { initial: {} },
       discard: { initial: false },
       options: { initial: {} },
-      environment_variables: { initial: [{ key: "", value: "" }] },
+      environment_variables: { initial: DEFAULT_ENV_VARIABLES },
       objectStoresConfiguration: { initial: [] },
       includeMergedBranches: { initial: false },
       displayedCommits: { initial: 25 },
@@ -723,5 +725,5 @@ const formGeneratorSchema = new Schema({
 export {
   datasetFormSchema, datasetSchema, datasetImportFormSchema, environmentSchema,
   formGeneratorSchema, issueFormSchema, newProjectSchema, notebooksSchema, notificationsSchema,
-  projectSchema, projectsSchema, statuspageSchema, userSchema, webSocketSchema
+  projectSchema, projectsSchema, statuspageSchema, userSchema, webSocketSchema, DEFAULT_ENV_VARIABLES
 };

--- a/client/src/model/RenkuModels.js
+++ b/client/src/model/RenkuModels.js
@@ -391,6 +391,7 @@ const notebooksSchema = new Schema({
       commit: { initial: {} },
       discard: { initial: false },
       options: { initial: {} },
+      environment_variables: { initial: [{ key: "", value: "" }] },
       objectStoresConfiguration: { initial: [] },
       includeMergedBranches: { initial: false },
       displayedCommits: { initial: 25 },

--- a/client/src/model/RenkuModels.js
+++ b/client/src/model/RenkuModels.js
@@ -364,8 +364,6 @@ const projectSchema = new Schema({
   },
 });
 
-const DEFAULT_ENV_VARIABLES = [{ key: "", value: "" }];
-
 const notebooksSchema = new Schema({
   autosaves: {
     schema: {
@@ -393,7 +391,7 @@ const notebooksSchema = new Schema({
       commit: { initial: {} },
       discard: { initial: false },
       options: { initial: {} },
-      environment_variables: { initial: DEFAULT_ENV_VARIABLES },
+      environment_variables: { initial: [] },
       objectStoresConfiguration: { initial: [] },
       includeMergedBranches: { initial: false },
       displayedCommits: { initial: 25 },
@@ -725,5 +723,5 @@ const formGeneratorSchema = new Schema({
 export {
   datasetFormSchema, datasetSchema, datasetImportFormSchema, environmentSchema,
   formGeneratorSchema, issueFormSchema, newProjectSchema, notebooksSchema, notificationsSchema,
-  projectSchema, projectsSchema, statuspageSchema, userSchema, webSocketSchema, DEFAULT_ENV_VARIABLES
+  projectSchema, projectsSchema, statuspageSchema, userSchema, webSocketSchema,
 };

--- a/client/src/notebooks/NotebookStart.present.js
+++ b/client/src/notebooks/NotebookStart.present.js
@@ -48,6 +48,7 @@ import { NotebooksHelper } from "./index";
 import { ObjectStoresConfigurationButton, ObjectStoresConfigurationModal } from "./ObjectStoresConfig.present";
 import ProgressIndicator, { ProgressStyle, ProgressType } from "../utils/components/progress/Progress";
 import EnvironmentVariables from "./components/EnviromentVariables";
+import { useSelector } from "react-redux";
 
 function ProjectSessionLockAlert({ lockStatus }) {
   if (lockStatus == null) return null;
@@ -124,17 +125,10 @@ function StartNotebookServer(props) {
   const location = useLocation();
 
   const [showShareLinkModal, setShowShareLinkModal] = useState(location?.state?.showShareLinkModal ?? false);
-  const [environmentVariables, setEnvironmentVariables] = useState([ { key: "", value: "" }]);
-
+  const environmentVariables = useSelector(state => state.stateModel.notebooks.filters?.environment_variables);
   const setNotebookEnvVariables = (variables) => {
     props.handlers.setNotebookEnvVariables(variables);
-    setEnvironmentVariables(variables);
   };
-
-  useEffect(() => {
-    if (props.envVariablesQueryParams)
-      setEnvironmentVariables(props.envVariablesQueryParams);
-  }, []); // eslint-disable-line
 
   const toggleShareLinkModal = () => setShowShareLinkModal(!showShareLinkModal);
 

--- a/client/src/notebooks/Notebooks.container.js
+++ b/client/src/notebooks/Notebooks.container.js
@@ -30,6 +30,7 @@ import { StatusHelper } from "../model/Model";
 import { Url } from "../utils/helpers/url";
 import { sleep } from "../utils/helpers/HelperFunctions";
 import ShowSessionFullscreen from "./components/SessionFullScreen";
+import { DEFAULT_ENV_VARIABLES } from "../model/RenkuModels";
 
 
 /**
@@ -303,7 +304,7 @@ class StartNotebookServer extends Component {
 
     const environmentVariables = this.getEnvironmentVariablesFromSearch(currentSearch);
     this.customEnvVariables = currentSearch && this.autostart && environmentVariables.length ?
-      environmentVariables : undefined;
+      environmentVariables : DEFAULT_ENV_VARIABLES;
 
     this.state = {
       autosavesCommit: false,
@@ -421,14 +422,7 @@ class StartNotebookServer extends Component {
   }
 
   setNotebookEnvVariables(variables) {
-    const env_variables = {};
-    if (variables?.length > 0) {
-      variables.map( variable => {
-        if (variable.key && variable.value)
-          env_variables[variable.key] = variable.value;
-      });
-    }
-    this.coordinator.setNotebookEnvironmentVariables(env_variables);
+    this.coordinator.setNotebookEnvironmentVariables(variables);
   }
 
   getEnvironmentVariablesFromSearch(search) {

--- a/client/src/notebooks/Notebooks.container.js
+++ b/client/src/notebooks/Notebooks.container.js
@@ -30,7 +30,6 @@ import { StatusHelper } from "../model/Model";
 import { Url } from "../utils/helpers/url";
 import { sleep } from "../utils/helpers/HelperFunctions";
 import ShowSessionFullscreen from "./components/SessionFullScreen";
-import { DEFAULT_ENV_VARIABLES } from "../model/RenkuModels";
 
 
 /**
@@ -304,7 +303,7 @@ class StartNotebookServer extends Component {
 
     const environmentVariables = this.getEnvironmentVariablesFromSearch(currentSearch);
     this.customEnvVariables = currentSearch && this.autostart && environmentVariables.length ?
-      environmentVariables : DEFAULT_ENV_VARIABLES;
+      environmentVariables : [];
 
     this.state = {
       autosavesCommit: false,

--- a/client/src/notebooks/Notebooks.container.js
+++ b/client/src/notebooks/Notebooks.container.js
@@ -429,7 +429,11 @@ class StartNotebookServer extends Component {
     Object.keys(search).map( key => {
       if (key.startsWith("env[")) {
         const env_key = key.split("env[").pop().split("]").shift();
-        variables.push({ key: env_key, value: search[key] });
+        const value = search[key];
+        if (Array.isArray(value))
+          value.forEach(val => variables.push({ key: env_key, value: val }));
+        else
+          variables.push({ key: env_key, value: search[key] });
       }
     });
     return variables;

--- a/client/src/notebooks/Notebooks.state.js
+++ b/client/src/notebooks/Notebooks.state.js
@@ -28,6 +28,7 @@ import _ from "lodash";
 import { API_ERRORS } from "../api-client/errors";
 import { notebooksSchema } from "../model";
 import { parseINIString, sleep } from "../utils/helpers/HelperFunctions";
+import { formatEnvironmentVariables } from "../api-client/utils";
 
 
 const POLLING_INTERVAL = 3000;
@@ -1266,7 +1267,7 @@ class NotebooksCoordinator {
     const image = projectOptions.image ?
       projectOptions.image :
       null;
-    const env_variables = this.model.get("filters.environment_variables");
+    const env_variables = formatEnvironmentVariables(this.model.get("filters.environment_variables"));
 
     return this.client.startNotebook(namespace, project, branch, commit, image, options, env_variables);
   }

--- a/client/src/notebooks/Notebooks.state.js
+++ b/client/src/notebooks/Notebooks.state.js
@@ -472,6 +472,10 @@ class NotebooksCoordinator {
     this.model.set(`filters.options.${option}`, value);
   }
 
+  setNotebookEnvironmentVariables(values) {
+    this.model.set(`filters.environment_variables`, values);
+  }
+
   setObjectStoresConfiguration(value) {
     this.model.set("filters.objectStoresConfiguration", value);
   }
@@ -1262,8 +1266,9 @@ class NotebooksCoordinator {
     const image = projectOptions.image ?
       projectOptions.image :
       null;
+    const env_variables = this.model.get("filters.environment_variables");
 
-    return this.client.startNotebook(namespace, project, branch, commit, image, options);
+    return this.client.startNotebook(namespace, project, branch, commit, image, options, env_variables);
   }
 
   stopNotebook(serverName, force = false) {

--- a/client/src/notebooks/Notebooks.test.js
+++ b/client/src/notebooks/Notebooks.test.js
@@ -372,23 +372,29 @@ describe("rendering", () => {
     document.body.appendChild(div);
     await act(async () => {
       ReactDOM.render(
-        <MemoryRouter>
-          <StartNotebookServer {...props} />
-        </MemoryRouter>, div);
+        <Provider store={model.reduxStore}>
+          <MemoryRouter>
+            <StartNotebookServer {...props} />
+          </MemoryRouter>
+        </Provider>, div);
     });
     await act(async () => {
       ReactDOM.render(
-        <MemoryRouter>
-          <StartNotebookServer {...props} scope={scope} />
-        </MemoryRouter>, div);
+        <Provider store={model.reduxStore}>
+          <MemoryRouter>
+            <StartNotebookServer {...props} scope={scope} />
+          </MemoryRouter>
+        </Provider>, div);
     });
     // autostart session
     const autostartFakeLocation = { pathname: "", search: "autostart=1" };
     await act(async () => {
       ReactDOM.render(
-        <MemoryRouter>
-          <StartNotebookServer {...props} location={autostartFakeLocation} />
-        </MemoryRouter>, div);
+        <Provider store={model.reduxStore}>
+          <MemoryRouter>
+            <StartNotebookServer {...props} location={autostartFakeLocation} />
+          </MemoryRouter>
+        </Provider>, div);
     });
   });
 

--- a/client/src/notebooks/components/EnviromentVariables.tsx
+++ b/client/src/notebooks/components/EnviromentVariables.tsx
@@ -19,7 +19,7 @@ import React, { ChangeEvent } from "react";
 import { Button, Col, FormGroup, Input, Label, Row } from "../../utils/ts-wrappers";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faTrash } from "@fortawesome/free-solid-svg-icons";
-import { InputLabel } from "../../utils/components/formlabels/FormLabels";
+import { ErrorLabel, InputLabel } from "../../utils/components/formlabels/FormLabels";
 
 interface EnvironmentVariablesProps {
   environmentVariables: EnvVariablesField[];
@@ -43,13 +43,20 @@ function EnvironmentVariables({ environmentVariables, setEnvironmentVariables }:
     setEnvironmentVariables([...environmentVariables, object]);
   };
 
+  const isKeyDuplicated = (key: string) => {
+    if (!key)
+      return false;
+    return environmentVariables.filter( variable => variable.key === key).length >= 2;
+  };
+
   const removeFields = (index: number) => {
     let data = [...environmentVariables];
     data.splice(index, 1);
     setEnvironmentVariables(data);
   };
 
-  const content = environmentVariables?.map((input, index) => {
+  const form = environmentVariables?.map((input, index) => {
+    const isDuplicated = isKeyDuplicated(input.key);
     return (
       <Row key={index}>
         <Col xs={5}>
@@ -58,8 +65,10 @@ function EnvironmentVariables({ environmentVariables, setEnvironmentVariables }:
             <Input
               name="variable"
               value={input.key}
+              invalid={isDuplicated}
               onChange={(event: ChangeEvent<HTMLInputElement>) => handleFormChange(index, "key", event.target.value)}
             />
+            {isDuplicated ? <ErrorLabel text="Variable names must be unique" /> : null }
           </FormGroup>
         </Col>
         <Col xs={5}>
@@ -68,11 +77,12 @@ function EnvironmentVariables({ environmentVariables, setEnvironmentVariables }:
             <Input
               name="value"
               value={input.value}
-              onChange={(event: ChangeEvent<HTMLInputElement>) => handleFormChange(index, "value", event.target.value)}
+              onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                handleFormChange(index, "value", event.target.value)}
             />
           </FormGroup>
         </Col>
-        <Col xs={2} className="d-flex align-items-center justify-content-start">
+        <Col xs={2} className="d-flex align-items-start justify-content-start">
           <Button
             size="sm"
             className="border-0 text-danger bg-transparent mb-3"
@@ -97,7 +107,7 @@ function EnvironmentVariables({ environmentVariables, setEnvironmentVariables }:
   return <div className="mt-3">
     <InputLabel text="Environment Variables" isRequired={false} />
     {header}
-    {content}
+    {form}
     <div><Button className="btn-outline-rk-green my-1" onClick={addFields}>Add Variable</Button></div>
   </div>;
 }

--- a/client/src/notebooks/components/EnviromentVariables.tsx
+++ b/client/src/notebooks/components/EnviromentVariables.tsx
@@ -1,0 +1,105 @@
+/*!
+ * Copyright 2022 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React, { ChangeEvent } from "react";
+import { Button, Col, FormGroup, Input, Label, Row } from "../../utils/ts-wrappers";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faTrash } from "@fortawesome/free-solid-svg-icons";
+import { InputLabel } from "../../utils/components/formlabels/FormLabels";
+
+interface EnvironmentVariablesProps {
+  environmentVariables: EnvVariablesField[];
+  setEnvironmentVariables: Function;
+}
+
+export interface EnvVariablesField {
+  key: string;
+  value: string;
+}
+
+function EnvironmentVariables({ environmentVariables, setEnvironmentVariables }: EnvironmentVariablesProps) {
+  const handleFormChange = (index: number, name: "key" | "value", value: string) => {
+    let data: EnvVariablesField[] = [...environmentVariables];
+    data[index][name] = value;
+    setEnvironmentVariables(data);
+  };
+
+  const addFields = () => {
+    let object = { key: "", value: "" };
+    setEnvironmentVariables([...environmentVariables, object]);
+  };
+
+  const removeFields = (index: number) => {
+    let data = [...environmentVariables];
+    data.splice(index, 1);
+    setEnvironmentVariables(data);
+  };
+
+  const content = environmentVariables?.map((input, index) => {
+    return (
+      <Row key={index}>
+        <Col xs={5}>
+          <FormGroup className="field-group">
+            <Label for="variable" size="sm" className="text-muted d-md-none">Variable</Label>
+            <Input
+              name="variable"
+              value={input.key}
+              onChange={(event: ChangeEvent<HTMLInputElement>) => handleFormChange(index, "key", event.target.value)}
+            />
+          </FormGroup>
+        </Col>
+        <Col xs={5}>
+          <FormGroup className="field-group">
+            <Label for="variable" size="sm" className="text-muted d-md-none">Value</Label>
+            <Input
+              name="value"
+              value={input.value}
+              onChange={(event: ChangeEvent<HTMLInputElement>) => handleFormChange(index, "value", event.target.value)}
+            />
+          </FormGroup>
+        </Col>
+        <Col xs={2} className="d-flex align-items-center justify-content-start">
+          <Button
+            size="sm"
+            className="border-0 text-danger bg-transparent mb-3"
+            onClick={() => removeFields(index)}>
+            <FontAwesomeIcon icon={faTrash} />
+          </Button>
+        </Col>
+      </Row>
+    );
+  });
+
+  const header = !environmentVariables?.length ? null :
+    <Row className="my-2 d-none d-sm-none d-md-flex d-xl-flex">
+      <Col sm={5}>
+        <Label className="small">Variable</Label>
+      </Col>
+      <Col sm={5}>
+        <Label className="small">Value</Label>
+      </Col>
+    </Row>;
+
+  return <div className="mt-3">
+    <InputLabel text="Environment Variables" isRequired={false} />
+    {header}
+    {content}
+    <div><Button className="btn-outline-rk-green my-1" onClick={addFields}>Add Variable</Button></div>
+  </div>;
+}
+
+export default EnvironmentVariables;


### PR DESCRIPTION
This PR add the env variables fields in start session form.

### Testing
- User should be able to start a session with environment variables
![start session link with env variables](https://user-images.githubusercontent.com/43388408/195278039-c9d519ad-1d3f-47dc-a363-d93306dde18a.gif)

- Verify environment variable is available
![verify sesssio environments variables](https://user-images.githubusercontent.com/43388408/195296651-56f27c07-ce15-42f2-9653-41b4b93be26d.gif)


- Create a session link to share with environment variables
![open a session with env variables](https://user-images.githubusercontent.com/43388408/195278056-41bb34a5-37dd-4306-8b36-b4acc3680c4a.gif)

Closes #2058 


*Note: Added renku-notebooks dependency just to make available other functionalities merged before in master
/deploy #persist renku-notebooks=master extra-values=notebooks.amalthea.image.repository=registry.dev.renku.ch/tasko.olevski/renku-images/amalthea,notebooks.amalthea.image.tag=0.5.2-n014.h50ddcaa