### PR TITLE
build: release 2.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changes
 
+# [2.16.0](https://github.com/SwissDataScienceCenter/renku-ui/compare/2.15.0...2.16.0) (2023-01-09)
+
+### Features
+
+* update realtime the KG status indexing percentage ([#2255](https://github.com/SwissDataScienceCenter/renku-ui/issues/2255))
+* refresh the developer documentation ([#2165](https://github.com/SwissDataScienceCenter/renku-ui/issues/2165), [#2275](https://github.com/SwissDataScienceCenter/renku-ui/issues/2275))
+
+### BREAKING CHANGES
+
+* Requires renku-graph v2.26.0 or greater
+
+
 ## [2.15.0](https://github.com/SwissDataScienceCenter/renku-ui/compare/2.14.0...2.15.0) (2023-01-04)
 
 ### Bug Fixes

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "renku-ui",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "renku-ui",
-      "version": "2.15.0",
+      "version": "2.16.0",
       "dependencies": {
         "@ckeditor/ckeditor5-react": "^5.0.2",
         "@fortawesome/fontawesome-svg-core": "^1.2.35",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "renku-ui",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "private": true,
   "dependencies": {
     "@ckeditor/ckeditor5-react": "^5.0.2",

--- a/helm-chart/renku-ui/Chart.yaml
+++ b/helm-chart/renku-ui/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.0'
 description: A Helm chart for the Renku UI
 name: renku-ui
 icon: https://github.com/SwissDataScienceCenter/renku-sphinx-theme/raw/master/renku_sphinx_theme/static/favicon.png
-version: 2.15.0
+version: 2.16.0

--- a/helm-chart/renku-ui/values.yaml
+++ b/helm-chart/renku-ui/values.yaml
@@ -53,7 +53,7 @@ client:
 
   image:
     repository: renku/renku-ui
-    tag: "2.15.0"
+    tag: "2.16.0"
     pullPolicy: IfNotPresent
 
     ## Optionally specify an array of imagePullSecrets.
@@ -182,7 +182,7 @@ server:
 
   image:
     repository: renku/renku-ui-server
-    tag: "2.15.0"
+    tag: "2.16.0"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "renku-ui-server",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "renku-ui-server",
-      "version": "2.15.0",
+      "version": "2.16.0",
       "dependencies": {
         "@sentry/node": "^6.19.7",
         "@sentry/tracing": "^6.19.7",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "renku-ui-server",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "description": "Server for renku API",
   "private": true,
   "main": "dist/index.js",


### PR DESCRIPTION
Release including the KG status endpoint breaking change

/deploy #persist #cypress renku=auto-update/renku-graph-2.26.0
