### PR TITLE
feat(client): update session start options and flow for resource pools 

### DIFF
--- a/client/src/features/dataServices/dataServices.d.ts
+++ b/client/src/features/dataServices/dataServices.d.ts
@@ -40,6 +40,8 @@ export interface ResourceClass {
   default_storage: number;
 
   default: boolean;
+
+  matches?: boolean;
 }
 
 export interface Resources {

--- a/client/src/features/dataServices/dataServices.d.ts
+++ b/client/src/features/dataServices/dataServices.d.ts
@@ -50,3 +50,10 @@ export interface Resources {
   gpu: number;
   storage: number;
 }
+
+export interface ResourcePoolsQueryParams {
+  cpuRequest?: number;
+  gpuRequest?: number;
+  memoryRequest?: number;
+  storageRequest?: number;
+}

--- a/client/src/features/dataServices/dataServices.d.ts
+++ b/client/src/features/dataServices/dataServices.d.ts
@@ -21,6 +21,9 @@ export interface ResourcePool {
   name: string;
   classes: ResourceClass[];
   quota: Resources;
+  // TODO(@leafty): remove "?"
+  default?: boolean;
+  public?: boolean;
 }
 
 export interface ResourceClass {
@@ -41,7 +44,7 @@ export interface ResourceClass {
 
   default: boolean;
 
-  matches?: boolean;
+  matching?: boolean;
 }
 
 export interface Resources {

--- a/client/src/features/dataServices/dataServices.d.ts
+++ b/client/src/features/dataServices/dataServices.d.ts
@@ -21,6 +21,7 @@ export interface ResourcePool {
   name: string;
   classes: ResourceClass[];
   quota: Resources;
+  // eslint-disable-next-line spellcheck/spell-checker
   // TODO(@leafty): remove "?"
   default?: boolean;
   public?: boolean;
@@ -44,6 +45,7 @@ export interface ResourceClass {
 
   default: boolean;
 
+  // eslint-disable-next-line spellcheck/spell-checker
   // TODO(@leafty): remove "?"
   matching?: boolean;
 }

--- a/client/src/features/dataServices/dataServices.d.ts
+++ b/client/src/features/dataServices/dataServices.d.ts
@@ -44,6 +44,7 @@ export interface ResourceClass {
 
   default: boolean;
 
+  // TODO(@leafty): remove "?"
   matching?: boolean;
 }
 

--- a/client/src/features/dataServices/dataServicesApi.ts
+++ b/client/src/features/dataServices/dataServicesApi.ts
@@ -17,7 +17,7 @@
  */
 
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/dist/query/react";
-import { ResourcePool } from "./dataServices";
+import { ResourcePool, ResourcePoolsQueryParams } from "./dataServices";
 
 export const dataServicesApi = createApi({
   reducerPath: "dataServices",
@@ -25,10 +25,18 @@ export const dataServicesApi = createApi({
     baseUrl: "/ui-server/api/data",
   }),
   endpoints: (builder) => ({
-    getResourcePools: builder.query<ResourcePool[], Record<string, never>>({
-      query: () => {
+    getResourcePools: builder.query<ResourcePool[], ResourcePoolsQueryParams>({
+      query: ({ cpuRequest, gpuRequest, memoryRequest, storageRequest }) => {
+        const params = {
+          ...(cpuRequest ? { cpuRequest } : {}),
+          ...(gpuRequest ? { gpuRequest } : {}),
+          ...(memoryRequest ? { memoryRequest } : {}),
+          ...(storageRequest ? { storageRequest } : {}),
+        };
+        console.warn("TODO!", params);
         return {
           url: "resource_pools",
+          // params
         };
       },
     }),

--- a/client/src/features/dataServices/dataServicesApi.ts
+++ b/client/src/features/dataServices/dataServicesApi.ts
@@ -28,15 +28,14 @@ export const dataServicesApi = createApi({
     getResourcePools: builder.query<ResourcePool[], ResourcePoolsQueryParams>({
       query: ({ cpuRequest, gpuRequest, memoryRequest, storageRequest }) => {
         const params = {
-          ...(cpuRequest ? { cpuRequest } : {}),
-          ...(gpuRequest ? { gpuRequest } : {}),
-          ...(memoryRequest ? { memoryRequest } : {}),
-          ...(storageRequest ? { storageRequest } : {}),
+          ...(cpuRequest ? { cpu: cpuRequest } : {}),
+          ...(gpuRequest ? { gpu: gpuRequest } : {}),
+          ...(memoryRequest ? { memory: memoryRequest } : {}),
+          ...(storageRequest ? { max_storage: storageRequest } : {}),
         };
-        console.warn("TODO!", params);
         return {
           url: "resource_pools",
-          // params
+          params,
         };
       },
     }),

--- a/client/src/features/project/Project.d.ts
+++ b/client/src/features/project/Project.d.ts
@@ -297,9 +297,6 @@ export interface ProjectConfigSection {
   sessions?: {
     defaultUrl?: string;
 
-    /** Session class from the resource pool API */
-    // sessionClass?: number;
-
     /** Disk storage in Gigabytes */
     storage?: number;
 

--- a/client/src/features/project/Project.d.ts
+++ b/client/src/features/project/Project.d.ts
@@ -298,7 +298,7 @@ export interface ProjectConfigSection {
     defaultUrl?: string;
 
     /** Session class from the resource pool API */
-    sessionClass?: number;
+    // sessionClass?: number;
 
     /** Disk storage in Gigabytes */
     storage?: number;

--- a/client/src/features/project/projectCoreApi.ts
+++ b/client/src/features/project/projectCoreApi.ts
@@ -88,8 +88,11 @@ interface UpdateConfigRawResponse {
   };
 }
 
-function versionedUrlEndpoint(endpoint: string, versionUrl?: string) {
-  const urlPath = versionUrl ? `${versionUrl}/${endpoint}` : endpoint;
+function versionedUrlEndpoint(
+  endpoint: string,
+  versionUrl: string | undefined | null
+) {
+  const urlPath = versionUrl ? `${versionUrl}/${endpoint}` : `/${endpoint}`;
   return `/renku${urlPath}`;
 }
 

--- a/client/src/features/project/projectCoreApi.ts
+++ b/client/src/features/project/projectCoreApi.ts
@@ -52,7 +52,6 @@ interface GetConfigRawResponse {
 
 const KNOWN_CONFIG_KEYS = [
   "interactive.default_url",
-  // "interactive.session_class",
   "interactive.lfs_auto_fetch",
   "interactive.disk_request",
   "interactive.cpu_request",
@@ -335,9 +334,6 @@ const transformGetConfigRawResponse = (
     config: {
       sessions: {
         defaultUrl: projectSessionsConfig["interactive.default_url"],
-        // sessionClass: safeParseInt(
-        //   projectSessionsConfig["interactive.session_class"]
-        // ),
         storage: safeParseInt(
           projectSessionsConfig["interactive.disk_request"]
         ),
@@ -353,9 +349,6 @@ const transformGetConfigRawResponse = (
     default: {
       sessions: {
         defaultUrl: defaultSessionsConfig["interactive.default_url"],
-        // sessionClass: safeParseInt(
-        //   defaultSessionsConfig["interactive.session_class"]
-        // ),
         storage: safeParseInt(
           defaultSessionsConfig["interactive.disk_request"]
         ),

--- a/client/src/features/project/projectCoreApi.ts
+++ b/client/src/features/project/projectCoreApi.ts
@@ -52,7 +52,7 @@ interface GetConfigRawResponse {
 
 const KNOWN_CONFIG_KEYS = [
   "interactive.default_url",
-  "interactive.session_class",
+  // "interactive.session_class",
   "interactive.lfs_auto_fetch",
   "interactive.disk_request",
   "interactive.cpu_request",
@@ -335,9 +335,9 @@ const transformGetConfigRawResponse = (
     config: {
       sessions: {
         defaultUrl: projectSessionsConfig["interactive.default_url"],
-        sessionClass: safeParseInt(
-          projectSessionsConfig["interactive.session_class"]
-        ),
+        // sessionClass: safeParseInt(
+        //   projectSessionsConfig["interactive.session_class"]
+        // ),
         storage: safeParseInt(
           projectSessionsConfig["interactive.disk_request"]
         ),
@@ -353,9 +353,9 @@ const transformGetConfigRawResponse = (
     default: {
       sessions: {
         defaultUrl: defaultSessionsConfig["interactive.default_url"],
-        sessionClass: safeParseInt(
-          defaultSessionsConfig["interactive.session_class"]
-        ),
+        // sessionClass: safeParseInt(
+        //   defaultSessionsConfig["interactive.session_class"]
+        // ),
         storage: safeParseInt(
           defaultSessionsConfig["interactive.disk_request"]
         ),

--- a/client/src/features/project/useProjectCoreSupport.ts
+++ b/client/src/features/project/useProjectCoreSupport.ts
@@ -75,7 +75,7 @@ export const useCoreSupport = ({
   };
 };
 
-const computeBackendData = ({
+export const computeBackendData = ({
   availableVersions,
   projectVersion,
 }: {

--- a/client/src/notebooks/NotebookStart.present.js
+++ b/client/src/notebooks/NotebookStart.present.js
@@ -1159,7 +1159,7 @@ function StartNotebookOptions(props) {
     );
 
   const { all, fetched } = props.notebooks;
-  const { filters } = props;
+  const { filters, options } = props;
   if (!fetched) {
     return (
       <Label>
@@ -1167,6 +1167,13 @@ function StartNotebookOptions(props) {
       </Label>
     );
   }
+
+  if (Object.keys(options.global).length === 0 || options.fetching)
+    return (
+      <Label>
+        Loading session parameters... <Loader size={14} inline />
+      </Label>
+    );
 
   if (Object.keys(all).length > 0) {
     const currentCommit = filters.commit?.id;

--- a/client/src/notebooks/NotebookStart.present.js
+++ b/client/src/notebooks/NotebookStart.present.js
@@ -1167,12 +1167,14 @@ function StartNotebookOptions(props) {
       </Label>
     );
 
-  if (Object.keys(options.global).length === 0 || options.fetching)
-    return (
-      <Label>
-        Loading session parameters... <Loader size={14} inline />
-      </Label>
-    );
+  if (Object.keys(options.global).length === 0 || options.fetching) {
+    console.log("no options?", options);
+    // return (
+    //   <Label>
+    //     Loading session parameters... <Loader size={14} inline />
+    //   </Label>
+    // );
+  }
 
   if (Object.keys(all).length > 0) {
     const currentCommit = filters.commit?.id;
@@ -1182,19 +1184,21 @@ function StartNotebookOptions(props) {
       return false;
     });
     if (currentNotebook) {
-      return [
-        <StartNotebookOptionsRunning
-          key="notebook-options-running"
-          notebook={all[currentNotebook]}
-        />,
-        <ShareLinkSessionModal
-          key="shareLinkModal"
-          toggleModal={props.toggleShareLinkModal}
-          showModal={props.showShareLinkModal}
-          notebookFilePath={props.notebookFilePath}
-          {...props}
-        />,
-      ];
+      return (
+        <>
+          <StartNotebookOptionsRunning
+            key="notebook-options-running"
+            notebook={all[currentNotebook]}
+          />
+          <ShareLinkSessionModal
+            key="shareLinkModal"
+            toggleModal={props.toggleShareLinkModal}
+            showModal={props.showShareLinkModal}
+            notebookFilePath={props.notebookFilePath}
+            {...props}
+          />
+        </>
+      );
     }
   }
 
@@ -1353,6 +1357,8 @@ class ServerOptionLaunch extends Component {
   render() {
     const { ci } = this.props;
     const { warnings } = this.props.options;
+
+    console.log(this.props.options);
 
     const ciStatus = NotebooksHelper.checkCiStatus(ci);
     const globalNotification =

--- a/client/src/notebooks/NotebookStart.present.js
+++ b/client/src/notebooks/NotebookStart.present.js
@@ -1159,21 +1159,13 @@ function StartNotebookOptions(props) {
     );
 
   const { all, fetched } = props.notebooks;
-  const { filters, options } = props;
-  if (!fetched)
+  const { filters } = props;
+  if (!fetched) {
     return (
       <Label>
         Verifying available sessions... <Loader size={14} inline />
       </Label>
     );
-
-  if (Object.keys(options.global).length === 0 || options.fetching) {
-    console.log("no options?", options);
-    // return (
-    //   <Label>
-    //     Loading session parameters... <Loader size={14} inline />
-    //   </Label>
-    // );
   }
 
   if (Object.keys(all).length > 0) {
@@ -1357,8 +1349,6 @@ class ServerOptionLaunch extends Component {
   render() {
     const { ci } = this.props;
     const { warnings } = this.props.options;
-
-    console.log(this.props.options);
 
     const ciStatus = NotebooksHelper.checkCiStatus(ci);
     const globalNotification =

--- a/client/src/notebooks/Notebooks.container.js
+++ b/client/src/notebooks/Notebooks.container.js
@@ -663,6 +663,7 @@ class StartNotebookServer extends Component {
   }
 
   async refreshPipelines(force = false) {
+    console.log("refreshPipelines()");
     if (this._isMounted) {
       const { accessLevel, user } = this.props;
       // await this.coordinator.fetchNotebookOptions(); // TODO: this should not be here
@@ -709,6 +710,7 @@ class StartNotebookServer extends Component {
   }
 
   async triggerAutoStart() {
+    console.log("triggerAutoStart()");
     if (this._isMounted) {
       if (
         this.autostart &&
@@ -717,8 +719,14 @@ class StartNotebookServer extends Component {
       ) {
         const data = this.model.get();
         const ciStatus = NotebooksHelper.checkCiStatus(data.ci);
-        const fetched =
-          data.notebooks.fetched && data.options.fetched && !ciStatus.ongoing;
+        // const fetched =
+        //   data.notebooks.fetched && data.options.fetched && !ciStatus.ongoing;
+        const fetched = data.notebooks.fetched && !ciStatus.ongoing;
+        console.log([
+          data.notebooks.fetched,
+          data.options.fetched,
+          !ciStatus.ongoing,
+        ]);
         if (fetched) {
           // start when the image is available
           if (ciStatus.available) {

--- a/client/src/notebooks/Notebooks.container.js
+++ b/client/src/notebooks/Notebooks.container.js
@@ -672,7 +672,6 @@ class StartNotebookServer extends Component {
       this.coordinator.setCommit(commit);
       await this.getProjectConfig();
       await this.getResourcePools();
-      console.log("refreshPipelines() - call site");
       this.refreshPipelines();
     }
   }
@@ -680,7 +679,6 @@ class StartNotebookServer extends Component {
   async getProjectConfig() {
     const metadata = this.props.model.get("project.metadata");
     const { defaultBranch, externalUrl: projectRepositoryUrl } = metadata;
-    console.log({ metadata });
 
     const store = this.props.model.reduxStore;
 
@@ -714,7 +712,6 @@ class StartNotebookServer extends Component {
       availableVersions,
       projectVersion,
     });
-    console.log({ coreSupport });
 
     // Get project config
     const getConfig = store.dispatch(
@@ -727,7 +724,6 @@ class StartNotebookServer extends Component {
 
     const { data: projectConfig } = await getConfig;
     this.state.projectConfig = projectConfig;
-    console.log({ projectConfig });
   }
 
   async getResourcePools() {
@@ -746,29 +742,11 @@ class StartNotebookServer extends Component {
 
     const { data: resourcePools } = await getResourcePools;
     this.state.resourcePools = resourcePools;
-    console.log({ resourcePools });
-
-    // const {
-    //   data: realResourcePools,
-    //   isLoading,
-    //   isError,
-    // } = useGetResourcePoolsQuery(
-    //   {
-    //     cpuRequest: projectConfig?.config.sessions?.legacyConfig?.cpuRequest,
-    //     gpuRequest: projectConfig?.config.sessions?.legacyConfig?.gpuRequest,
-    //     memoryRequest:
-    //       projectConfig?.config.sessions?.legacyConfig?.memoryRequest,
-    //     storageRequest: projectConfig?.config.sessions?.storage,
-    //   },
-    //   { skip: enableFakeResourcePools || !projectConfig }
-    // );
   }
 
   async refreshPipelines(force = false) {
-    console.log("refreshPipelines()");
     if (this._isMounted) {
       const { accessLevel, user } = this.props;
-      // await this.coordinator.fetchNotebookOptions(); // TODO: this should not be here
       const callback = () => {
         // eslint-disable-line @typescript-eslint/no-empty-function
       };
@@ -812,7 +790,6 @@ class StartNotebookServer extends Component {
   }
 
   async triggerAutoStart() {
-    console.log("triggerAutoStart()");
     if (this._isMounted) {
       if (
         this.autostart &&
@@ -821,14 +798,7 @@ class StartNotebookServer extends Component {
       ) {
         const data = this.model.get();
         const ciStatus = NotebooksHelper.checkCiStatus(data.ci);
-        // const fetched =
-        //   data.notebooks.fetched && data.options.fetched && !ciStatus.ongoing;
         const fetched = data.notebooks.fetched && !ciStatus.ongoing;
-        console.log([
-          data.notebooks.fetched,
-          data.options.fetched,
-          !ciStatus.ongoing,
-        ]);
         if (fetched) {
           // Check that we can auto-assign a session class
           const resourcePools = this.state.resourcePools;

--- a/client/src/notebooks/Notebooks.container.js
+++ b/client/src/notebooks/Notebooks.container.js
@@ -665,7 +665,7 @@ class StartNotebookServer extends Component {
   async refreshPipelines(force = false) {
     if (this._isMounted) {
       const { accessLevel, user } = this.props;
-      await this.coordinator.fetchNotebookOptions(); // TODO: this should not be here
+      // await this.coordinator.fetchNotebookOptions(); // TODO: this should not be here
       const callback = () => {
         // eslint-disable-line @typescript-eslint/no-empty-function
       };

--- a/client/src/notebooks/Notebooks.container.js
+++ b/client/src/notebooks/Notebooks.container.js
@@ -32,6 +32,14 @@ import { StatusHelper } from "../model/Model";
 import { Url } from "../utils/helpers/url";
 import { sleep } from "../utils/helpers/HelperFunctions";
 import ShowSessionFullscreen from "./components/SessionFullScreen";
+import { versionsApi } from "../features/versions/versionsApi";
+import { projectCoreApi } from "../features/project/projectCoreApi";
+import { computeBackendData } from "../features/project/useProjectCoreSupport";
+import { dataServicesApi } from "../features/dataServices/dataServicesApi";
+import {
+  setSessionClass,
+  setStorage,
+} from "../features/session/startSessionOptionsSlice";
 
 /**
  * This component is needed to map properties from the redux store and keep local states cleared by the
@@ -343,6 +351,9 @@ class StartNotebookServer extends Component {
       showShareLinkModal: props.location?.state?.showShareLinkModal,
       filePath: props.location?.state?.filePath,
       scope: props.scope,
+      projectConfig: null,
+      resourcePools: null,
+      rtkQuerySubscriptions: [],
     };
 
     this.handlers = {
@@ -385,6 +396,7 @@ class StartNotebookServer extends Component {
   componentWillUnmount() {
     this.coordinator.stopNotebookPolling();
     this.coordinator.stopCiPolling();
+    this.state.rtkQuerySubscriptions.forEach((unsubscribe) => unsubscribe());
     this._isMounted = false;
   }
 
@@ -658,8 +670,98 @@ class StartNotebookServer extends Component {
       }
 
       this.coordinator.setCommit(commit);
+      await this.getProjectConfig();
+      await this.getResourcePools();
+      console.log("refreshPipelines() - call site");
       this.refreshPipelines();
     }
+  }
+
+  async getProjectConfig() {
+    const metadata = this.props.model.get("project.metadata");
+    const { defaultBranch, externalUrl: projectRepositoryUrl } = metadata;
+    console.log({ metadata });
+
+    const store = this.props.model.reduxStore;
+
+    // Re-implementation of useCoreSupport() without hooks
+    const getMigrationStatus = store.dispatch(
+      projectCoreApi.endpoints.getMigrationStatus.initiate({
+        gitUrl: projectRepositoryUrl ?? "",
+        branch: defaultBranch,
+      })
+    );
+    this.state.rtkQuerySubscriptions.push(getMigrationStatus.unsubscribe);
+
+    const getCoreVersions = store.dispatch(
+      versionsApi.endpoints.getCoreVersions.initiate()
+    );
+    this.state.rtkQuerySubscriptions.push(getCoreVersions.unsubscribe);
+
+    const { data: migrationStatus } = await getMigrationStatus;
+    const { data: coreVersions } = await getCoreVersions;
+
+    const availableVersions = coreVersions?.metadataVersions;
+    const projectVersion =
+      migrationStatus?.details?.core_compatibility_status.type === "detail"
+        ? parseInt(
+            migrationStatus.details.core_compatibility_status
+              .project_metadata_version
+          )
+        : undefined;
+
+    const coreSupport = computeBackendData({
+      availableVersions,
+      projectVersion,
+    });
+    console.log({ coreSupport });
+
+    // Get project config
+    const getConfig = store.dispatch(
+      projectCoreApi.endpoints.getConfig.initiate({
+        projectRepositoryUrl,
+        versionUrl: coreSupport.versionUrl,
+      })
+    );
+    this.state.rtkQuerySubscriptions.push(getConfig.unsubscribe);
+
+    const { data: projectConfig } = await getConfig;
+    this.state.projectConfig = projectConfig;
+    console.log({ projectConfig });
+  }
+
+  async getResourcePools() {
+    const store = this.props.model.reduxStore;
+    const projectConfig = this.state.projectConfig;
+    const getResourcePools = store.dispatch(
+      dataServicesApi.endpoints.getResourcePools.initiate({
+        cpuRequest: projectConfig?.config.sessions?.legacyConfig?.cpuRequest,
+        gpuRequest: projectConfig?.config.sessions?.legacyConfig?.gpuRequest,
+        memoryRequest:
+          projectConfig?.config.sessions?.legacyConfig?.memoryRequest,
+        storageRequest: projectConfig?.config.sessions?.storage,
+      })
+    );
+    this.state.rtkQuerySubscriptions.push(getResourcePools.unsubscribe);
+
+    const { data: resourcePools } = await getResourcePools;
+    this.state.resourcePools = resourcePools;
+    console.log({ resourcePools });
+
+    // const {
+    //   data: realResourcePools,
+    //   isLoading,
+    //   isError,
+    // } = useGetResourcePoolsQuery(
+    //   {
+    //     cpuRequest: projectConfig?.config.sessions?.legacyConfig?.cpuRequest,
+    //     gpuRequest: projectConfig?.config.sessions?.legacyConfig?.gpuRequest,
+    //     memoryRequest:
+    //       projectConfig?.config.sessions?.legacyConfig?.memoryRequest,
+    //     storageRequest: projectConfig?.config.sessions?.storage,
+    //   },
+    //   { skip: enableFakeResourcePools || !projectConfig }
+    // );
   }
 
   async refreshPipelines(force = false) {
@@ -728,6 +830,43 @@ class StartNotebookServer extends Component {
           !ciStatus.ongoing,
         ]);
         if (fetched) {
+          // Check that we can auto-assign a session class
+          const resourcePools = this.state.resourcePools;
+          const defaultSessionClass = resourcePools
+            ?.flatMap((pool) => pool.classes)
+            .find((c) => c.default);
+          const firstMatchingSessionClass = defaultSessionClass?.matching
+            ? defaultSessionClass
+            : resourcePools
+                ?.filter((pool) => pool.default)
+                .flatMap((pool) => pool.classes)
+                .find((c) => c.matching);
+          if (firstMatchingSessionClass == null) {
+            this.setState({
+              autostartReady: true,
+              autostartTried: true,
+              launchError: {
+                frontendError: true,
+                pipelineError: false,
+                errorMessage:
+                  "The session cannot be started automatically, please select session options below.",
+              },
+              starting: false,
+            });
+            return;
+          }
+
+          const store = this.props.model.reduxStore;
+          await store.dispatch(setSessionClass(firstMatchingSessionClass.id));
+          if (
+            this.state.projectConfig?.config.sessions?.storage != null &&
+            this.state.projectConfig.config.sessions.storage > 0
+          ) {
+            await store.dispatch(
+              setStorage(this.state.projectConfig.config.sessions.storage)
+            );
+          }
+
           // start when the image is available
           if (ciStatus.available) {
             this.setState({ autostartReady: true });

--- a/client/src/notebooks/Notebooks.container.js
+++ b/client/src/notebooks/Notebooks.container.js
@@ -747,6 +747,7 @@ class StartNotebookServer extends Component {
   async refreshPipelines(force = false) {
     if (this._isMounted) {
       const { accessLevel, user } = this.props;
+      await this.coordinator.fetchNotebookOptions(); // TODO: this should not be here
       const callback = () => {
         // eslint-disable-line @typescript-eslint/no-empty-function
       };
@@ -798,7 +799,8 @@ class StartNotebookServer extends Component {
       ) {
         const data = this.model.get();
         const ciStatus = NotebooksHelper.checkCiStatus(data.ci);
-        const fetched = data.notebooks.fetched && !ciStatus.ongoing;
+        const fetched =
+          data.notebooks.fetched && data.options.fetched && !ciStatus.ongoing;
         if (fetched) {
           // Check that we can auto-assign a session class
           const resourcePools = this.state.resourcePools;

--- a/client/src/notebooks/Notebooks.state.js
+++ b/client/src/notebooks/Notebooks.state.js
@@ -30,6 +30,7 @@ import { formatEnvironmentVariables } from "../api-client/utils";
 import { startSessionOptionsSlice } from "../features/session/startSessionOptionsSlice";
 import { notebooksSchema } from "../model";
 import { parseINIString, sleep } from "../utils/helpers/HelperFunctions";
+import { projectCoreApi } from "../features/project/projectCoreApi";
 
 const POLLING_INTERVAL = 3000;
 const POLLING_CI = 5; // in seconds, for the sleep function
@@ -1287,6 +1288,16 @@ class NotebooksCoordinator {
     const env_variables = formatEnvironmentVariables(
       this.model.get("filters.environment_variables")
     );
+
+    console.log({
+      namespace,
+      project,
+      branch,
+      commit,
+      image,
+      options,
+      env_variables,
+    });
 
     return this.client.startNotebook(
       namespace,

--- a/client/src/notebooks/Notebooks.state.js
+++ b/client/src/notebooks/Notebooks.state.js
@@ -1262,10 +1262,8 @@ class NotebooksCoordinator {
     const options = {
       resource_class_id: startSessionOptions.sessionClass ?? null,
       storage: startSessionOptions.storage ?? null,
-      serverOptions: {
-        defaultUrl: startSessionOptions.defaultUrl,
-        lfs_auto_fetch: startSessionOptions.lfsAutoFetch,
-      },
+      default_url: startSessionOptions.defaultUrl,
+      lfs_auto_fetch: startSessionOptions.lfsAutoFetch,
     };
     const cloudstorage = this.model.get("filters.objectStoresConfiguration");
     if (cloudstorage.length > 0) options["cloudstorage"] = cloudstorage;

--- a/client/src/notebooks/Notebooks.state.js
+++ b/client/src/notebooks/Notebooks.state.js
@@ -1255,6 +1255,8 @@ class NotebooksCoordinator {
 
   // * Change notebook status * //
   startServer(forceBaseImage = false) {
+    console.log("startServer()");
+
     const reduxStore = this.model.reduxStore;
     const startSessionOptions =
       reduxStore.getState()[startSessionOptionsSlice.name];

--- a/client/src/notebooks/Notebooks.state.js
+++ b/client/src/notebooks/Notebooks.state.js
@@ -30,7 +30,6 @@ import { formatEnvironmentVariables } from "../api-client/utils";
 import { startSessionOptionsSlice } from "../features/session/startSessionOptionsSlice";
 import { notebooksSchema } from "../model";
 import { parseINIString, sleep } from "../utils/helpers/HelperFunctions";
-import { projectCoreApi } from "../features/project/projectCoreApi";
 
 const POLLING_INTERVAL = 3000;
 const POLLING_CI = 5; // in seconds, for the sleep function
@@ -1256,8 +1255,6 @@ class NotebooksCoordinator {
 
   // * Change notebook status * //
   startServer(forceBaseImage = false) {
-    console.log("startServer()");
-
     const reduxStore = this.model.reduxStore;
     const startSessionOptions =
       reduxStore.getState()[startSessionOptionsSlice.name];
@@ -1288,16 +1285,6 @@ class NotebooksCoordinator {
     const env_variables = formatEnvironmentVariables(
       this.model.get("filters.environment_variables")
     );
-
-    console.log({
-      namespace,
-      project,
-      branch,
-      commit,
-      image,
-      options,
-      env_variables,
-    });
 
     return this.client.startNotebook(
       namespace,

--- a/client/src/notebooks/components/StartSessionLoader.tsx
+++ b/client/src/notebooks/components/StartSessionLoader.tsx
@@ -112,6 +112,11 @@ function StartNotebookAutostartLoader(
   }, [fetching, isSessionVisible]); //eslint-disable-line
 
   useEffect(() => {
+    console.log({
+      ci: !ciStatus.ongoing,
+      data: !!data.fetched,
+      options: !!options.fetched,
+    });
     setFetching({
       ci: !ciStatus.ongoing,
       data: !!data.fetched,

--- a/client/src/notebooks/components/StartSessionLoader.tsx
+++ b/client/src/notebooks/components/StartSessionLoader.tsx
@@ -112,11 +112,6 @@ function StartNotebookAutostartLoader(
   }, [fetching, isSessionVisible]); //eslint-disable-line
 
   useEffect(() => {
-    console.log({
-      ci: !ciStatus.ongoing,
-      data: !!data.fetched,
-      options: !!options.fetched,
-    });
     setFetching({
       ci: !ciStatus.ongoing,
       data: !!data.fetched,

--- a/client/src/notebooks/components/options/SessionClassOption.module.scss
+++ b/client/src/notebooks/components/options/SessionClassOption.module.scss
@@ -3,6 +3,11 @@
 @import "~bootstrap/scss/maps";
 @import "~bootstrap/scss/mixins";
 
+.requirements {
+  color: var(--bs-rk-text);
+  font-size: small;
+}
+
 .control {
   background: var(--bs-rk-white);
   --bs-border-color: var(--bs-rk-border-input);
@@ -51,6 +56,12 @@
 
     @include media-breakpoint-up(sm) {
       grid-column: auto;
+    }
+
+    color: var(--bs-danger);
+
+    &Matches {
+      color: var(--bs-rk-green);
     }
   }
 

--- a/client/src/notebooks/components/options/SessionClassOption.module.scss
+++ b/client/src/notebooks/components/options/SessionClassOption.module.scss
@@ -6,6 +6,10 @@
 .requirements {
   color: var(--bs-rk-text);
   font-size: small;
+
+  &NotMet {
+    color: var(--bs-danger);
+  }
 }
 
 .control {

--- a/client/src/notebooks/components/options/SessionClassOption.tsx
+++ b/client/src/notebooks/components/options/SessionClassOption.tsx
@@ -309,8 +309,6 @@ export const SessionClassSelector = ({
       unstyled
       classNames={selectClassNames}
       components={selectComponents}
-      // for dev
-      // menuIsOpen
     />
   );
 };

--- a/client/src/notebooks/components/options/SessionClassOption.tsx
+++ b/client/src/notebooks/components/options/SessionClassOption.tsx
@@ -60,18 +60,6 @@ export const SessionClassOption = () => {
   const location = useLocation();
   const searchParams = new URLSearchParams(location.search);
 
-  const enableFakeResourcePools = !!searchParams.get("useFakeResourcePools");
-
-  const {
-    data: realResourcePools,
-    isLoading,
-    isError,
-  } = useGetResourcePoolsQuery({}, { skip: enableFakeResourcePools });
-
-  const resourcePools = enableFakeResourcePools
-    ? fakeResourcePools
-    : realResourcePools;
-
   // Project options
   const { defaultBranch, externalUrl: projectRepositoryUrl } = useSelector<
     RootStateOrAny,
@@ -90,6 +78,28 @@ export const SessionClassOption = () => {
     },
     { skip: !coreSupportComputed }
   );
+
+  // Resource pools
+  const enableFakeResourcePools = !!searchParams.get("useFakeResourcePools");
+
+  const {
+    data: realResourcePools,
+    isLoading,
+    isError,
+  } = useGetResourcePoolsQuery(
+    {
+      cpuRequest: projectConfig?.config.sessions?.legacyConfig?.cpuRequest,
+      gpuRequest: projectConfig?.config.sessions?.legacyConfig?.gpuRequest,
+      memoryRequest:
+        projectConfig?.config.sessions?.legacyConfig?.memoryRequest,
+      storageRequest: projectConfig?.config.sessions?.storage,
+    },
+    { skip: enableFakeResourcePools || !projectConfig }
+  );
+
+  const resourcePools = enableFakeResourcePools
+    ? fakeResourcePools
+    : realResourcePools;
 
   const defaultSessionClass = useMemo(
     () =>
@@ -111,7 +121,7 @@ export const SessionClassOption = () => {
 
   const dispatch = useDispatch();
 
-  // Reset session class when unmounting
+  // Reset session class when we navigate away
   useEffect(() => {
     return () => {
       dispatch(reset());

--- a/client/src/notebooks/components/options/SessionClassOption.tsx
+++ b/client/src/notebooks/components/options/SessionClassOption.tsx
@@ -31,7 +31,7 @@ import Select, {
   components,
 } from "react-select";
 import { Col, FormGroup, Label } from "reactstrap";
-import { ErrorAlert } from "../../../components/Alert";
+import { ErrorAlert, WarnAlert } from "../../../components/Alert";
 import { Loader } from "../../../components/Loader";
 import {
   ResourceClass,
@@ -167,7 +167,10 @@ export const SessionClassOption = () => {
     <Col xs={12}>
       <FormGroup className="field-group">
         <Label>Session class</Label>
-        <SessionRequirements projectConfig={projectConfig} />
+        <SessionRequirements
+          projectConfig={projectConfig}
+          resourcePools={resourcePools}
+        />
         <SessionClassSelector
           resourcePools={resourcePools}
           currentSessionClass={currentSessionClass}
@@ -181,9 +184,13 @@ export const SessionClassOption = () => {
 
 interface SessionRequirementsProps {
   projectConfig: ProjectConfig | undefined;
+  resourcePools: ResourcePool[];
 }
 
-function SessionRequirements({ projectConfig }: SessionRequirementsProps) {
+function SessionRequirements({
+  projectConfig,
+  resourcePools,
+}: SessionRequirementsProps) {
   if (!projectConfig) {
     return null;
   }
@@ -198,34 +205,50 @@ function SessionRequirements({ projectConfig }: SessionRequirementsProps) {
     return null;
   }
 
+  const noMatchingClass = !resourcePools
+    .flatMap((pool) => pool.classes)
+    .some((c) => c.matches);
+
   return (
-    <div className={cx("d-flex", "flex-row", "flex-wrap", styles.requirements)}>
-      <span className="me-3">Session requirements:</span>
-      {cpuRequest && (
-        <>
-          {" "}
-          <span className="me-3">{cpuRequest} CPUs</span>
-        </>
+    <>
+      <div
+        className={cx("d-flex", "flex-row", "flex-wrap", styles.requirements)}
+      >
+        <span className="me-3">Session requirements:</span>
+        {cpuRequest && (
+          <>
+            {" "}
+            <span className="me-3">{cpuRequest} CPUs</span>
+          </>
+        )}
+        {memoryRequest && (
+          <>
+            {" "}
+            <span className="me-3">{memoryRequest} GB RAM</span>
+          </>
+        )}
+        {storageRequest && (
+          <>
+            {" "}
+            <span className="me-3">{storageRequest} GB Disk</span>
+          </>
+        )}
+        {gpuRequest && (
+          <>
+            {" "}
+            <span>{gpuRequest} GPUs</span>
+          </>
+        )}
+      </div>
+      {noMatchingClass && (
+        <WarnAlert className="mb-1">
+          <p className="mb-0">
+            It seems that no session class you have access to can match the
+            compute requirements to launch a session
+          </p>
+        </WarnAlert>
       )}
-      {memoryRequest && (
-        <>
-          {" "}
-          <span className="me-3">{memoryRequest} GB RAM</span>
-        </>
-      )}
-      {storageRequest && (
-        <>
-          {" "}
-          <span className="me-3">{storageRequest} GB Disk</span>
-        </>
-      )}
-      {gpuRequest && (
-        <>
-          {" "}
-          <span>{gpuRequest} GPUs</span>
-        </>
-      )}
-    </div>
+    </>
   );
 }
 
@@ -410,7 +433,7 @@ export const fakeResourcePools: ResourcePool[] = [
         max_storage: 40,
         default_storage: 5,
         default: true,
-        matches: true,
+        matches: false,
       },
     ],
   },
@@ -433,7 +456,7 @@ export const fakeResourcePools: ResourcePool[] = [
         max_storage: 40,
         default_storage: 10,
         default: false,
-        matches: true,
+        matches: false,
       },
       {
         id: 4,
@@ -444,7 +467,7 @@ export const fakeResourcePools: ResourcePool[] = [
         max_storage: 40,
         default_storage: 10,
         default: false,
-        matches: true,
+        matches: false,
       },
       {
         id: 5,
@@ -455,7 +478,7 @@ export const fakeResourcePools: ResourcePool[] = [
         max_storage: 40,
         default_storage: 10,
         default: false,
-        matches: true,
+        matches: false,
       },
       {
         id: 6,
@@ -466,7 +489,7 @@ export const fakeResourcePools: ResourcePool[] = [
         max_storage: 40,
         default_storage: 10,
         default: false,
-        matches: true,
+        matches: false,
       },
     ],
   },
@@ -489,7 +512,7 @@ export const fakeResourcePools: ResourcePool[] = [
         max_storage: 40,
         default_storage: 10,
         default: false,
-        matches: true,
+        matches: false,
       },
       {
         id: 8,
@@ -500,7 +523,7 @@ export const fakeResourcePools: ResourcePool[] = [
         max_storage: 40,
         default_storage: 10,
         default: false,
-        matches: true,
+        matches: false,
       },
       {
         id: 9,
@@ -511,7 +534,7 @@ export const fakeResourcePools: ResourcePool[] = [
         max_storage: 40,
         default_storage: 10,
         default: false,
-        matches: true,
+        matches: false,
       },
       {
         id: 10,
@@ -522,7 +545,7 @@ export const fakeResourcePools: ResourcePool[] = [
         max_storage: 40,
         default_storage: 10,
         default: false,
-        matches: true,
+        matches: false,
       },
     ],
   },
@@ -545,7 +568,7 @@ export const fakeResourcePools: ResourcePool[] = [
         max_storage: 40,
         default_storage: 10,
         default: false,
-        matches: true,
+        matches: false,
       },
       {
         id: 12,
@@ -556,7 +579,7 @@ export const fakeResourcePools: ResourcePool[] = [
         max_storage: 40,
         default_storage: 10,
         default: false,
-        matches: true,
+        matches: false,
       },
       {
         id: 13,
@@ -567,7 +590,7 @@ export const fakeResourcePools: ResourcePool[] = [
         max_storage: 40,
         default_storage: 10,
         default: false,
-        matches: true,
+        matches: false,
       },
       {
         id: 14,
@@ -578,7 +601,7 @@ export const fakeResourcePools: ResourcePool[] = [
         max_storage: 40,
         default_storage: 10,
         default: false,
-        matches: true,
+        matches: false,
       },
     ],
   },

--- a/client/src/notebooks/components/options/SessionClassOption.tsx
+++ b/client/src/notebooks/components/options/SessionClassOption.tsx
@@ -129,21 +129,27 @@ export const SessionClassOption = () => {
   }, [dispatch]);
 
   // Set initial session class
+  // Order of preference:
+  // 1. Default session class if it satisfies the compute requirements
+  // 2. The first session class from the default pool which satisfies
+  //    the compute requirements
+  // 3. The default session class otherwise
   useEffect(() => {
     if (projectConfig == null || resourcePools == null) {
       return;
     }
-    console.log({ projectConfig });
-    // const sessionClassIdFromConfig =
-    //   projectConfig.config.sessions?.sessionClass ??
-    //   projectConfig.default.sessions?.sessionClass;
     const initialSessionClassId =
-      // resourcePools
-      //   ?.flatMap((pool) => pool.classes)
-      //   .find((c) => c.id == sessionClassIdFromConfig)?.id ??
       resourcePools
         ?.flatMap((pool) => pool.classes)
-        .find((c) => c.id == defaultSessionClass?.id)?.id ?? 0;
+        .find((c) => c.id == defaultSessionClass?.id && c.matching)?.id ??
+      resourcePools
+        ?.filter((pool) => pool.default)
+        .flatMap((pool) => pool.classes)
+        .find((c) => c.matching)?.id ??
+      resourcePools
+        ?.flatMap((pool) => pool.classes)
+        .find((c) => c.id == defaultSessionClass?.id)?.id ??
+      0;
     dispatch(setSessionClass(initialSessionClassId));
   }, [defaultSessionClass?.id, dispatch, projectConfig, resourcePools]);
 
@@ -224,7 +230,7 @@ function SessionRequirements({
 
   const noMatchingClass = !resourcePools
     .flatMap((pool) => pool.classes)
-    .some((c) => c.matches);
+    .some((c) => c.matching);
 
   return (
     <>
@@ -391,7 +397,7 @@ const OptionOrSingleValueContent = ({
     "text-wrap",
     "text-break",
     styles.label,
-    sessionClass.matches && styles.labelMatches
+    sessionClass.matching && styles.labelMatches
   );
   const detailValueClassName = cx(styles.detail, styles.detailValue);
   const detailLabelClassName = cx(styles.detail, styles.detailLabel);
@@ -399,9 +405,9 @@ const OptionOrSingleValueContent = ({
     <>
       <span className={labelClassName}>
         <FontAwesomeIcon
-          icon={sessionClass.matches ? faCheckCircle : faExclamationTriangle}
+          icon={sessionClass.matching ? faCheckCircle : faExclamationTriangle}
           fixedWidth
-        />
+        />{" "}
         {sessionClass.name}
       </span>{" "}
       <span className={detailValueClassName}>{sessionClass.cpu}</span>{" "}
@@ -450,7 +456,7 @@ export const fakeResourcePools: ResourcePool[] = [
         max_storage: 40,
         default_storage: 5,
         default: true,
-        matches: false,
+        matching: false,
       },
     ],
   },
@@ -473,7 +479,7 @@ export const fakeResourcePools: ResourcePool[] = [
         max_storage: 40,
         default_storage: 10,
         default: false,
-        matches: false,
+        matching: false,
       },
       {
         id: 4,
@@ -484,7 +490,7 @@ export const fakeResourcePools: ResourcePool[] = [
         max_storage: 40,
         default_storage: 10,
         default: false,
-        matches: false,
+        matching: false,
       },
       {
         id: 5,
@@ -495,7 +501,7 @@ export const fakeResourcePools: ResourcePool[] = [
         max_storage: 40,
         default_storage: 10,
         default: false,
-        matches: false,
+        matching: false,
       },
       {
         id: 6,
@@ -506,7 +512,7 @@ export const fakeResourcePools: ResourcePool[] = [
         max_storage: 40,
         default_storage: 10,
         default: false,
-        matches: false,
+        matching: false,
       },
     ],
   },
@@ -529,7 +535,7 @@ export const fakeResourcePools: ResourcePool[] = [
         max_storage: 40,
         default_storage: 10,
         default: false,
-        matches: false,
+        matching: false,
       },
       {
         id: 8,
@@ -540,7 +546,7 @@ export const fakeResourcePools: ResourcePool[] = [
         max_storage: 40,
         default_storage: 10,
         default: false,
-        matches: false,
+        matching: false,
       },
       {
         id: 9,
@@ -551,7 +557,7 @@ export const fakeResourcePools: ResourcePool[] = [
         max_storage: 40,
         default_storage: 10,
         default: false,
-        matches: false,
+        matching: false,
       },
       {
         id: 10,
@@ -562,7 +568,7 @@ export const fakeResourcePools: ResourcePool[] = [
         max_storage: 40,
         default_storage: 10,
         default: false,
-        matches: false,
+        matching: false,
       },
     ],
   },
@@ -585,7 +591,7 @@ export const fakeResourcePools: ResourcePool[] = [
         max_storage: 40,
         default_storage: 10,
         default: false,
-        matches: false,
+        matching: false,
       },
       {
         id: 12,
@@ -596,7 +602,7 @@ export const fakeResourcePools: ResourcePool[] = [
         max_storage: 40,
         default_storage: 10,
         default: false,
-        matches: false,
+        matching: false,
       },
       {
         id: 13,
@@ -607,7 +613,7 @@ export const fakeResourcePools: ResourcePool[] = [
         max_storage: 40,
         default_storage: 10,
         default: false,
-        matches: false,
+        matching: false,
       },
       {
         id: 14,
@@ -618,7 +624,7 @@ export const fakeResourcePools: ResourcePool[] = [
         max_storage: 40,
         default_storage: 10,
         default: false,
-        matches: false,
+        matching: false,
       },
     ],
   },

--- a/client/src/notebooks/components/options/SessionClassOption.tsx
+++ b/client/src/notebooks/components/options/SessionClassOption.tsx
@@ -191,8 +191,9 @@ export const SessionClassOption = () => {
       <FormGroup className="field-group">
         <Label>Session class</Label>
         <SessionRequirements
-          projectConfig={projectConfig}
+          currentSessionClass={currentSessionClass}
           resourcePools={resourcePools}
+          projectConfig={projectConfig}
         />
         <SessionClassSelector
           resourcePools={resourcePools}
@@ -206,11 +207,13 @@ export const SessionClassOption = () => {
 };
 
 interface SessionRequirementsProps {
-  projectConfig: ProjectConfig | undefined;
+  currentSessionClass?: ResourceClass | undefined;
   resourcePools: ResourcePool[];
+  projectConfig: ProjectConfig | undefined;
 }
 
 function SessionRequirements({
+  currentSessionClass,
   projectConfig,
   resourcePools,
 }: SessionRequirementsProps) {
@@ -228,6 +231,9 @@ function SessionRequirements({
     return null;
   }
 
+  const currentSessionClassNotMatching =
+    currentSessionClass?.matching === false;
+
   const noMatchingClass = !resourcePools
     .flatMap((pool) => pool.classes)
     .some((c) => c.matching);
@@ -235,7 +241,13 @@ function SessionRequirements({
   return (
     <>
       <div
-        className={cx("d-flex", "flex-row", "flex-wrap", styles.requirements)}
+        className={cx(
+          "d-flex",
+          "flex-row",
+          "flex-wrap",
+          styles.requirements,
+          currentSessionClassNotMatching && styles.requirementsNotMet
+        )}
       >
         <span className="me-3">Session requirements:</span>
         {cpuRequest && (
@@ -263,6 +275,17 @@ function SessionRequirements({
           </>
         )}
       </div>
+      {currentSessionClassNotMatching && (
+        <div
+          className={cx(
+            styles.requirements,
+            currentSessionClassNotMatching && styles.requirementsNotMet
+          )}
+        >
+          <FontAwesomeIcon icon={faExclamationTriangle} /> This session class
+          does not match the compute requirements
+        </div>
+      )}
       {noMatchingClass && (
         <WarnAlert className="mb-1">
           <p className="mb-0">

--- a/client/src/notebooks/components/options/SessionClassOption.tsx
+++ b/client/src/notebooks/components/options/SessionClassOption.tsx
@@ -40,6 +40,7 @@ import {
 import { useGetResourcePoolsQuery } from "../../../features/dataServices/dataServicesApi";
 import {
   setSessionClass,
+  reset,
   useStartSessionOptionsSelector,
 } from "../../../features/session/startSessionOptionsSlice";
 import styles from "./SessionClassOption.module.scss";
@@ -54,7 +55,6 @@ import {
   faExclamationTriangle,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { TimeCaption } from "../../../components/TimeCaption";
 
 export const SessionClassOption = () => {
   const location = useLocation();
@@ -110,6 +110,13 @@ export const SessionClassOption = () => {
   );
 
   const dispatch = useDispatch();
+
+  // Reset session class when unmounting
+  useEffect(() => {
+    return () => {
+      dispatch(reset());
+    };
+  }, [dispatch]);
 
   // Set initial session class
   useEffect(() => {

--- a/client/src/notebooks/components/options/SessionClassOption.tsx
+++ b/client/src/notebooks/components/options/SessionClassOption.tsx
@@ -201,6 +201,7 @@ export const SessionClassOption = () => {
           defaultSessionClass={defaultSessionClass}
           onChange={onChange}
         />
+        <SessionClassWarning currentSessionClass={currentSessionClass} />
       </FormGroup>
     </Col>
   );
@@ -275,17 +276,6 @@ function SessionRequirements({
           </>
         )}
       </div>
-      {currentSessionClassNotMatching && (
-        <div
-          className={cx(
-            styles.requirements,
-            currentSessionClassNotMatching && styles.requirementsNotMet
-          )}
-        >
-          <FontAwesomeIcon icon={faExclamationTriangle} /> This session class
-          does not match the compute requirements
-        </div>
-      )}
       {noMatchingClass && (
         <WarnAlert className="mb-1">
           <p className="mb-0">
@@ -295,6 +285,33 @@ function SessionRequirements({
         </WarnAlert>
       )}
     </>
+  );
+}
+
+interface SessionClassWarningProps {
+  currentSessionClass?: ResourceClass | undefined;
+}
+
+function SessionClassWarning({
+  currentSessionClass,
+}: SessionClassWarningProps) {
+  const currentSessionClassNotMatching =
+    currentSessionClass?.matching === false;
+
+  if (!currentSessionClassNotMatching) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cx(
+        styles.requirements,
+        currentSessionClassNotMatching && styles.requirementsNotMet
+      )}
+    >
+      <FontAwesomeIcon icon={faExclamationTriangle} /> This session class does
+      not match the compute requirements
+    </div>
   );
 }
 

--- a/client/src/notebooks/components/options/SessionClassOption.tsx
+++ b/client/src/notebooks/components/options/SessionClassOption.tsx
@@ -43,9 +43,18 @@ import {
   useStartSessionOptionsSelector,
 } from "../../../features/session/startSessionOptionsSlice";
 import styles from "./SessionClassOption.module.scss";
-import { StateModelProject } from "../../../features/project/Project";
+import {
+  ProjectConfig,
+  StateModelProject,
+} from "../../../features/project/Project";
 import { useCoreSupport } from "../../../features/project/useProjectCoreSupport";
 import { useGetConfigQuery } from "../../../features/project/projectCoreApi";
+import {
+  faCheckCircle,
+  faExclamationTriangle,
+} from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { TimeCaption } from "../../../components/TimeCaption";
 
 export const SessionClassOption = () => {
   const location = useLocation();
@@ -107,17 +116,17 @@ export const SessionClassOption = () => {
     if (projectConfig == null || resourcePools == null) {
       return;
     }
-    const sessionClassIdFromConfig =
-      projectConfig.config.sessions?.sessionClass ??
-      projectConfig.default.sessions?.sessionClass;
+    console.log({ projectConfig });
+    // const sessionClassIdFromConfig =
+    //   projectConfig.config.sessions?.sessionClass ??
+    //   projectConfig.default.sessions?.sessionClass;
     const initialSessionClassId =
+      // resourcePools
+      //   ?.flatMap((pool) => pool.classes)
+      //   .find((c) => c.id == sessionClassIdFromConfig)?.id ??
       resourcePools
         ?.flatMap((pool) => pool.classes)
-        .find((c) => c.id == sessionClassIdFromConfig)?.id ??
-      resourcePools
-        ?.flatMap((pool) => pool.classes)
-        .find((c) => c.id == defaultSessionClass?.id)?.id ??
-      0;
+        .find((c) => c.id == defaultSessionClass?.id)?.id ?? 0;
     dispatch(setSessionClass(initialSessionClassId));
   }, [defaultSessionClass?.id, dispatch, projectConfig, resourcePools]);
 
@@ -158,6 +167,7 @@ export const SessionClassOption = () => {
     <Col xs={12}>
       <FormGroup className="field-group">
         <Label>Session class</Label>
+        <SessionRequirements projectConfig={projectConfig} />
         <SessionClassSelector
           resourcePools={resourcePools}
           currentSessionClass={currentSessionClass}
@@ -168,6 +178,56 @@ export const SessionClassOption = () => {
     </Col>
   );
 };
+
+interface SessionRequirementsProps {
+  projectConfig: ProjectConfig | undefined;
+}
+
+function SessionRequirements({ projectConfig }: SessionRequirementsProps) {
+  if (!projectConfig) {
+    return null;
+  }
+
+  const cpuRequest = projectConfig?.config.sessions?.legacyConfig?.cpuRequest;
+  const memoryRequest =
+    projectConfig?.config.sessions?.legacyConfig?.memoryRequest;
+  const storageRequest = projectConfig?.config.sessions?.storage;
+  const gpuRequest = projectConfig?.config.sessions?.legacyConfig?.gpuRequest;
+
+  if (!cpuRequest && !memoryRequest && !storageRequest && !gpuRequest) {
+    return null;
+  }
+
+  return (
+    <div className={cx("d-flex", "flex-row", "flex-wrap", styles.requirements)}>
+      <span className="me-3">Session requirements:</span>
+      {cpuRequest && (
+        <>
+          {" "}
+          <span className="me-3">{cpuRequest} CPUs</span>
+        </>
+      )}
+      {memoryRequest && (
+        <>
+          {" "}
+          <span className="me-3">{memoryRequest} GB RAM</span>
+        </>
+      )}
+      {storageRequest && (
+        <>
+          {" "}
+          <span className="me-3">{storageRequest} GB Disk</span>
+        </>
+      )}
+      {gpuRequest && (
+        <>
+          {" "}
+          <span>{gpuRequest} GPUs</span>
+        </>
+      )}
+    </div>
+  );
+}
 
 interface SessionClassSelectorProps {
   resourcePools: ResourcePool[];
@@ -203,6 +263,8 @@ export const SessionClassSelector = ({
       unstyled
       classNames={selectClassNames}
       components={selectComponents}
+      // for dev
+      // menuIsOpen
     />
   );
 };
@@ -285,12 +347,23 @@ interface OptionOrSingleValueContentProps {
 const OptionOrSingleValueContent = ({
   sessionClass,
 }: OptionOrSingleValueContentProps) => {
-  const labelClassName = cx("text-wrap", "text-break", styles.label);
+  const labelClassName = cx(
+    "text-wrap",
+    "text-break",
+    styles.label,
+    sessionClass.matches && styles.labelMatches
+  );
   const detailValueClassName = cx(styles.detail, styles.detailValue);
   const detailLabelClassName = cx(styles.detail, styles.detailLabel);
   return (
     <>
-      <span className={labelClassName}>{sessionClass.name}</span>{" "}
+      <span className={labelClassName}>
+        <FontAwesomeIcon
+          icon={sessionClass.matches ? faCheckCircle : faExclamationTriangle}
+          fixedWidth
+        />
+        {sessionClass.name}
+      </span>{" "}
       <span className={detailValueClassName}>{sessionClass.cpu}</span>{" "}
       <span className={detailLabelClassName}>CPUs</span>{" "}
       <span className={detailValueClassName}>{sessionClass.memory}</span>
@@ -337,6 +410,7 @@ export const fakeResourcePools: ResourcePool[] = [
         max_storage: 40,
         default_storage: 5,
         default: true,
+        matches: true,
       },
     ],
   },
@@ -359,6 +433,7 @@ export const fakeResourcePools: ResourcePool[] = [
         max_storage: 40,
         default_storage: 10,
         default: false,
+        matches: true,
       },
       {
         id: 4,
@@ -369,6 +444,7 @@ export const fakeResourcePools: ResourcePool[] = [
         max_storage: 40,
         default_storage: 10,
         default: false,
+        matches: true,
       },
       {
         id: 5,
@@ -379,6 +455,7 @@ export const fakeResourcePools: ResourcePool[] = [
         max_storage: 40,
         default_storage: 10,
         default: false,
+        matches: true,
       },
       {
         id: 6,
@@ -389,6 +466,7 @@ export const fakeResourcePools: ResourcePool[] = [
         max_storage: 40,
         default_storage: 10,
         default: false,
+        matches: true,
       },
     ],
   },
@@ -411,6 +489,7 @@ export const fakeResourcePools: ResourcePool[] = [
         max_storage: 40,
         default_storage: 10,
         default: false,
+        matches: true,
       },
       {
         id: 8,
@@ -421,6 +500,7 @@ export const fakeResourcePools: ResourcePool[] = [
         max_storage: 40,
         default_storage: 10,
         default: false,
+        matches: true,
       },
       {
         id: 9,
@@ -431,6 +511,7 @@ export const fakeResourcePools: ResourcePool[] = [
         max_storage: 40,
         default_storage: 10,
         default: false,
+        matches: true,
       },
       {
         id: 10,
@@ -441,6 +522,7 @@ export const fakeResourcePools: ResourcePool[] = [
         max_storage: 40,
         default_storage: 10,
         default: false,
+        matches: true,
       },
     ],
   },
@@ -463,6 +545,7 @@ export const fakeResourcePools: ResourcePool[] = [
         max_storage: 40,
         default_storage: 10,
         default: false,
+        matches: true,
       },
       {
         id: 12,
@@ -473,6 +556,7 @@ export const fakeResourcePools: ResourcePool[] = [
         max_storage: 40,
         default_storage: 10,
         default: false,
+        matches: true,
       },
       {
         id: 13,
@@ -483,6 +567,7 @@ export const fakeResourcePools: ResourcePool[] = [
         max_storage: 40,
         default_storage: 10,
         default: false,
+        matches: true,
       },
       {
         id: 14,
@@ -493,6 +578,7 @@ export const fakeResourcePools: ResourcePool[] = [
         max_storage: 40,
         default_storage: 10,
         default: false,
+        matches: true,
       },
     ],
   },

--- a/client/src/notebooks/components/options/SessionStorageOption.tsx
+++ b/client/src/notebooks/components/options/SessionStorageOption.tsx
@@ -45,7 +45,6 @@ import styles from "./SessionStorageOption.module.scss";
 import { StateModelProject } from "../../../features/project/Project";
 import { useCoreSupport } from "../../../features/project/useProjectCoreSupport";
 import { useGetConfigQuery } from "../../../features/project/projectCoreApi";
-import { WarnAlert } from "../../../components/Alert";
 
 export const SessionStorageOption = () => {
   const location = useLocation();

--- a/client/src/notebooks/components/options/SessionStorageOption.tsx
+++ b/client/src/notebooks/components/options/SessionStorageOption.tsx
@@ -51,18 +51,6 @@ export const SessionStorageOption = () => {
   const location = useLocation();
   const searchParams = new URLSearchParams(location.search);
 
-  const enableFakeResourcePools = !!searchParams.get("useFakeResourcePools");
-
-  const {
-    data: realResourcePools,
-    isLoading,
-    isError,
-  } = useGetResourcePoolsQuery({}, { skip: enableFakeResourcePools });
-
-  const resourcePools = enableFakeResourcePools
-    ? fakeResourcePools
-    : realResourcePools;
-
   // Project options
   const { defaultBranch, externalUrl: projectRepositoryUrl } = useSelector<
     RootStateOrAny,
@@ -81,6 +69,28 @@ export const SessionStorageOption = () => {
     },
     { skip: !coreSupportComputed }
   );
+
+  // Resource pools
+  const enableFakeResourcePools = !!searchParams.get("useFakeResourcePools");
+
+  const {
+    data: realResourcePools,
+    isLoading,
+    isError,
+  } = useGetResourcePoolsQuery(
+    {
+      cpuRequest: projectConfig?.config.sessions?.legacyConfig?.cpuRequest,
+      gpuRequest: projectConfig?.config.sessions?.legacyConfig?.gpuRequest,
+      memoryRequest:
+        projectConfig?.config.sessions?.legacyConfig?.memoryRequest,
+      storageRequest: projectConfig?.config.sessions?.storage,
+    },
+    { skip: enableFakeResourcePools || !projectConfig }
+  );
+
+  const resourcePools = enableFakeResourcePools
+    ? fakeResourcePools
+    : realResourcePools;
 
   const { storage, sessionClass: currentSessionClassId } =
     useStartSessionOptionsSelector();

--- a/client/src/notebooks/components/options/SessionStorageOption.tsx
+++ b/client/src/notebooks/components/options/SessionStorageOption.tsx
@@ -45,6 +45,7 @@ import styles from "./SessionStorageOption.module.scss";
 import { StateModelProject } from "../../../features/project/Project";
 import { useCoreSupport } from "../../../features/project/useProjectCoreSupport";
 import { useGetConfigQuery } from "../../../features/project/projectCoreApi";
+import { WarnAlert } from "../../../components/Alert";
 
 export const SessionStorageOption = () => {
   const location = useLocation();

--- a/client/src/project/components/ProjectSettingsSessions.tsx
+++ b/client/src/project/components/ProjectSettingsSessions.tsx
@@ -669,7 +669,9 @@ function ComputeResourceOption({
         {devAccess && (
           <ResetOption
             optionId={optionId}
-            disabled={disabled}
+            // eslint-disable-next-line spellcheck/spell-checker
+            // TODO(@leafty): remove `|| currentValue === ""` once https://github.com/SwissDataScienceCenter/renku-python/issues/3544 is fixed
+            disabled={disabled || currentValue === ""}
             onReset={onReset}
           />
         )}

--- a/tests/cypress/fixtures/dataServices/resource-pools.json
+++ b/tests/cypress/fixtures/dataServices/resource-pools.json
@@ -2,6 +2,8 @@
   {
     "id": 1,
     "name": "Public pool",
+    "default": true,
+    "public": true,
     "quota": {
       "cpu": 100,
       "memory": 1000,
@@ -17,7 +19,8 @@
         "gpu": 0,
         "max_storage": 20,
         "default_storage": 5,
-        "default": false
+        "default": true,
+        "matching": false
       },
       {
         "id": 2,
@@ -27,13 +30,16 @@
         "gpu": 0,
         "max_storage": 40,
         "default_storage": 5,
-        "default": true
+        "default": false,
+        "matching": true
       }
     ]
   },
   {
     "id": 2,
     "name": "Special pool",
+    "default": false,
+    "public": false,
     "quota": {
       "cpu": 200,
       "memory": 8000,
@@ -49,7 +55,8 @@
         "gpu": 0,
         "max_storage": 40,
         "default_storage": 10,
-        "default": false
+        "default": false,
+        "matching": true
       },
       {
         "id": 4,
@@ -59,7 +66,8 @@
         "gpu": 1,
         "max_storage": 40,
         "default_storage": 10,
-        "default": false
+        "default": false,
+        "matching": true
       },
       {
         "id": 5,
@@ -69,7 +77,8 @@
         "gpu": 1,
         "max_storage": 40,
         "default_storage": 10,
-        "default": false
+        "default": false,
+        "matching": true
       },
       {
         "id": 6,
@@ -79,13 +88,16 @@
         "gpu": 1,
         "max_storage": 40,
         "default_storage": 10,
-        "default": false
+        "default": false,
+        "matching": true
       }
     ]
   },
   {
     "id": 3,
     "name": "Special GPU pool",
+    "default": false,
+    "public": false,
     "quota": {
       "cpu": 200,
       "memory": 8000,
@@ -101,7 +113,8 @@
         "gpu": 4,
         "max_storage": 40,
         "default_storage": 10,
-        "default": false
+        "default": false,
+        "matching": true
       },
       {
         "id": 8,
@@ -111,7 +124,8 @@
         "gpu": 4,
         "max_storage": 40,
         "default_storage": 10,
-        "default": false
+        "default": false,
+        "matching": true
       },
       {
         "id": 9,
@@ -121,8 +135,8 @@
         "gpu": 8,
         "max_storage": 40,
         "default_storage": 10,
-        "public": false,
-        "default": false
+        "default": false,
+        "matching": true
       },
       {
         "id": 10,
@@ -132,13 +146,16 @@
         "gpu": 8,
         "max_storage": 40,
         "default_storage": 10,
-        "default": false
+        "default": false,
+        "matching": true
       }
     ]
   },
   {
     "id": 4,
     "name": "High memory pool",
+    "default": false,
+    "public": false,
     "quota": {
       "cpu": 200,
       "memory": 64000,
@@ -154,7 +171,8 @@
         "gpu": 0,
         "max_storage": 40,
         "default_storage": 10,
-        "default": false
+        "default": false,
+        "matching": true
       },
       {
         "id": 12,
@@ -164,7 +182,8 @@
         "gpu": 0,
         "max_storage": 40,
         "default_storage": 10,
-        "default": false
+        "default": false,
+        "matching": true
       },
       {
         "id": 13,
@@ -174,7 +193,8 @@
         "gpu": 0,
         "max_storage": 40,
         "default_storage": 10,
-        "default": false
+        "default": false,
+        "matching": true
       },
       {
         "id": 14,
@@ -184,7 +204,8 @@
         "gpu": 0,
         "max_storage": 40,
         "default_storage": 10,
-        "default": false
+        "default": false,
+        "matching": true
       }
     ]
   }

--- a/tests/cypress/support/renkulab-fixtures/dataServices.ts
+++ b/tests/cypress/support/renkulab-fixtures/dataServices.ts
@@ -28,7 +28,7 @@ export const DataServices = <T extends FixturesConstructor>(Parent: T) => {
       name = "getResourcePools",
       fixture = "dataServices/resource-pools.json"
     ) {
-      cy.intercept("/ui-server/api/data/resource_pools", {
+      cy.intercept("/ui-server/api/data/resource_pools*", {
         fixture,
       }).as(name);
       return this;


### PR DESCRIPTION
* Update the session start options to show which session classes match the compute requirements.
* Update the quick start flow to auto-select a suitable session class or fall back to the option screen if non is suitable.

Start options:
![renku-ci-ui-2620 dev renku ch_projects_johann thiebaut1_another-playground-project_sessions_new](https://github.com/SwissDataScienceCenter/renku-ui/assets/951086/45f09a2c-bbd7-4699-ab56-9268d1f4407f)
![renku-ci-ui-2620 dev renku ch_projects_johann thiebaut1_another-playground-project_sessions_new (1)](https://github.com/SwissDataScienceCenter/renku-ui/assets/951086/0f192f59-7bbe-4bf2-aeba-d7594542066e)
![renku-ci-ui-2620 dev renku ch_projects_johann thiebaut1_another-playground-project_sessions_new (2)](https://github.com/SwissDataScienceCenter/renku-ui/assets/951086/813caeef-99e8-4f49-abd9-63748e374c61)

Quick start not finding a suitable session class:
![renku-ci-ui-2620 dev renku ch_projects_johann thiebaut1_another-playground-project_sessions_new (4)](https://github.com/SwissDataScienceCenter/renku-ui/assets/951086/359c3f48-5913-49f6-b9f5-ccaccf0aa749)

/deploy extra-values=crc.image.tag=sha-d9cef4d renku=crac-service-helm-chart renku-notebooks=feat-work-with-crac #persist #cypress