### PR TITLE
fix: pre-fill all values in the new project form (#2026)(#2089)

### DIFF
--- a/client/src/project/new/ProjectNew.container.js
+++ b/client/src/project/new/ProjectNew.container.js
@@ -456,7 +456,7 @@ class NewProject extends Component {
     try {
       const data = getDataFromParams(searchParams);
       if (data)
-        this.coordinator.setAutomated(data);
+        this.coordinator.setAutomated(data, undefined, this.projectsCoordinator);
 
       // do not update url if is importing a dataset
       if (!props.importingDataset) {

--- a/client/src/project/new/components/ProjectIdentifier.tsx
+++ b/client/src/project/new/components/ProjectIdentifier.tsx
@@ -41,7 +41,7 @@ const ProjectIdentifier = ({ input, isRequired }: ProjectIdentifierProps) => {
   return (
     <FormGroup className="field-group">
       <InputLabel text="Identifier" isRequired={isRequired} />
-      <Input id="slug" readOnly value={slug} />
+      <Input id="slug" data-cy="project-slug" readOnly value={slug} />
       <InputHintLabel text="This is automatically derived from Namespace and Title" />
     </FormGroup>
   );

--- a/client/src/project/new/components/ShareLinkModal.js
+++ b/client/src/project/new/components/ShareLinkModal.js
@@ -121,7 +121,14 @@ function ShareLinkModal(props) {
   }, [createUrl, include, input, userTemplates]);
 
   const handleCheckbox = (target, event) => {
-    setInclude({ ...include, [target]: event.target.checked });
+    // select the template source if is selected a custom template
+    if (target === "template" && event.target.checked && available.templateRepo)
+      setInclude({ ...include, templateRepo: event.target.checked, [target]: event.target.checked });
+    // deselect template if deselect templateRepo
+    else if (target === "templateRepo" && !event.target.checked && available.template)
+      setInclude({ ...include, template: false, [target]: event.target.checked });
+    else
+      setInclude({ ...include, [target]: event.target.checked });
   };
 
   const labels = Object.keys(include).map(item => (
@@ -129,7 +136,7 @@ function ShareLinkModal(props) {
       <Label check className={`text-capitalize${available[item] ? " cursor-pointer" : " text-muted cursor-pointer"}`}>
         <Input
           type="checkbox"
-          disabled={available[item] ? false : true}
+          disabled={!available[item]}
           checked={include[item]}
           onChange={e => handleCheckbox(item, e)}
         /> {item === "templateRepo" ? "template source" : item}

--- a/e2e/cypress/integration/local/newProject.spec.ts
+++ b/e2e/cypress/integration/local/newProject.spec.ts
@@ -117,3 +117,71 @@ describe("Add new project", () => {
     cy.get_cy("create-project-form").should("not.exist");
   });
 });
+
+describe("Add new project shared link", () => {
+  const fixtures = new Fixtures(cy);
+  fixtures.useMockedData = Cypress.env("USE_FIXTURES") === true;
+
+  beforeEach(() => {
+    fixtures.config().versions().userTest().namespaces();
+    fixtures.projects().landingUserProjects("getLandingUserProjects");
+  });
+
+  it("prefill values all values (custom template)", () => {
+    // eslint-disable-next-line max-len
+    const customValues = "?data=eyJ0aXRsZSI6Im5ldyBwcm9qZWN0IiwiZGVzY3JpcHRpb24iOiIgdGhpcyBhIGN1c3RvbSBkZXNjcmlwdGlvbiIsIm5hbWVzcGFjZSI6ImUyZSIsInZpc2liaWxpdHkiOiJpbnRlcm5hbCIsInVybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9Td2lzc0RhdGFTY2llbmNlQ2VudGVyL3Jlbmt1LXByb2plY3QtdGVtcGxhdGUiLCJyZWYiOiJtYXN0ZXIiLCJ0ZW1wbGF0ZSI6IkN1c3RvbS9SLW1pbmltYWwifQ%3D%3D";
+    fixtures
+      .templates(false, "*", "getTemplates")
+      .getNamespace("internal-space", "getInternalNamespace", "projects/namespace-128.json");
+    cy.visit(`projects/new${customValues}`);
+    cy.wait("@getTemplates");
+
+    // check title
+    cy.get_cy("field-group-title").should("contain.value", "new project");
+    // check description
+    cy.get_cy("field-group-description").should("contain.text", "this a custom description");
+    // check namespace
+    cy.get_cy("project-slug").should("contain.value", "e2e/new-project");
+    // check visibility
+    cy.get_cy("visibility-public").should("not.be.checked");
+    cy.get_cy("visibility-internal").should("be.checked");
+    cy.get_cy("visibility-private").should("not.be.checked");
+
+    // check custom template source
+    // eslint-disable-next-line max-len
+    cy.get_cy("url-repository").should("contain.value", "https://github.com/SwissDataScienceCenter/renku-project-template");
+    cy.get_cy("ref-repository").should("contain.value", "master");
+
+    // check selected template
+    cy.get_cy("project-template-card").get(".selected").should("contain.text", "Basic R (4.1.2) Project");
+  });
+
+  it("prefill values custom template", () => {
+    // eslint-disable-next-line max-len
+    const customValues = "?data=eyJ0aXRsZSI6Im5ldyBwcm9qZWN0IiwiZGVzY3JpcHRpb24iOiIgdGhpcyBhIGN1c3RvbSBkZXNjcmlwdGlvbiIsIm5hbWVzcGFjZSI6ImUyZSIsInZpc2liaWxpdHkiOiJpbnRlcm5hbCIsInVybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9Td2lzc0RhdGFTY2llbmNlQ2VudGVyL3Jlbmt1LXByb2plY3QtdGVtcGxhdGUiLCJyZWYiOiJtYXN0ZXIifQ%3D%3D";
+    const templateUrl = "https://github.com/SwissDataScienceCenter/renku-project-template";
+    const templateRef = "master";
+    fixtures
+      .templates(false, "*", "getTemplates")
+      .getNamespace("internal-space", "getInternalNamespace", "projects/namespace-128.json");
+    cy.visit(`projects/new${customValues}`);
+    cy.wait("@getTemplates");
+
+    // check custom templates
+    cy.get_cy("url-repository").should("contain.value", templateUrl);
+    cy.get_cy("ref-repository").should("contain.value", templateRef);
+  });
+
+  it("prefill values renkuLab template", () => {
+    // eslint-disable-next-line max-len
+    const customValues = "?data=eyJ0ZW1wbGF0ZSI6IlJlbmt1L2p1bGlhLW1pbmltYWwifQ%3D%3D";
+    fixtures
+      .templates(false, "*", "getTemplates")
+      .getNamespace("internal-space", "getInternalNamespace", "projects/namespace-128.json");
+    cy.visit(`projects/new${customValues}`);
+    cy.wait("@getTemplates");
+
+    // check selected template
+    cy.get_cy("project-template-card").get(".selected").should("contain.text", "Basic Julia (1.7.1) Project");
+  });
+});


### PR DESCRIPTION
This PR is to pre-fill all values in the new project form.

- Fixed interminal spin when selecting a namespace.
- Show url and ref of custom templates if included, previously it was only if the template was also included.
- added e2e test of all cases

Closes #2026 

/deploy #persist