### PR TITLE
chore(deps): update react-ipynb-renderer from 2.0.1 to 2.1.2

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -49,7 +49,7 @@
         "react-cookie-consent": "^8.0.1",
         "react-dom": "^18.2.0",
         "react-helmet": "^6.1.0",
-        "react-ipynb-renderer": "^2.0.1",
+        "react-ipynb-renderer": "^2.1.2",
         "react-js-pagination": "^3.0.2",
         "react-katex": "^3.0.1",
         "react-markdown": "^8.0.7",
@@ -33192,9 +33192,9 @@
       }
     },
     "node_modules/react-ipynb-renderer": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/react-ipynb-renderer/-/react-ipynb-renderer-2.0.1.tgz",
-      "integrity": "sha512-RVzzQ3nadhoujW/iJZ1BxL7n7rGUgJuHKpNR0XKBtbWxi3AVFt1Ek4HcYBHn22Jso/xTg6moVW7AJlrE/L63Uw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/react-ipynb-renderer/-/react-ipynb-renderer-2.1.2.tgz",
+      "integrity": "sha512-TPZOVnYr4ySBmjJ7K5lz3VQ0l4aoH0roDKWSWz/AWXoSIawti3teaj1JmUi0hqCPuArg55hJIJqEoWDh7ZJKPg==",
       "dependencies": {
         "ansi-to-react": "^6.1.6",
         "dompurify": "^2.4.1",
@@ -65289,9 +65289,9 @@
       }
     },
     "react-ipynb-renderer": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/react-ipynb-renderer/-/react-ipynb-renderer-2.0.1.tgz",
-      "integrity": "sha512-RVzzQ3nadhoujW/iJZ1BxL7n7rGUgJuHKpNR0XKBtbWxi3AVFt1Ek4HcYBHn22Jso/xTg6moVW7AJlrE/L63Uw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/react-ipynb-renderer/-/react-ipynb-renderer-2.1.2.tgz",
+      "integrity": "sha512-TPZOVnYr4ySBmjJ7K5lz3VQ0l4aoH0roDKWSWz/AWXoSIawti3teaj1JmUi0hqCPuArg55hJIJqEoWDh7ZJKPg==",
       "requires": {
         "ansi-to-react": "^6.1.6",
         "dompurify": "^2.4.1",

--- a/client/package.json
+++ b/client/package.json
@@ -44,7 +44,7 @@
     "react-cookie-consent": "^8.0.1",
     "react-dom": "^18.2.0",
     "react-helmet": "^6.1.0",
-    "react-ipynb-renderer": "^2.0.1",
+    "react-ipynb-renderer": "^2.1.2",
     "react-js-pagination": "^3.0.2",
     "react-katex": "^3.0.1",
     "react-markdown": "^8.0.7",


### PR DESCRIPTION
Supersedes #2556.

/deploy renku-core=bugfix/2124-fetch-template-errors renku=2315ui-project-status #persist #notest #cypress