### PR TITLE
fix(tests): force the UI to wait in "expand a workflow - waiting"

### DIFF
--- a/tests/cypress/e2e/workflows.spec.ts
+++ b/tests/cypress/e2e/workflows.spec.ts
@@ -77,6 +77,10 @@ describe("iteract with workflows", () => {
 
   it("expand a workflow - waiting", () => {
     fixtures.getWorkflows("workflows/workflows-list-links-mappings.json");
+    cy.intercept("/ui-server/api/renku/*/workflow_plans.show?*", {
+      fixture: "workflows/workflow-show-links-mappings.json",
+      delay: 1_000,
+    });
     cy.visit("/projects/e2e/local-test-project/workflows");
     cy.get_cy("workflows-browser")
       .children()


### PR DESCRIPTION
See https://github.com/SwissDataScienceCenter/renku-ui/actions/runs/5078713055/jobs/9123592615?pr=2546:
the UI updates too fast for cypress.