### PR TITLE
build(server): remove default autoscaling settings

### DIFF
--- a/helm-chart/renku-ui/values.yaml
+++ b/helm-chart/renku-ui/values.yaml
@@ -224,8 +224,8 @@ server:
 
   ## Configure autoscaling
   # configure autoscale only where needed
-  # autoscaling:
-  #   enabled: true
+  autoscaling:
+    enabled: false
   #   minReplicas: 2
   #   maxReplicas: 5
   #   cpuUtilization: 70

--- a/helm-chart/renku-ui/values.yaml
+++ b/helm-chart/renku-ui/values.yaml
@@ -226,9 +226,9 @@ server:
   # configure autoscale only where needed
   autoscaling:
     enabled: false
-  #   minReplicas: 2
-  #   maxReplicas: 5
-  #   cpuUtilization: 70
+    # minReplicas: 2
+    # maxReplicas: 5
+    # cpuUtilization: 70
 
   resources:
     requests:

--- a/helm-chart/renku-ui/values.yaml
+++ b/helm-chart/renku-ui/values.yaml
@@ -223,11 +223,12 @@ server:
     #      - chart-example.local
 
   ## Configure autoscaling
-  autoscaling:
-    enabled: true
-    minReplicas: 1
-    maxReplicas: 5
-    cpuUtilization: 95
+  # configure autoscale only where needed
+  # autoscaling:
+  #   enabled: true
+  #   minReplicas: 2
+  #   maxReplicas: 5
+  #   cpuUtilization: 70
 
   resources:
     requests:


### PR DESCRIPTION
Disable UI server default autoscaling settings since it might collide with settings in some deployments (E.G. in the CI deployments where the reserved resources are _very_ low).

/deploy renku=000-connect-btn #persist #cypress
