### PR TITLE
refactor: provide type information for appContext

### DIFF
--- a/client/src/features/inactiveKgProjects/InactiveKgProjects.tsx
+++ b/client/src/features/inactiveKgProjects/InactiveKgProjects.tsx
@@ -56,7 +56,6 @@ function InactiveKGProjectsPage({ socket }: InactiveKGProjectsPageProps) {
   const projectList = useInactiveProjectSelector(
     (state) => state.kgInactiveProjects
   );
-  // @ts-ignore
   const { client } = useContext(AppContext);
   const dispatch = useDispatch();
 

--- a/client/src/features/kgSearch/KgSearchPage.tsx
+++ b/client/src/features/kgSearch/KgSearchPage.tsx
@@ -85,7 +85,6 @@ function SearchPage({ userName, isLoggedUser, model }: SearchPageProps) {
   );
   const [isOpenFilterModal, setIsOpenFilterModal] = useState(false);
   const [isOpenFilter, setIsOpenFilter] = useState(true);
-  // @ts-ignore
   const { client } = useContext(AppContext);
   const user = useSelector((state: any) => state.stateModel.user);
   const dispatch = useDispatch();

--- a/client/src/utils/components/entities/VisibilityIcon.tsx
+++ b/client/src/utils/components/entities/VisibilityIcon.tsx
@@ -36,7 +36,6 @@ export interface VisibilityIconProps {
 }
 const VisibilityIcon = ({ visibility, className }: VisibilityIconProps) => {
   const ref = useRef(null);
-  // @ts-ignore
   const { client } = useContext(AppContext);
   if (!visibility) return null;
   const icon = {

--- a/client/src/utils/context/appContext.ts
+++ b/client/src/utils/context/appContext.ts
@@ -18,6 +18,13 @@
 
 import React from "react";
 
-const AppContext = React.createContext(null);
+type IAppContext = {
+  client: any;
+  params: unknown;
+  location: unknown;
+};
+
+const AppContext = React.createContext<IAppContext>({ client: undefined, params: undefined, location: undefined });
 
 export default AppContext;
+export type { IAppContext };


### PR DESCRIPTION

This provides type information for appContext so it is not necessary to do `//@ts-ignore` everywhere that the appContext is used.