### PR TITLE
chore(client): fix webpack warning

### DIFF
--- a/client/craco.config.js
+++ b/client/craco.config.js
@@ -12,8 +12,8 @@ module.exports = {
   webpack: {
     configure: {
       output: {
-        filename: `[name].[hash]-${version}.js`,
-        chunkFilename: `[name].[hash]-${version}.chunk.js`,
+        filename: `[name].[fullhash]-${version}.js`,
+        chunkFilename: `[name].[fullhash]-${version}.chunk.js`,
       },
     },
   },


### PR DESCRIPTION
Fixes a Webpack deprecation warning:

```
[DEP_WEBPACK_TEMPLATE_PATH_PLUGIN_REPLACE_PATH_VARIABLES_HASH] DeprecationWarning: [hash] is now [fullhash] (also consider using [chunkhash] or [contenthash], see documentation for details)
```