### PR TITLE
fix: overflow title in lineage (#2132)

### DIFF
--- a/client/src/file/File.present.js
+++ b/client/src/file/File.present.js
@@ -83,19 +83,18 @@ class FileCard extends React.Component {
     return (
       <Card className="border-rk-light">
         <CardHeader id="file-card-header"
-          className="d-flex align-items-center bg-white justify-content-between pe-3 ps-3" >
-          <div className="d-flex align-items-end">
+          className="d-flex align-items-center bg-white justify-content-between pe-3 ps-3 flex-wrap" >
+          <div className="d-flex align-items-end overflow-hidden gap-2">
             {this.props.isLFSBadge}
-            <span className="fw-bold">{this.props.filePath}</span>
-          &nbsp;
-            {this.props.fileSize ? <span><small> {formatBytes(this.props.fileSize)}</small></span> : null}
-          &nbsp;
+            <div className="fw-bold text-truncate">{this.props.filePath}</div>
+            {this.props.fileSize ?
+              <div className="flex-grow-0 flex-shrink-0">
+                <small> {formatBytes(this.props.fileSize)}</small></div> : null}
             {/* <span className="fileBarIconButton"> */}
-            <Clipboard clipboardText={this.props.filePath} className="icon-link"/>
+            <Clipboard clipboardText={this.props.filePath} className="icon-link d-flex"/>
             {/* </span> */}
-          &nbsp;
           </div>
-          <div className="d-flex align-items-end">
+          <div className="d-flex align-items-center">
             {this.props.buttonShareLinkSession}
             {this.props.buttonDownload}
             {this.props.buttonJupyter}

--- a/client/src/file/Lineage.present.js
+++ b/client/src/file/Lineage.present.js
@@ -277,18 +277,17 @@ class FileLineage extends Component {
       );
 
     return <Card className="border-rk-light">
-      <CardHeader className="d-flex align-items-center bg-white justify-content-between pe-3 ps-3">
-        <div className="d-flex align-items-end">
+      <CardHeader className="d-flex align-items-center bg-white justify-content-between pe-3 ps-3 flex-wrap">
+        <div className="d-flex align-items-end overflow-hidden gap-2">
           {isLFSBadge}
-          <strong>{this.props.path}</strong>
-        &nbsp;
-          {this.props.fileSize ? <span><small> {formatBytes(this.props.fileSize)}</small></span> : null}
-        &nbsp;
-          <span className="fileBarIconButton"><Clipboard clipboardText={this.props.path} /></span>
-        &nbsp;
+          <div className="fw-bold text-truncate">{this.props.path}</div>
+          {this.props.fileSize ?
+            <div className="flex-grow-0 flex-shrink-0">
+              <small> {formatBytes(this.props.fileSize)}</small></div> : null}
+          <span className="fileBarIconButton"><Clipboard clipboardText={this.props.path} className="d-flex" /></span>
         </div>
 
-        <div className="d-flex align-items-end">
+        <div className="d-flex align-items-center">
           <span className="fileBarIconButton">{buttonDownload}</span>
           <span className="fileBarIconButton">{buttonJupyter}</span>
           <span className="fileBarIconButton">{buttonGit}</span>


### PR DESCRIPTION
PR to fix overflow title in file/lineage view.

![lineage title overflow](https://user-images.githubusercontent.com/43388408/207354879-1b798e2d-7907-46ef-b15a-723d73eb905d.gif)


Closes #2132 

/deploy #persist