### PR TITLE
fix(client): improve headers layout

### DIFF
--- a/client/src/dataset/Dataset.present.js
+++ b/client/src/dataset/Dataset.present.js
@@ -389,18 +389,19 @@ export default function DatasetView(props) {
       }
       <div className="mb-4">
         <EntityHeader
-          title={dataset.title}
-          description=""
-          itemType="dataset"
-          tagList={dataset.keywords}
           creators={dataset?.published?.creator}
-          labelCaption={datasetPublished ? "Published" : "Created"}
-          timeCaption={timeCaption}
+          description=""
           devAccess={false}
-          url={dataset.identifier}
+          hideEmptyTags={true}
+          imageUrl={imageUrl}
+          itemType="dataset"
+          labelCaption={datasetPublished ? "Published" : "Created"}
           links={linksHeader}
           otherButtons={[deleteOption, modifyButton, addToProject]}
-          imageUrl={imageUrl}
+          tagList={dataset.keywords}
+          timeCaption={timeCaption}
+          title={dataset.title}
+          url={dataset.identifier}
         />
       </div>
       <DisplayMetadata

--- a/client/src/project/Project.present.js
+++ b/client/src/project/Project.present.js
@@ -270,22 +270,23 @@ function ProjectViewHeaderMinimal(props) {
   return (
     <Fragment>
       <EntityHeader
-        title={props.metadata.title}
-        visibility={props.metadata.visibility}
-        description={props.metadata.description}
-        itemType="project"
-        slug={slug}
-        tagList={props.metadata.tagList}
         creators={props.metadata.owner ? [props.metadata.owner] : []}
-        labelCaption={"Updated"}
-        timeCaption={props.metadata.lastActivityAt}
-        launchNotebookUrl={props.launchNotebookUrl}
-        sessionAutostartUrl={props.sessionAutostartUrl}
+        description={props.metadata.description}
         devAccess={props.metadata.accessLevel > ACCESS_LEVELS.DEVELOPER}
-        url={projectUrl}
-        links={linksHeader}
-        statusButton={statusButton}
+        hideEmptyTags={true}
         imageUrl={props.metadata.avatarUrl}
+        itemType="project"
+        labelCaption={"Updated"}
+        launchNotebookUrl={props.launchNotebookUrl}
+        links={linksHeader}
+        sessionAutostartUrl={props.sessionAutostartUrl}
+        slug={slug}
+        statusButton={statusButton}
+        tagList={props.metadata.tagList}
+        timeCaption={props.metadata.lastActivityAt}
+        title={props.metadata.title}
+        url={projectUrl}
+        visibility={props.metadata.visibility}
       />
     </Fragment>);
 }

--- a/client/src/styles/components/_renku_cards.scss
+++ b/client/src/styles/components/_renku_cards.scss
@@ -74,6 +74,12 @@
   line-height: 150px;
 }
 
+.card-bg-title--small {
+  position: absolute;
+  font-size: 100px;
+  margin-top: 30px;
+}
+
 .card-title {
   font-size: 27px;
   color: var(--bs-dark);
@@ -82,6 +88,7 @@
 }
 
 .card-tags {
+  margin-top: 8px;
   min-height: 24px;
 }
 

--- a/client/src/styles/components/_renku_cards.scss
+++ b/client/src/styles/components/_renku_cards.scss
@@ -16,6 +16,7 @@
   height: 198px;
   border-radius: 8px 8px 0 0;
   background-size: cover;
