### PR TITLE
Do not request sidecar health too early

### DIFF
--- a/client/src/notebooks/components/SaveSession.tsx
+++ b/client/src/notebooks/components/SaveSession.tsx
@@ -30,12 +30,30 @@ import type { CloseModalProps, ModalProps } from "./Sidecar";
 
 interface SaveSessionProps extends ModalProps {
   hasSaveAccess: boolean;
+  isSessionReady: boolean;
   isLogged: boolean;
   notebook: Notebook;
   urlList: any;
 }
 
 function SaveSession(props: SaveSessionProps) {
+  const { closeModal, isOpen } = props;
+
+  const body = (!props.isSessionReady) ?
+    <p>The session is not available yet.</p> :
+    <RunningSaveSessionBody {...props} />;
+
+  return <Modal className="modal-session" isOpen={isOpen} toggle={closeModal}>
+    <ModalHeader toggle={closeModal}>
+    Save Session
+    </ModalHeader>
+    <ModalBody>
+      {body}
+    </ModalBody>
+  </Modal>;
+}
+
+function RunningSaveSessionBody(props: SaveSessionProps) {
   const { closeModal, isOpen } = props;
   const serverName = props.notebook.data.name;
   const { data, error, isLoading } = useHealthQuery({ serverName });
@@ -51,14 +69,7 @@ function SaveSession(props: SaveSessionProps) {
 
   else body = <SaveSessionStatusBody closeModal={closeModal} isOpen={isOpen} sessionName={serverName} />;
 
-  return <Modal className="modal-session" isOpen={isOpen} toggle={closeModal}>
-    <ModalHeader toggle={closeModal}>
-    Save Session
-    </ModalHeader>
-    <ModalBody>
-      {body}
-    </ModalBody>
-  </Modal>;
+  return body;
 }
 
 function AnonymousSessionBody({ closeModal }: CloseModalProps) {
@@ -191,6 +202,7 @@ interface SaveSessionSaveBodyProps extends SaveSessionBodyProps {
 
 function SaveSessionBody({ closeModal, gitStatus, saveSession, saving }: SaveSessionSaveBodyProps) {
   const [commitMessage, setCommitMessage] = React.useState(undefined);
+  const saveText = saving ? <span><Loader inline={true} size={16} />Saving Session</span> : "Save Session";
   return (
     <Row>
       <Col>
@@ -213,7 +225,7 @@ function SaveSessionBody({ closeModal, gitStatus, saveSession, saving }: SaveSes
             </Button>
             <Button type="submit" onClick={() => { saveSession(commitMessage); }} data-cy="save-session-modal-button"
               disabled={saving} className="float-right mt-1  ms-2 btn-rk-green" >
-                  Save Session
+              {saveText}
             </Button>
           </div>
         </Fragment>

--- a/client/src/notebooks/components/SessionFullScreen.tsx
+++ b/client/src/notebooks/components/SessionFullScreen.tsx
@@ -154,12 +154,14 @@ function ShowSessionFullscreen(props: ShowSessionFullscreenProps) {
     isOpen={showModalStopSession}/>;
   const saveSessionModal = <SaveSession
     isLogged={props.isLogged}
+    isSessionReady={isTheSessionReady}
     hasSaveAccess={props.accessLevel >= ACCESS_LEVELS.DEVELOPER}
     notebook={notebook}
     closeModal={toggleSaveSession}
     urlList={urlList}
     isOpen={showModalSaveSession}/>;
   const pullSessionModal = <PullSession
+    isSessionReady={isTheSessionReady}
     notebook={notebook}
     closeModal={togglePullSession}
     urlList={urlList}


### PR DESCRIPTION
The save/pull buttons were not always working because the UI was requesting session sidecar health before it could possibly be available.

Fix #2100

/deploy extra-values=gateway.gitlabUrl=https://gitlab.dev.renku.ch/ #persist