### PR TITLE
fix(client): align elements in the datasets file browser

### DIFF
--- a/client/src/utils/components/FileExplorer.js
+++ b/client/src/utils/components/FileExplorer.js
@@ -104,37 +104,28 @@ class TreeNode extends Component {
     const eltClassName = order + " " + hidden;
     if (this.props.node.jsonObj !== null) {
       elementToRender = this.props.insideProject ?
-        <div className={eltClassName}>
+        <div className={`fs-element ${eltClassName}`} data-cy="dataset-fs-element">
           <Link to= {`${this.props.lineageUrl}/${this.props.node.jsonObj.atLocation}`} >
-            <div className="fs-element" data-cy="dataset-fs-element">
-              {icon} {this.props.node.name}
-            </div>
+            {icon} {this.props.node.name}
           </Link>
         </div>
         :
-        <div className={eltClassName}>
-          <div className="fs-element" data-cy="dataset-fs-element" style={{ cursor: "default" }}>
-            {icon} {this.props.node.name}
-          </div>
+        <div className={`fs-element ${eltClassName}`} data-cy="dataset-fs-element" style={{ cursor: "default" }}>
+          <a>{icon} {this.props.node.name}</a>
         </div>
       ;
     }
     else {
-      elementToRender = this.state.childrenOpen ?
-        <div className={eltClassName} >
-          <div className="fs-element" data-cy="dataset-fs-folder" onClick={this.handleIconClick} >
-            {icon} {this.props.node.name}
-          </div>
-          <div className="ps-3">
-            {children}
-          </div>
+      const secondElement = this.state.childrenOpen ?
+        (<div className="ps-3">{children}</div>) :
+        null;
+
+      elementToRender = (<>
+        <div className={`fs-element ${eltClassName}`} data-cy="dataset-fs-folder" onClick={this.handleIconClick}>
+          <a>{icon} {this.props.node.name}</a>
         </div>
-        :
-        <div className={eltClassName} >
-          <div className="fs-element" data-cy="dataset-fs-folder" onClick={this.handleIconClick}>
-            {icon} {this.props.node.name}
-          </div>
-        </div>;
+        {secondElement}
+      </>);
     }
     return elementToRender;
   }


### PR DESCRIPTION
Elements rendered on the file browser were not properly aligned. This PR fixes it

![image](https://user-images.githubusercontent.com/43481553/213487365-db2ab4b5-aad8-4b34-9f3e-94c812384862.png)

/deploy #persist #cypress
