### PR TITLE
feat: add refresh button (#1986)

### DIFF
--- a/client/src/features/session/sidecarApi.ts
+++ b/client/src/features/session/sidecarApi.ts
@@ -2,6 +2,14 @@ import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 
 type HealthState = { status: string };
 
+interface SidecarRequestArgs {
+  serverName: string;
+}
+
+interface SaveArgs extends SidecarRequestArgs {
+  message?: string;
+}
+
 interface JsonRpcResult {
   id: number;
   jsonRpc: string;
@@ -18,25 +26,16 @@ interface GitStatusResult extends JsonRpcResult {
   };
 }
 
-interface SaveArgs {
-  serverName: string;
-  message?: string;
+interface RenkuOpResult extends JsonRpcResult {
+  result: string;
+  error?: {
+    code: number;
+    message: string;
+  };
 }
 
-interface SaveResult extends JsonRpcResult {
-  result: string;
-  error?: {
-    code: number;
-    message: string;
-  };
-}
-interface PullResult extends JsonRpcResult {
-  result: string;
-  error?: {
-    code: number;
-    message: string;
-  };
-}
+interface SaveResult extends RenkuOpResult {}
+interface PullResult extends RenkuOpResult {}
 
 export const sessionSidecarApi = createApi({
   reducerPath: "sessionSidecarApi",
@@ -44,8 +43,8 @@ export const sessionSidecarApi = createApi({
   tagTypes: [],
   keepUnusedDataFor: 0,
   endpoints: (builder) => ({
-    gitStatus: builder.query<GitStatusResult, string>({
-      query: (serverName: string) => {
+    gitStatus: builder.query<GitStatusResult, SidecarRequestArgs>({
+      query: (args) => {
         const body = {
           id: 0,
           jsonrpc: "2.0",
@@ -54,14 +53,14 @@ export const sessionSidecarApi = createApi({
         return {
           body,
           method: "POST",
-          url: `${serverName}/sidecar/jsonrpc`,
+          url: `${args.serverName}/sidecar/jsonrpc`,
         };
       },
     }),
-    health: builder.query<HealthState, string>({
-      query: (serverName: string) => {
+    health: builder.query<HealthState, SidecarRequestArgs>({
+      query: (args) => {
         return {
-          url: `${serverName}/sidecar/health`,
+          url: `${args.serverName}/sidecar/health`,
         };
       },
     }),
@@ -83,7 +82,7 @@ export const sessionSidecarApi = createApi({
         };
       },
     }),
-    renkuPull: builder.mutation<PullResult, SaveArgs>({
+    renkuPull: builder.mutation<PullResult, SidecarRequestArgs>({
       query: (args) => {
         const body = {
           id: 0,
@@ -100,7 +99,11 @@ export const sessionSidecarApi = createApi({
   }),
 });
 
-export const { useGitStatusQuery, useHealthQuery, useRenkuSaveMutation, useRenkuPullMutation } =
-  sessionSidecarApi;
+export const {
+  useGitStatusQuery,
+  useHealthQuery,
+  useRenkuSaveMutation,
+  useRenkuPullMutation,
+} = sessionSidecarApi;
 
 export type { GitStatusResult, HealthState };

--- a/client/src/features/session/sidecarApi.ts
+++ b/client/src/features/session/sidecarApi.ts
@@ -30,6 +30,13 @@ interface SaveResult extends JsonRpcResult {
     message: string;
   };
 }
+interface PullResult extends JsonRpcResult {
+  result: string;
+  error?: {
+    code: number;
+    message: string;
+  };
+}
 
 export const sessionSidecarApi = createApi({
   reducerPath: "sessionSidecarApi",
@@ -76,10 +83,24 @@ export const sessionSidecarApi = createApi({
         };
       },
     }),
+    renkuPull: builder.mutation<PullResult, SaveArgs>({
+      query: (args) => {
+        const body = {
+          id: 0,
+          jsonrpc: "2.0",
+          method: "git/pull",
+        };
+        return {
+          body,
+          method: "POST",
+          url: `${args.serverName}/sidecar/jsonrpc`,
+        };
+      },
+    }),
   }),
 });
 
-export const { useGitStatusQuery, useHealthQuery, useRenkuSaveMutation } =
+export const { useGitStatusQuery, useHealthQuery, useRenkuSaveMutation, useRenkuPullMutation } =
   sessionSidecarApi;
 
 export type { GitStatusResult, HealthState };

--- a/client/src/notebooks/components/PullSession.tsx
+++ b/client/src/notebooks/components/PullSession.tsx
@@ -1,0 +1,184 @@
+/*!
+ * Copyright 2022 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState } from "react";
+
+import { Button, Col, Modal, ModalBody, ModalHeader, Row } from "../../utils/ts-wrappers";
+import { Loader } from "../../utils/components/Loader";
+import { Notebook } from "./Session";
+import { useGitStatusQuery, useHealthQuery, useRenkuPullMutation } from "../../features/session/sidecarApi";
+import type { GitStatusResult } from "../../features/session/sidecarApi";
+import { commitsPhrasing } from "./SaveSession";
+
+function CenteredLoader() {
+  return <div className="d-flex justify-content-center">
+    <div><Loader size="16" inline="true" margin="2" /></div>
+  </div>;
+}
+
+interface ModalProps {
+  isOpen: boolean;
+  closeModal: Function;
+}
+
+interface PullSessionProps extends ModalProps {
+  hasPullAccess: boolean;
+  isLogged: boolean;
+  notebook: Notebook;
+  urlList: any;
+}
+
+function PullSession(props: PullSessionProps) {
+  const { closeModal, isOpen } = props;
+  const sessionName = props.notebook.data.name;
+  const { data, error, isLoading } = useHealthQuery(sessionName);
+
+  let body = null;
+  if (isLoading)
+    body = <CenteredLoader />;
+
+  else if (error != null || data == null || data.status !== "running")
+    body = <NoSidecarBody closeModal={closeModal} isOpen={isOpen} />;
+
+  else body = <PullSessionStatusBody closeModal={closeModal} isOpen={isOpen} sessionName={sessionName} />;
+
+  return <Modal className="modal-session" isOpen={isOpen} toggle={closeModal}>
+    <ModalHeader toggle={closeModal}>
+      Refresh Session
+    </ModalHeader>
+    <ModalBody>
+      {body}
+    </ModalBody>
+  </Modal>;
+}
+
+function NoSidecarBody({ closeModal }: ModalProps) {
+
+  return (<Row>
+    <Col>
+      <div>It is not possible to offer a one-click refresh for this session.</div>
+      <div className="d-flex justify-content-end">
+        <Button className="float-right mt-1 btn-outline-rk-green"
+          onClick={closeModal}>
+          Back to Session
+        </Button>
+      </div>
+    </Col>
+  </Row>
+  );
+}
+
+interface PullSessionStatusBodyProps extends ModalProps {
+  sessionName: string;
+}
+
+function PullSessionStatusBody({ closeModal, isOpen, sessionName }: PullSessionStatusBodyProps) {
+  const [succeeded, setSucceeded] = useState<boolean|undefined>(undefined);
+  const { data, error, isFetching } = useGitStatusQuery(sessionName);
+  const [renkuPull, { isLoading: pulling }] = useRenkuPullMutation();
+
+  const pullSession = async (commitMessage: string|undefined) => {
+    setSucceeded(undefined);
+    const result = await renkuPull({ serverName: sessionName }).unwrap();
+    if (result.error == null)
+      setSucceeded(true);
+    else
+      setSucceeded(false);
+  };
+
+  if (isFetching || data == null) return <CenteredLoader />;
+  if (error) return <NoSidecarBody closeModal={closeModal} isOpen={isOpen} />;
+  if (succeeded === false) return <PullSessionFailedBody closeModal={closeModal} isOpen={isOpen} />;
+  if (succeeded === true) return <PullSessionUpToDateBody closeModal={closeModal} isOpen={isOpen} />;
+  if (data.result.behind > 0) {
+    return <PullSessionNoFFBody
+      closeModal={closeModal}
+      gitStatus={data}
+      isOpen={isOpen}
+      sessionName={sessionName}
+      pulling={pulling}
+      pullSession={pullSession} />;
+  }
+  if (!data.result.clean || data.result.ahead > 0)
+    return <PullSessionUpToDateBody closeModal={closeModal} isOpen={isOpen} />;
+  return <PullSessionUpToDateBody closeModal={closeModal} isOpen={isOpen} />;
+}
+
+
+function PullSessionUpToDateBody({ closeModal }: ModalProps) {
+  return (
+    <Row>
+      <Col>
+        <p>Your session is up-to-date. There are no changes that need pulling.</p>
+        <div className="d-flex justify-content-end">
+          <Button className="float-right mt-1 btn-rk-green" onClick={closeModal}>
+            Back to Session
+          </Button>
+        </div>
+      </Col>
+    </Row>
+  );
+}
+
+
+function PullSessionFailedBody({ closeModal }: ModalProps) {
+  return (
+    <Row>
+      <Col>
+        <p>Session pull failed. Please try to pull by running `<code>renku pull</code>` in the terminal.</p>
+        <div className="d-flex justify-content-end">
+          <Button className="float-right mt-1 btn-rk-green" onClick={closeModal}>
+            Back to Session
+          </Button>
+        </div>
+      </Col>
+    </Row>
+  );
+}
+
+interface PullSessionBodyProps extends PullSessionStatusBodyProps {
+  gitStatus: GitStatusResult;
+  pullSession: Function;
+  pulling: boolean;
+}
+
+function PullSessionNoFFBody({ closeModal, gitStatus, pullSession, pulling }: PullSessionBodyProps) {
+  const commitsToken = commitsPhrasing(gitStatus.result.behind);
+
+  return (<Row>
+    <Col>
+      <div className="mb-3">
+        This session is behind the server by {commitsToken}.
+        Continue to pull those changes in your current session.
+      </div>
+      <div className="d-flex justify-content-end">
+        <Button className="float-right mt-1 btn-outline-rk-green"
+          onClick={closeModal}>
+          Back to Session
+        </Button>
+        <Button type="submit" onClick={() => { pullSession(); }} data-cy="pull-session-modal-button"
+          disabled={pulling} className="float-right mt-1  ms-2 btn-rk-green" >
+          Continue
+        </Button>
+      </div>
+    </Col>
+  </Row>
+  );
+}
+
+export default PullSession;

--- a/client/src/notebooks/components/PullSession.tsx
+++ b/client/src/notebooks/components/PullSession.tsx
@@ -27,8 +27,6 @@ import { CenteredLoader, InformationalBody, commitsPhrasing } from "./Sidecar";
 import type { CloseModalProps, ModalProps } from "./Sidecar";
 
 interface PullSessionProps extends ModalProps {
-  hasPullAccess: boolean;
-  isLogged: boolean;
   notebook: Notebook;
   urlList: any;
 }

--- a/client/src/notebooks/components/PullSession.tsx
+++ b/client/src/notebooks/components/PullSession.tsx
@@ -45,8 +45,8 @@ interface PullSessionProps extends ModalProps {
 
 function PullSession(props: PullSessionProps) {
   const { closeModal, isOpen } = props;
-  const sessionName = props.notebook.data.name;
-  const { data, error, isLoading } = useHealthQuery(sessionName);
+  const serverName = props.notebook.data.name;
+  const { data, error, isLoading } = useHealthQuery({ serverName });
 
   let body = null;
   if (isLoading)
@@ -55,7 +55,7 @@ function PullSession(props: PullSessionProps) {
   else if (error != null || data == null || data.status !== "running")
     body = <NoSidecarBody closeModal={closeModal} isOpen={isOpen} />;
 
-  else body = <PullSessionStatusBody closeModal={closeModal} isOpen={isOpen} sessionName={sessionName} />;
+  else body = <PullSessionStatusBody closeModal={closeModal} isOpen={isOpen} sessionName={serverName} />;
 
   return <Modal className="modal-session" isOpen={isOpen} toggle={closeModal}>
     <ModalHeader toggle={closeModal}>
@@ -89,7 +89,7 @@ interface PullSessionStatusBodyProps extends ModalProps {
 
 function PullSessionStatusBody({ closeModal, isOpen, sessionName }: PullSessionStatusBodyProps) {
   const [succeeded, setSucceeded] = useState<boolean|undefined>(undefined);
-  const { data, error, isFetching } = useGitStatusQuery(sessionName);
+  const { data, error, isFetching } = useGitStatusQuery({ serverName: sessionName });
   const [renkuPull, { isLoading: pulling }] = useRenkuPullMutation();
 
   const pullSession = async (commitMessage: string|undefined) => {

--- a/client/src/notebooks/components/PullSession.tsx
+++ b/client/src/notebooks/components/PullSession.tsx
@@ -165,7 +165,7 @@ function PullSessionBody({ closeModal, gitStatus, pullSession, pulling }: PullSe
           onClick={closeModal}>
           Back to Session
         </Button>
-        <Button type="submit" onClick={() => { pullSession(); }} data-cy="pull-session-modal-button"
+        <Button type="submit" onClick={() => { pullSession(); }} data-cy="pull-changes-modal-button"
           disabled={pulling} className="float-right mt-1  ms-2 btn-rk-green" >
           Continue
         </Button>

--- a/client/src/notebooks/components/SaveSession.tsx
+++ b/client/src/notebooks/components/SaveSession.tsx
@@ -45,8 +45,8 @@ interface SaveSessionProps extends ModalProps {
 
 function SaveSession(props: SaveSessionProps) {
   const { closeModal, isOpen } = props;
-  const sessionName = props.notebook.data.name;
-  const { data, error, isLoading } = useHealthQuery(sessionName);
+  const serverName = props.notebook.data.name;
+  const { data, error, isLoading } = useHealthQuery({ serverName });
 
   let body = null;
   if (!props.isLogged) body = <AnonymousSessionBody closeModal={closeModal} isOpen={isOpen} />;
@@ -57,7 +57,7 @@ function SaveSession(props: SaveSessionProps) {
   else if (error != null || data == null || data.status !== "running")
     body = <NoSidecarBody closeModal={closeModal} isOpen={isOpen} />;
 
-  else body = <SaveSessionStatusBody closeModal={closeModal} isOpen={isOpen} sessionName={sessionName} />;
+  else body = <SaveSessionStatusBody closeModal={closeModal} isOpen={isOpen} sessionName={serverName} />;
 
   return <Modal className="modal-session" isOpen={isOpen} toggle={closeModal}>
     <ModalHeader toggle={closeModal}>
@@ -126,7 +126,7 @@ interface SaveSessionStatusBodyProps extends ModalProps {
 
 function SaveSessionStatusBody({ closeModal, isOpen, sessionName }: SaveSessionStatusBodyProps) {
   const [succeeded, setSucceeded] = useState<boolean|undefined>(undefined);
-  const { data, error, isFetching } = useGitStatusQuery(sessionName);
+  const { data, error, isFetching } = useGitStatusQuery({ serverName: sessionName });
   const [renkuSave, { isLoading: saving }] = useRenkuSaveMutation();
 
   const saveSession = async (commitMessage: string|undefined) => {

--- a/client/src/notebooks/components/SaveSession.tsx
+++ b/client/src/notebooks/components/SaveSession.tsx
@@ -286,3 +286,4 @@ function SaveSessionBody({ closeModal, gitStatus, saveSession, saving }: SaveSes
 
 
 export default SaveSession;
+export { commitsPhrasing };

--- a/client/src/notebooks/components/SessionButtons.tsx
+++ b/client/src/notebooks/components/SessionButtons.tsx
@@ -85,8 +85,9 @@ function PullSessionBtn({ togglePullSession }: PullSessionProps) {
         <ArrowClockwise className="text-rk-dark" title="pull"/>
       </Button>
       <ThrottledTooltip
+        placement="bottom"
         target="pull-changes-button"
-        tooltip="Refresh session" />
+        tooltip="Pull changes" />
     </div>
   );
 }

--- a/client/src/notebooks/components/SessionButtons.tsx
+++ b/client/src/notebooks/components/SessionButtons.tsx
@@ -17,7 +17,7 @@
  */
 
 import { Link } from "react-router-dom";
-import { ArrowLeft, Briefcase, Button, Journals, Save, StopCircle } from "../../utils/ts-wrappers";
+import { ArrowClockwise, ArrowLeft, Briefcase, Button, Journals, Save, StopCircle } from "../../utils/ts-wrappers";
 import React from "react";
 import { ThrottledTooltip } from "../../utils/components/Tooltip";
 
@@ -74,6 +74,23 @@ function SaveSessionBtn({ toggleSaveSession }: SaveSessionProps) {
   );
 }
 
+interface PullSessionProps {
+  togglePullSession: Function;
+}
+function PullSessionBtn({ togglePullSession }: PullSessionProps) {
+  return (
+    <div>
+      <Button id="pull-session-button" data-cy="pull-session-button"
+        className="border-0 bg-transparent text-dark p-0 no-focus" onClick={() => togglePullSession()}>
+        <ArrowClockwise className="text-rk-dark" title="Pull"/>
+      </Button>
+      <ThrottledTooltip
+        target="pull-session-button"
+        tooltip="Refresh session" />
+    </div>
+  );
+}
+
 interface ResourcesProps {
   toggleModalResources: Function;
 }
@@ -103,4 +120,4 @@ function AboutBtn({ toggleModalAbout, projectName }: AboutProps) {
   );
 }
 
-export { AboutBtn, GoBackBtn, ResourcesBtn, SaveSessionBtn, StopSessionBtn };
+export { AboutBtn, GoBackBtn, PullSessionBtn, ResourcesBtn, SaveSessionBtn, StopSessionBtn };

--- a/client/src/notebooks/components/SessionButtons.tsx
+++ b/client/src/notebooks/components/SessionButtons.tsx
@@ -80,12 +80,12 @@ interface PullSessionProps {
 function PullSessionBtn({ togglePullSession }: PullSessionProps) {
   return (
     <div>
-      <Button id="pull-session-button" data-cy="pull-session-button"
+      <Button id="pull-changes-button" data-cy="pull-changes-button"
         className="border-0 bg-transparent text-dark p-0 no-focus" onClick={() => togglePullSession()}>
-        <ArrowClockwise className="text-rk-dark" title="Pull"/>
+        <ArrowClockwise className="text-rk-dark" title="pull"/>
       </Button>
       <ThrottledTooltip
-        target="pull-session-button"
+        target="pull-changes-button"
         tooltip="Refresh session" />
     </div>
   );

--- a/client/src/notebooks/components/SessionFullScreen.tsx
+++ b/client/src/notebooks/components/SessionFullScreen.tsx
@@ -28,7 +28,7 @@ import { AboutSessionModal } from "./AboutSessionModal";
 import { ResourcesSessionModel } from "./ResourcesSessionModal";
 import SaveSession from "./SaveSession";
 import StopSession from "./StopSession";
-import { AboutBtn, GoBackBtn, ResourcesBtn, SaveSessionBtn, StopSessionBtn } from "./SessionButtons";
+import { AboutBtn, GoBackBtn, PullSessionBtn, ResourcesBtn, SaveSessionBtn, StopSessionBtn } from "./SessionButtons";
 import { Notebook, SessionHandlers } from "./Session";
 import useWindowSize from "../../utils/helpers/UseWindowsSize";
 import { Url } from "../../utils/helpers/url";
@@ -37,6 +37,7 @@ import { SESSION_TABS, SessionJupyter } from "../Notebooks.present";
 import StartSessionProgressBar, { SessionStatusData } from "./StartSessionProgressBar";
 import { AUTOSAVED_PREFIX } from "../../utils/helpers/HelperFunctions";
 import SessionUnavailable from "./SessionUnavailable";
+import PullSession from "./PullSession";
 
 /**
  *  renku-ui
@@ -75,6 +76,9 @@ function ShowSessionFullscreen(props: ShowSessionFullscreenProps) {
 
   const [showModalSaveSession, setShowModalSaveSession] = useState(false);
   const toggleSaveSession = () => setShowModalSaveSession(!showModalSaveSession);
+
+  const [showModalPullSession, setShowModalPullSession] = useState(false);
+  const togglePullSession = () => setShowModalPullSession(!showModalPullSession);
 
   const { height } = useWindowSize();
   const ref = useRef<any>(null);
@@ -154,6 +158,13 @@ function ShowSessionFullscreen(props: ShowSessionFullscreenProps) {
     closeModal={toggleSaveSession}
     urlList={urlList}
     isOpen={showModalSaveSession}/>;
+  const pullSessionModal = <PullSession
+    isLogged={props.isLogged}
+    notebook={notebook}
+    closeModal={togglePullSession}
+    urlList={urlList}
+    isOpen={showModalPullSession}
+    hasPullAccess={props.accessLevel >= ACCESS_LEVELS.DEVELOPER}/>;
   /* end modals */
 
   let content;
@@ -192,6 +203,7 @@ function ShowSessionFullscreen(props: ShowSessionFullscreenProps) {
         <div className="fullscreen-header d-flex gap-3">
           <div className="d-flex gap-3 flex-grow-0 align-items-center">
             <GoBackBtn urlBack={urlBack} />
+            <PullSessionBtn togglePullSession={togglePullSession} />
             <SaveSessionBtn toggleSaveSession={toggleSaveSession} />
             <ResourcesBtn toggleModalResources={toggleModalResources} />
             <StopSessionBtn toggleStopSession={toggleStopSession} />
@@ -213,6 +225,7 @@ function ShowSessionFullscreen(props: ShowSessionFullscreenProps) {
       {aboutModal}
       {resourcesModal}
       {saveSessionModal}
+      {pullSessionModal}
       {stopSessionModal}
     </div>
   );

--- a/client/src/notebooks/components/SessionFullScreen.tsx
+++ b/client/src/notebooks/components/SessionFullScreen.tsx
@@ -159,12 +159,10 @@ function ShowSessionFullscreen(props: ShowSessionFullscreenProps) {
     urlList={urlList}
     isOpen={showModalSaveSession}/>;
   const pullSessionModal = <PullSession
-    isLogged={props.isLogged}
     notebook={notebook}
     closeModal={togglePullSession}
     urlList={urlList}
-    isOpen={showModalPullSession}
-    hasPullAccess={props.accessLevel >= ACCESS_LEVELS.DEVELOPER}/>;
+    isOpen={showModalPullSession} />;
   /* end modals */
 
   let content;

--- a/client/src/notebooks/components/Sidecar.tsx
+++ b/client/src/notebooks/components/Sidecar.tsx
@@ -43,7 +43,7 @@ interface ModalProps extends CloseModalProps {
 }
 
 interface InformationalProps extends CloseModalProps {
-  children: React.ReactElement | React.ReactElement[]
+  children: React.ReactNode
 }
 
 function InformationalBody({ closeModal, children }: InformationalProps) {

--- a/client/src/notebooks/components/Sidecar.tsx
+++ b/client/src/notebooks/components/Sidecar.tsx
@@ -1,0 +1,67 @@
+/*!
+ * Copyright 2022 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+
+import { Button, Col, Row } from "../../utils/ts-wrappers";
+import { Loader } from "../../utils/components/Loader";
+
+
+function commitsPhrasing(numberOfCommits: number) {
+  return numberOfCommits > 1 ?
+      `${numberOfCommits} commits` :
+      `${numberOfCommits} commit`;
+}
+
+function CenteredLoader() {
+  return <div className="d-flex justify-content-center">
+    <div><Loader size="16" inline="true" margin="2" /></div>
+  </div>;
+}
+
+interface CloseModalProps {
+  closeModal: Function;
+}
+
+interface ModalProps extends CloseModalProps {
+  isOpen: boolean;
+}
+
+interface InformationalProps extends CloseModalProps {
+  children: React.ReactElement | React.ReactElement[]
+}
+
+function InformationalBody({ closeModal, children }: InformationalProps) {
+
+  return (<Row>
+    <Col>
+      {children}
+      <div className="d-flex justify-content-end">
+        <Button className="float-right mt-1 btn-outline-rk-green"
+          onClick={closeModal}>
+            Back to Session
+        </Button>
+      </div>
+    </Col>
+  </Row>
+  );
+}
+
+
+export { CenteredLoader, InformationalBody, commitsPhrasing };
+export type { CloseModalProps, ModalProps };

--- a/client/src/utils/components/Tooltip.js
+++ b/client/src/utils/components/Tooltip.js
@@ -57,14 +57,17 @@ function standardToggler(tooltipOpen, setTooltipOpen, lastToggleTime, setLastTog
  *
  * @param {string} [target] - id of the element on which the tooltip should be shown
  * @param {string} [tooltip] - the text of the tooltip
+ * @param {string} [placement] - the location for the tooltip, defaults to top,
+ *  see https://reactstrap.github.io/?path=/docs/components-tooltip--tooltip
  */
 function ThrottledTooltip(props) {
   const [tooltipOpen, setTooltipOpen] = useState(false);
   const [lastToggleTime, setLastToggleTime] = useState(Date.now());
 
   const toggle = standardToggler(tooltipOpen, setTooltipOpen, lastToggleTime, setLastToggleTime);
+  const placement = props.placement ?? "top";
 
-  return <Tooltip placement="top" target={props.target} isOpen={tooltipOpen} toggle={toggle}
+  return <Tooltip placement={placement} target={props.target} isOpen={tooltipOpen} toggle={toggle}
     delay={{ show: 25, hide: 250 }}>
     {props.tooltip}
   </Tooltip>;

--- a/client/src/utils/ts-wrappers.js
+++ b/client/src/utils/ts-wrappers.js
@@ -39,6 +39,7 @@ import {
 } from "reactstrap";
 
 import {
+  ArrowClockwise as WrappedArrowClockwise,
   ArrowLeft as WrappedArrowLeft,
   Briefcase as WrappedBriefcase,
   CheckCircleFill as WrappedCheckCircleFill,
@@ -66,6 +67,10 @@ import {
 
 function Alert(props) {
   return <WrappedAlert {...props} />;
+}
+
+function ArrowClockwise(props) {
+  return <WrappedArrowClockwise {...props} />;
 }
 
 function Button(props) {
@@ -261,6 +266,7 @@ function XCircleFill(props) {
   return <WrappedXCircleFill {...props} />;
 }
 
+export { ArrowClockwise };
 export { Accordion, AccordionItem, AccordionHeader, AccordionBody };
 export { Alert, Button, ButtonGroup, CheckCircleFill, XCircleFill };
 export { Card, CardBody, CardText, CardFooter, Col, DropdownItem };

--- a/e2e/cypress/integration/local/session.spec.ts
+++ b/e2e/cypress/integration/local/session.spec.ts
@@ -84,7 +84,7 @@ describe("display a session", () => {
       .contains("It is not possible to offer a one-click save for this session.").should("be.visible");
   });
 
-  it.only("save session button -- session clean", () => {
+  it("save session button -- session clean", () => {
     fixtures.getSidecarHealth().getGitStatusClean();
     cy.gui_open_session();
     // save session
@@ -104,5 +104,49 @@ describe("display a session", () => {
     cy.get(".modal-dialog").get("h5").contains("Save Session").should("be.visible");
     cy.get(".modal-dialog").get("div")
       .contains("You have work in this session that has not yet been saved to the server.").should("be.visible");
+  });
+
+  it("pull changes button -- no sidecar", () => {
+    fixtures.getSidecarHealth(false);
+    cy.gui_open_session();
+    // pull changes
+    cy.get_cy("pull-changes-button").click();
+    cy.get(".modal-dialog").should("exist");
+    cy.get(".modal-dialog").get("h5").contains("Refresh Session").should("be.visible");
+    cy.get(".modal-dialog").get("div")
+      .contains("It is not possible to offer a one-click refresh for this session.").should("be.visible");
+  });
+
+  it("pull changes button -- session clean", () => {
+    fixtures.getSidecarHealth().getGitStatusClean();
+    cy.gui_open_session();
+    // pull changes
+    cy.get_cy("pull-changes-button").click();
+    cy.get(".modal-dialog").should("exist");
+    cy.get(".modal-dialog").get("h5").contains("Refresh Session").should("be.visible");
+    cy.get(".modal-dialog").get("div")
+      .contains("Your session is up-to-date.").should("be.visible");
+  });
+
+  it("pull changes button -- session behind", () => {
+    fixtures.getSidecarHealth().getGitStatusBehind();
+    cy.gui_open_session();
+    // pull changes
+    cy.get_cy("pull-changes-button").click();
+    cy.get(".modal-dialog").should("exist");
+    cy.get(".modal-dialog").get("h5").contains("Refresh Session").should("be.visible");
+    cy.get(".modal-dialog").get("div")
+      .contains("This session is behind the server").should("be.visible");
+  });
+
+  it("pull changes button -- session diverged", () => {
+    fixtures.getSidecarHealth().getGitStatusDiverged();
+    cy.gui_open_session();
+    // pull changes
+    cy.get_cy("pull-changes-button").click();
+    cy.get(".modal-dialog").should("exist");
+    cy.get(".modal-dialog").get("h5").contains("Refresh Session").should("be.visible");
+    cy.get(".modal-dialog").get("div")
+      .contains("Your session has diverged from the origin.").should("be.visible");
   });
 });

--- a/e2e/cypress/integration/local/session.spec.ts
+++ b/e2e/cypress/integration/local/session.spec.ts
@@ -72,4 +72,12 @@ describe("display a session", () => {
     cy.get_cy("stop-session-modal-button").should("exist");
 
   });
+
+  it("save session button", () => {
+    cy.gui_open_session();
+    // save session
+    cy.get_cy("save-session-button").click();
+    cy.get_cy("save-session-modal-button").should("exist");
+
+  });
 });

--- a/e2e/cypress/integration/local/session.spec.ts
+++ b/e2e/cypress/integration/local/session.spec.ts
@@ -73,11 +73,36 @@ describe("display a session", () => {
 
   });
 
-  it("save session button", () => {
+  it("save session button -- no sidecar", () => {
+    fixtures.getSidecarHealth(false);
     cy.gui_open_session();
     // save session
     cy.get_cy("save-session-button").click();
-    cy.get_cy("save-session-modal-button").should("exist");
+    cy.get(".modal-dialog").should("exist");
+    cy.get(".modal-dialog").get("h5").contains("Save Session").should("be.visible");
+    cy.get(".modal-dialog").get("div")
+      .contains("It is not possible to offer a one-click save for this session.").should("be.visible");
+  });
 
+  it.only("save session button -- session clean", () => {
+    fixtures.getSidecarHealth().getGitStatusClean();
+    cy.gui_open_session();
+    // save session
+    cy.get_cy("save-session-button").click();
+    cy.get(".modal-dialog").should("exist");
+    cy.get(".modal-dialog").get("h5").contains("Save Session").should("be.visible");
+    cy.get(".modal-dialog").get("div")
+      .contains("Your session is up-to-date.").should("be.visible");
+  });
+
+  it("save session button -- session ahead", () => {
+    fixtures.getSidecarHealth().getGitStatusDirty();
+    cy.gui_open_session();
+    // save session
+    cy.get_cy("save-session-button").click();
+    cy.get(".modal-dialog").should("exist");
+    cy.get(".modal-dialog").get("h5").contains("Save Session").should("be.visible");
+    cy.get(".modal-dialog").get("div")
+      .contains("You have work in this session that has not yet been saved to the server.").should("be.visible");
   });
 });

--- a/e2e/cypress/support/renkulab-fixtures/sessions.ts
+++ b/e2e/cypress/support/renkulab-fixtures/sessions.ts
@@ -57,7 +57,93 @@ function Sessions<T extends FixturesConstructor>(Parent: T) {
       ).as(name);
       return this;
     }
+
+    getGitStatusDirty(name = "getGitStatus") {
+      const fixture = this.useMockedData ? {
+        body: {
+          "result": {
+            "clean": false,
+            "ahead": 0,
+            "behind": 0,
+            "branch": "master",
+            "commit": "7bede1a",
+            "status": "# branch.oid 7bede1a\n" +
+              "# branch.head master\n" +
+              "# branch.upstream origin/master\n" +
+              "# branch.ab +0 -0\n? bar.txt\n"
+          },
+          "id": 0,
+          "jsonrpc": "2.0"
+        } } : undefined;
+
+      cy.intercept(
+        "/sessions/*/sidecar/jsonrpc",
+        fixture
+      ).as(name);
+      return this;
+    }
+
+    getGitStatusDiverged(name = "getGitStatus") {
+      const fixture = this.useMockedData ? {
+        body: {
+          "result": {
+            "clean": true,
+            "ahead": 1,
+            "behind": 1,
+            "branch": "local-behind",
+            "commit": "d705881",
+            "status": "# branch.oid d705881\n" +
+              "# branch.head local-behind\n" +
+              "# branch.upstream origin/local-behind\n# branch.ab +1 -1\n"
+          },
+          "id": 0,
+          "jsonrpc": "2.0"
+        } } : undefined;
+
+      cy.intercept(
+        "/sessions/*/sidecar/jsonrpc",
+        fixture
+      ).as(name);
+      return this;
+    }
+
+    getGitStatusClean(name = "getGitStatus") {
+      const fixture = this.useMockedData ? {
+        body: {
+          "result": {
+            "clean": true,
+            "ahead": 0,
+            "behind": 0,
+            "branch": "local-behind",
+            "commit": "d705881",
+            "status": "# branch.oid d705881\n" +
+              "# branch.head local-behind\n" +
+              "# branch.upstream origin/local-behind\n# branch.ab +0 -0\n"
+          },
+          "id": 0,
+          "jsonrpc": "2.0"
+        } } : undefined;
+
+      cy.intercept(
+        "/sessions/*/sidecar/jsonrpc",
+        fixture
+      ).as(name);
+      return this;
+    }
+
+    getSidecarHealth(isRunning = true, name = "getSidecarHealth") {
+      const status = isRunning ? "running" : "down";
+      const fixture = this.useMockedData ? { body: {
+        "status": status
+      } } : undefined;
+      cy.intercept(
+        "/sessions/*/sidecar/health*",
+        fixture
+      ).as(name);
+      return this;
+    }
   };
+
 }
 
 export { Sessions };

--- a/e2e/cypress/support/renkulab-fixtures/sessions.ts
+++ b/e2e/cypress/support/renkulab-fixtures/sessions.ts
@@ -58,6 +58,54 @@ function Sessions<T extends FixturesConstructor>(Parent: T) {
       return this;
     }
 
+    getGitStatusBehind(name = "getGitStatus") {
+      const fixture = this.useMockedData ? {
+        body: {
+          "result": {
+            "clean": true,
+            "ahead": 0,
+            "behind": 1,
+            "branch": "local-behind",
+            "commit": "d705881",
+            "status": "# branch.oid d705881\n" +
+              "# branch.head local-behind\n" +
+              "# branch.upstream origin/local-behind\n# branch.ab +0 -1\n"
+          },
+          "id": 0,
+          "jsonrpc": "2.0"
+        } } : undefined;
+
+      cy.intercept(
+        "/sessions/*/sidecar/jsonrpc",
+        fixture
+      ).as(name);
+      return this;
+    }
+
+    getGitStatusClean(name = "getGitStatus") {
+      const fixture = this.useMockedData ? {
+        body: {
+          "result": {
+            "clean": true,
+            "ahead": 0,
+            "behind": 0,
+            "branch": "local-behind",
+            "commit": "d705881",
+            "status": "# branch.oid d705881\n" +
+              "# branch.head local-behind\n" +
+              "# branch.upstream origin/local-behind\n# branch.ab +0 -0\n"
+          },
+          "id": 0,
+          "jsonrpc": "2.0"
+        } } : undefined;
+
+      cy.intercept(
+        "/sessions/*/sidecar/jsonrpc",
+        fixture
+      ).as(name);
+      return this;
+    }
+
     getGitStatusDirty(name = "getGitStatus") {
       const fixture = this.useMockedData ? {
         body: {
@@ -95,30 +143,6 @@ function Sessions<T extends FixturesConstructor>(Parent: T) {
             "status": "# branch.oid d705881\n" +
               "# branch.head local-behind\n" +
               "# branch.upstream origin/local-behind\n# branch.ab +1 -1\n"
-          },
-          "id": 0,
-          "jsonrpc": "2.0"
-        } } : undefined;
-
-      cy.intercept(
-        "/sessions/*/sidecar/jsonrpc",
-        fixture
-      ).as(name);
-      return this;
-    }
-
-    getGitStatusClean(name = "getGitStatus") {
-      const fixture = this.useMockedData ? {
-        body: {
-          "result": {
-            "clean": true,
-            "ahead": 0,
-            "behind": 0,
-            "branch": "local-behind",
-            "commit": "d705881",
-            "status": "# branch.oid d705881\n" +
-              "# branch.head local-behind\n" +
-              "# branch.upstream origin/local-behind\n# branch.ab +0 -0\n"
           },
           "id": 0,
           "jsonrpc": "2.0"


### PR DESCRIPTION
As decided in #1956, the plan is to handle only the simplest case where the session is behind the orgin, but is not dirty and has not diverged.

1. Session is not behind origin (could be ahead)

![image](https://user-images.githubusercontent.com/1196411/198274903-333b04e5-1ba0-4652-b083-e9ccf8a36719.png)

2. Session is strictly behind origin

![image](https://user-images.githubusercontent.com/1196411/198275217-58207387-618d-4bd6-a768-85f4844f9803.png)

3. Session is dirty

![image](https://user-images.githubusercontent.com/1196411/198273913-e31c9697-d30c-417b-9e9d-a5cf98b660f9.png)

4. Session is behind and ahead of origin

![image](https://user-images.githubusercontent.com/1196411/198275825-f5ca6929-8f8b-4a87-bcd5-aad63a71cf4d.png)


6. No sidecar or anonymous

![image](https://user-images.githubusercontent.com/1196411/198274705-00aa03c0-928c-4f6c-b789-b5ed3a0a97fb.png)


Closes #1986 
/deploy renku=000-fix-acceptance-tests-after-changing-gitlab-url extra-values=gateway.gitlabUrl=https://gitlab.dev.renku.ch/ #persist