### PR TITLE
fix(client): do not crash the UI when showing all workflows

### DIFF
--- a/client/src/workflows/Workflows.present.tsx
+++ b/client/src/workflows/Workflows.present.tsx
@@ -306,7 +306,7 @@ function orderWorkflows(
 ) {
   const filtered = !showInactive
     ? workflows.filter((w) => w.active)
-    : workflows;
+    : [...workflows];
 
   // ? Pre-sort by a unique prop to guarantee consistency
   const preSorted = filtered.sort((a, b) =>

--- a/client/src/workflows/Workflows.present.tsx
+++ b/client/src/workflows/Workflows.present.tsx
@@ -237,6 +237,7 @@ function WorkflowsListFilters({
       <div className="input-filter-box--workflows form-rk-yellow">
         <div className="form-check form-switch">
           <Input
+            data-cy="workflows-inactive-toggle"
             type="switch"
             id="wfExcludeInactive"
             label="label here"

--- a/tests/cypress/e2e/workflows.spec.ts
+++ b/tests/cypress/e2e/workflows.spec.ts
@@ -29,7 +29,7 @@ describe("iteract with workflows", () => {
     fixtures.projectLockStatus().projectMigrationUpToDate();
   });
 
-  it("get list of workflow and interact", () => {
+  it("get list of workflows and interact", () => {
     fixtures.getWorkflows("workflows/workflows-list-links-mappings.json");
     cy.visit("/projects/e2e/local-test-project/workflows");
     cy.get_cy("workflows-page").should("exist");

--- a/tests/cypress/e2e/workflows.spec.ts
+++ b/tests/cypress/e2e/workflows.spec.ts
@@ -46,6 +46,32 @@ describe("iteract with workflows", () => {
     cy.get_cy("workflows-browser").children().first().contains("pipeline");
   });
 
+  it("view inactive workflows and interact", () => {
+    fixtures.getWorkflows(
+      "workflows/workflows-list-links-mappings-inactive.json"
+    );
+    cy.visit("/projects/e2e/local-test-project/workflows");
+    cy.get_cy("workflows-page").should("exist");
+    cy.wait("@getWorkflows");
+
+    // Click "Show inactive workflows"
+    cy.get_cy("workflows-inactive-toggle").should("exist").click();
+
+    cy.get_cy("workflows-browser")
+      .should("exist")
+      .children()
+      .should("have.length", 4);
+    cy.get_cy("workflows-browser").children().first().contains("pipeline");
+
+    // change ordering
+    cy.gui_workflows_change_sorting("Estimated duration");
+    cy.get_cy("workflows-browser").children().first().contains("train");
+
+    // change order direction
+    cy.gui_workflows_change_sort_order();
+    cy.get_cy("workflows-browser").children().first().contains("pipeline");
+  });
+
   it("expand a workflow - waiting", () => {
     fixtures.getWorkflows("workflows/workflows-list-links-mappings.json");
     cy.visit("/projects/e2e/local-test-project/workflows");

--- a/tests/cypress/fixtures/workflows/workflows-list-links-mappings-inactive.json
+++ b/tests/cypress/fixtures/workflows/workflows-list-links-mappings-inactive.json
@@ -1,0 +1,65 @@
+{
+  "result": {
+    "plans": [
+      {
+        "children": [],
+        "id": "/plans/59d7c0e72966478ba61eaad737c6ce8e",
+        "creators": [],
+        "touches_existing_files": false,
+        "keywords": [],
+        "duration": 5,
+        "last_executed": "2022-07-19T16:25:38+02:00",
+        "description": null,
+        "name": "evaluation",
+        "number_of_executions": 5,
+        "created": "2022-07-19T15:10:40+02:00",
+        "type": "Plan"
+      },
+      {
+        "children": [],
+        "id": "/plans/d1341c90f2b2464dba2bd933fc716007",
+        "creators": [],
+        "touches_existing_files": false,
+        "keywords": [],
+        "duration": 4,
+        "last_executed": "2022-07-19T16:25:38+02:00",
+        "description": "Train a model",
+        "name": "train",
+        "number_of_executions": 5,
+        "created": "2022-07-19T16:25:01+02:00",
+        "type": "Plan"
+      },
+      {
+        "children": [
+          "/plans/d1341c90f2b2464dba2bd933fc716007",
+          "/plans/59d7c0e72966478ba61eaad737c6ce8e"
+        ],
+        "id": "/plans/952c938055a041168f6e795ae33b0d22",
+        "creators": [],
+        "touches_existing_files": false,
+        "keywords": [],
+        "duration": 10,
+        "last_executed": null,
+        "description": null,
+        "name": "pipeline",
+        "number_of_executions": null,
+        "created": "2022-07-19T16:25:27+02:00",
+        "type": "CompositePlan"
+      },
+      {
+        "children": [],
+        "id": "/plans/0b287509ce164a399bab4a0266a4777a",
+        "creators": [],
+        "touches_existing_files": false,
+        "keywords": [],
+        "duration": 5,
+        "last_executed": "2022-07-19T15:11:32+02:00",
+        "description": null,
+        "name": "preprocessing",
+        "number_of_executions": 3,
+        "created": "2022-07-19T15:09:53+02:00",
+        "type": "Plan"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
The workflows list passed from RTK query is read-only, but we call `.sort()` to order the workflow list. As a fix, we simply copy the list into a new array when we list all workflows ("show inactive workflows" toggle).

Fixes #2488.

/deploy #persist #cypress