### PR TITLE
fix(client): fix `versionedUrlEndpoint()`

### DIFF
--- a/client/src/features/project/projectCoreApi.ts
+++ b/client/src/features/project/projectCoreApi.ts
@@ -34,8 +34,12 @@ function versionedUrlEndpoint(
   endpoint: string,
   versionUrl: string | null | undefined
 ) {
-  const urlPath = versionUrl ? `${versionUrl}/${endpoint}` : `/${endpoint}`;
-  return `/renku${urlPath}`;
+  const endpoint_ = endpoint.startsWith("/") ? endpoint.slice(1) : endpoint;
+  const versionUrl_ = versionUrl?.startsWith("/")
+    ? versionUrl.slice(1)
+    : versionUrl;
+  const urlPath = versionUrl_ ? `${versionUrl_}/${endpoint_}` : endpoint_;
+  return `/renku/${urlPath}`;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/client/src/features/project/projectCoreApi.ts
+++ b/client/src/features/project/projectCoreApi.ts
@@ -30,8 +30,11 @@ import type {
 } from "./Project.d";
 import { MigrationStartScopes } from "./projectEnums";
 
-function versionedUrlEndpoint(endpoint: string, versionUrl?: string) {
-  const urlPath = versionUrl ? `${versionUrl}/${endpoint}` : endpoint;
+function versionedUrlEndpoint(
+  endpoint: string,
+  versionUrl: string | null | undefined
+) {
+  const urlPath = versionUrl ? `${versionUrl}/${endpoint}` : `/${endpoint}`;
   return `/renku${urlPath}`;
 }
 


### PR DESCRIPTION
This can cause issue for projects using an unsupported metadata version.

/deploy #persist #cypress