### PR TITLE
refactor(client): update RTK slice selector hooks

### DIFF
--- a/client/.storybook/preview.js
+++ b/client/.storybook/preview.js
@@ -3,12 +3,12 @@ import { enhancer as withReduxEnhancer } from "addon-redux";
 import "../src/styles/index.scss";
 
 import AppContext from "../src/utils/context/appContext";
-import { createStoreWithEnhancers } from "../src/utils/helpers/EnhancedState.js";
+import { createStore } from "../src/utils/helpers/EnhancedState.js";
 import { MemoryRouter } from "react-router-dom";
 
 // This how the documentation recommends introducing the store into storybook
 // https://storybook.js.org/addons/@dreamworld/addon-redux/
-export const store = createStoreWithEnhancers({}, [withReduxEnhancer]);
+export const store = createStore({}, [withReduxEnhancer]);
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },

--- a/client/.storybook/store.js
+++ b/client/.storybook/store.js
@@ -1,6 +1,6 @@
-import { createStoreWithEnhancers } from "../src/utils/helpers/EnhancedState.js";
+import { createStore } from "../src/utils/helpers/EnhancedState.js";
 import { enhancer as withReduxEnhancer } from "addon-redux";
 
-const store = createStoreWithEnhancers({}, [withReduxEnhancer]);
+const store = createStore({}, [withReduxEnhancer]);
 
 export default store;

--- a/client/src/components/Logs.tsx
+++ b/client/src/components/Logs.tsx
@@ -17,7 +17,7 @@
  */
 
 import React, { useEffect } from "react";
