### PR TITLE
feat: add get namespaces graphql

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -237,6 +237,7 @@
           "telepresence",
           "textarea",
           "thead",
+          "typename",
           "toastify",
           "toggler",
           "toml",

--- a/client/src/api-client/index.js
+++ b/client/src/api-client/index.js
@@ -159,7 +159,8 @@ class APIClient {
    *
    * @param {string} url - API url
    * @param {object} [parameters] - Optional parameters object to be provided to clientFetch.
-   * @param {number} [parameters.maxIterations] - Maximum iterations before throwing an error. Used to prevent
+   * @param {object} [parameters.options] - Fetch options, like method, headers... Default only include basic headers.
+   * @param {number} [options.maxIterations] - Maximum iterations before throwing an error. Used to prevent
    *   long/endless loops that would trigger the gateway rate limit. Set 0 for unlimited.
    * @example "for await" syntax that consumes the async iterator
    * for await (const partialData of clientIterableFetch("myApiUrl")) { console.log(partialData) }

--- a/client/src/project/new/ProjectNew.state.js
+++ b/client/src/project/new/ProjectNew.state.js
@@ -367,7 +367,7 @@ class NewProjectCoordinator {
   getSlugAndReset() {
     const creation = this.model.get("meta.creation");
     this.resetCreationResult();
-    return `${creation.newNamespace}/${creation.newName}`;
+    return `${creation.newNamespace}/${creation.newNameSlug}`;
   }
 
   resetCreationResult() {


### PR DESCRIPTION
This PR is to fetch groups by minimum access level, it must include subgroups with inherited rights from the parent group.

Closes #2027 

/deploy extra-values=notebooks.amalthea.resourceUsageCheck.enabled=true   #persist