### PR TITLE
Shape Up #1 - Fixes and changes to fourth prototype

### DIFF
--- a/client/src/workflows/Workflows.present.tsx
+++ b/client/src/workflows/Workflows.present.tsx
@@ -301,7 +301,7 @@ function WorkflowDetail({ fullPath, selectedAvailable, waiting, workflow, workfl
     );
   }
 
-  return (<>{content}</>);
+  return (<div id="workflowsDetailsContent">{content}</div>);
 }
 
 
@@ -355,6 +355,12 @@ function WorkflowTreeDetail({
         <code className="mb-0">
           {details.full_command}
           <Clipboard clipboardText={details.full_command} />
+        </code>
+      </WorkflowTreeDetailRow>
+      <WorkflowTreeDetailRow name="Renku command">
+        <code className="mb-0">
+          {details.renkuCommand}
+          <Clipboard clipboardText={details.renkuCommand} />
         </code>
       </WorkflowTreeDetailRow>
     </>);

--- a/client/src/workflows/Workflows.state.ts
+++ b/client/src/workflows/Workflows.state.ts
@@ -78,7 +78,8 @@ function adjustWorkflowDetails(workflowDetails: Record<string, any>, fullPath: s
       null :
       Url.get(Url.pages.project.workflows.detail, {
         namespace: "", path: fullPath, target: "/" + workflowDetails.latest.replace(PLANS_PREFIX, "")
-      })
+      }),
+    renkuCommand: `renku workflow execute ${workflowDetails.name}`
   };
 }
 


### PR DESCRIPTION
Changes to browser components:
- Remove "steps" from composite workflow browser executions row
- Add the `renku rerun <workflow>` command to the details view with copy/paste
-  change interaction on the browser elements: open on element click, collapse on arrow click
- Add auto-scroll to the top of the details section when clicking on a new workflow (it requires a project with many workflows)

/deploy renku-core=workflow-ui-feature-branch #persist