-import { RootStateOrAny, useDispatch } from "react-redux";
+import { useDispatch } from "react-redux";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSave, faSyncAlt } from "@fortawesome/free-solid-svg-icons";
 import {
@@ -318,9 +318,7 @@ interface EnvironmentLogsProps {
   name: string;
 }
 const EnvironmentLogs = ({ name, annotations }: EnvironmentLogsProps) => {
-  const displayModal = useDisplaySelector(
-    (state: RootStateOrAny) => state[displaySlice.name].modals.sessionLogs
-  );
+  const displayModal = useDisplaySelector((state) => state.modals.sessionLogs);
   const { logs, fetchLogs } = useGetSessionLogs(
     displayModal.targetServer,
     displayModal.show

--- a/client/src/components/entityHeader/EntityHeader.tsx
+++ b/client/src/components/entityHeader/EntityHeader.tsx
@@ -141,9 +141,7 @@ function EntityHeader({
   }
 
   // Set up support for logs modal
-  const displayModal = useDisplaySelector(
-    (state: RootStateOrAny) => state[displaySlice.name].modals.sessionLogs
-  );
+  const displayModal = useDisplaySelector((state) => state.modals.sessionLogs);
   const envLogs =
     itemType === "project" ? (
       <EnvironmentLogs

--- a/client/src/components/ssh/ssh.tsx
+++ b/client/src/components/ssh/ssh.tsx
@@ -26,7 +26,6 @@ import { Modal, ModalBody, ModalHeader } from "../../utils/ts-wrappers";
 import { Loader } from "../Loader";
 import { useGetNotebooksQuery } from "../../features/versions/versionsApi";
 import {
-  displaySlice,
   hideSshModal,
   showSshModal,
   toggleSshModal,
@@ -83,9 +82,7 @@ function SshModal() {
   });
   let useLocalMigration = false;
   const { client } = useContext(AppContext);
-  const displayModal = useDisplaySelector(
-    (state: RootStateOrAny) => state[displaySlice.name].modals.ssh
-  );
+  const displayModal = useDisplaySelector((state) => state.modals.ssh);
   const location = useLocation();
   const dispatch = useDispatch();
 

--- a/client/src/features/dashboard/components/InactiveKgProjects.tsx
+++ b/client/src/features/dashboard/components/InactiveKgProjects.tsx
@@ -24,9 +24,7 @@ import React from "react";
 
 export function ProjectsInactiveKGWarning() {
   const user = useSelector((state: RootStateOrAny) => state.stateModel.user);
-  const projectList = useInactiveProjectSelector(
-    (state) => state.kgInactiveProjects
-  );
+  const projectList = useInactiveProjectSelector();
   const { data, isFetching, isLoading } = useGetInactiveProjects(
     user?.data?.id
   );

--- a/client/src/features/dashboard/components/ProjectsDashboard.tsx
+++ b/client/src/features/dashboard/components/ProjectsDashboard.tsx
@@ -273,9 +273,7 @@ interface SessionsToShowProps {
   currentSessions: Notebook["data"][];
 }
 function SessionsToShow({ currentSessions }: SessionsToShowProps) {
-  const displayModal = useDisplaySelector(
-    (state: RootStateOrAny) => state[displaySlice.name].modals.sessionLogs
-  );
+  const displayModal = useDisplaySelector((state) => state.modals.sessionLogs);
   const [items, setItems] = useState<any[]>([]);
   const { client } = useContext(AppContext);
 

--- a/client/src/features/display/displaySlice.ts
+++ b/client/src/features/display/displaySlice.ts
@@ -17,7 +17,7 @@
  */
 
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-import { TypedUseSelectorHook, useSelector } from "react-redux";
+import { createSliceSelector } from "../../utils/customHooks/UseSliceSelector";
 import { Display, ProjectConfig, SessionConfig } from "./display";
 
 const initialState: Display = {
@@ -74,5 +74,5 @@ export const displaySlice = createSlice({
 
 export const { showSshModal, hideSshModal, toggleSshModal, reset } =
   displaySlice.actions;
-export const useDisplaySelector: TypedUseSelectorHook<Display> = useSelector;
-export default displaySlice;
+
+export const useDisplaySelector = createSliceSelector(displaySlice);

--- a/client/src/features/display/index.ts
+++ b/client/src/features/display/index.ts
@@ -1,4 +1,5 @@
-import displaySlice, {
+import {
+  displaySlice,
   showSshModal,
   hideSshModal,
   toggleSshModal,

--- a/client/src/features/inactiveKgProjects/InactiveKgProjects.tsx
+++ b/client/src/features/inactiveKgProjects/InactiveKgProjects.tsx
@@ -57,9 +57,7 @@ function InactiveKGProjectsPage({ socket }: InactiveKGProjectsPageProps) {
   const { data, isFetching, isLoading, error } = useGetInactiveProjects(
     user?.data?.id
   );
-  const projectList = useInactiveProjectSelector(
-    (state) => state.kgInactiveProjects
-  );
+  const projectList = useInactiveProjectSelector();
   const { client } = useContext(AppContext);
   const dispatch = useDispatch();
 

--- a/client/src/features/inactiveKgProjects/inactiveKgProjectsSlice.ts
+++ b/client/src/features/inactiveKgProjects/inactiveKgProjectsSlice.ts
@@ -17,12 +17,11 @@
  */
 
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-import { TypedUseSelectorHook, useSelector } from "react-redux";
+import { createSliceSelector } from "../../utils/customHooks/UseSliceSelector";
 import { InactiveKgProjects } from "./InactiveKgProjects";
 
 const initialState: InactiveKgProjects[] = [];
 
-type RootStateInactiveProjects = { kgInactiveProjects: InactiveKgProjects[] };
 interface ActivationStatus {
   id: number;
   progress: number;
@@ -58,6 +57,7 @@ export const kgInactiveProjectsSlice = createSlice({
 
 export const { updateList, addFullList, updateProgress } =
   kgInactiveProjectsSlice.actions;
-export const useInactiveProjectSelector: TypedUseSelectorHook<RootStateInactiveProjects> =
-  useSelector;
-export default kgInactiveProjectsSlice;
+
+export const useInactiveProjectSelector = createSliceSelector(
+  kgInactiveProjectsSlice
+);

--- a/client/src/features/workflows/WorkflowsSlice.ts
+++ b/client/src/features/workflows/WorkflowsSlice.ts
@@ -17,13 +17,11 @@
  */
 
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-import { TypedUseSelectorHook, useSelector } from "react-redux";
-
+import { createSliceSelector } from "../../utils/customHooks/UseSliceSelector";
 import { WorkflowsDisplay } from "./Workflows";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-type RootStateWorkflowsDisplay = WorkflowsDisplay;
 const initialState: WorkflowsDisplay = {
   details: {},
   expanded: [],
@@ -74,6 +72,4 @@ export const workflowsSlice = createSlice({
   },
 });
 
-export const useWorkflowsSelector: TypedUseSelectorHook<RootStateWorkflowsDisplay> =
-  useSelector;
-export default workflowsSlice;
+export const useWorkflowsSelector = createSliceSelector(workflowsSlice);

--- a/client/src/model/Model.js
+++ b/client/src/model/Model.js
@@ -219,10 +219,7 @@ class StateModel {
       let slice = null;
       if (!stateHolder) {
         slice = "stateModel";
-        stateHolder = createStore(
-          { [slice]: schema.reducer() },
-          this.constructor.name
-        );
+        stateHolder = createStore({ [slice]: schema.reducer() });
       }
       this._stateModel = new ReduxStateModel(
         this,

--- a/client/src/utils/customHooks/UseSliceSelector.ts
+++ b/client/src/utils/customHooks/UseSliceSelector.ts
@@ -1,0 +1,31 @@
+/*!
+ * Copyright 2023 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Slice, SliceCaseReducers } from "@reduxjs/toolkit";
+import { RootStateOrAny, useSelector } from "react-redux";
+
+export const createSliceSelector =
+  <TSliceState, TSliceName extends string>(
+    slice: Slice<TSliceState, SliceCaseReducers<TSliceState>, TSliceName>
+  ) =>
+  <TState = TSliceState>(selector?: (state: TSliceState) => TState) =>
+    useSelector<RootStateOrAny, TState>(
+      selector
+        ? (state) => selector(state[slice.name])
+        : (state) => state[slice.name]
+    );

--- a/client/src/utils/customHooks/UseSliceSelector.ts
+++ b/client/src/utils/customHooks/UseSliceSelector.ts
@@ -20,9 +20,7 @@ import { Slice, SliceCaseReducers } from "@reduxjs/toolkit";
 import { RootStateOrAny, useSelector } from "react-redux";
 
 export const createSliceSelector =
-  <TSliceState, TSliceName extends string>(
-    slice: Slice<TSliceState, SliceCaseReducers<TSliceState>, TSliceName>
-  ) =>
+  <TSliceState>(slice: Slice<TSliceState, SliceCaseReducers<TSliceState>>) =>
   <TState = TSliceState>(selector?: (state: TSliceState) => TState) =>
     useSelector<RootStateOrAny, TState>(
       selector

--- a/client/src/utils/helpers/EnhancedState.ts
+++ b/client/src/utils/helpers/EnhancedState.ts
@@ -17,7 +17,7 @@
  */
 
 /**
- *
+ * Exposes createStore() which creates the redux store used by the Renku UI
  */
 
 import {

--- a/client/src/utils/helpers/EnhancedState.ts
+++ b/client/src/utils/helpers/EnhancedState.ts
@@ -17,56 +17,55 @@
  */
 
 /**
- *  incubator-renku-ui
  *
- *  UIState.js
- *  Utility UI state management.
  */
 
-import { configureStore } from "@reduxjs/toolkit";
-import { projectKgApi } from "../../features/projects/ProjectKgApi";
-import { sessionSidecarApi } from "../../features/session/sidecarApi";
-import { projectApi } from "../../features/projects/ProjectsApi";
-import { projectCoreApi } from "../../features/project/projectCoreApi";
-import { kgSearchApi } from "../../features/kgSearch";
-import { recentUserActivityApi } from "../../features/recentUserActivity/RecentUserActivityApi";
+import {
+  Action,
+  AnyAction,
+  ReducersMapObject,
+  StoreEnhancer,
+  configureStore,
+} from "@reduxjs/toolkit";
+import { displaySlice } from "../../features/display/displaySlice";
 import { inactiveKgProjectsApi } from "../../features/inactiveKgProjects/InactiveKgProjectsApi";
-import kgInactiveProjectsSlice from "../../features/inactiveKgProjects/inactiveKgProjectsSlice";
+import { kgInactiveProjectsSlice } from "../../features/inactiveKgProjects/inactiveKgProjectsSlice";
+import { kgSearchApi } from "../../features/kgSearch";
+import { projectCoreApi } from "../../features/project/projectCoreApi";
+import { projectKgApi } from "../../features/projects/ProjectKgApi";
+import { projectApi } from "../../features/projects/ProjectsApi";
+import { recentUserActivityApi } from "../../features/recentUserActivity/RecentUserActivityApi";
 import { sessionApi } from "../../features/session/sessionApi";
+import { sessionSidecarApi } from "../../features/session/sidecarApi";
 import { versionsApi } from "../../features/versions/versionsApi";
-import displaySlice from "../../features/display/displaySlice";
 import { workflowsApi } from "../../features/workflows/WorkflowsApi";
-import workflowsSlice from "../../features/workflows/WorkflowsSlice";
+import { workflowsSlice } from "../../features/workflows/WorkflowsSlice";
 
-function createStore(renkuStateModelReducer) {
-  return createStoreWithEnhancers(renkuStateModelReducer);
-}
-
-function createStoreWithEnhancers(
-  renkuStateModelReducer,
-  enhancers = undefined
-) {
-  renkuStateModelReducer[kgSearchApi.reducerPath] = kgSearchApi.reducer;
-  renkuStateModelReducer[projectApi.reducerPath] = projectApi.reducer;
-  renkuStateModelReducer[projectCoreApi.reducerPath] = projectCoreApi.reducer;
-  renkuStateModelReducer[projectKgApi.reducerPath] = projectKgApi.reducer;
-  renkuStateModelReducer[sessionSidecarApi.reducerPath] =
-    sessionSidecarApi.reducer;
-  renkuStateModelReducer[sessionApi.reducerPath] = sessionApi.reducer;
-  renkuStateModelReducer[recentUserActivityApi.reducerPath] =
-    recentUserActivityApi.reducer;
-  renkuStateModelReducer[inactiveKgProjectsApi.reducerPath] =
-    inactiveKgProjectsApi.reducer;
-  renkuStateModelReducer[kgInactiveProjectsSlice.name] =
-    kgInactiveProjectsSlice.reducer;
-  renkuStateModelReducer[versionsApi.reducerPath] = versionsApi.reducer;
-  renkuStateModelReducer[displaySlice.name] = displaySlice.reducer;
-  renkuStateModelReducer[workflowsApi.reducerPath] = workflowsApi.reducer;
-  renkuStateModelReducer[workflowsSlice.name] = workflowsSlice.reducer;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const createStore = <S = any, A extends Action = AnyAction>(
+  renkuStateModelReducer: ReducersMapObject<S, A>,
+  enhancers: StoreEnhancer[] | undefined = undefined
+) => {
+  const enhancedReducer = {
+    ...renkuStateModelReducer,
+    [kgSearchApi.reducerPath]: kgSearchApi.reducer,
+    [projectApi.reducerPath]: projectApi.reducer,
+    [projectCoreApi.reducerPath]: projectCoreApi.reducer,
+    [projectKgApi.reducerPath]: projectKgApi.reducer,
+    [sessionSidecarApi.reducerPath]: sessionSidecarApi.reducer,
+    [sessionApi.reducerPath]: sessionApi.reducer,
+    [recentUserActivityApi.reducerPath]: recentUserActivityApi.reducer,
+    [inactiveKgProjectsApi.reducerPath]: inactiveKgProjectsApi.reducer,
+    [kgInactiveProjectsSlice.name]: kgInactiveProjectsSlice.reducer,
+    [versionsApi.reducerPath]: versionsApi.reducer,
+    [displaySlice.name]: displaySlice.reducer,
+    [workflowsApi.reducerPath]: workflowsApi.reducer,
+    [workflowsSlice.name]: workflowsSlice.reducer,
+  };
 
   // For the moment, disable the custom middleware, since it causes problems for our app.
   const store = configureStore({
-    reducer: renkuStateModelReducer,
+    reducer: enhancedReducer,
     middleware: (getDefaultMiddleware) =>
       getDefaultMiddleware({
         immutableCheck: false,
@@ -85,7 +84,7 @@ function createStoreWithEnhancers(
     enhancers,
   });
   return store;
-}
+};
 
 // TODO: Introduce a mock store for testing
 // import configureMockStore from 'redux-mock-store'
@@ -93,6 +92,3 @@ function createStoreWithEnhancers(
 //   const mockStore = configureMockStore([thunk]);
 //   return mockStore;
 // }
-
-export { createStore };
-export { createStoreWithEnhancers };

--- a/client/src/workflows/Workflows.container.tsx
+++ b/client/src/workflows/Workflows.container.tsx
@@ -17,7 +17,7 @@
  */
 
 import React from "react";
-import { RootStateOrAny, useDispatch } from "react-redux";
+import { useDispatch } from "react-redux";
 import { useParams } from "react-router-dom";
 
 import { WorkflowsTreeBrowser as WorkflowsTreeBrowserPresent } from "./Workflows.present";
@@ -95,9 +95,7 @@ function WorkflowsList({
     dispatch(workflowsSlice.actions.setOrderProperty({ newProperty }));
   const setDetailExpanded = (targetDetails: Record<string, any>) =>
     dispatch(workflowsSlice.actions.setDetail({ targetDetails }));
-  const workflowsDisplay = useWorkflowsSelector(
-    (state: RootStateOrAny) => state[workflowsSlice.name]
-  );
+  const workflowsDisplay = useWorkflowsSelector();
 
   // Fetch workflow list
   const skipList = !versionUrl || !repositoryUrl || unsupported;


### PR DESCRIPTION
The new `createSliceSelector()` helper function creates a React hook which simplifies writing state selectors for RTK slices.

Other updates:
* Moved `client/src/utils/helpers/EnhancedState.js` to TypeScript and export only one function, `createStore()`.

/deploy #persist #cypress renku=leafty/update-tests-renku-ui-2495