### PR TITLE
fix(client): fix `notebookWarning()` broken invocation after #2452

### DIFF
--- a/client/src/project/Project.present.js
+++ b/client/src/project/Project.present.js
@@ -900,7 +900,8 @@ class ProjectStartNotebookServer extends Component {
       backUrl,
       defaultBackButton,
     } = this.props;
-    const warning = notebookWarning(user.logged, metadata.accessLevel, forkUrl, location.pathname, externalUrl);
+    const warning = notebookWarning(user.logged, metadata.accessLevel, forkUrl,
+      location.pathname, externalUrl, this.props);
 
     const locationEnhanced =
       location && location.state && location.state.successUrl


### PR DESCRIPTION
In PR #2452, the line https://github.com/SwissDataScienceCenter/renku-ui/blob/39853035225ac330e34beb8ce11392e9116181a5/client/src/project/Project.present.js#L903 was not updated like https://github.com/SwissDataScienceCenter/renku-ui/blob/39853035225ac330e34beb8ce11392e9116181a5/client/src/project/Project.present.js#L858-L859.

This PR should also fix the `UnprivilegedSessionSpec` Selenium acceptance test.

/deploy #persist #cypress