### PR TITLE
Release 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fixes
 
-* restrict visibility on fork ([#2296](https://github.com/SwissDataScienceCenter/renku-ui/issues/2296), [#2299](https://github.com/SwissDataScienceCenter/renku-ui/issues/2299))
+* restrict visibility options to be compatible with namespace and parent project in fork dialog ([#2296](https://github.com/SwissDataScienceCenter/renku-ui/issues/2296), [#2299](https://github.com/SwissDataScienceCenter/renku-ui/issues/2299))
 
 # [3.0.0](https://github.com/SwissDataScienceCenter/renku-ui/compare/2.16.0...3.0.0) (2023-01-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changes
 
+# [3.1.0](https://github.com/SwissDataScienceCenter/renku-ui/compare/3.0.0...3.1.0) (2023-01-24)
+
+### Features
+
+* change text on the quickstart session button from "start" to "connect" when a session is running ([#1381](https://github.com/SwissDataScienceCenter/renku-ui/issues/1381), [#2268](https://github.com/SwissDataScienceCenter/renku-ui/issues/2268))
+
+### Bug Fixes
+
+* restrict visibility on fork ([#2296](https://github.com/SwissDataScienceCenter/renku-ui/issues/2296), [#2299](https://github.com/SwissDataScienceCenter/renku-ui/issues/2299))
+
 # [3.0.0](https://github.com/SwissDataScienceCenter/renku-ui/compare/2.16.0...3.0.0) (2023-01-17)
 
 ### Features

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "renku-ui",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "renku-ui",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "dependencies": {
         "@ckeditor/ckeditor5-react": "^5.0.2",
         "@fortawesome/fontawesome-svg-core": "^1.2.35",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "renku-ui",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "private": true,
   "dependencies": {
     "@ckeditor/ckeditor5-react": "^5.0.2",

--- a/client/src/project/overview/ProjectOverview.present.js
+++ b/client/src/project/overview/ProjectOverview.present.js
@@ -185,12 +185,12 @@ class OverviewCommits extends Component {
           </span>
           <div>
             {badge}
-            <RefreshButton action={commits.refresh} updating={commits.fetching} message="Refresh commits" />
+            <RefreshButton action={commits.refresh} updating={commits.fetching}
+              message="Refresh commits" dataCy="refresh-commits" />
             {buttonGit}
           </div>
         </CardHeader>
         <CardBody className="p-4 pt-3 pb-3 lh-lg">
-          {/* <CardBody className="p-0 lh-lg"> */}
           {body}
           {info}
         </CardBody>

--- a/client/src/utils/components/buttons/Button.js
+++ b/client/src/utils/components/buttons/Button.js
@@ -82,16 +82,21 @@ function ButtonWithMenu(props) {
  * @param {function} props.action - function to trigger when clicking on the button
  * @param {boolean} [props.updating] - pilot the spin, should be true when performing the action
  * @param {boolean} [props.message] - tooltip message to trigger on hover
+ * @param {boolean} [props.dataCy] - add data-cy property
  */
 function RefreshButton(props) {
   const id = "button_" + simpleHash(props.action.toString());
   const tooltip = props.message ?
     (<UncontrolledTooltip key="tooltip" placement="top" target={id}>{props.message}</UncontrolledTooltip>) :
     null;
+  let extraProps = {};
+  if (props.dataCy)
+    extraProps["data-cy"] = props.dataCy;
 
   return (
     <Fragment>
-      <Button key="button" className="ms-2 p-0" color="link" size="sm" id={id} onClick={() => props.action()}>
+      <Button key="button" className="ms-2 p-0" color="link" size="sm" id={id}
+        onClick={() => props.action()} {...extraProps}>
         <FontAwesomeIcon icon={faSyncAlt} spin={props.updating} />
       </Button>
       {tooltip}

--- a/helm-chart/renku-ui/Chart.yaml
+++ b/helm-chart/renku-ui/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.0'
 description: A Helm chart for the Renku UI
 name: renku-ui
 icon: https://github.com/SwissDataScienceCenter/renku-sphinx-theme/raw/master/renku_sphinx_theme/static/favicon.png
-version: 3.0.0
+version: 3.1.0

--- a/helm-chart/renku-ui/values.yaml
+++ b/helm-chart/renku-ui/values.yaml
@@ -53,7 +53,7 @@ client:
 
   image:
     repository: renku/renku-ui
-    tag: "3.0.0"
+    tag: "3.1.0"
     pullPolicy: IfNotPresent
 
     ## Optionally specify an array of imagePullSecrets.
@@ -182,7 +182,7 @@ server:
 
   image:
     repository: renku/renku-ui-server
-    tag: "3.0.0"
+    tag: "3.1.0"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "renku-ui-server",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "renku-ui-server",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "dependencies": {
         "@sentry/node": "^6.19.7",
         "@sentry/tracing": "^6.19.7",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "renku-ui-server",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Server for renku API",
   "private": true,
   "main": "dist/index.js",


### PR DESCRIPTION
Release 3.1.0

This includes another minor PR to add a `data-cy` value to the "refresh commits" buttons -- it helps for the Cypress acceptance tests.

/deploy renku=000-connect-btn #persist #cypress