### PR TITLE
fix(client): update Time.js to not throw an error on invalid dates

### DIFF
--- a/client/src/utils/helpers/Time.js
+++ b/client/src/utils/helpers/Time.js
@@ -51,12 +51,19 @@ class Time {
   }
 
   static toIsoTimezoneString(inputDate, type = "datetime") {
-    // add the timezone manually and then convert to ISO string
-    const date = this.parseDate(inputDate);
-    const isoDate = new Date(
-      date.getTime() - date.getTimezoneOffset() * 60000
-    ).toISOString();
-    return this.toIsoString(isoDate, type);
+    try {
+      // add the timezone manually and then convert to ISO string
+      const date = this.parseDate(inputDate);
+      const isoDate = new Date(
+        date.getTime() - date.getTimezoneOffset() * 60000
+      ).toISOString();
+      return this.toIsoString(isoDate, type);
+    } catch (error) {
+      if (error.message === "Invalid date") {
+        return "Invalid date";
+      }
+      throw error;
+    }
   }
 
   static getReadableDate(inputDate) {

--- a/tests/cypress/e2e/workflows.spec.ts
+++ b/tests/cypress/e2e/workflows.spec.ts
@@ -49,7 +49,7 @@ describe("iteract with workflows", () => {
     cy.get_cy("workflows-browser").children().first().contains("pipeline");
   });
 
-  it.only("view inactive workflows and interact", () => {
+  it("view inactive workflows and interact", () => {
     fixtures.getWorkflows(
       "workflows/workflows-list-links-mappings-inactive.json"
     );
@@ -75,7 +75,7 @@ describe("iteract with workflows", () => {
     cy.get_cy("workflows-browser").children().first().contains("pipeline");
   });
 
-  it.only("expand a workflow - waiting", () => {
+  it("expand a workflow - waiting", () => {
     fixtures.getWorkflows("workflows/workflows-list-links-mappings.json");
     cy.visit("/projects/e2e/local-test-project/workflows");
     cy.get_cy("workflows-browser")

--- a/tests/cypress/e2e/workflows.spec.ts
+++ b/tests/cypress/e2e/workflows.spec.ts
@@ -49,7 +49,7 @@ describe("iteract with workflows", () => {
     cy.get_cy("workflows-browser").children().first().contains("pipeline");
   });
 
-  it("view inactive workflows and interact", () => {
+  it.only("view inactive workflows and interact", () => {
     fixtures.getWorkflows(
       "workflows/workflows-list-links-mappings-inactive.json"
     );
@@ -75,7 +75,7 @@ describe("iteract with workflows", () => {
     cy.get_cy("workflows-browser").children().first().contains("pipeline");
   });
 
-  it("expand a workflow - waiting", () => {
+  it.only("expand a workflow - waiting", () => {
     fixtures.getWorkflows("workflows/workflows-list-links-mappings.json");
     cy.visit("/projects/e2e/local-test-project/workflows");
     cy.get_cy("workflows-browser")


### PR DESCRIPTION
It seems that `tests/cypress/e2e/workflows.spec.ts` often fails due to fixture data not providing datetimes when expected.

/deploy #persist #cypress renku=0000-ui-3.5.0