### PR TITLE
sessions: handle corrupted autosaves and improve warning messages positioning

### DIFF
--- a/client/src/notebooks/NotebookStart.present.js
+++ b/client/src/notebooks/NotebookStart.present.js
@@ -93,7 +93,9 @@ function StartNotebookAdvancedOptions(props) {
     </div>
     <div className="field-group">
       <AutosavesInfoAlert autosaves={autosaves} autosavesId={props.autosavesCommit}
-        currentId={props.filters.commit?.id} deleteAutosave={deleteAutosave} setCommit={setCommit} />
+        autosavesWrong={props.autosavesWrong} currentId={props.filters.commit?.id}
+        deleteAutosave={deleteAutosave} setCommit={setCommit}
+      />
     </div>
     <div className="field-group">
       <StartNotebookBranches {...props} disabled={props.disabled} />
@@ -196,7 +198,7 @@ function StartNotebookServer(props) {
   );
 }
 
-function AutosavesInfoAlert({ autosaves, autosavesId, currentId, deleteAutosave, setCommit }) {
+function AutosavesInfoAlert({ autosaves, autosavesId, autosavesWrong, currentId, deleteAutosave, setCommit }) {
   const [deleteOngoing, setDeleteOngoing] = useState(false);
   const [deleteResult, setDeleteResult] = useState(null);
 
@@ -237,6 +239,19 @@ function AutosavesInfoAlert({ autosaves, autosavesId, currentId, deleteAutosave,
           You might{" "}
           <Button size="sm" color="warning" onClick={() => window.location.reload()}>refresh the page</Button>
           {" "}and try again. The autosave may have been deleted in another session.
+        </p>
+      </WarnAlert>
+    );
+  }
+
+  if (autosavesWrong) {
+    return (
+      <WarnAlert dismissible={false} timeout={0}>
+        <p className="mb-0">
+          There might be unsaved work left from your last session, but data is corrupted and
+          restoring it is not possible.
+          <br />
+          The latest commit was picked instead.
         </p>
       </WarnAlert>
     );

--- a/client/src/notebooks/NotebookStart.present.js
+++ b/client/src/notebooks/NotebookStart.present.js
@@ -67,7 +67,6 @@ function SessionStartSidebar(props) {
     <h2>Start session</h2>
     <p>On the project<br /><b className="text-break">{props.pathWithNamespace}</b></p>
     <ProjectSessionLockAlert lockStatus={props.lockStatus} />
-    <LaunchErrorAlert autosaves={props.autosaves} launchError={props.launchError} ci={props.ci} />
 
     <div className="d-none d-md-block">
       <p>A session gives you an environment with resources for doing work.
@@ -179,6 +178,7 @@ function StartNotebookServer(props) {
 
   return (
     <Row>
+      <LaunchErrorAlert autosaves={props.autosaves} launchError={props.launchError} ci={props.ci} />
       <Col sm={12} md={3} lg={4}>
         <SessionStartSidebar autosaves={autosaves} ci={props.ci}
           launchError={props.launchError} lockStatus={props.lockStatus}


### PR DESCRIPTION
This fixes the issue reported in #2086 

The problem seems to happen when the commit specified in the autosaves is not available in the reference branch. There might be a few reasons for that, and it's very difficult to guess the correct one in every case.

Since it doesn't seem to happen frequently, I decided to handle it by showing a warning to the user (see next screen) and removing the corrupted autosave to prevent the problem from happening again. We could also decide to leave the branch and point the user in that direction, but that seems more fragile (PVS can't allow that, so it might not always work)

![image](https://user-images.githubusercontent.com/43481553/196962606-70a78b07-4374-4ed8-98da-d01cac1882f0.png)

**How to test**

Create a corrupted branch: pick any repo, create a new branch with this pattern:
```
renku/autosave/<user>/<exising_branch>/<fake_commit_sha-7-chars>/fake_commit_sha-7-chars
```
Here is an example with my user, swap it with yours
```
renku/autosave/lorenzo.cavazzi.tech@myemail.com/master/1111111/1111111
```

------------

I added another fix here since the warning for failed autostarts was moved to a potentially (very) narrow side column. I moved it to the top. First screenshot is the previous solution, second is the newest in this PR

![Screenshot_20221020_151317](https://user-images.githubusercontent.com/43481553/196963868-52c4b215-b3fa-4acf-a047-0cbd250bd72c.png)

![Screenshot_20221020_151445](https://user-images.githubusercontent.com/43481553/196963895-3742a87f-2183-41db-a4bc-7bfaf80680cf.png)


/deploy #persist
fix #2086
