### PR TITLE
fix: no show session loader when other values than session state change

### DIFF
--- a/client/src/notebooks/components/SessionFullScreen.tsx
+++ b/client/src/notebooks/components/SessionFullScreen.tsx
@@ -105,7 +105,7 @@ function ShowSessionFullscreen(props: ShowSessionFullscreenProps) {
     else {
       setSessionStatus({ ...notebook.data.status, isTheSessionReady: false } as SessionStatusData);
     }
-  }, [notebook.data.status]);
+  }, [notebook.data.status?.state]); // eslint-disable-line
 
   // redirect immediately if the session fail
   if (history && notebook.data?.status?.state === SessionStatus.failed)

--- a/e2e/cypress/fixtures/sessions/sessionsV2.json
+++ b/e2e/cypress/fixtures/sessions/sessionsV2.json
@@ -20,7 +20,11 @@
           "memory":"1G",
           "storage":"1G"
         },
-        "usage": {}
+        "usage": {
+          "cpu": 0.007691289,
+          "memory": "0.09G",
+          "storage": "0.00G"
+        }
       },
       "started":"2022-02-28T14:15:59+00:00",
       "state":{

--- a/e2e/cypress/support/renkulab-fixtures/sessions.ts
+++ b/e2e/cypress/support/renkulab-fixtures/sessions.ts
@@ -26,10 +26,25 @@ function Sessions<T extends FixturesConstructor>(Parent: T) {
   return class SessionsFixtures extends Parent {
 
     getSessions(name = "getSessions", namespace = "*", resultFile = "sessions/sessions.json") {
-      const fixture = this.useMockedData ? { fixture: resultFile } : undefined;
+      const fixtureA = this.useMockedData ? { fixture: "sessions/sessionsV2.json" } : undefined;
+      const fixtureB = this.useMockedData ? { fixture: resultFile } : undefined;
+
+      // intercept: different times to get different results
       cy.intercept(
         "/ui-server/api/notebooks/servers?namespace=" + namespace,
-        fixture
+        fixtureA
+      ).as(name);
+      cy.intercept(
+        "/ui-server/api/notebooks/servers?namespace=" + namespace,
+        { times: 4 }, fixtureB
+      ).as(name);
+      cy.intercept(
+        "/ui-server/api/notebooks/servers?namespace=" + namespace,
+        { times: 4 }, fixtureA
+      ).as(name);
+      cy.intercept(
+        "/ui-server/api/notebooks/servers?namespace=" + namespace,
+        { times: 4 }, fixtureB
       ).as(name);
       return this;
     }


### PR DESCRIPTION
PR to fix session shows loader when session resources data change.


/deploy extra-values=notebooks.amalthea.resourceUsageCheck.enabled=true #persist