### PR TITLE
fix: allow up to 100 namespaces and sort them

### DIFF
--- a/client/src/features/projects/projectsApi.ts
+++ b/client/src/features/projects/projectsApi.ts
@@ -35,6 +35,19 @@ interface MemberProjectResponse {
   hasNextPage: boolean;
 }
 
+type Namespace = {
+  id: number;
+  name: string;
+  path: string;
+  kind: string;
+  full_path: string;
+  parent_id: number | null;
+  avatar_url: string | null;
+  web_url: string;
+  members_count_with_descendants: number;
+  root_repository_size: number;
+};
+
 function convertProjects(response: any): MemberProjectResponse {
   try {
     const projects = response?.data?.projects?.nodes;
@@ -60,9 +73,9 @@ export const projectsApi = createApi({
   reducerPath: "projects",
   baseQuery: fetchBaseQuery({ baseUrl: "/ui-server/api" }),
   endpoints: (builder) => ({
-    getNamespaces: builder.query({
+    getNamespaces: builder.query<Namespace[], boolean>({
       query: (ownerOnly?: boolean) => ({
-        url: `/namespaces${ownerOnly ? "?owned_only=true" : ""}`,
+        url: `/namespaces?per_page=100${ownerOnly ? "&owned_only=true" : ""}`,
         method: "GET",
       }),
     }),

--- a/client/src/utils/customHooks/UseGetNamespaces.ts
+++ b/client/src/utils/customHooks/UseGetNamespaces.ts
@@ -28,8 +28,12 @@ function useGetNamespaces(ownedOnly: boolean) {
   const { data, isFetching, isLoading, refetch } =
     useGetNamespacesQuery(ownedOnly);
 
+  const sortedList = data
+    ? [...data].sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
+    : [];
+
   return {
-    list: data ?? [],
+    list: sortedList ?? [],
     fetching: isFetching,
     fetched: !isFetching && !isLoading,
     refetchNamespaces: refetch,


### PR DESCRIPTION
Some users have more than 20 namespaces. Increase the limit used when showing the namespace list in the project creation dropdown.

/deploy #persist #cypress