### PR TITLE
fix: do not query for datasets if it is not possible

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -31688,9 +31688,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.24",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
-      "integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
+      "version": "8.4.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.25.tgz",
+      "integrity": "sha512-7taJ/8t2av0Z+sQEvNzCkpDynl0tX3uJMCODi6nT3PfASC7dYCWV9aQ+uiCf+KBD4SEFcu+GvJdGdwzQ6OSjCw==",
       "dev": true,
       "funding": [
         {
@@ -64319,9 +64319,9 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.4.24",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
-      "integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
+      "version": "8.4.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.25.tgz",
+      "integrity": "sha512-7taJ/8t2av0Z+sQEvNzCkpDynl0tX3uJMCODi6nT3PfASC7dYCWV9aQ+uiCf+KBD4SEFcu+GvJdGdwzQ6OSjCw==",
       "dev": true,
       "requires": {
         "nanoid": "^3.3.6",

--- a/client/src/features/project/dataset/ProjectDatasetsView.tsx
+++ b/client/src/features/project/dataset/ProjectDatasetsView.tsx
@@ -213,6 +213,7 @@ function ProjectDatasetsView(props: any) {
   useEffect(() => {
     const datasetsLoading = datasets.core === SpecialPropVal.UPDATING;
     if (datasetsLoading || !coreSupportComputed) return;
+    if (!backendAvailable) return;
 
     if (
       datasets.core.datasets === null ||
@@ -222,6 +223,7 @@ function ProjectDatasetsView(props: any) {
       history.replace({ state: { reload: false } });
     }
   }, [
+    backendAvailable,
     coreSupportComputed,
     datasets.core,
     fetchDatasets,


### PR DESCRIPTION
If the backend cannot return datasets, do not try to get them.

/deploy #persist #cypress renku=core-svc-horizontal-scaling renku-core=v2.6.0 extra-values=global.renku.cli_version=2.6.0rc1 renku-gateway=master
