### PR TITLE
fix(client)!: update KG status indexing percentage

### DIFF
--- a/client/src/file/KnowledgeGraphStatus.present.js
+++ b/client/src/file/KnowledgeGraphStatus.present.js
@@ -45,15 +45,16 @@ function KnowledgeGraphStatus(props) {
   const { error, progress, webhookJustCreated } = props;
   if (error != null) {
     return <MigrationWarnAlert>
-      Knowledge Graph integration must be activated to view the lineage, but&nbsp;
+      Knowledge Graph integration must be activated to view the lineage, but
       there is a problem with the knowledge graph integration for this project. To resolve this problem,
-      you should contact the development team on&nbsp;
+      you should contact the development team on {" "}
       <a href={Links.GITTER}
-        target="_blank" rel="noreferrer noopener">Gitter</a> or&nbsp;
+        target="_blank" rel="noreferrer noopener">Gitter</a> or{" "}
       <a href={Links.GITHUB}
         target="_blank" rel="noreferrer noopener">GitHub</a>.
     </MigrationWarnAlert>;
   }
+
   if (progress == null) {
     return (
       <Loader />
@@ -111,7 +112,7 @@ function KnowledgeGraphStatus(props) {
     return (
       <div>
         <Alert color="primary">
-          <p>Knowledge Graph is building... {parseInt(progress)}%</p>
+          <p>Knowledge Graph is building... {progress}%</p>
           <Progress value={progress} />
         </Alert>
       </div>

--- a/client/src/project/Project.present.js
+++ b/client/src/project/Project.present.js
@@ -514,7 +514,7 @@ class ProjectViewHeader extends Component {
 class ProjectNav extends Component {
   render() {
     return (
-      <div className="pb-3 rk-search-bar pt-4 mt-1">
+      <div className="pb-3 rk-search-bar pt-4 mt-1" data-cy="project-navbar">
         <Col className="d-flex pb-2 mb-1 justify-content-start" md={12} lg={12}>
           <Nav pills className="nav-pills-underline">
             <NavItem>
@@ -617,7 +617,7 @@ class ProjectViewOverviewNav extends Component {
     //   <RenkuNavLink to={`${this.props.overviewUrl}/results`} title="Results" />
     // </NavItem>
     return (
-      <Nav className="flex-column nav-light nav-pills-underline">
+      <Nav className="flex-column nav-light nav-pills-underline" data-cy="project-overview-nav">
         <NavItem>
           <RenkuNavLink to={this.props.baseUrl} title="General" id="nav-overview-general" />
         </NavItem>
@@ -638,12 +638,12 @@ class ProjectViewOverviewNav extends Component {
 class ProjectViewOverview extends Component {
   render() {
     const { projectCoordinator } = this.props;
-    return <Col key="overview">
+    return <Col key="overview" data-cy="project-overview">
       <Row>
         <Col key="nav" sm={12} md={2}>
           <ProjectViewOverviewNav {...this.props} />
         </Col>
-        <Col key="content" sm={12} md={10}>
+        <Col key="content" sm={12} md={10} data-cy="project-overview-content">
           <Switch>
             <Route exact path={this.props.baseUrl} render={props => {
               return <ProjectViewGeneral readme={this.props.data.readme} {...this.props} />;

--- a/client/src/utils/components/progress/Progress.css
+++ b/client/src/utils/components/progress/Progress.css
@@ -34,7 +34,6 @@
 
 .progress-bar {
     height: var(--progress_height);
-    background-color: #E6E9ED;
     width: 100%;
     overflow: hidden;
     position: relative;

--- a/tests/cypress/fixtures/project/project-status-done.json
+++ b/tests/cypress/fixtures/project/project-status-done.json
@@ -1,0 +1,12 @@
+{
+  "activated": true,
+  "progress": {
+    "done": 5,
+    "total": 5,
+    "percentage": 100.0
+  },
+  "details": {
+    "status": "success",
+    "message": "triples store"
+  }
+}

--- a/tests/cypress/fixtures/project/project-status-processing.json
+++ b/tests/cypress/fixtures/project/project-status-processing.json
@@ -1,0 +1,12 @@
+{
+  "activated": true,
+  "progress": {
+    "done": 2,
+    "total": 5,
+    "percentage": 40.0
+  },
+  "details": {
+    "status": "in-progress",
+    "message": "generating triples"
+  }
+}

--- a/tests/cypress/support/renkulab-fixtures/projects.ts
+++ b/tests/cypress/support/renkulab-fixtures/projects.ts
@@ -261,7 +261,11 @@ function Projects<T extends FixturesConstructor>(Parent: T) {
         body: { message: "Hook valid" }
       }).as(validationName);
       cy.intercept("/ui-server/api/projects/*/graph/status", {
-        body: { done: 1, total: 1, progress: 100.0 }
+        body: {
+          activated: true,
+          progress: { done: 5, total: 5, percentage: 100.0 },
+          details: { status: "success", message: "triples store" }
+        }
       });
       cy.intercept(`/ui-server/api/renku/${coreVersion}/version`, {
         body: {
@@ -351,6 +355,18 @@ function Projects<T extends FixturesConstructor>(Parent: T) {
       const fixture = this.useMockedData ? { fixture: result } : undefined;
       cy.intercept(
         `/ui-server/api/groups/${namespace}`,
+        fixture
+      ).as(name);
+      return this;
+    }
+
+    getStatusProcessing(finished = false, name = "getStatusProcessing") {
+      const result = finished ?
+        "project/project-status-done.json" :
+        "project/project-status-processing.json";
+      const fixture = this.useMockedData ? { fixture: result } : undefined;
+      cy.intercept(
+        "/ui-server/api/projects/*/graph/status",
         fixture
       ).as(name);
       return this;


### PR DESCRIPTION
This adapts the UI to the [new response from the KG status endpoint](https://github.com/SwissDataScienceCenter/renku-ui/issues/2230), and restores the percentage indication when indexing a project.

As a comparison, on the following video the current PR deployment is on the left and "dev" on the right.

![Peek 2022-12-21 14-15](https://user-images.githubusercontent.com/43481553/208915750-2b7d3ace-a7fe-4c6f-a4c0-4319c1396d80.gif)

BREAKING CHANGE: requires a yet-unreleased version of renku-graph

re https://github.com/SwissDataScienceCenter/renku-graph/pull/1253
/deploy renku-graph=development #persist #cypress
