### PR TITLE
Show session table without overflowing

### DIFF
--- a/client/src/notebooks/Notebooks.present.js
+++ b/client/src/notebooks/Notebooks.present.js
@@ -425,36 +425,38 @@ class NotebookServerRowFull extends Component {
     </span>) : null;
 
     return (
-      <div className="d-flex flex-row bg-white border-0 border-radius-8
-        rk-search-result rk-search-result-100 cursor-auto overflow-visible">
-        <span className={this.props.standalone ? "me-3 mt-2" : "me-3 mt-1"}>{icon}</span>
-        <Col className="d-flex align-items-start flex-column col-10 overflow-hidden">
-          <div className="project d-inline-block text-truncate">
-            {project}
+      <div className="d-flex flex-row justify-content-between bg-white border-0 border-radius-8
+        rk-search-result rk-search-result-100 cursor-auto">
+        <div className="d-flex flex-grow-1">
+          <span className={this.props.standalone ? "me-3 mt-2" : "me-3 mt-1"}>{icon}</span>
+          <div className="d-flex flex-column align-items-start  overflow-hidden">
+            <div className="project d-inline-block text-truncate">
+              {project}
+            </div>
+            <table>
+              <tbody className="gx-4 text-rk-text">
+                <tr>
+                  <td className="text-dark fw-bold">Branch</td>
+                  <td className="text-dark">{branch}</td>
+                </tr>
+                <tr>
+                  <td className="text-dark fw-bold">Commit</td>
+                  <td className="text-dark">{commit}</td>
+                </tr>
+                <tr>
+                  <td className="pe-3 text-dark fw-bold">Resources</td>
+                  <td className="text-dark">{resourceList}</td>
+                </tr>
+                <tr>
+                  <td colSpan="2">{statusOut}</td>
+                </tr>
+              </tbody>
+            </table>
           </div>
-          <table>
-            <tbody className="gx-4 text-rk-text">
-              <tr>
-                <td className="text-dark fw-bold">Branch</td>
-                <td className="text-dark">{branch}</td>
-              </tr>
-              <tr>
-                <td className="text-dark fw-bold">Commit</td>
-                <td className="text-dark">{commit}</td>
-              </tr>
-              <tr>
-                <td className="pe-3 text-dark fw-bold">Resources</td>
-                <td className="text-dark">{resourceList}</td>
-              </tr>
-              <tr>
-                <td colSpan="2">{statusOut}</td>
-              </tr>
-            </tbody>
-          </table>
-        </Col>
-        <Col className="d-flex align-items-end flex-column flex-shrink-0">
+        </div>
+        <div>
           {action}
-        </Col>
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
# Screenshots

<img width="779" alt="image" src="https://user-images.githubusercontent.com/1196411/218076869-3d561ea8-6121-482e-a048-987388e3c214.png">


<img width="787" alt="image" src="https://user-images.githubusercontent.com/1196411/218076069-4c8f3e7d-2c68-44d1-ba82-cdea5314f9ba.png">

<img width="1086" alt="image" src="https://user-images.githubusercontent.com/1196411/218076038-10ca8c5d-eb56-4ef2-a428-4efd15fe4f9c.png">

<img width="1369" alt="image" src="https://user-images.githubusercontent.com/1196411/218076136-27316f0a-8509-4558-8398-4aad0543feab.png">


Fix #2345

/deploy #persist #cypress 