### PR TITLE
fix(client): prevent dropping pinned images

### DIFF
--- a/client/src/notebooks/NotebookStart.present.js
+++ b/client/src/notebooks/NotebookStart.present.js
@@ -1137,9 +1137,11 @@ class ServerOptionLaunch extends Component {
         onClick={this.props.toggleShareLinkModal}>
         <FontAwesomeIcon className="text-rk-green" icon={faLink} /> Create link</DropdownItem>
     );
-    const startButton = <Button key="start-session" color="rk-green" disabled={!hasImage} onClick={this.checkServer}>
-      Start session
-    </Button>;
+    const startButton = (
+      <Button key="start-session" color="rk-green" disabled={!hasImage} onClick={() => this.checkServer(false)}>
+        Start session
+      </Button>
+    );
     const startButtonWithMenu = <ButtonWithMenu key="button-menu" color="rk-green" default={startButton}
       direction="up" isPrincipal={true}>
       {createLink}
@@ -1214,7 +1216,9 @@ class AutosavedDataModal extends Component {
             <p>Please refer to this {docsLink} to get further information.</p>
           </ModalBody>
           <ModalFooter>
-            <Button className="btn-rk-green" onClick={this.props.handlers.startServer}>Launch session</Button>
+            <Button className="btn-rk-green" onClick={() => this.props.handlers.startServer(false)}>
+              Launch session
+            </Button>
           </ModalFooter>
         </Modal>
       </div>


### PR DESCRIPTION
This fixes a nasty bug accidentally introduced here #2410 that prevents pinned images from being picked up correctly.

In the screenshot, I tested a project with a pinned image that was picked up correctly -- it's from a different commit than the current one.

![image](https://user-images.githubusercontent.com/43481553/231520943-876a9d05-959b-4dea-93c9-d0a77474b22d.png)

You can use this project to test it https://dev.renku.ch/projects/lorenzo.cavazzi.tech/1408-pinned-image

/deploy #persist #cypress renku=renku-ui-3.4.2-updates
fix #2458