### PR TITLE
fix(client): use project slug for links

### DIFF
--- a/client/src/project/new/ProjectNew.state.js
+++ b/client/src/project/new/ProjectNew.state.js
@@ -367,7 +367,7 @@ class NewProjectCoordinator {
   getSlugAndReset() {
     const creation = this.model.get("meta.creation");
     this.resetCreationResult();
-    return `${creation.newNamespace}/${creation.newName}`;
+    return `${creation.newNamespace}/${creation.newNameSlug}`;
   }
 
   resetCreationResult() {


### PR DESCRIPTION
When project creation succeeds but one of the following APIs fails (E.G. the webhook creation) the user gets a warning and can click on a "go to the project" button. The links was broken for projects with different name and slug.
This PR fixes it.

![image](https://user-images.githubusercontent.com/43481553/206742768-44cac2ae-ec41-4a5b-8e2e-0573313974bb.png)

/deploy #persist #cypress
