### PR TITLE
feat: add session actions in dashboard (#2305)

### DIFF
--- a/client/src/features/dashboard/components/ProjectsDashboard.tsx
+++ b/client/src/features/dashboard/components/ProjectsDashboard.tsx
@@ -204,7 +204,6 @@ interface SessionsToShowProps {
   currentSessions: Notebook["data"][];
 }
 function SessionsToShow({ currentSessions }: SessionsToShowProps) {
-  // @ts-ignore
   const { client } = useContext(AppContext);
   const [items, setItems] = useState<any[]>([]);
   // serverLogs

--- a/client/src/features/dashboard/components/ProjectsDashboard.tsx
+++ b/client/src/features/dashboard/components/ProjectsDashboard.tsx
@@ -40,6 +40,8 @@ import { formatProjectMetadata } from "../../../utils/helpers/ProjectFunctions";
 import ListBarSession from "../../../utils/components/list/ListBarSessions";
 import { getFormattedSessionsAnnotations } from "../../../utils/helpers/SessionFunctions";
 import { Notebook } from "../../../notebooks/components/Session";
+import useGetSessionLogs from "../../../utils/customHooks/UseGetSessionLogs";
+import { useStopSessionMutation } from "../../session/sessionApi";
 
 interface ProjectAlertProps {
   total?: number;
@@ -202,9 +204,15 @@ interface SessionsToShowProps {
   currentSessions: Notebook["data"][];
 }
 function SessionsToShow({ currentSessions }: SessionsToShowProps) {
-  const [items, setItems] = useState<SessionProject[]>([]);
   // @ts-ignore
   const { client } = useContext(AppContext);
+  const [items, setItems] = useState<any[]>([]);
+  // serverLogs
+  const [serverLogs, setServerLogs] = useState("");
+  const [showLogs, setShowLogs] = useState<boolean>(false);
+  const { logs, fetchLogs } = useGetSessionLogs(serverLogs, showLogs);
+  //stop session
+  const [stopSession] = useStopSessionMutation();
 
   useEffect( () => {
     const getProjectCurrentSessions = async () => {
@@ -229,6 +237,8 @@ function SessionsToShow({ currentSessions }: SessionsToShowProps) {
         visibility={item.visibility} slug={item.slug} creators={item.creators}
         timeCaption={item.timeCaption} description={item.description} id={item.id}
         url={item.url} title={item.title} itemType={EntityType.Project} imageUrl={item.imageUrl}
+        showLogs={showLogs} setShowLogs={setShowLogs} setServerLogs={setServerLogs}
+        stopSession={stopSession} fetchLogs={fetchLogs} logs={logs}
       />;
     });
     return <div className="session-list">{element}</div>;

--- a/client/src/features/session/sessionApi.ts
+++ b/client/src/features/session/sessionApi.ts
@@ -1,0 +1,57 @@
+/*!
+ * Copyright 2023 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/dist/query/react";
+
+interface StopSessionArgs {
+  serverName: string;
+}
+
+interface GetLogsArgs {
+  serverName: string;
+  lines: number;
+}
+
+export const sessionApi = createApi({
+  reducerPath: "sessionApi",
+  baseQuery: fetchBaseQuery({ baseUrl: "/ui-server/api/notebooks/" }),
+  tagTypes: [],
+  keepUnusedDataFor: 0,
+  endpoints: (builder) => ({
+    stopSession: builder.mutation<boolean, StopSessionArgs>({
+      query: (args) => {
+        return {
+          method: "DELETE",
+          url: `servers/${args.serverName}`,
+        };
+      },
+    }),
+    getLogs: builder.query<any, GetLogsArgs>({
+      query: (args) => {
+        return {
+          url: `logs/${args.serverName}`,
+          params: { max_lines: args.lines }
+        };
+      },
+    }),
+  }),
+});
+
+export const {
+  useStopSessionMutation,
+  useGetLogsQuery
+} = sessionApi;

--- a/client/src/landing/NavBar.js
+++ b/client/src/landing/NavBar.js
@@ -297,8 +297,9 @@ class LoggedInNavBar extends Component {
                   <RenkuNavLink to="/search" title="Search" id="link-search"
                     icon={searchIcon} className="d-flex gap-2 align-items-center" />
                 </NavItem>
-                <NavItem className="nav-item col-4 col-lg-auto pe-lg-4">
-                  <RenkuNavLink to="/sessions" title="Sessions" id="link-sessions" />
+                <NavItem id="link-dashboard" data-cy="link-dashboard" to="/"
+                  className="nav-item col-4 col-lg-auto pe-lg-4">
+                  <RenkuNavLink to="/" title="Dashboard" id="link-dashboard" />
                 </NavItem>
                 <NavItem className="nav-item col-1 col-lg-auto">
                   <RenkuToolbarItemPlus currentPath={this.props.location.pathname} />

--- a/client/src/project/Project.present.js
+++ b/client/src/project/Project.present.js
@@ -476,7 +476,7 @@ class ProjectViewHeaderOverview extends Component {
 }
 
 
-function getShowSessionURL(annotations, serverName) {
+export function getShowSessionURL(annotations, serverName) {
   return Url.get(Url.pages.project.session.show, {
     namespace: annotations["namespace"],
     path: annotations["projectName"],

--- a/client/src/utils/components/Logs.tsx
+++ b/client/src/utils/components/Logs.tsx
@@ -39,15 +39,17 @@ import { LOG_ERROR_KEY } from "../../notebooks/Notebooks.state";
 import { faSyncAlt
 } from "@fortawesome/free-solid-svg-icons";
 
-interface ILogs {
+export interface ILogs {
   data: Record<string, string>;
   fetching: boolean;
   fetched: boolean;
-  show: string;
+  show: string | boolean;
 }
 
 function getLogsToShow(logs: ILogs) {
   const logsWithData: Record<string, string> = {};
+  if (!logs || logs.data === undefined)
+    return logsWithData;
   if (logs.data && typeof logs.data !== "string") {
     Object.keys(logs.data).map(key => {
       if (logs.data[key].length > 0)
@@ -57,7 +59,7 @@ function getLogsToShow(logs: ILogs) {
   return logsWithData;
 }
 
-interface IFetchableLogs {
+export interface IFetchableLogs {
   fetchLogs: (name: string, fullLogs?: boolean) => Promise<ILogs["data"]>;
   logs: ILogs;
 }
@@ -267,13 +269,13 @@ function SessionLogs(props: LogBodyProps) {
 interface EnvironmentLogsProps {
   annotations: Record<string, string>;
   fetchLogs: IFetchableLogs["fetchLogs"];
-  logs: ILogs;
+  logs?: ILogs;
   name: string;
   toggleLogs: (name:string) => unknown;
 }
 const EnvironmentLogs = ({ logs, name, toggleLogs, fetchLogs, annotations }: EnvironmentLogsProps) => {
 
-  if (!logs.show || logs.show !== name)
+  if (!logs?.show || logs?.show !== name || !logs)
     return null;
 
   return (

--- a/client/src/utils/components/list/ListBar.scss
+++ b/client/src/utils/components/list/ListBar.scss
@@ -111,7 +111,7 @@
 
 .container-sessions {
     display: grid;
-    grid-template-columns: 126px fit-content(80px) fit-content(200px) auto auto fit-content(50px) 150px;
+    grid-template-columns: 126px fit-content(80px) fit-content(200px) auto auto fit-content(30px) 150px;
     grid-template-rows: auto auto auto;
     grid-auto-rows: 1fr;
     gap: 0 20px;
@@ -153,8 +153,8 @@
         align-items: center;
     }
 
-    .text-session-status {
-        width: 55px;
+    .session-status-text {
+        width: 60px;
     }
 
     .session-time {
@@ -195,7 +195,7 @@
         .session-info, .entity-date {
             display: none;
         }
-        .text-session-status {
+        .session-status-text {
             width: 100%;
         }
         .session-time {
@@ -287,7 +287,7 @@
         .session-resources {
             display: none;
         }
-        .text-session-status {
+        .session-status-text {
             width: 100%;
         }
         .session-time {
@@ -358,7 +358,7 @@
         .session-resources, .session-info {
             display: none;
         }
-        .text-session-status {
+        .session-status-text {
             width: 100%;
         }
         .session-time {

--- a/client/src/utils/components/list/ListBarSessions.tsx
+++ b/client/src/utils/components/list/ListBarSessions.tsx
@@ -168,7 +168,6 @@ function ListBarSession(
     logs,
   }: ListBarSessionProps) {
 
-  // @ts-ignore
   const { client } = useContext(AppContext);
   const [commit, setCommit] = useState(null);
   const [sessionStatus, setSessionStatus] = useState(SessionStatus.starting);

--- a/client/src/utils/components/list/ListBarSessions.tsx
+++ b/client/src/utils/components/list/ListBarSessions.tsx
@@ -24,7 +24,6 @@ import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
 
 import { ListElementProps } from "./List.d";
 import "./ListBar.scss";
-import { getMainActionByEntity } from "./ListBar";
 import { ExternalLink } from "../ExternalLinks";
 import { TimeCaption } from "../TimeCaption";
 import VisibilityIcon from "../entities/VisibilityIcon";
@@ -37,6 +36,8 @@ import { stylesByItemType } from "../../helpers/HelperFunctions";
 import AppContext from "../../context/appContext";
 import Time from "../../helpers/Time";
 import { getStatusObject } from "../../../notebooks/Notebooks.present";
+import { SessionButton } from "../entities/Buttons";
+import { EnvironmentLogs, IFetchableLogs, ILogs } from "../Logs";
 import { Notebook } from "../../../notebooks/components/Session";
 
 /** Helper function for formatting the resource list */
@@ -81,7 +82,7 @@ function SessionStatusIcon ({ status, data, sessionId, errorSession, defaultImag
     <div id={sessionId}
       className={`d-flex align-items-center gap-1 ${status === SessionStatus.failed ? "cursor-pointer" : ""}`} >
       <Badge color={data.color} >{data.icon}</Badge>
-      <span className={`text-${data.color} small text-session-status`}>{data.text}</span>
+      <span className={`text-${data.color} small session-status-text`}>{data.text}</span>
       {popover}
     </div>);
 }
@@ -139,6 +140,12 @@ function SessionDetailsPopOver({ commit, image }: SessionDetailsPopOverProps) {
  */
 interface ListBarSessionProps extends ListElementProps {
   notebook: Notebook["data"];
+  showLogs: boolean;
+  setShowLogs: Function;
+  setServerLogs: Function;
+  stopSession: Function;
+  fetchLogs: IFetchableLogs["fetchLogs"];
+  logs: ILogs | undefined;
 }
 function ListBarSession(
   { id,
@@ -153,17 +160,23 @@ function ListBarSession(
     visibility,
     imageUrl,
     notebook,
+    showLogs,
+    setShowLogs,
+    setServerLogs,
+    stopSession,
+    fetchLogs,
+    logs,
   }: ListBarSessionProps) {
 
   // @ts-ignore
   const { client } = useContext(AppContext);
   const [commit, setCommit] = useState(null);
+  const [sessionStatus, setSessionStatus] = useState(SessionStatus.starting);
   const history = useHistory();
-  const handleClick = useCallback((e: React.MouseEvent<HTMLElement>) => {
-    e.preventDefault();
-    history.push(url);
-  }, [url]); //eslint-disable-line
 
+  useEffect(() => {
+    setSessionStatus(notebook?.status?.state);
+  }, [notebook?.status?.state]);
   useEffect(() => {
     client.getCommits(id, notebook.annotations.branch).then(
       (commitsFetched: Record<string, any>) => {
@@ -178,18 +191,24 @@ function ListBarSession(
     );
   }, [notebook.annotations]); // eslint-disable-line
 
+  const handleClick = useCallback((e: React.MouseEvent<HTMLElement>) => {
+    e.preventDefault();
+    history.push(url);
+  }, [url]); //eslint-disable-line
+  const toggleLogs = (serverName: string) => {
+    setShowLogs(!showLogs);
+    setServerLogs(serverName);
+  };
 
   const imageStyles = imageUrl ? { backgroundImage: `url("${imageUrl}")` } : {};
   const colorByType = stylesByItemType(itemType);
-  const mainButton = getMainActionByEntity(itemType, slug);
 
   /* session part */
   const resources = notebook.resources?.requests;
   const startTime = Time.toIsoTimezoneString(notebook.started, "datetime-short");
   const sessionId = notebook.name;
-  const data = getStatusObject(notebook?.status?.state, notebook.annotations["default_image_used"]) ;
-  const sessionTimeLabel = notebook?.status?.state === SessionStatus.running ? `${data.text} since ` : data.text;
-  // session component
+  const statusData = getStatusObject(sessionStatus, notebook.annotations["default_image_used"]) ;
+  const sessionTimeLabel = sessionStatus === SessionStatus.running ? `${statusData.text} since ` : statusData.text;
   const sessionDetailsPopover = commit ? <SessionDetailsPopOver commit={commit} image={notebook.image} /> : null;
 
   return (
@@ -230,8 +249,10 @@ function ListBarSession(
           time={timeCaption}
           className="text-rk-text-light text-truncate"/>
       </div>
-      <div className={`entity-action d-flex align-items-baseline gap-1 ${!mainButton ? "d-none" : ""}`}>
-        {mainButton}
+      <div className="entity-action d-flex align-items-baseline gap-1">
+        <SessionButton
+          notebook={notebook} sessionStatus={sessionStatus}
+          setSessionStatus={setSessionStatus} setServerLogs={toggleLogs} stopSession={stopSession} />
       </div>
       <div className="session-resources text-truncate"><ResourceList resources={resources} /></div>
       <div className="session-time text-truncate">
@@ -249,9 +270,16 @@ function ListBarSession(
       </div>
       <div className="session-icon">
         <SessionStatusIcon
-          status={notebook.status?.state} data={data} defaultImage={notebook.annotations["default_image_used"]}
+          status={sessionStatus} data={statusData} defaultImage={notebook.annotations["default_image_used"]}
           errorSession={notebook.status.message || ""} sessionId={sessionId} />
       </div>
+      <EnvironmentLogs
+        fetchLogs={fetchLogs}
+        toggleLogs={toggleLogs}
+        logs={logs}
+        name={notebook.name}
+        annotations={notebook.annotations}
+      />
     </div>);
 }
 

--- a/client/src/utils/customHooks/UseGetSessionLogs.ts
+++ b/client/src/utils/customHooks/UseGetSessionLogs.ts
@@ -1,0 +1,52 @@
+/*!
+ * Copyright 2023 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEffect, useState } from "react";
+import { useGetLogsQuery } from "../../features/session/sessionApi";
+import { ILogs } from "../components/Logs";
+
+/**
+ *  useGetSessionLogs custom hook
+ *
+ *  useGetSessionLogs.ts
+ *  hook to fetch logs by serverName
+ */
+function useGetSessionLogs(serverName: string, show: boolean | string) {
+  const { data, isFetching, isLoading, error, refetch } =
+    useGetLogsQuery({ serverName, lines: 250 }, { skip: serverName === "" });
+  const [logs, setLogs] = useState<ILogs | undefined>(undefined);
+  const fetchLogs = () => {
+    return refetch().then((result) => {
+      if (result.isSuccess)
+        return Promise.resolve(result.data as ILogs["data"]);
+      return Promise.reject({} as ILogs["data"]);
+    }) as Promise<ILogs["data"]>;
+  };
+
+  useEffect(() => {
+    setLogs({
+      data,
+      fetched: !isFetching && !error,
+      fetching: isFetching || isLoading,
+      show: show ? serverName : false,
+    });
+  }, [ data, show, isFetching, isLoading, serverName ]); //eslint-disable-line
+
+  return { logs, fetchLogs };
+}
+
+export default useGetSessionLogs;

--- a/client/src/utils/helpers/EnhancedState.js
+++ b/client/src/utils/helpers/EnhancedState.js
@@ -32,6 +32,7 @@ import kgSearchFormSlice from "../../features/kgSearch/KgSearchSlice";
 import { recentUserActivityApi } from "../../features/recentUserActivity/RecentUserActivityApi";
 import { inactiveKgProjectsApi } from "../../features/inactiveKgProjects/InactiveKgProjectsApi";
 import kgInactiveProjectsSlice from "../../features/inactiveKgProjects/inactiveKgProjectsSlice";
+import { sessionApi } from "../../features/session/sessionApi";
 
 function createStore(renkuStateModelReducer, _name = "renku") {
   return createStoreWithEnhancers(renkuStateModelReducer);
@@ -42,6 +43,7 @@ function createStoreWithEnhancers(renkuStateModelReducer, enhancers = undefined)
   renkuStateModelReducer[projectApi.reducerPath] = projectApi.reducer;
   renkuStateModelReducer[projectKgApi.reducerPath] = projectKgApi.reducer;
   renkuStateModelReducer[sessionSidecarApi.reducerPath] = sessionSidecarApi.reducer;
+  renkuStateModelReducer[sessionApi.reducerPath] = sessionApi.reducer;
   renkuStateModelReducer[recentUserActivityApi.reducerPath] = recentUserActivityApi.reducer;
   renkuStateModelReducer[inactiveKgProjectsApi.reducerPath] = inactiveKgProjectsApi.reducer;
   renkuStateModelReducer[kgSearchFormSlice.name] = kgSearchFormSlice.reducer;
@@ -60,7 +62,8 @@ function createStoreWithEnhancers(renkuStateModelReducer, enhancers = undefined)
         .concat(projectApi.middleware)
         .concat(projectKgApi.middleware)
         .concat(sessionSidecarApi.middleware)
-        .concat(recentUserActivityApi.middleware),
+        .concat(recentUserActivityApi.middleware)
+        .concat(sessionApi.middleware),
     enhancers
   });
   return store;

--- a/tests/cypress/e2e/local/dashboard.spec.ts
+++ b/tests/cypress/e2e/local/dashboard.spec.ts
@@ -143,7 +143,7 @@ describe("dashboard", () => {
         cy.get_cy("container-session").first().find(".session-info").should("contain.text", "master");
         cy.get_cy("container-session").first().find(".session-icon").should("have.text", "Error");
         cy.get_cy("container-session").first().find(".entity-action")
-          .find("button").first().should("contain.text", "Connect");
+          .find("button").first().should("contain.text", "Stop");
 
 
       });


### PR DESCRIPTION
PR to add get logs, stop session and link to Dashboard.

![dashboard sessions](https://user-images.githubusercontent.com/43388408/217183750-571ae62b-de31-4448-8aa4-01a06d98f3b1.gif)

### testing
- It should show all existing sessions
- If a session is in Error it should show the error icon, the error message and the main action to stop the session.
- If a session is starting or running, it should show "Connect" as the main action and the corresponding icon.
- If the session is being stopped, it should show "Stop" as the main action, but disabled.
- The user should be able to get Logs in all cases

/deploy renku=000-ui-dashboard #persist #cypress