### PR TITLE
fix(client): start sessions with base images on broken pinned images

### DIFF
--- a/client/src/notebooks/NotebookStart.present.js
+++ b/client/src/notebooks/NotebookStart.present.js
@@ -1099,7 +1099,7 @@ class ServerOptionLaunch extends Component {
     this.setState({ showModal: !this.state.showModal });
   }
 
-  checkServer() {
+  checkServer(forceBaseImage = false) {
     const { filters } = this.props;
     const { autosaved } = this.props.data;
     const selectedBranchName = filters.branch.name;
@@ -1111,7 +1111,7 @@ class ServerOptionLaunch extends Component {
       this.toggleModal();
     }
     else {
-      this.props.handlers.startServer();
+      this.props.handlers.startServer(forceBaseImage);
     }
   }
 
@@ -1150,7 +1150,7 @@ class ServerOptionLaunch extends Component {
 
     const startBaseButton = (hasImage) ?
       null :
-      <Button key="start-base" color="primary" onClick={this.checkServer}>
+      <Button key="start-base" color="primary" onClick={() => this.checkServer(true)}>
         Start with base image
       </Button>;
 

--- a/client/src/notebooks/Notebooks.container.js
+++ b/client/src/notebooks/Notebooks.container.js
@@ -765,10 +765,10 @@ class StartNotebookServer extends Component {
     history.push({ pathname: localUrl, search: "", state: { ...state, redirectFromStartServer: true } });
   }
 
-  internalStartServer() {
+  internalStartServer(forceBaseImage = false) {
     // The core internal logic extracted here for re-use
     const { location, history } = this.props;
-    return this.coordinator.startServer().then((data) => {
+    return this.coordinator.startServer(forceBaseImage).then((data) => {
       this.setState({ "starting": false });
       // redirect user when necessary
       if (!history || !location)
@@ -789,16 +789,16 @@ class StartNotebookServer extends Component {
     });
   }
 
-  startServer() {
+  startServer(forceBaseImage = false) {
     //* Data from notebooks/servers endpoint needs some time to update properly.
     //* To avoid flickering UI, just set a temporary state and display a loading wheel.
     this.setState({ "starting": true, launchError: null });
-    this.internalStartServer().catch((error) => {
+    this.internalStartServer(forceBaseImage).catch((error) => {
       if (error.cause && error.cause.response && error.cause.response.status) {
         if (error.cause.response.status === 500) {
           // Some failures just go away. Try again to see if it works the second time.
           setTimeout(() => {
-            this.internalStartServer().catch((error) => {
+            this.internalStartServer(forceBaseImage).catch((error) => {
               this.handleNotebookStartError(error);
             });
           }, 3000);

--- a/client/src/notebooks/Notebooks.state.js
+++ b/client/src/notebooks/Notebooks.state.js
@@ -1252,7 +1252,7 @@ class NotebooksCoordinator {
 
 
   // * Change notebook status * //
-  startServer() {
+  startServer(forceBaseImage = false) {
     const options = {
       serverOptions: this.model.get("filters.options"),
     };
@@ -1266,7 +1266,7 @@ class NotebooksCoordinator {
     const branch = filters.branch && filters.branch.name ? filters.branch.name : filters.defaultBranch;
     const commit = filters.commit && filters.commit.id ? filters.commit.id : "latest";
     const projectOptions = this.model.get("options.project");
-    const image = projectOptions.image ?
+    const image = projectOptions.image && !forceBaseImage ?
       projectOptions.image :
       null;
     const env_variables = formatEnvironmentVariables(this.model.get("filters.environment_variables"));


### PR DESCRIPTION
Restores the "start with base image" button for pinned images with a broken image.

@olevski Using an example like the project `lorenzo.cavazzi.tech/pinned-image-broken`, everything works well but I noticed that the `GET /servers` endpoint returns `false` on the annotation `default_image_used`.

1. Should I pass some specific value to the `POST /servers` API to properly set the `default_image_used` annotation?
2. [_very_ minor] Any chance we can get a real `true/false` boolean for that field instead of a stringified Pythonish boolean `"False"/"True"`?

```
"annotations": {
        ...
        "renku.io/default_image_used": "False",
},
```

/deploy #persist #cypress renku=renku-ui-3.4.0-tests
fix #2395