+  overflow: hidden;
 }
 .card-header-entity--large {
   height: 130px;
@@ -75,9 +76,9 @@
 }
 
 .card-bg-title--small {
-  position: absolute;
   font-size: 100px;
-  margin-top: 30px;
+  margin-top: 0;
+  padding-top: 30px;
 }
 
 .card-title {

--- a/client/src/utils/components/entities/Tags.tsx
+++ b/client/src/utils/components/entities/Tags.tsx
@@ -28,11 +28,12 @@ import { RootStateOrAny, useSelector } from "react-redux";
  */
 
 export interface EntityTagsProps {
+  hideEmptyTags: boolean;
+  multiline: boolean;
   tagList: string[];
-  multiline: boolean
 }
 
-function EntityTags ({ tagList, multiline }: EntityTagsProps) {
+function EntityTags ({ hideEmptyTags, multiline, tagList }: EntityTagsProps) {
   const ref = useRef(null);
   const multilineStyles = multiline ? "d-flex flex-wrap text-rk-text-light" : "text-truncate text-dark";
   const isUpdatingValue = useSelector((state: RootStateOrAny ) =>
@@ -45,6 +46,9 @@ function EntityTags ({ tagList, multiline }: EntityTagsProps) {
       </div>
     );
   }
+
+  if (!tagList?.length && hideEmptyTags)
+    return null;
 
   const tooltip = tagList?.length > 0 ?
     <ThrottledTooltip target={ref} tooltip={tagList?.map(tag => `#${tag}`).join(", ")} /> : null;

--- a/client/src/utils/components/entityHeader/EntityHeader.scss
+++ b/client/src/utils/components/entityHeader/EntityHeader.scss
@@ -6,6 +6,7 @@
     border-radius: 8px;
     background-position-x: center;
     background-position-y: top;
+    overflow: hidden;
 }
 
 .entity-type-visibility {

--- a/client/src/utils/components/entityHeader/EntityHeader.tsx
+++ b/client/src/utils/components/entityHeader/EntityHeader.tsx
@@ -43,6 +43,7 @@ export interface EntityHeaderProps {
   description: string;
   devAccess: boolean;
   email?: string;
+  hideEmptyTags?: boolean;
   itemType: EntityType;
   labelCaption: string;
   launchNotebookUrl: string;
@@ -61,7 +62,7 @@ export interface EntityHeaderProps {
 }
 
 function EntityHeader({
-  creators, description, devAccess, itemType, labelCaption, launchNotebookUrl, links,
+  creators, description, devAccess, hideEmptyTags = false, itemType, labelCaption, launchNotebookUrl, links,
   otherButtons, sessionAutostartUrl, showFullHeader = true, slug, statusButton, tagList, timeCaption,
   title, url, visibility, imageUrl
 }: EntityHeaderProps) {
@@ -78,6 +79,7 @@ function EntityHeader({
       <div className="entity-image">
         <div style={imageStyles}
           className={`header-entity-image ${!imageUrl ? `card-header-entity--${itemType}` : ""}`}>
+          <div className="card-bg-title card-bg-title--small">{title}</div>
         </div>
       </div>
       <div className="entity-time-tags">
@@ -86,7 +88,7 @@ function EntityHeader({
           showTooltip={true}
           time={timeCaption}
           className="text-rk-text-light"/>
-        <EntityTags tagList={tagList} multiline={true} />
+        <EntityTags tagList={tagList} multiline={true} hideEmptyTags={hideEmptyTags} />
       </div>
       <div className="entity-action d-flex align-items-baseline gap-1">
         {mainButton}


### PR DESCRIPTION
This PR addresses a few layout details in the new headers.

* Restore the missing title in the default avatar on the projects and datasets detail pages.
* Add minimal margin to entity tags to prevent collapsing into the description (in the image, the previous version with the collapsed content)
    ![Screenshot_20230103_144933](https://user-images.githubusercontent.com/43481553/210372653-8699ffa9-e388-4120-b28d-d9a6bfbdcb2d.png)
* Remove extra space on the detail pages when tags are missing. This happened only on small and medium window sizes (in the image, the previous version with the extra space on the bottom)
    ![Screenshot_20230103_145107](https://user-images.githubusercontent.com/43481553/210372887-2a593d85-bc91-4291-9247-08a70ba89338.png)


/deploy renku=renku-ui-2.15.0-tests #persist #cypress