### PR TITLE
fix(client): make the text not selectable in entity cards

### DIFF
--- a/client/src/components/entityHeader/EntityHeader.tsx
+++ b/client/src/components/entityHeader/EntityHeader.tsx
@@ -168,7 +168,9 @@ function EntityHeader({
             }`}
           >
             {!imageUrl ? (
-              <div className="card-bg-title card-bg-title--small">{title}</div>
+              <div className="card-bg-title card-bg-title--small user-select-none">
+                {title}
+              </div>
             ) : null}
           </div>
         </div>

--- a/client/src/components/list/ListBar.tsx
+++ b/client/src/components/list/ListBar.tsx
@@ -75,7 +75,9 @@ function ListBar({
             }`}
           >
             {!imageUrl ? (
-              <div className="card-bg-title card-bg-title--small">{title}</div>
+              <div className="card-bg-title card-bg-title--small user-select-none">
+                {title}
+              </div>
             ) : null}
           </div>
         </Link>

--- a/client/src/components/list/ListBarSessions.tsx
+++ b/client/src/components/list/ListBarSessions.tsx
@@ -277,7 +277,9 @@ function ListBarSession({
             }`}
           >
             {!imageUrl ? (
-              <div className="card-bg-title card-bg-title--small">{title}</div>
+              <div className="card-bg-title card-bg-title--small user-select-none">
+                {title}
+              </div>
             ) : null}
           </div>
         </Link>

--- a/client/src/components/list/ListCard.tsx
+++ b/client/src/components/list/ListCard.tsx
@@ -60,7 +60,9 @@ function ListCard({
               !imageUrl ? `card-header-entity--${itemType}` : ""
             }`}
           >
-            {!imageUrl ? <div className="card-bg-title">{title}</div> : null}
+            {!imageUrl ? (
+              <div className="card-bg-title user-select-none">{title}</div>
+            ) : null}
           </div>
           <EntityButton type={itemType} slug={path as string} />
           <div className="card-body">


### PR DESCRIPTION
See issue here:
![Screenshot 2023-05-25 at 11 56 46](https://github.com/SwissDataScienceCenter/renku-ui/assets/951086/fd3a4f99-bcb0-433a-8549-7eb7c26b4909)

/deploy #persist #cypress
