### PR TITLE
minor: change to lint rule for var and arg

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -28,14 +28,19 @@
   "overrides": [
     {
       "files": ["**/*.ts", "**/*.tsx"],
-      "plugins": ["@typescript-eslint", "react", "react-hooks", "spellcheck"],
+      "plugins": [
+        "@typescript-eslint",
+        "jest",
+        "react",
+        "react-hooks",
+        "spellcheck"
+      ],
       "extends": [
         "eslint:recommended",
         "plugin:@typescript-eslint/recommended",
         // We probably want to turn this on at some point
         // "plugin:@typescript-eslint/recommended-requiring-type-checking",
         "plugin:react/recommended",
-        // We probably want to turn this on at some point
         "plugin:react-hooks/recommended",
         "plugin:jest/recommended",
         "prettier"
@@ -44,7 +49,7 @@
         "project": ["./tsconfig.json"]
       },
       "rules": {
-        "@typescript-eslint/no-unused-vars": ["warn"]
+        "@typescript-eslint/no-unused-vars": "warn"
       }
     }
   ],

--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -15,23 +15,39 @@
   },
   "extends": [
     "eslint:recommended",
-    "plugin:@typescript-eslint/recommended",
     "plugin:react/recommended",
     "plugin:jest/recommended",
     "prettier"
   ],
-  "plugins": [
-    "react",
-    "react-hooks",
-    "jest",
-    "spellcheck",
-    "@typescript-eslint"
-  ],
+  "plugins": ["react", "react-hooks", "jest", "spellcheck"],
   "settings": {
     "react": {
       "version": "detect"
     }
   },
