### PR TITLE
Remove unused route in client/src/project/Project.present.js

### DIFF
--- a/client/src/project/Project.present.js
+++ b/client/src/project/Project.present.js
@@ -1113,7 +1113,6 @@ function ProjectView(props) {
         <Route path={props.editDatasetUrl} render={() => null} />
         <Route path={props.datasetUrl} render={() => null} />
         <Route path={props.sessionShowUrl} render={() => null} />
-        <Route path={props.newDatasetUrl} component={() => <ProjectNav key="nav" {...props} />} />
         <Route component={() => <ProjectNav key="nav" {...props} />} />
       </Switch>
       <Row key="content">


### PR DESCRIPTION
The removed route is never hit as the `datasetUrl` one is always hit beforehand.
Also, displaying the project navbar would not follow the convention used in other screens using a "Back to <project>" button.

/deploy #persist #cypress