### PR TITLE
fix: tests after gitlab url changed

### DIFF
--- a/e2e/cypress/support/authentication/gui_commands.ts
+++ b/e2e/cypress/support/authentication/gui_commands.ts
@@ -17,7 +17,6 @@
  */
 
 import { User, userToUsername } from "./user.interfaces";
-const GITLAB_PROVIDER = Cypress.env("GITLAB_PROVIDER");
 
 Cypress.Commands.add("gui_kc_login", (user: User, startFromHome = false) => {
   if (startFromHome) {
@@ -35,11 +34,11 @@ Cypress.Commands.add("gui_kc_login", (user: User, startFromHome = false) => {
     if (url.includes("auth/realms/Renku/login-actions/authenticate")) {
       cy.gui_kc_register(user);
     }
-    else if (url.includes(`${GITLAB_PROVIDER}/auth/realms/Renku/protocol/openid-connect/auth`)) {
+    else if (url.includes(`/auth/realms/Renku/protocol/openid-connect/auth`)) {
       // Next logging again in dev
       cy.gui_kc_login(user, false);
     }
-    else if (url.includes(`${GITLAB_PROVIDER}/gitlab/oauth/authorize`)) {
+    else if (url.includes(`/oauth/authorize`)) {
       // Accept gitlab authorization
       cy.get("[data-qa-selector='authorization_button']").click();
       cy.gui_is_welcome_page_logged_user(user);

--- a/server/src/utils/url.ts
+++ b/server/src/utils/url.ts
@@ -31,9 +31,9 @@ export function validateCSP(url: string, csp: string): CheckURLResponse {
     const originUrl = new URL(config.server.url);
     const frameAncestor = csp.split(";").find( (p: string) => p.split(" ")?.includes("frame-ancestors"));
 
-    // If is not set framer-ancestor it can be use in iframes
+    // If is not set framer-ancestor it can't be use in iframes
     if (!frameAncestor)
-      return { ...response, isIframeValid: true, detail: "No include frame-ancestor in Content-Security-Policy (CSP)" };
+      return { ...response, isIframeValid: false, detail: "No frame-ancestor exists in Content-Security-Policy (CSP)" };
 
     const allowedSources = frameAncestor?.split(" ");
 

--- a/server/tests/utils/url.test.ts
+++ b/server/tests/utils/url.test.ts
@@ -29,7 +29,7 @@ describe("Test url util functions", () => {
     expect(validateCSP("abcdef", "frame-ancestors *").isIframeValid).toBe(false);
 
     // CSP doesn t have frame-ancestors
-    expect(validateCSP(url, "default-src 'none' ; base-uri 'self'").isIframeValid).toBe(true);
+    expect(validateCSP(url, "default-src 'none' ; base-uri 'self'").isIframeValid).toBe(false);
 
     // all domain valid
     expect(validateCSP(url, "frame-ancestors *").isIframeValid).toBe(true);


### PR DESCRIPTION
This PR is to fix e2e and acceptance tests after gitlab url changed.

List of changes needed to fix the tests:
- the gitlabUrl set in gateway.gitlaburl should be `https://gitlab.dev.renku.ch/`.
- The CSP at https://gitlab.dev.renku.ch/ should include the frame-ancestors `https://*.renku.ch`. 
- The necessary changes to the acceptance tests are in the `000-fix-acceptance-tests-after-changing-gitlab-url `branch in the renku repository

/deploy renku=000-fix-acceptance-tests-after-changing-gitlab-url extra-values=gateway.gitlabUrl=https://gitlab.dev.renku.ch/ #persist