### PR TITLE
build: release 2.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 **session**
 * add refresh button to session ([#1986](https://github.com/SwissDataScienceCenter/renku-ui/issues/1986),  [#2091](https://github.com/SwissDataScienceCenter/renku-ui/issues/2091))
+* add progress indicator when prepare a session ([#2064](https://github.com/SwissDataScienceCenter/renku-ui/issues/2064),  [#2104](https://github.com/SwissDataScienceCenter/renku-ui/issues/2104))
 
 **workflows**
 * initial workflow support on project page ([#2038](https://github.com/SwissDataScienceCenter/renku-ui/issues/2038), [#2041](https://github.com/SwissDataScienceCenter/renku-ui/issues/2041), [#2050](https://github.com/SwissDataScienceCenter/renku-ui/issues/2050),  [#2065](https://github.com/SwissDataScienceCenter/renku-ui/issues/2065), [#2071](https://github.com/SwissDataScienceCenter/renku-ui/issues/2071),  [#2082](https://github.com/SwissDataScienceCenter/renku-ui/issues/2082), [#2087](https://github.com/SwissDataScienceCenter/renku-ui/issues/2087), [#2092](https://github.com/SwissDataScienceCenter/renku-ui/issues/2092), [#2102](https://github.com/SwissDataScienceCenter/renku-ui/issues/2102), [#2105](https://github.com/SwissDataScienceCenter/renku-ui/issues/2105), [#2099](https://github.com/SwissDataScienceCenter/renku-ui/issues/2099))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,6 @@
 
 **session**
 * add refresh button to session ([#1986](https://github.com/SwissDataScienceCenter/renku-ui/issues/1986),  [#2091](https://github.com/SwissDataScienceCenter/renku-ui/issues/2091))
-* add progress indicator when prepare a session ([#2064](https://github.com/SwissDataScienceCenter/renku-ui/issues/2064),  [#2104](https://github.com/SwissDataScienceCenter/renku-ui/issues/2104))
-
 * use the same component for session preparation and start progress ([#2064](https://github.com/SwissDataScienceCenter/renku-ui/issues/2064) [#2104](https://github.com/SwissDataScienceCenter/renku-ui/issues/2104))
 
 **workflows**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 **session**
 * add refresh button to session ([#1986](https://github.com/SwissDataScienceCenter/renku-ui/issues/1986),  [#2091](https://github.com/SwissDataScienceCenter/renku-ui/issues/2091))
-* use the same component for session preparation and start progress ([#2064](https://github.com/SwissDataScienceCenter/renku-ui/issues/2064) [#2104](https://github.com/SwissDataScienceCenter/renku-ui/issues/2104))
+* use the same component for session preparation and start progress ([#2064](https://github.com/SwissDataScienceCenter/renku-ui/issues/2064), [#2104](https://github.com/SwissDataScienceCenter/renku-ui/issues/2104))
 
 **workflows**
 * initial workflow support on project page ([#2038](https://github.com/SwissDataScienceCenter/renku-ui/issues/2038), [#2041](https://github.com/SwissDataScienceCenter/renku-ui/issues/2041), [#2050](https://github.com/SwissDataScienceCenter/renku-ui/issues/2050),  [#2065](https://github.com/SwissDataScienceCenter/renku-ui/issues/2065), [#2071](https://github.com/SwissDataScienceCenter/renku-ui/issues/2071),  [#2082](https://github.com/SwissDataScienceCenter/renku-ui/issues/2082), [#2087](https://github.com/SwissDataScienceCenter/renku-ui/issues/2087), [#2092](https://github.com/SwissDataScienceCenter/renku-ui/issues/2092), [#2102](https://github.com/SwissDataScienceCenter/renku-ui/issues/2102), [#2105](https://github.com/SwissDataScienceCenter/renku-ui/issues/2105), [#2099](https://github.com/SwissDataScienceCenter/renku-ui/issues/2099))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 **projects**
 * display shared link values in the new project form ([#2026](https://github.com/SwissDataScienceCenter/renku-ui/issues/2026), [#2089](https://github.com/SwissDataScienceCenter/renku-ui/issues/2089))
-* correctly cache response from KG endpoint([#2096](https://github.com/SwissDataScienceCenter/renku-ui/issues/2096))
+* correctly cache response from KG endpoint ([#2096](https://github.com/SwissDataScienceCenter/renku-ui/issues/2096), [#2097](https://github.com/SwissDataScienceCenter/renku-ui/issues/2097))
 
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-
 # Changes
 
 ## [2.11.0](https://github.com/SwissDataScienceCenter/renku-ui/compare/2.10.1...2.11.0) (2022-11-07)
@@ -20,6 +19,8 @@
 **session**
 * add refresh button to session ([#1986](https://github.com/SwissDataScienceCenter/renku-ui/issues/1986),  [#2091](https://github.com/SwissDataScienceCenter/renku-ui/issues/2091))
 * add progress indicator when prepare a session ([#2064](https://github.com/SwissDataScienceCenter/renku-ui/issues/2064),  [#2104](https://github.com/SwissDataScienceCenter/renku-ui/issues/2104))
+
+* use the same component for session preparation and start progress ([#2064](https://github.com/SwissDataScienceCenter/renku-ui/issues/2064) [#2104](https://github.com/SwissDataScienceCenter/renku-ui/issues/2104))
 
 **workflows**
 * initial workflow support on project page ([#2038](https://github.com/SwissDataScienceCenter/renku-ui/issues/2038), [#2041](https://github.com/SwissDataScienceCenter/renku-ui/issues/2041), [#2050](https://github.com/SwissDataScienceCenter/renku-ui/issues/2050),  [#2065](https://github.com/SwissDataScienceCenter/renku-ui/issues/2065), [#2071](https://github.com/SwissDataScienceCenter/renku-ui/issues/2071),  [#2082](https://github.com/SwissDataScienceCenter/renku-ui/issues/2082), [#2087](https://github.com/SwissDataScienceCenter/renku-ui/issues/2087), [#2092](https://github.com/SwissDataScienceCenter/renku-ui/issues/2092), [#2102](https://github.com/SwissDataScienceCenter/renku-ui/issues/2102), [#2105](https://github.com/SwissDataScienceCenter/renku-ui/issues/2105), [#2099](https://github.com/SwissDataScienceCenter/renku-ui/issues/2099))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,37 @@
-# [2.10.1](https://github.com/SwissDataScienceCenter/renku-ui/compare/2.10.0...2.10.1) (2022-10-20)
+
+# Changes
+
+## [2.11.0](https://github.com/SwissDataScienceCenter/renku-ui/compare/2.10.1...2.11.0) (2022-11-07)
+
+
+### Bug Fixes
+
+**sessions**
+* handle corrupted autosaves and improve warnings ([#2088](https://github.com/SwissDataScienceCenter/renku-ui/issues/2088))
+* fix progress updates on session start ([#2095](https://github.com/SwissDataScienceCenter/renku-ui/issues/2095),  [#2098](https://github.com/SwissDataScienceCenter/renku-ui/issues/2098))
+
+**projects**
+* display shared link values in the new project form ([#2026](https://github.com/SwissDataScienceCenter/renku-ui/issues/2026), [#2089](https://github.com/SwissDataScienceCenter/renku-ui/issues/2089))
+* correctly cache response from KG endpoint([#2096](https://github.com/SwissDataScienceCenter/renku-ui/issues/2096))
+
+
+### Features
+
+**session**
+* add refresh button to session ([#1986](https://github.com/SwissDataScienceCenter/renku-ui/issues/1986),  [#2091](https://github.com/SwissDataScienceCenter/renku-ui/issues/2091))
+
+**workflows**
+* initial workflow support on project page ([#2038](https://github.com/SwissDataScienceCenter/renku-ui/issues/2038), [#2041](https://github.com/SwissDataScienceCenter/renku-ui/issues/2041), [#2050](https://github.com/SwissDataScienceCenter/renku-ui/issues/2050),  [#2065](https://github.com/SwissDataScienceCenter/renku-ui/issues/2065), [#2071](https://github.com/SwissDataScienceCenter/renku-ui/issues/2071),  [#2082](https://github.com/SwissDataScienceCenter/renku-ui/issues/2082), [#2087](https://github.com/SwissDataScienceCenter/renku-ui/issues/2087), [#2092](https://github.com/SwissDataScienceCenter/renku-ui/issues/2092), [#2102](https://github.com/SwissDataScienceCenter/renku-ui/issues/2102), [#2105](https://github.com/SwissDataScienceCenter/renku-ui/issues/2105), [#2099](https://github.com/SwissDataScienceCenter/renku-ui/issues/2099))
+
+**misc**
+* add gitlab logo in landing page  ([#1955](https://github.com/SwissDataScienceCenter/renku-ui/issues/1955), [#2106](https://github.com/SwissDataScienceCenter/renku-ui/issues/2106))
+
+### BREAKING CHANGES
+
+* Requires renku-python v1.9.0 or greater
+
+
+## [2.10.1](https://github.com/SwissDataScienceCenter/renku-ui/compare/2.10.0...2.10.1) (2022-10-20)
 
 
 ### Bug Fixes
@@ -7,7 +40,7 @@
 
 
 
-# [2.10.0](https://github.com/SwissDataScienceCenter/renku-ui/compare/2.9.0...2.10.0) (2022-10-17)
+## [2.10.0](https://github.com/SwissDataScienceCenter/renku-ui/compare/2.9.0...2.10.0) (2022-10-17)
 
 
 ### Bug Fixes
@@ -29,9 +62,6 @@
 ### BREAKING CHANGES
 
 * Requires renku-notebook v1.12.0 or greater
-
-
-# Changes
 
 ## [2.9.0](https://github.com/SwissDataScienceCenter/renku-ui/compare/2.8.2...2.9.0) (2022-09-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Bug Fixes
 
 **sessions**
-* handle corrupted autosaves and improve warnings ([#2088](https://github.com/SwissDataScienceCenter/renku-ui/issues/2088))
+* handle corrupted autosaves and improve warnings ([#2086](https://github.com/SwissDataScienceCenter/renku-ui/issues/2086), [#2088](https://github.com/SwissDataScienceCenter/renku-ui/issues/2088))
 * fix progress updates on session start ([#2095](https://github.com/SwissDataScienceCenter/renku-ui/issues/2095),  [#2098](https://github.com/SwissDataScienceCenter/renku-ui/issues/2098))
 
 **projects**

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "renku-ui",
-  "version": "2.10.1",
+  "version": "2.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "renku-ui",
-      "version": "2.10.1",
+      "version": "2.11.0",
       "dependencies": {
         "@ckeditor/ckeditor5-react": "^5.0.2",
         "@fortawesome/fontawesome-svg-core": "^1.2.35",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "renku-ui",
-  "version": "2.10.1",
+  "version": "2.11.0",
   "private": true,
   "dependencies": {
     "@ckeditor/ckeditor5-react": "^5.0.2",

--- a/helm-chart/renku-ui/Chart.yaml
+++ b/helm-chart/renku-ui/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.0'
 description: A Helm chart for the Renku UI
 name: renku-ui
 icon: https://github.com/SwissDataScienceCenter/renku-sphinx-theme/raw/master/renku_sphinx_theme/static/favicon.png
-version: 2.10.1
+version: 2.11.0

--- a/helm-chart/renku-ui/values.yaml
+++ b/helm-chart/renku-ui/values.yaml
@@ -53,7 +53,7 @@ client:
 
   image:
     repository: renku/renku-ui
-    tag: "2.10.1"
+    tag: "2.11.0"
     pullPolicy: IfNotPresent
 
     ## Optionally specify an array of imagePullSecrets.
@@ -182,7 +182,7 @@ server:
 
   image:
     repository: renku/renku-ui-server
-    tag: "2.10.1"
+    tag: "2.11.0"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "renku-ui-server",
-  "version": "2.10.1",
+  "version": "2.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "renku-ui-server",
-      "version": "2.10.1",
+      "version": "2.11.0",
       "dependencies": {
         "@sentry/node": "^6.16.1",
         "@sentry/tracing": "^6.16.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "renku-ui-server",
-  "version": "2.10.1",
+  "version": "2.11.0",
   "description": "Server for renku API",
   "private": true,
   "main": "dist/index.js",


### PR DESCRIPTION
Updates to the version numbers and changelog for the post-sprint release

/deploy extra-values=gateway.gitlabUrl=https://gitlab.dev.renku.ch/ #persist

fix #2108