### PR TITLE
chore(client): update wrong label on search page

### DIFF
--- a/client/src/utils/helpers/KgSearchFunctions.ts
+++ b/client/src/utils/helpers/KgSearchFunctions.ts
@@ -54,7 +54,7 @@ export const mapSearchResultToEntity =
       description: entity.description,
       tagList: entity.keywords,
       timeCaption: entity.date,
-      labelCaption: "Creation",
+      labelCaption: "Created",
       creators,
       itemType: entity.type,
       slug: entity.type === EntityType.Project ? entity.namespace : "",


### PR DESCRIPTION
Fix wrong label on search page.
`Creation` --> `Created`

<img width="238" alt="image" src="https://user-images.githubusercontent.com/43481553/215356856-cfd47f1d-310e-40a7-8a8d-7a7bca9bb6ba.png">

/deploy #persist #cypress renku=update-renku-ui-3.1.0
