### PR TITLE
chore(client): bump autosuggest container z-index

### DIFF
--- a/.github/workflows/test-and-ci.yml
+++ b/.github/workflows/test-and-ci.yml
@@ -103,7 +103,7 @@ jobs:
           browser: chrome
           start: npm run start
           wait-on: http://localhost:3000
-          wait-on-timeout: 180
+          wait-on-timeout: 300
           working-directory: tests
       - uses: actions/upload-artifact@v3
         if: failure() # Cypress screenshots will be generated only if the test failed, thus we store screenshots only on failures

--- a/client/src/features/dashboard/components/ProjectsDashboard.tsx
+++ b/client/src/features/dashboard/components/ProjectsDashboard.tsx
@@ -225,7 +225,7 @@ function SessionsToShow({ currentSessions }: SessionsToShowProps) {
     getProjectCurrentSessions();
   }, [currentSessions]); // eslint-disable-line
 
-  if (items) {
+  if (items?.length) {
     const element = items.map((item: SessionProject) => {
       return <>
         <EnvironmentLogs

--- a/client/src/project/new/Project.style.css
+++ b/client/src/project/new/Project.style.css
@@ -26,7 +26,7 @@
   border: 1px solid #aaa;
   border-top-width: 0;
   background-color: #fff;
-  z-index: 2;
+  z-index: 3;
   max-height: 560px;
   overflow-y: auto;
   border-radius: 0 0 8px 8px;


### PR DESCRIPTION
This minor change prevents react autosuggest dropdowns from being overlayed by group buttons: in the example, I have quite a few groups listed on the namespace. The "Choose File" group button has a `z-index` of 2 and, on the "New Project" page, it shows on top of the autosuggest dropdown menu.

![image](https://user-images.githubusercontent.com/43481553/226568284-9b044f7b-33b8-48d9-90a5-b057cd54d9ba.png)

![image](https://user-images.githubusercontent.com/43481553/226568296-a88e0700-61d8-4529-a8ab-3badaa9d4aac.png)

/deploy #persist #cypress
