### PR TITLE
feat: add styles button with menu and group button (#2200)

### DIFF
--- a/client/src/notebooks/NotebookStart.present.js
+++ b/client/src/notebooks/NotebookStart.present.js
@@ -1144,7 +1144,8 @@ class ServerOptionLaunch extends Component {
     const startButton = <Button key="start-session" color="rk-green" disabled={!hasImage} onClick={this.checkServer}>
       Start session
     </Button>;
-    const startButtonWithMenu = <ButtonWithMenu key="button-menu" color="rk-green" default={startButton} direction="up">
+    const startButtonWithMenu = <ButtonWithMenu key="button-menu" color="rk-green" default={startButton}
+      direction="up" isPrincipal={true}>
       {createLink}
     </ButtonWithMenu>;
 

--- a/client/src/notebooks/Notebooks.present.js
+++ b/client/src/notebooks/Notebooks.present.js
@@ -677,7 +677,9 @@ const NotebookServerRowAction = memo((props) => {
   if (status === SessionStatus.running || status === SessionStatus.starting) {
     const state = scope?.filePath ? { filePath: scope?.filePath } : undefined;
     defaultAction = (
-      <Link className="btn btn-outline-rk-green" to={{ pathname: props.localUrl, state }}>Open</Link>);
+      <Link data-cy="open-session" className="btn btn-outline-rk-green" to={{ pathname: props.localUrl, state }}>
+        Open
+      </Link>);
     actions.openExternal = (<DropdownItem href={props.url} target="_blank" >
       <FontAwesomeIcon className="text-rk-green" icon={faExternalLinkAlt} /> Open in new tab
     </DropdownItem>);
@@ -691,7 +693,7 @@ const NotebookServerRowAction = memo((props) => {
 
   return (
     <ButtonWithMenu
-      data-cy="sessions-button" className="sessionsButton" size="sm" default={defaultAction} color="rk-green">
+      className="sessionsButton" size="sm" default={defaultAction} color="rk-green">
       {actions.openExternal}
       {actions.logs}
       {actions.stop}

--- a/client/src/project/Project.present.js
+++ b/client/src/project/Project.present.js
@@ -28,7 +28,7 @@ import React, { Component, Fragment, useState, useEffect } from "react";
 import { Helmet } from "react-helmet";
 import { Link, Route, Switch } from "react-router-dom";
 import {
-  Alert, Button, ButtonGroup, Card, CardBody, CardHeader, Col, DropdownItem,
+  Alert, Button, Card, CardBody, CardHeader, Col, DropdownItem,
   Modal, Row, Nav, NavItem, UncontrolledTooltip
 } from "reactstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -54,7 +54,7 @@ import { ForkProject } from "./new";
 import { ProjectSettingsGeneral, ProjectSettingsNav, ProjectSettingsSessions } from "./settings";
 import { WorkflowsList } from "../workflows";
 import { ExternalLink } from "../utils/components/ExternalLinks";
-import { ButtonWithMenu, GoBackButton } from "../utils/components/buttons/Button";
+import { ButtonWithMenu, GoBackButton, RoundButtonGroup } from "../utils/components/buttons/Button";
 import { RenkuMarkdown } from "../utils/components/markdown/RenkuMarkdown";
 import { ErrorAlert, InfoAlert, WarnAlert } from "../utils/components/Alert";
 import { CoreErrorAlert } from "../utils/components/errors/CoreErrorAlert";
@@ -193,15 +193,30 @@ class ForkProjectModal extends Component {
         />
       );
     }
+
+    const buttons = [
+      <Button className="btn-outline-rk-green" id="fork-project" key="fork-project"
+        disabled={this.props.forkProjectDisabled} onClick={this.toggleFunction}>
+        Fork
+        <ThrottledTooltip
+          target="fork-project"
+          tooltip="Fork this project" />
+      </Button>,
+      <Button
+        id="project-forks"
+        key="counter-forks"
+        className="btn-outline-rk-green btn-icon-text"
+        disabled={this.props.forkProjectDisabled}
+        href={`${this.props.externalUrl}/-/forks`} target="_blank" rel="noreferrer noopener">
+        <FontAwesomeIcon size="sm" icon={faCodeBranch} /> {this.props.forksCount}
+        <ThrottledTooltip
+          target="project-forks"
+          tooltip="Forks" />
+      </Button>
+    ];
     return (
       <Fragment>
-        <Button className="btn-outline-rk-green" id="fork-project"
-          disabled={this.props.forkProjectDisabled} onClick={this.toggleFunction}>
-          Fork
-          <ThrottledTooltip
-            target="fork-project"
-            tooltip="Fork this project" />
-        </Button>
+        <RoundButtonGroup buttons={buttons}/>
         <Modal isOpen={this.state.open} toggle={this.toggleFunction}>
           {content}
         </Modal>
@@ -437,17 +452,9 @@ class ProjectViewHeaderOverview extends Component {
                 forkProjectDisabled={forkProjectDisabled}
                 projectVisibility={this.props.metadata.visibility}
                 user={this.props.user}
+                forksCount={metadata.forksCount}
+                externalUrl={this.props.externalUrl}
               />
-              <Button
-                id="project-forks"
-                className="btn-outline-rk-green btn-icon-text"
-                disabled={forkProjectDisabled}
-                href={`${this.props.externalUrl}/-/forks`} target="_blank" rel="noreferrer noopener">
-                <FontAwesomeIcon size="sm" icon={faCodeBranch} /> {metadata.forksCount}
-                <ThrottledTooltip
-                  target="project-forks"
-                  tooltip="Forks" />
-              </Button>
               <div id="project-stars">
                 <Button
                   className="btn-outline-rk-green btn-icon-text"
@@ -488,13 +495,11 @@ function StartSessionButton(props) {
     </Link>
   );
   return (
-    <ButtonGroup size="sm" className="ms-1">
-      <ButtonWithMenu className="startButton" size="sm" default={defaultAction} color="rk-green">
-        <DropdownItem>
-          <Link className="text-decoration-none" to={launchNotebookUrl}>Start with options</Link>
-        </DropdownItem>
-      </ButtonWithMenu>
-    </ButtonGroup>
+    <ButtonWithMenu className="startButton" size="sm" default={defaultAction} color="rk-green" isPrincipal={true}>
+      <DropdownItem>
+        <Link className="text-decoration-none" to={launchNotebookUrl}>Start with options</Link>
+      </DropdownItem>
+    </ButtonWithMenu>
   );
 }
 

--- a/client/src/project/new/components/SubmitFormButton.tsx
+++ b/client/src/project/new/components/SubmitFormButton.tsx
@@ -68,7 +68,7 @@ const SubmitFormButton = ({ input, meta, importingDataset, handlers }: SubmitFor
   );
   // when is also importing a new dataset show a different submit button
   const button = !importingDataset ? (
-    <ButtonWithMenu color="rk-green" default={createProject} direction="up">
+    <ButtonWithMenu color="rk-green" default={createProject} direction="up" isPrincipal={true}>
       {createLink}
     </ButtonWithMenu>
   ) : (

--- a/client/src/styles/bootstrap_ext/_button.scss
+++ b/client/src/styles/bootstrap_ext/_button.scss
@@ -15,19 +15,26 @@ $borderRadius: 1000px;
   border-radius: 0;
   padding: 5px 10px;
 }
-.btn-with-menu .btn:nth-child(1) {
+.btn-with-menu {
   border-radius: 1000px;
+}
+
+.btn-with-menu .btn:nth-child(1) {
+  border-radius: 1000px 0 0 1000px;
   padding: 5px 20px;
-  margin-right: 5px;
+  margin-right: 1px;
 }
+
+.btn-with-menu .btn-outline-rk-green.btn:nth-child(1) {
+  margin-right: 0;
+}
+
 .btn-with-menu .btn:nth-child(2) {
-  background-color: transparent;
-  border: none;
   box-shadow: none;
+  border-radius: 0 1000px 1000px 0;
+  border-left: 1px solid;
 }
-.btn-with-menu .btn:nth-child(2):focus {
-  color: $rk-green-highlight;
-}
+
 .btn-with-menu-options svg {
   margin-right: 12px;
 }
@@ -198,6 +205,7 @@ $borderRadius: 1000px;
   &:hover, &:focus, &.active {
     background-color: transparent;
     color: $rk-green-highlight;
+    border-color: $rk-green;
   }
   &:disabled {
     color: $rk-green;
@@ -212,6 +220,7 @@ $borderRadius: 1000px;
   &:hover, &:focus, &.active {
     background-color: transparent;
     color: $rk-pink-highlight;
+    border-color: $rk-pink;
   }
   &.disabled{
     background-color: transparent;
@@ -263,7 +272,7 @@ $borderRadius: 1000px;
   background-color: transparent;
 }
 
-.btn-group:not(.btn-with-menu) {
+.btn-group:not(.btn-with-menu, .round-button-group) {
   border-radius: 8px;
 
   button {
@@ -309,4 +318,18 @@ $borderRadius: 1000px;
 
 .fullscreen-back-button {
   padding: 5px 0 5px 16px;
+}
+
+.round-button-group {
+  .btn:first-child {
+    border-radius: 1000px 0 0 1000px;
+    padding-right: 20px;
+    padding-left: 20px;
+  }
+
+  .btn:last-child {
+    border-radius: 0 1000px 1000px 0;
+    padding-right: 20px;
+    padding-left: 20px;
+  }
 }

--- a/client/src/utils/components/buttons/Button.js
+++ b/client/src/utils/components/buttons/Button.js
@@ -24,13 +24,15 @@
 
 import React, { Fragment, useState } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faEllipsisV, faSyncAlt } from "@fortawesome/free-solid-svg-icons";
+import { faSyncAlt } from "@fortawesome/free-solid-svg-icons";
 import { Link } from "react-router-dom";
 import { Button, ButtonDropdown, DropdownToggle, DropdownMenu, UncontrolledTooltip, Col } from "reactstrap";
+import { ButtonGroup } from "reactstrap";
 import { simpleHash } from "../../helpers/HelperFunctions";
 import { SuccessLabel } from "../formlabels/FormLabels";
 import { Loader } from "../Loader";
 import { ThrottledTooltip } from "../Tooltip";
+import { ChevronDown } from "../../ts-wrappers";
 
 /**
  * A button with a menu (dropdown button)
@@ -39,25 +41,26 @@ import { ThrottledTooltip } from "../Tooltip";
  * @param {[DropdownItem]} [children] - The items to show in the menu
  * @param {"rk-blue" | "rk-green"| "rk-pink" } props.color - Indicate the color of the button
  * @param {string} props.id - Identifier
+ * @param {boolean} props.isPrincipal -  Indicate if is principal or secondary button
  */
 function ButtonWithMenu(props) {
   const [dropdownOpen, setOpen] = useState(false);
   const toggleOpen = () => setOpen(!dropdownOpen);
   const size = (props.size) ? props.size : "md";
   let bgColor = props.color || "rk-green";
+  const classes = props.isPrincipal ? "" : `btn-outline-${bgColor}`;
 
   const options = props.children ?
     (<>
-      <DropdownToggle data-cy="more-menu" >
-        <FontAwesomeIcon
-          data-cy="more-options-button"
-          className={`text-${props.color || "rk-green"} btn-with-menu-icon`} icon={faEllipsisV}/>
+      <DropdownToggle data-cy="more-menu" className={`${props.className} ${classes}`} >
+        <ChevronDown data-cy="more-options-button" size="20" className="btn-with-menu-icon" />
       </DropdownToggle>
       <DropdownMenu className="btn-with-menu-options" end>
         {props.children}
       </DropdownMenu>
     </>)
     : null;
+
 
   return <ButtonDropdown
     id={props.id}
@@ -166,4 +169,16 @@ function CardButton({ icon, color, handleClick }) {
   );
 }
 
-export { RefreshButton, ButtonWithMenu, CardButton, GoBackButton, InlineSubmitButton };
+/**
+ * Round Button group
+ * @param {IntrinsicAttributes & Element[]} buttons - Buttons to include in the group button
+ */
+function RoundButtonGroup({ buttons }) {
+  return (
+    <ButtonGroup className={`round-button-group`}>
+      {buttons}
+    </ButtonGroup>
+  );
+}
+
+export { RefreshButton, ButtonWithMenu, CardButton, GoBackButton, InlineSubmitButton, RoundButtonGroup };

--- a/client/src/utils/components/buttons/Buttons.stories.tsx
+++ b/client/src/utils/components/buttons/Buttons.stories.tsx
@@ -19,6 +19,7 @@ import * as React from "react";
 import { Button } from "../../ts-wrappers";
 import { faPen } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { ButtonWithMenu, RoundButtonGroup } from "./Button";
 
 
 interface LabelsProps {
@@ -86,4 +87,41 @@ export const SecondaryPink = (args: LabelsProps) => (
 SecondaryPink.args = {
   text: "My Button",
 };
+
+const defaultAction = <Button key="button-main-primary">Main Action</Button>;
+const options = [
+  <Button key="button-a">Option A</Button>,
+  <Button key="button-B">Option B</Button>
+];
+export const menuWithOptionPrimary = (args: LabelsProps) => (
+  <>
+    <ButtonWithMenu
+      default={defaultAction}
+      isPrincipal={true}
+      color="rk-green">
+      {options}
+    </ButtonWithMenu>
+  </>
+);
+const defaultActionSecondary = <Button key="button-a" className="btn-outline-rk-green">Main Action</Button>;
+export const menuWithOptionSecondary = (args: LabelsProps) => (
+  <>
+    <ButtonWithMenu
+      default={defaultActionSecondary}
+      isPrincipal={false}
+      color="rk-green">
+      {options}
+    </ButtonWithMenu>
+  </>
+);
+
+const optionsGroupButton = [
+  <Button key="button-x" className="btn-outline-rk-green">Option X</Button>,
+  <Button key="button-y" className="btn-outline-rk-green">Option y</Button>
+];
+export const roundButtonGroup = (args: LabelsProps) => (
+  <>
+    <RoundButtonGroup buttons={optionsGroupButton} />
+  </>
+);
 

--- a/client/src/utils/ts-wrappers.js
+++ b/client/src/utils/ts-wrappers.js
@@ -54,6 +54,7 @@ import {
   CardList as WrappedCardList,
   CaretDownFill as WrappedCaretDownFill,
   CaretRightFill as WrappedCaretRightFill,
+  ChevronDown as WrappedChevronDown,
   Diagram2 as WrappedDiagram2,
   Diagram3 as WrappedDiagram3,
   HddStack as WrappedHddStack,
@@ -132,6 +133,10 @@ function CaretDownFill(props) {
 
 function CaretRightFill(props) {
   return <WrappedCaretRightFill {...props} />;
+}
+
+function ChevronDown(props) {
+  return <WrappedChevronDown {...props} />;
 }
 
 function Diagram2(props) {
@@ -341,4 +346,4 @@ export { UncontrolledPopover, UncontrolledTooltip };
 export { ArrowLeft, Briefcase, CardList, Diagram3, Download, Globe, HddStack, InfoCircle, Journals, Lock };
 export { People, Save, StopCircle };
 export { Nav, NavItem, NavLink, TabContent, TabPane };
-export { Bookmarks, CaretDownFill, CaretRightFill, Calendar4, Diagram2, XLg };
+export { Bookmarks, CaretDownFill, CaretRightFill, Calendar4, ChevronDown, Diagram2, XLg };

--- a/tests/cypress/support/sessions/gui_commands.ts
+++ b/tests/cypress/support/sessions/gui_commands.ts
@@ -22,5 +22,5 @@ Cypress.Commands.add("gui_open_logs", () => {
 });
 
 Cypress.Commands.add("gui_open_session", () => {
-  cy.get(".sessionsButton").click();
+  cy.get_cy("open-session").click();
 });


### PR DESCRIPTION
PR to add button with menu and round group button styles.

![Screenshot 2022-12-20 at 14 47 14](https://user-images.githubusercontent.com/43388408/208681777-479c247a-8431-4c1c-b3a1-caf076813d2e.png)

![split-button](https://user-images.githubusercontent.com/43388408/208681458-c31cbcb9-9a8c-474b-96bc-d6a05ed2d613.gif)

Closes #2200 

/deploy #persist