+  "overrides": [
+    {
+      "files": ["**/*.ts", "**/*.tsx"],
+      "plugins": ["@typescript-eslint", "react", "react-hooks", "spellcheck"],
+      "extends": [
+        "eslint:recommended",
+        "plugin:@typescript-eslint/recommended",
+        // We probably want to turn this on at some point
+        // "plugin:@typescript-eslint/recommended-requiring-type-checking",
+        "plugin:react/recommended",
+        // We probably want to turn this on at some point
+        "plugin:react-hooks/recommended",
+        "plugin:jest/recommended",
+        "prettier"
+      ],
+      "parserOptions": {
+        "project": ["./tsconfig.json"]
+      },
+      "rules": {
+        "@typescript-eslint/no-unused-vars": ["warn"]
+      }
+    }
+  ],
   "rules": {
     "no-eval": "error",
     "no-unused-vars": [

--- a/client/src/components/dateFilter/DateFilter.tsx
+++ b/client/src/components/dateFilter/DateFilter.tsx
@@ -31,7 +31,6 @@ export interface DateFilterProps {
   onDatesChange: (dates: DatesFilter) => void;
 }
 
-/* eslint-disable no-unused-vars */
 export enum DateFilterTypes {
   all = "all",
   custom = "custom",
@@ -40,7 +39,6 @@ export enum DateFilterTypes {
   lastWeek = "lastWeek",
   older = "older", // before 90 days
 }
-/* eslint-enable no-unused-vars */
 
 export function stringToDateFilter(str: string) {
   return Object.values(DateFilterTypes).includes(str as DateFilterTypes)

--- a/client/src/components/entities/Entities.d.ts
+++ b/client/src/components/entities/Entities.d.ts
@@ -16,8 +16,6 @@
  * limitations under the License.
  */
 
-// These are used by the TS compiler does not realize it.
-/* eslint-disable no-unused-vars */
 export enum EntityType {
   Dataset = "dataset",
   Project = "project",
@@ -28,4 +26,3 @@ export enum WorkflowType {
   Simple = "Plan",
   Composite = "CompositePlan",
 }
-/* eslint-enable no-unused-vars */

--- a/client/src/components/list/List.d.tsx
+++ b/client/src/components/list/List.d.tsx
@@ -6,13 +6,10 @@ export interface Creator {
   name: string;
 }
 
-// These are used by the TS compiler does not realize it.
-/* eslint-disable no-unused-vars */
 export enum ListDisplayType {
   Card,
   Bar,
 }
-/* eslint-enable no-unused-vars */
 
 export interface ListElementProps {
   creators: EntityCreator[];

--- a/client/src/components/progress/Progress.tsx
+++ b/client/src/components/progress/Progress.tsx
@@ -25,8 +25,6 @@ import "./Progress.css";
  *  Progress component
  */
 
-// These values are actually used, but the ts compiler does not realize it
-/* eslint-disable no-unused-vars */
 export enum ProgressType {
   Determinate = "Determinate",
   Indeterminate = "Indeterminate",
@@ -36,7 +34,6 @@ export enum ProgressStyle {
   Light = "light",
   Dark = "dark",
 }
-/* eslint-enable no-unused-vars */
 
 export interface ProgressIndicatorProps {
   /**

--- a/client/src/components/progress/ProgressSteps.tsx
+++ b/client/src/components/progress/ProgressSteps.tsx
@@ -27,8 +27,6 @@ import { Loader } from "../Loader";
  *  Progress component
  */
 
-// These values are actually used, but the ts compiler does not realize it
-/* eslint-disable no-unused-vars */
 export enum ProgressType {
   Determinate = "Determinate",
   Indeterminate = "Indeterminate",
@@ -45,7 +43,6 @@ export enum StatusStepProgressBar {
   WAITING = "waiting",
   FAILED = "failed",
 }
-/* eslint-enable no-unused-vars */
 
 export interface StepsProgressBar {
   id: number;

--- a/client/src/components/sortingEntities/SortingEntities.tsx
+++ b/client/src/components/sortingEntities/SortingEntities.tsx
@@ -28,8 +28,6 @@ import "./SortingEntities.css";
  *  Sorting Entities input
  */
 
-// These are used by the TS compiler does not realize it.
-/* eslint-disable no-unused-vars */
 export enum SortingOptions {
   AscTitle = "name:asc",
   DescTitle = "name:desc",
@@ -38,7 +36,6 @@ export enum SortingOptions {
   AscMatchingScore = "matchingScore:asc",
   DescMatchingScore = "matchingScore:desc",
 }
-/* eslint-enable no-unused-vars */
 
 export function stringToSortingOption(str: string) {
   return Object.values(SortingOptions).includes(str as SortingOptions)

--- a/client/src/components/visibility/Visibility.tsx
+++ b/client/src/components/visibility/Visibility.tsx
@@ -42,14 +42,11 @@ import {
  *  Visibility input
  */
 
-// These are used by the TS compiler does not realize it.
-/* eslint-disable no-unused-vars */
 export enum Visibilities {
   Public = "public",
   Private = "private",
   Internal = "internal",
 }
-/* eslint-enable no-unused-vars */
 
 export interface VisibilityInputProps {
   /** It restrict the options to show */

--- a/client/src/features/dashboard/Dashboard.tsx
+++ b/client/src/features/dashboard/Dashboard.tsx
@@ -29,6 +29,7 @@ import "./Dashboard.scss";
 
 class DashboardWrapper extends Component {
   // ? Temporary wrapper to fetch sessions at least once when opening the dashboard.
+  /* eslint-disable react/prop-types */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   constructor(props: any) {
     super(props);
@@ -41,6 +42,7 @@ class DashboardWrapper extends Component {
     );
     notebookCoordinator.fetchNotebooks();
   }
+  /* eslint-enable react/prop-types */
 
   render() {
     return <Dashboard />;

--- a/client/src/features/kgSearch/KgSearch.d.ts
+++ b/client/src/features/kgSearch/KgSearch.d.ts
@@ -29,13 +29,10 @@ export interface KgSearchResultLink {
 
 export type KgAuthor = "user" | "all";
 
-// These are used by the TS compiler does not realize it.
-/* eslint-disable no-unused-vars */
 export enum EntityType {
   Project = "project",
   Dataset = "dataset",
 }
-/* eslint-enable no-unused-vars */
 
 export interface KgSearchResult {
   _links: KgSearchResultLink[];

--- a/client/src/features/project/ProjectEntityHeader.tsx
+++ b/client/src/features/project/ProjectEntityHeader.tsx
@@ -27,8 +27,7 @@ type ProjectEntityHeaderProps = EntityHeaderProps & { isInKg: boolean };
 function ProjectEntityHeader(props: ProjectEntityHeaderProps) {
   const { fullPath } = props;
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
-  const { data: _kgData } = useProjectMetadataQuery(
+  useProjectMetadataQuery(
     { projectPath: fullPath },
     { skip: !fullPath || props.isInKg != true }
   );

--- a/client/src/utils/helpers/url/Url.test.js
+++ b/client/src/utils/helpers/url/Url.test.js
@@ -25,8 +25,6 @@
 
 import { UrlRule, Url, getSearchParams, isSessionUrl } from "./Url";
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
 describe("UrlRule private class", () => {
   it("Initialization values and errors", () => {
     // Verify all the parameters, and try to trigger all possible errors based on wrong parameters.

--- a/client/src/workflows/Workflows.present.tsx
+++ b/client/src/workflows/Workflows.present.tsx
@@ -655,7 +655,13 @@ function WorkflowTreeDetail({
 
 /** VISUALIZER **/
 
-function UnavailableDetail({ className = "", text = "None" }) {
+function UnavailableDetail({
+  className = "",
+  text = "None",
+}: {
+  className?: string;
+  text?: string;
+}) {
   return (
     <span className={`fst-italic text-rk-text-light ${className}`}>{text}</span>
   );


### PR DESCRIPTION
Vars and args can start with `_` to indicate that they are unused. 