### PR TITLE
Dashboard: fix issue with trying to process deleted project data

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -43384,7 +43384,7 @@
       "version": "7.0.0",
       "dev": true,
       "requires": {
-        "autoprefixer": "^10.4.12",
+        "autoprefixer": "10.4.5",
         "cosmiconfig": "^7.0.1",
         "cosmiconfig-typescript-loader": "^1.0.0",
         "cross-spawn": "^7.0.3",
@@ -45789,7 +45789,7 @@
         "@storybook/ui": "6.5.15",
         "@types/node": "^14.0.10 || ^16.0.0",
         "@types/webpack": "^4.41.26",
-        "autoprefixer": "^9.8.6",
+        "autoprefixer": "10.4.5",
         "babel-loader": "^8.0.0",
         "case-sensitive-paths-webpack-plugin": "^2.3.0",
         "core-js": "^3.8.2",
@@ -45802,7 +45802,7 @@
         "global": "^4.4.0",
         "html-webpack-plugin": "^4.0.0",
         "pnp-webpack-plugin": "1.6.4",
-        "postcss": "^7.0.36",
+        "postcss": "^8.4.21",
         "postcss-flexbugs-fixes": "^4.2.1",
         "postcss-loader": "^4.2.0",
         "raw-loader": "^4.0.2",
@@ -45963,7 +45963,8 @@
           "dev": true
         },
         "autoprefixer": {
-          "version": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.5.tgz",
+          "version": "10.4.5",
+          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.5.tgz",
           "integrity": "sha512-Fvd8yCoA7lNX/OUllvS+aS1I7WRBclGXsepbvT8ZaPgrH24rgXpZzF0/6Hh3ZEkwg+0AES/Osd196VZmYoEFtw==",
           "dev": true,
           "requires": {
@@ -62169,7 +62170,7 @@
         "minimatch": "^3.0.4",
         "pidtree": "^0.3.0",
         "read-pkg": "^3.0.0",
-        "shell-quote": "^1.6.1",
+        "shell-quote": "^1.7.4",
         "string.prototype.padend": "^3.0.0"
       }
     },
@@ -62775,7 +62776,7 @@
       "integrity": "sha512-9SiofaZ9CWpQWxOwRh1b/r85KD5y7GgvsNt1056k6OYLvWUun0czCvogfJgylC22uJTwW1KzY3Gz65NZRlvoiQ==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.26"
+        "postcss": "^8.4.21"
       },
       "dependencies": {
         "picocolors": {
@@ -62785,8 +62786,7 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.39",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+          "version": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
           "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
           "dev": true,
           "requires": {
@@ -64738,7 +64738,7 @@
             "@csstools/postcss-text-decoration-shorthand": "^1.0.0",
             "@csstools/postcss-trigonometric-functions": "^1.0.2",
             "@csstools/postcss-unset-value": "^1.0.2",
-            "autoprefixer": "^10.4.13",
+            "autoprefixer": "10.4.5",
             "browserslist": "^4.21.4",
             "css-blank-pseudo": "^3.0.3",
             "css-has-pseudo": "^3.0.4",

--- a/client/src/features/projects/ProjectsApi.ts
+++ b/client/src/features/projects/ProjectsApi.ts
@@ -127,9 +127,10 @@ export const projectApi = createApi({
           try {
             const resultAllProjectData = await Promise.allSettled(projectRequests);
             const projectList = [];
-            for (const projectData of resultAllProjectData)
+            for (const projectData of resultAllProjectData) {
               if (projectData.status === "fulfilled" && !projectData.value.error)
                 projectList.push(formatProjectMetadata(projectData.value.data));
+            }
 
             return { data: projectList };
           }

--- a/client/src/features/projects/ProjectsApi.ts
+++ b/client/src/features/projects/ProjectsApi.ts
@@ -128,7 +128,8 @@ export const projectApi = createApi({
             const resultAllProjectData = await Promise.allSettled(projectRequests);
             const projectList = [];
             for (const projectData of resultAllProjectData)
-              if (projectData.status === "fulfilled") projectList.push(formatProjectMetadata(projectData.value.data));
+              if (projectData.status === "fulfilled" && !projectData.value.error)
+                projectList.push(formatProjectMetadata(projectData.value.data));
 
             return { data: projectList };
           }

--- a/tests/cypress.config.ts
+++ b/tests/cypress.config.ts
@@ -1,4 +1,27 @@
+import { spawnSync } from "child_process";
 import { defineConfig } from "cypress";
+
+const findChromium = () => {
+  const chromiumPath =
+    "/home/leafty/.local/share/flatpak/exports/bin/org.chromium.Chromium";
+  const versionStdOut = spawnSync(chromiumPath, ["--version"], {
+    encoding: "utf-8",
+  }).stdout;
+  const [, version] = /Chromium (\d+\.\d+\.\d+\.\d+)/.exec(versionStdOut);
+  const majorVersion = parseInt(version.split(".")[0]);
+
+  return {
+    name: "chromium",
+    channel: "stable",
+    family: "chromium",
+    displayName: "Chromium",
+    version,
+    path: chromiumPath,
+    majorVersion,
+    isHeaded: true,
+    isHeadless: false,
+  } as const;
+};
 
 export default defineConfig({
   env: {
@@ -10,10 +33,14 @@ export default defineConfig({
   viewportHeight: 1200,
 
   e2e: {
-    // setupNodeEvents(on, config) {
-    //   return require("./cypress/plugins/index.ts")(on, config);
-    // },
     baseUrl: "http://localhost:3000",
     specPattern: "cypress/e2e/**/*.{js,jsx,ts,tsx}",
+    setupNodeEvents(_on, config) {
+      const chromium = findChromium();
+      return {
+        ...config,
+        browsers: [...config.browsers, chromium],
+      };
+    },
   },
 });

--- a/tests/cypress.config.ts
+++ b/tests/cypress.config.ts
@@ -1,27 +1,4 @@
-import { spawnSync } from "child_process";
 import { defineConfig } from "cypress";
-
-const findChromium = () => {
-  const chromiumPath =
-    "/home/leafty/.local/share/flatpak/exports/bin/org.chromium.Chromium";
-  const versionStdOut = spawnSync(chromiumPath, ["--version"], {
-    encoding: "utf-8",
-  }).stdout;
-  const [, version] = /Chromium (\d+\.\d+\.\d+\.\d+)/.exec(versionStdOut);
-  const majorVersion = parseInt(version.split(".")[0]);
-
-  return {
-    name: "chromium",
-    channel: "stable",
-    family: "chromium",
-    displayName: "Chromium",
-    version,
-    path: chromiumPath,
-    majorVersion,
-    isHeaded: true,
-    isHeadless: false,
-  } as const;
-};
 
 export default defineConfig({
   env: {
@@ -33,14 +10,10 @@ export default defineConfig({
   viewportHeight: 1200,
 
   e2e: {
+    // setupNodeEvents(on, config) {
+    //   return require("./cypress/plugins/index.ts")(on, config);
+    // },
     baseUrl: "http://localhost:3000",
     specPattern: "cypress/e2e/**/*.{js,jsx,ts,tsx}",
-    setupNodeEvents(_on, config) {
-      const chromium = findChromium();
-      return {
-        ...config,
-        browsers: [...config.browsers, chromium],
-      };
-    },
   },
 });


### PR DESCRIPTION
Fixes a bug where the API `/projects/<project>?statistics=false&doNotTrack=true` 404 response is processed as project data. We now skip these items.

/deploy #persist #cypress renku=renku-ui-3.4.2-updates
Fixes #2437.