### PR TITLE
refactor(client): Fork component to use redux toolkit (#2157)

### DIFF
--- a/client/src/features/projects/ProjectApi.ts
+++ b/client/src/features/projects/ProjectApi.ts
@@ -35,16 +35,16 @@ export const projectApi = createApi({
   reducerPath: "projects",
   baseQuery: fetchBaseQuery({ baseUrl: "/ui-server/api" }),
   endpoints: (builder) => ({
-    namespaces: builder.query({
+    getNamespaces: builder.query({
       query: (arg) => ({ url: "/namespaces", method: "GET" }),
     }),
-    groupByPath: builder.query<any, string>({
+    getGroupByPath: builder.query<any, string>({
       query: (projectPath) => {
         const urlEncodedPath = encodeURIComponent(projectPath);
         return { url: `/groups/${urlEncodedPath}`, method: "GET" };
       }
     }),
-    memberProjects: builder.query<any, QueryParams>({
+    getMemberProjects: builder.query<any, QueryParams>({
       query: (queryParams: QueryParams ) => {
         const params = { "variables": null, "operationName": null };
         let query = `{
@@ -108,4 +108,4 @@ export const projectApi = createApi({
 
 // Export hooks for usage in function components, which are
 // auto-generated based on the defined endpoints
-export const { useNamespacesQuery, useGroupByPathQuery, useMemberProjectsQuery } = projectApi;
+export const { useGetNamespacesQuery, useGetGroupByPathQuery, useGetMemberProjectsQuery } = projectApi;

--- a/client/src/features/projects/ProjectApi.ts
+++ b/client/src/features/projects/ProjectApi.ts
@@ -1,0 +1,111 @@
+/*!
+ * Copyright 2022 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+import { formatProjectMetadata, ProjectMetadata } from "../../utils/helpers/ProjectFunctions";
+
+interface QueryParams {
+  per_page: number;
+  endCursor: string;
+}
+
+
+interface MemberProjectResponse {
+  data: ProjectMetadata[];
+  endCursor: string;
+  hasNextPage: boolean;
+}
+
+
+export const projectApi = createApi({
+  reducerPath: "projects",
+  baseQuery: fetchBaseQuery({ baseUrl: "/ui-server/api" }),
+  endpoints: (builder) => ({
+    namespaces: builder.query({
+      query: (arg) => ({ url: "/namespaces", method: "GET" }),
+    }),
+    groupByPath: builder.query<any, string>({
+      query: (projectPath) => {
+        const urlEncodedPath = encodeURIComponent(projectPath);
+        return { url: `/groups/${urlEncodedPath}`, method: "GET" };
+      }
+    }),
+    memberProjects: builder.query<any, QueryParams>({
+      query: (queryParams: QueryParams ) => {
+        const params = { "variables": null, "operationName": null };
+        let query = `{
+          projects(membership: true, first:${queryParams.per_page}, after:"${queryParams.endCursor}") {
+            pageInfo {
+              endCursor
+              hasNextPage
+            }
+            nodes {
+              id
+              name
+              fullPath
+              namespace {
+                fullPath
+              }
+              path,
+              httpUrlToRepo,
+              userPermissions {
+                adminProject,
+                pushCode,
+                removeProject
+              }
+            }
+          }
+        }`;
+        let headers = {
+          "Accept": "application/json",
+          "Content-Type": "application/json",
+          "X-Requested-With": "XMLHttpRequest"
+        };
+        return {
+          url: `/graphql`,
+          method: "POST",
+          body: JSON.stringify({ ...params, query }),
+          headers: new Headers(headers)
+        };
+      },
+      transformResponse: (response: any): MemberProjectResponse => {
+        try {
+          const projects = response?.data?.projects?.nodes;
+          const pageInfo = response?.data?.projects?.pageInfo;
+          const data = projects?.map((project: any) => formatProjectMetadata(project));
+          return {
+            endCursor: pageInfo.endCursor,
+            hasNextPage: pageInfo.hasNextPage,
+            data,
+          };
+        }
+        catch (e) {
+          return {
+            data: [],
+            endCursor: "",
+            hasNextPage: false,
+          };
+        }
+      },
+      keepUnusedDataFor: 5,
+    }),
+  })
+});
+
+// Export hooks for usage in function components, which are
+// auto-generated based on the defined endpoints
+export const { useNamespacesQuery, useGroupByPathQuery, useMemberProjectsQuery } = projectApi;

--- a/client/src/project/Project.present.js
+++ b/client/src/project/Project.present.js
@@ -187,14 +187,9 @@ class ForkProjectModal extends Component {
       content = (
         <ForkProject
           client={this.props.client}
-          history={this.props.history}
-          id={this.props.id}
-          model={this.props.model}
-          notifications={this.props.notifications}
-          projectVisibility={this.props.projectVisibility}
-          title={this.props.title}
+          forkedId={this.props.id}
+          forkedTitle={this.props.title}
           toggleModal={this.toggleFunction}
-          user={this.props.user}
         />
       );
     }
@@ -1017,13 +1012,9 @@ function ProjectCollaborationFork(props) {
     <Col sm={12} md={10}>
       <ForkProject
         client={props.client}
-        id={props.metadata.id}
-        history={props.history}
-        model={props.model}
-        notifications={props.notifications}
-        title={props.metadata.title}
+        forkedId={props.metadata.id}
+        forkedTitle={props.metadata.title}
         toggleModal={null}
-        user={props.user}
       />
     </Col>
   </Row>;

--- a/client/src/project/new/ProjectNew.container.js
+++ b/client/src/project/new/ProjectNew.container.js
@@ -38,7 +38,7 @@ import { atobUTF8, btoaUTF8 } from "../../utils/helpers/Encoding";
 import { newProjectSchema } from "../../model/RenkuModels";
 import AppContext from "../../utils/context/appContext";
 import useGetNamespaces from "../../utils/customHooks/UseGetNamespaces";
-import useGetProjects from "../../utils/customHooks/UseGetProjects";
+import useGetUserProjects from "../../utils/customHooks/UseGetProjects";
 import useGetVisibilities from "../../utils/customHooks/UseGetVisibilities";
 
 const CUSTOM_REPO_NAME = "Custom";
@@ -93,7 +93,7 @@ function addForkNotification(notifications, url, info, startingLocation, success
 function ForkProject(props) {
   const { client, forkedId, forkedTitle, toggleModal } = props;
   const namespaces = useGetNamespaces();
-  const { projectsMember, isFetchingProjects } = useGetProjects();
+  const { projectsMember, isFetchingProjects } = useGetUserProjects();
 
   const [title, setTitle] = useState(forkedTitle);
   const [namespace, setNamespace] = useState("");

--- a/client/src/project/new/ProjectNew.container.js
+++ b/client/src/project/new/ProjectNew.container.js
@@ -25,17 +25,21 @@
 
 import React, { Component, useEffect, useState, useRef } from "react";
 // TODO: switch to useSelector
-import { connect } from "react-redux";
-import { withRouter } from "react-router-dom";
+import { connect, useSelector } from "react-redux";
+import { useLocation, withRouter } from "react-router-dom";
+import { useHistory } from "react-router";
 
 import { NewProject as NewProjectPresent, ForkProject as ForkProjectPresent } from "./ProjectNew.present";
 import { NewProjectCoordinator, validateTitle, checkTitleDuplicates } from "./ProjectNew.state";
 import { ProjectsCoordinator } from "../shared";
-import { gitLabUrlFromProfileUrl, slugFromTitle, refreshIfNecessary } from "../../utils/helpers/HelperFunctions";
+import { gitLabUrlFromProfileUrl, slugFromTitle } from "../../utils/helpers/HelperFunctions";
 import { Url, getSearchParams } from "../../utils/helpers/url";
 import { atobUTF8, btoaUTF8 } from "../../utils/helpers/Encoding";
 import { newProjectSchema } from "../../model/RenkuModels";
 import AppContext from "../../utils/context/appContext";
+import useGetNamespaces from "../../utils/customHooks/UseGetNamespaces";
+import useGetProjects from "../../utils/customHooks/UseGetProjects";
+import useGetVisibilities from "../../utils/customHooks/UseGetVisibilities";
 
 const CUSTOM_REPO_NAME = "Custom";
 
@@ -86,85 +90,10 @@ function addForkNotification(notifications, url, info, startingLocation, success
 }
 
 
-/**
- * This component is needed to map properties from the redux store and keep local states cleared by the
- * mapping function. We can remove it when we switch to the useSelector hook
- *
- * @param {object} props.client - client object
- * @param {object} props.model - redux model
- * @param {object} props.history - react history object
- * @param {object} props.notifications - notifications object
- * @param {string} props.title - reference project title
- * @param {number} props.id - reference project id
- * @param {function} props.toggleModal - function to toggle the modal on and off
- */
-class ForkProjectMapper extends Component {
-  constructor(props) {
-    super(props);
-    this.model = props.model;
-    this.projectsCoordinator = new ProjectsCoordinator(props.client, this.model.subModel("projects"));
-
-    this.handlers = {
-      getNamespaces: this.getNamespaces.bind(this),
-      getProjects: this.getProjects.bind(this),
-      getVisibilities: this.getVisibilities.bind(this),
-    };
-  }
-
-  componentDidMount() {
-    // fetch if not yet available and refresh if older than 10 seconds
-    const currentState = this.model.get("projects");
-    refreshIfNecessary(
-      currentState.namespaces.fetching, currentState.namespaces.fetched, () => { this.getNamespaces(); }
-    );
-    refreshIfNecessary(
-      currentState.featured.fetching, currentState.featured.fetched, () => { this.getProjects(); }
-    );
-  }
-
-  async getNamespaces() {
-    return await this.projectsCoordinator.getNamespaces();
-  }
-
-  async getProjects() {
-    return await this.projectsCoordinator.getFeatured();
-  }
-
-  async getVisibilities(namespace) {
-    return await this.projectsCoordinator.getVisibilities(namespace, this.props.projectVisibility);
-  }
-
-  render() {
-    const { client, id, history, notifications, title, toggleModal } = this.props;
-
-    // ? This is a quickfix to prevent re-drawing the component.
-    // ? Projects and namespaces should be mapped through `connect`
-    // ? Previous state: https://github.com/SwissDataScienceCenter/renku-ui/pull/2144
-    const namespaces = this.model.get("projects.namespaces");
-    const tp = this.model.get("projects.featured");
-    const projects = { fetched: tp.fetched, fetching: tp.fetching, list: tp.member };
-    const user = { logged: this.props.user.logged, username: this.props.user.data.username };
-
-    return (
-      <ForkProject
-        client={client}
-        forkedId={id}
-        forkedTitle={title}
-        handlers={this.handlers}
-        history={history}
-        namespaces={namespaces}
-        notifications={notifications}
-        projects={projects}
-        toggleModal={toggleModal}
-        user={user}
-      />
-    );
-  }
-}
-
-
 function ForkProject(props) {
-  const { forkedTitle, handlers, namespaces, projects, toggleModal, user } = props;
+  const { client, forkedId, forkedTitle, toggleModal } = props;
+  const namespaces = useGetNamespaces();
+  const { projectsMember, isFetchingProjects } = useGetProjects();
 
   const [title, setTitle] = useState(forkedTitle);
   const [namespace, setNamespace] = useState("");
@@ -179,13 +108,26 @@ function ForkProject(props) {
   const [forkVisibilityError, setForkVisibilityError] = useState(null);
   const [forkUrl, setForkUrl] = useState(null);
 
+  const { availableVisibilities, isFetchingVisibilities } = useGetVisibilities(fullNamespace);
+  const { logged, data: { username } = null } = useSelector( (state) => state.stateModel.user);
+
+  const history = useHistory();
+  const location = useLocation();
+
+  useEffect(()=> {
+    if (!logged) {
+      const loginUrl = Url.get(Url.pages.login.link, { pathname: location.pathname });
+      history.push(loginUrl);
+    }
+  }, []); //eslint-disable-line
+
   // Monitor changes to projects list
   useEffect(() => {
-    if (!projects.list || !projects.list.length)
+    if (!projectsMember || !projectsMember.length)
       setProjectsPaths([]);
     else
-      setProjectsPaths(projects.list.map(project => project.path_with_namespace.toLowerCase()));
-  }, [projects.list]);
+      setProjectsPaths(projectsMember.map(project => project.path_with_namespace.toLowerCase()));
+  }, [projectsMember]);
 
   // Monitor changes to title, namespace or projects slug list to check for errors
   useEffect(() => {
@@ -218,21 +160,17 @@ function ForkProject(props) {
       setVisibility(null);
 
       // calculate visibilities values
-      const availableVisibilities = await handlers.getVisibilities(namespace);
       setVisibilities(availableVisibilities ?? null);
       setVisibility(availableVisibilities?.default ?? null);
     };
-    if (fullNamespace) {
+    if (fullNamespace && !isFetchingVisibilities) {
       getVisibilities(fullNamespace);
     }
     else {
       setVisibilities(null);
       setVisibility(null);
     }
-    // the useEffect uses the function handlers.getVisibility,
-    // if we include it as a dependency the effect will be trigger many times
-    // since the function changes in each rendering.
-  }, [fullNamespace]); // eslint-disable-line
+  }, [fullNamespace, availableVisibilities, isFetchingVisibilities]); // eslint-disable-line
 
   // Monitor component mounted state -- helper to prevent illegal action when the fork takes long
   const mounted = useRef(false);
@@ -246,7 +184,6 @@ function ForkProject(props) {
   const fork = async () => {
     // TODO: re-add notifications after #1585 is addressed-- for some reason the project's sub-components
     // TODO: ("mrView", "issuesVIew", ...) trigger a re-render after adding a notification, losing local states.
-    const { client, forkedId, history } = props;
 
     const path = slugFromTitle(title, true);
     // const startingLocation = history.location.pathname;
@@ -360,7 +297,7 @@ function ForkProject(props) {
   };
 
   const adjustedHandlers = {
-    getNamespaces: handlers.getNamespaces,
+    getNamespaces: namespaces?.refetchNamespaces,
     setNamespace: setNamespaceP,
     setProperty: setPropertyP
   };
@@ -377,12 +314,13 @@ function ForkProject(props) {
       handlers={adjustedHandlers}
       namespace={namespace}
       namespaces={namespaces}
-      projects={projects}
+      projects={projectsMember}
       title={title}
       toggleModal={toggleModal}
-      user={user}
+      user={{ logged, username }}
       visibilities={visibilities}
       visibility={visibility}
+      isFetchingProjects={isFetchingProjects}
     />
   );
 }
@@ -608,7 +546,7 @@ class NewProject extends Component {
 NewProject.contextType = AppContext;
 const NewProjectContainer = withRouter(NewProject);
 
-export { NewProjectContainer as NewProject, CUSTOM_REPO_NAME, ForkProjectMapper as ForkProject };
+export { NewProjectContainer as NewProject, CUSTOM_REPO_NAME, ForkProject };
 
 // test only
 export { getDataFromParams };

--- a/client/src/project/new/ProjectNew.present.js
+++ b/client/src/project/new/ProjectNew.present.js
@@ -52,10 +52,10 @@ import AppContext from "../../utils/context/appContext";
 import "./Project.style.css";
 
 function ForkProject(props) {
-  const { error, fork, forkedTitle, forking, forkUrl, namespaces, projects, toggleModal } = props;
+  const { error, fork, forkedTitle, forking, forkUrl, namespaces, isFetchingProjects, toggleModal } = props;
 
   const fetching = {
-    projects: projects.fetching,
+    projects: isFetchingProjects,
     namespaces: namespaces.fetching
   };
 

--- a/client/src/project/new/ProjectNew.test.js
+++ b/client/src/project/new/ProjectNew.test.js
@@ -37,6 +37,7 @@ import { testClient as client } from "../../api-client";
 import { btoaUTF8 } from "../../utils/helpers/Encoding";
 import { generateFakeUser } from "../../user/User.test";
 import AppContext from "../../utils/context/appContext";
+import { Provider } from "react-redux";
 
 
 const fakeHistory = createMemoryHistory({
@@ -166,14 +167,16 @@ describe("rendering", () => {
     document.body.appendChild(div);
     await act(async () => {
       ReactDOM.render(
-        <MemoryRouter>
-          <ForkProject
-            client={client}
-            model={model}
-            history={fakeHistory}
-            user={loggedUser}
-          />
-        </MemoryRouter>
+        <Provider store={model.reduxStore}>
+          <MemoryRouter>
+            <ForkProject
+              client={client}
+              model={model}
+              history={fakeHistory}
+              user={loggedUser}
+            />
+          </MemoryRouter>
+        </Provider>
         , div);
     });
   });

--- a/client/src/project/shared/Projects.state.js
+++ b/client/src/project/shared/Projects.state.js
@@ -23,8 +23,8 @@
  *  Projects controller code.
  */
 
-import { ACCESS_LEVELS } from "../../api-client";
 import { computeVisibilities } from "../../utils/helpers/HelperFunctions";
+import { formatProjectMetadata } from "../../utils/helpers/ProjectFunctions";
 
 
 class ProjectsCoordinator {
@@ -34,44 +34,7 @@ class ProjectsCoordinator {
   }
 
   _starredProjectMetadata(project) {
-    let accessLevel = 0;
-    // check permissions from v4 API
-    if (project?.permissions) {
-      if (project?.permissions?.project_access)
-        accessLevel = Math.max(accessLevel, project.permissions.project_access.access_level);
-      if (project?.permissions?.group_access)
-        accessLevel = Math.max(accessLevel, project.permissions.group_access.access_level);
-    }
-    // check permissions from GraphQL -- // ? REF: https://docs.gitlab.com/ee/user/permissions.html
-    else if (project?.userPermissions) {
-      if (project.userPermissions.removeProject)
-        accessLevel = Math.max(accessLevel, ACCESS_LEVELS.OWNER);
-      else if (project.userPermissions.adminProject)
-        accessLevel = Math.max(accessLevel, ACCESS_LEVELS.MAINTAINER);
-      else if (project.userPermissions.pushCode)
-        accessLevel = Math.max(accessLevel, ACCESS_LEVELS.DEVELOPER);
-    }
-
-    // Project id can be a number e.g. 1234 or a string with the format: gid://gitlab/Project/1234
-    const projectFullId = typeof (project.id) === "number" ? [] : project.id.split("/");
-    const projectId = projectFullId.length > 1 ? projectFullId[projectFullId.length - 1] : project.id;
-
-    return {
-      id: projectId,
-      name: project.name,
-      path_with_namespace: project.path_with_namespace ?? project?.fullPath,
-      description: project.description,
-      tag_list: project.tag_list,
-      star_count: project.star_count,
-      owner: project.owner,
-      last_activity_at: project.last_activity_at,
-      access_level: accessLevel,
-      http_url_to_repo: project.http_url_to_repo ? project.http_url_to_repo : project.httpUrlToRepo,
-      namespace: project.namespace,
-      path: project.path,
-      avatar_url: project.avatar_url,
-      visibility: project.visibility
-    };
+    return formatProjectMetadata(project);
   }
 
   async getFeatured() {

--- a/client/src/utils/customHooks/UseGetNamespaces.ts
+++ b/client/src/utils/customHooks/UseGetNamespaces.ts
@@ -1,0 +1,39 @@
+/*!
+ * Copyright 2022 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import { useNamespacesQuery } from "../../features/projects/ProjectApi";
+
+/**
+ *  useGetNamespaces custom hook
+ *
+ *  UseGetNamespaces.ts
+ *  hook to fetch Namespaces
+ */
+function useGetNamespaces() {
+  const { data, isFetching, isLoading, refetch } = useNamespacesQuery({});
+
+  return {
+    list: data ?? [],
+    fetching: isFetching,
+    fetched: !isFetching && !isLoading,
+    refetchNamespaces: refetch
+  };
+}
+
+export default useGetNamespaces;

--- a/client/src/utils/customHooks/UseGetNamespaces.ts
+++ b/client/src/utils/customHooks/UseGetNamespaces.ts
@@ -17,7 +17,7 @@
  */
 
 
-import { useNamespacesQuery } from "../../features/projects/ProjectApi";
+import { useGetNamespacesQuery } from "../../features/projects/ProjectApi";
 
 /**
  *  useGetNamespaces custom hook
@@ -26,7 +26,7 @@ import { useNamespacesQuery } from "../../features/projects/ProjectApi";
  *  hook to fetch Namespaces
  */
 function useGetNamespaces() {
-  const { data, isFetching, isLoading, refetch } = useNamespacesQuery({});
+  const { data, isFetching, isLoading, refetch } = useGetNamespacesQuery({});
 
   return {
     list: data ?? [],

--- a/client/src/utils/customHooks/UseGetProjects.ts
+++ b/client/src/utils/customHooks/UseGetProjects.ts
@@ -1,0 +1,60 @@
+/*!
+ * Copyright 2022 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useState } from "react";
+import { useMemberProjectsQuery } from "../../features/projects/ProjectApi";
+
+/**
+ *  useGetProjects custom hook
+ *
+ *  UseGetProjects.ts
+ *  hook to fetch member projects
+ */
+function useGetProjects() {
+  const [projectsMember, setProjectsMembers] = useState<any[]>([]);
+  const [endCursor, setEndCursor] = useState("");
+  const [isFetchingProjects, setIsFetchingProjects] = useState(false);
+  const { data, isFetching } = useMemberProjectsQuery({ per_page: 100, endCursor });
+
+  // continue fetching if there is more data
+  useEffect(() => {
+    if (data) {
+      if (data?.hasNextPage)
+        setEndCursor(data.endCursor);
+      else
+        setIsFetchingProjects(isFetching);
+    }
+    else {
+      setIsFetchingProjects(isFetching);
+    }
+  }, [ data?.hasNextPage, data?.endCursor, isFetching ]); //eslint-disable-line
+
+  // concat projects if is endCursor is not an initial value
+  useEffect(() => {
+    if (isFetching)
+      return;
+    if (endCursor === "")
+      setProjectsMembers(data.data);
+    else
+      setProjectsMembers([...projectsMember, ...data.data]);
+  }, [ data?.data, isFetching, endCursor ]); //eslint-disable-line
+
+  return { projectsMember, isFetchingProjects };
+}
+
+export default useGetProjects;

--- a/client/src/utils/customHooks/UseGetProjects.ts
+++ b/client/src/utils/customHooks/UseGetProjects.ts
@@ -17,7 +17,7 @@
  */
 
 import { useEffect, useState } from "react";
-import { useMemberProjectsQuery } from "../../features/projects/ProjectApi";
+import { useGetMemberProjectsQuery } from "../../features/projects/ProjectApi";
 
 /**
  *  useGetProjects custom hook
@@ -25,11 +25,11 @@ import { useMemberProjectsQuery } from "../../features/projects/ProjectApi";
  *  UseGetProjects.ts
  *  hook to fetch member projects
  */
-function useGetProjects() {
+function useGetUserProjects() {
   const [projectsMember, setProjectsMembers] = useState<any[]>([]);
   const [endCursor, setEndCursor] = useState("");
   const [isFetchingProjects, setIsFetchingProjects] = useState(false);
-  const { data, isFetching } = useMemberProjectsQuery({ per_page: 100, endCursor });
+  const { data, isFetching } = useGetMemberProjectsQuery({ per_page: 100, endCursor });
 
   // continue fetching if there is more data
   useEffect(() => {
@@ -57,4 +57,4 @@ function useGetProjects() {
   return { projectsMember, isFetchingProjects };
 }
 
-export default useGetProjects;
+export default useGetUserProjects;

--- a/client/src/utils/customHooks/UseGetVisibilities.ts
+++ b/client/src/utils/customHooks/UseGetVisibilities.ts
@@ -18,7 +18,7 @@
 
 import { useEffect, useState } from "react";
 import { computeVisibilities } from "../helpers/HelperFunctions";
-import { useGroupByPathQuery } from "../../features/projects/ProjectApi";
+import { useGetGroupByPathQuery } from "../../features/projects/ProjectApi";
 
 /**
  *  useGetVisibilities custom hook
@@ -28,7 +28,7 @@ import { useGroupByPathQuery } from "../../features/projects/ProjectApi";
  */
 function useGetVisibilities(namespace: any) {
   const { data, isFetching, isLoading } =
-    useGroupByPathQuery(namespace?.full_path, { skip: !namespace || namespace?.kind !== "group" });
+    useGetGroupByPathQuery(namespace?.full_path, { skip: !namespace || namespace?.kind !== "group" });
   const [availableVisibilities, setAvailableVisibilities] = useState<any>(null);
 
   useEffect(() => {

--- a/client/src/utils/customHooks/UseGetVisibilities.ts
+++ b/client/src/utils/customHooks/UseGetVisibilities.ts
@@ -1,0 +1,52 @@
+/*!
+ * Copyright 2022 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useState } from "react";
+import { computeVisibilities } from "../helpers/HelperFunctions";
+import { useGroupByPathQuery } from "../../features/projects/ProjectApi";
+
+/**
+ *  useGetVisibilities custom hook
+ *
+ *  UseGetVisibilities.ts
+ *  hook to get visibilities and fetch groups if the namespace is of type group
+ */
+function useGetVisibilities(namespace: any) {
+  const { data, isFetching, isLoading } =
+    useGroupByPathQuery(namespace?.full_path, { skip: !namespace || namespace?.kind !== "group" });
+  const [availableVisibilities, setAvailableVisibilities] = useState<any>(null);
+
+  useEffect(() => {
+    if (isFetching || isLoading || !namespace)
+      return;
+
+    let options: string[] = [];
+    if (namespace?.kind === "user") {
+      options.push("public");
+      setAvailableVisibilities(computeVisibilities(options));
+    }
+    else if (namespace?.kind === "group") {
+      options.push(data.visibility);
+      setAvailableVisibilities(computeVisibilities(options));
+    }
+  }, [isFetching, isLoading, data, namespace]);
+
+  return { availableVisibilities, isFetchingVisibilities: isFetching };
+}
+
+export default useGetVisibilities;

--- a/client/src/utils/helpers/EnhancedState.js
+++ b/client/src/utils/helpers/EnhancedState.js
@@ -26,10 +26,12 @@
 import { configureStore } from "@reduxjs/toolkit";
 import { projectKgApi } from "../../features/projects/ProjectKgApi";
 import { sessionSidecarApi } from "../../features/session/sidecarApi";
+import { projectApi } from "../../features/projects/ProjectApi";
 
 function createStore(renkuStateModelReducer, name = "renku") {
   renkuStateModelReducer[projectKgApi.reducerPath] = projectKgApi.reducer;
   renkuStateModelReducer[sessionSidecarApi.reducerPath] = sessionSidecarApi.reducer;
+  renkuStateModelReducer[projectApi.reducerPath] = projectApi.reducer;
   // For the moment, disable the custom middleware, since it causes
   // problems for our app.
   const store = configureStore({
@@ -39,7 +41,8 @@ function createStore(renkuStateModelReducer, name = "renku") {
         immutableCheck: false,
         serializableCheck: false,
       }).concat(projectKgApi.middleware)
-        .concat(sessionSidecarApi.middleware),
+        .concat(sessionSidecarApi.middleware)
+        .concat(projectApi.middleware),
   });
   return store;
 }

--- a/client/src/utils/helpers/HelperFunctions.js
+++ b/client/src/utils/helpers/HelperFunctions.js
@@ -375,7 +375,7 @@ function toCapitalized(aString) {
 
 /**
  * computeVisibilities.
- * @param {[string]} options
+ * @param {string[]} options
  */
 const computeVisibilities = (options) => {
   if (options.includes("private")) {

--- a/client/src/utils/helpers/ProjectFunctions.ts
+++ b/client/src/utils/helpers/ProjectFunctions.ts
@@ -1,0 +1,80 @@
+/*!
+ * Copyright 2022 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ACCESS_LEVELS } from "../../api-client";
+
+interface ProjectMetadata {
+  id: string | number;
+  name: string;
+  path_with_namespace: string;
+  description: string;
+  tag_list?: string[];
+  star_count: number;
+  owner: Record<string, string | number>
+  last_activity_at: string;
+  access_level: number;
+  http_url_to_repo: string;
+  namespace: Record<string, string | number | null>;
+  path: string;
+  avatar_url: string;
+  visibility: string;
+}
+
+function formatProjectMetadata(project: any): ProjectMetadata {
+  let accessLevel = 0;
+  // check permissions from v4 API
+  if (project?.permissions) {
+    if (project?.permissions?.project_access)
+      accessLevel = Math.max(accessLevel, project.permissions.project_access.access_level);
+    if (project?.permissions?.group_access)
+      accessLevel = Math.max(accessLevel, project.permissions.group_access.access_level);
+  }
+  // check permissions from GraphQL -- // ? REF: https://docs.gitlab.com/ee/user/permissions.html
+  else if (project?.userPermissions) {
+    if (project.userPermissions.removeProject)
+      accessLevel = Math.max(accessLevel, ACCESS_LEVELS.OWNER);
+    else if (project.userPermissions.adminProject)
+      accessLevel = Math.max(accessLevel, ACCESS_LEVELS.MAINTAINER);
+    else if (project.userPermissions.pushCode)
+      accessLevel = Math.max(accessLevel, ACCESS_LEVELS.DEVELOPER);
+  }
+
+  // Project id can be a number e.g. 1234 or a string with the format: gid://gitlab/Project/1234
+  const projectFullId = typeof (project.id) === "number" ? [] : project.id.split("/");
+  const projectId = projectFullId.length > 1 ? projectFullId[projectFullId.length - 1] : project.id;
+
+  return {
+    id: projectId,
+    name: project.name,
+    path_with_namespace: project.path_with_namespace ?? project?.fullPath,
+    description: project.description,
+    tag_list: project.tag_list,
+    star_count: project.star_count,
+    owner: project.owner,
+    last_activity_at: project.last_activity_at,
+    access_level: accessLevel,
+    http_url_to_repo: project.http_url_to_repo ? project.http_url_to_repo : project.httpUrlToRepo,
+    namespace: project.namespace,
+    path: project.path,
+    avatar_url: project.avatar_url,
+    visibility: project.visibility
+  };
+}
+
+export { formatProjectMetadata };
+export type { ProjectMetadata };
+


### PR DESCRIPTION
PR to refactor fork component to use redux toolkit to fetch namespaces, groups and member projects.

Closes #2157 


/deploy #persist