### PR TITLE
fix(client): set autocomplete to off for the delete project confirmation box

### DIFF
--- a/client/src/features/project/components/ProjectSettingsGeneralDeleteProject.tsx
+++ b/client/src/features/project/components/ProjectSettingsGeneralDeleteProject.tsx
@@ -149,6 +149,7 @@ export const ProjectSettingsGeneralDeleteProject = ({
                   type="text"
                   value={confirmText}
                   onChange={onChangeConfirmBox}
+                  autoComplete="off"
                 />
                 <div className="mt-2 d-flex flex-row justify-content-end">
                   <Button color="outline-danger" onClick={onCloseModal}>


### PR DESCRIPTION
The autocomplete suggestions offered by the browser are not useful (other project names which were deleted).

/deploy renku-core=develop renku=2315ui-project-status #persist #cypress