### PR TITLE
Remove conspicuous "," in the add dataset screen

### DIFF
--- a/client/src/features/project/dataset/ProjectDatasetsView.tsx
+++ b/client/src/features/project/dataset/ProjectDatasetsView.tsx
@@ -279,7 +279,7 @@ function ProjectDatasetsView(props: any) {
           <>
             <Col key="btn" md={12}>
               <GoBackButton data-cy="go-back-dataset" label="Back to list" url={props.datasetsUrl}/>
-            </Col>,
+            </Col>
             <ProjectAddDataset key="projectsAddDataset" {...props} />
           </>}/>
       <Route path={props.editDatasetUrl}


### PR DESCRIPTION
See screenshot:
![image](https://user-images.githubusercontent.com/951086/232035257-dd67f631-6e45-4170-ac30-bc0ff9010dcd.png)

This is most likely a typo, an extra "," is seen above "Add Dataset".