### PR TITLE
feat: unify start session flow (#2115)

### DIFF
--- a/client/src/notebooks/Notebooks.container.js
+++ b/client/src/notebooks/Notebooks.container.js
@@ -743,6 +743,16 @@ class StartNotebookServer extends Component {
     this.coordinator.setObjectStoresConfiguration(value);
   }
 
+  redirectToShowSession(data, state, history) {
+    const annotations = NotebooksHelper.cleanAnnotations(data.annotations, "renku.io");
+    const localUrl = Url.get(Url.pages.project.session.show, {
+      namespace: annotations["namespace"],
+      path: annotations["projectName"],
+      server: data.name,
+    });
+    history.push({ pathname: localUrl, search: "", state: { ...state, redirectFromStartServer: true } });
+  }
+
   internalStartServer() {
     // The core internal logic extracted here for re-use
     const { location, history } = this.props;
@@ -753,23 +763,15 @@ class StartNotebookServer extends Component {
         return;
       if (location.state && location.state.successUrl && history.location.pathname === location.pathname) {
         if (this.autostart && !this.state.autostartTried) {
-          // Derive the local Url and connect to the notebook
-          const annotations = NotebooksHelper.cleanAnnotations(data.annotations, "renku.io");
-          const localUrl = Url.get(Url.pages.project.session.show, {
-            namespace: annotations["namespace"],
-            path: annotations["projectName"],
-            server: data.name,
-          });
-          const state = { filePath: this.customNotebookFilePath, redirectFromStartServer: true };
-
+          const state = { filePath: this.customNotebookFilePath };
           // ? Start with a short delay to prevent missing server information from "GET /servers" API
           setTimeout(() => {
             this.setState({ autostartTried: true });
-            history.push({ pathname: localUrl, search: "", state });
+            this.redirectToShowSession(data, state, history);
           }, 3000);
         }
         else {
-          history.push(location.state.successUrl);
+          this.redirectToShowSession(data, {}, history);
         }
       }
     });

--- a/client/src/notebooks/components/StartSessionLoader.tsx
+++ b/client/src/notebooks/components/StartSessionLoader.tsx
@@ -1,0 +1,143 @@
+/*!
+ * Copyright 2022 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { NotebooksHelper } from "../Notebooks.state";
+import React, { useEffect, useState } from "react";
+import ProgressStepsIndicator, { StatusStepProgressBar } from "../../utils/components/progress/ProgressSteps";
+import { RootStateOrAny, useSelector } from "react-redux";
+import { GoBackButton } from "../../utils/components/buttons/Button";
+import { ProgressStyle, ProgressType } from "../../utils/components/progress/Progress";
+
+interface CIStatus {
+  ongoing: boolean;
+}
+
+interface StatusFetching {
+  ci: boolean;
+  data: boolean;
+  options: boolean;
+}
+
+interface StartNotebookAutostartLoaderProps {
+  ci: {
+    stage: Record<string, any>
+  };
+  data: Record<string, any>;
+  notebooks: Record<string, any>;
+  options: Record<string, any>;
+  backUrl: string;
+}
+function StartNotebookAutostartLoader(props: StartNotebookAutostartLoaderProps) {
+  const { ci, data, notebooks, options, backUrl } = props;
+  const ciStatus = NotebooksHelper.checkCiStatus(ci) as CIStatus;
+  const [fetching, setFetching] = useState<StatusFetching>({
+    ci: !ciStatus.ongoing,
+    data: !!data.fetched,
+    options: !!options.fetched
+  });
+  const [steps, setSteps] = useState([
+    {
+      id: 0,
+      status: StatusStepProgressBar.EXECUTING,
+      step: "Checking project data"
+    },
+    {
+      id: 1,
+      status: StatusStepProgressBar.WAITING,
+      step: "Checking GitLab jobs"
+    },
+    {
+      id: 2,
+      status: StatusStepProgressBar.WAITING,
+      step: "Checking existing sessions"
+    }
+  ]);
+
+  useEffect(() => {
+    let fetched = !notebooks.fetched ? [] : Object.keys(fetching).filter((k ) => {
+      const key = k as keyof StatusFetching;
+      return fetching[key];
+    });
+    if (!fetched.length)
+      return;
+    const statuses = steps;
+    if (fetching.ci)
+      statuses[0].status = StatusStepProgressBar.READY;
+
+    if (fetching.options)
+      statuses[1].status = StatusStepProgressBar.READY;
+
+    if (notebooks.fetched !== false)
+      statuses[2].status = StatusStepProgressBar.READY;
+
+    setSteps(statuses);
+  }, [fetching]); //eslint-disable-line
+
+  useEffect(() => {
+    setFetching({
+      ci: !ciStatus.ongoing,
+      data: !!data.fetched,
+      options: !!options.fetched
+    });
+  }, [ ciStatus.ongoing, data.fetched, options.fetched ]);
+
+  const pathWithNamespace = useSelector( (state: RootStateOrAny) =>
+    state.stateModel.project?.metadata.pathWithNamespace);
+  const backButtonSessions = (
+    <GoBackButton label={`Cancel Session Start & back to ${pathWithNamespace}`} url={backUrl} />);
+  return (
+    <>
+      {backButtonSessions}
+      <div className="progress-box-small">
+        <ProgressStepsIndicator
+          description="Checking current status to start your session"
+          type={ProgressType.Determinate}
+          style={ProgressStyle.Light}
+          title="Step 1 of 2: Checking if launch is possible"
+          status={steps}
+        />
+      </div>
+    </>
+  );
+}
+
+interface StartNotebookLoaderProps {
+  backUrl: string;
+}
+function StartNotebookLoader({ backUrl }: StartNotebookLoaderProps) {
+  return (
+    <>
+      {backUrl}
+      <div className="progress-box-small">
+        <ProgressStepsIndicator
+          description="Checking current status to start your session"
+          type={ProgressType.Determinate}
+          style={ProgressStyle.Light}
+          title="Step 1 of 2: Checking if launch is possible"
+          status={[{
+            id: 0,
+            status: StatusStepProgressBar.EXECUTING,
+            step: "Checking current sessions"
+          }]}
+        />
+      </div>
+    </>
+  );
+}
+
+export { StartNotebookLoader, StartNotebookAutostartLoader };

--- a/client/src/utils/components/buttons/Button.js
+++ b/client/src/utils/components/buttons/Button.js
@@ -100,9 +100,10 @@ function RefreshButton(props) {
  *
  * @param {string} props.url url to go back to
  * @param {string} props.label text next to the arrow
+ * @param {string} props.activeClassName personalize class to attach
  */
-function GoBackButton({ className, label, url }) {
-
+function GoBackButton(props) {
+  const { className = "", label, url } = props;
   const linkClasses = (className) ?
     className + " link-rk-text text-decoration-none" :
     "link-rk-text text-decoration-none";


### PR DESCRIPTION
PR to apply the same Auto start session flow to Start a session with options flow.

![start session with options flow](https://user-images.githubusercontent.com/43388408/201093787-e7f46d43-42d6-497d-b201-5c5666ba3301.gif)

Current flows to test:
- Quick start session from project header button or project card button
- Start session from link
- Start session with options
- Error starting a session (autostart, from link or with options)

Closes #2115 

/deploy renku=2115-unify-start-session-flow #persist