### PR TITLE
fix(client): prevent endless loader on migration errors

### DIFF
--- a/client/src/features/project/components/migrations/ProjectCoreMigrations.tsx
+++ b/client/src/features/project/components/migrations/ProjectCoreMigrations.tsx
@@ -77,9 +77,13 @@ export function ProjectMigrationStatus({
     gitUrl,
     branch,
   });
-  const { backendAvailable, computed: coreSupportComputed } = coreSupport;
+  const {
+    backendAvailable,
+    computed: coreSupportComputed,
+    backendErrorMessage: coreSupportError,
+  } = coreSupport;
   const isSupported = coreSupportComputed && backendAvailable;
-  const checkingSupport = !coreSupportComputed;
+  const checkingSupport = !coreSupportComputed && !coreSupportError;
 
   const skip = !gitUrl || !branch;
   const { data, isLoading, isFetching, error } =

--- a/client/src/features/project/dataset/ProjectDatasetsView.tsx
+++ b/client/src/features/project/dataset/ProjectDatasetsView.tsx
@@ -197,6 +197,7 @@ function ProjectDatasetsView(props: any) {
   const {
     backendAvailable,
     computed: coreSupportComputed,
+    backendErrorMessage: coreSupportError,
     versionUrl,
   } = coreSupport;
 
@@ -212,7 +213,7 @@ function ProjectDatasetsView(props: any) {
 
   useEffect(() => {
     const datasetsLoading = datasets.core === SpecialPropVal.UPDATING;
-    if (datasetsLoading || !coreSupportComputed) return;
+    if (datasetsLoading || (!coreSupportComputed && !coreSupportError)) return;
     if (!backendAvailable) return;
 
     if (
@@ -225,6 +226,7 @@ function ProjectDatasetsView(props: any) {
   }, [
     backendAvailable,
     coreSupportComputed,
+    coreSupportError,
     datasets.core,
     fetchDatasets,
     history,


### PR DESCRIPTION
When the check_migrations API errors, we show an endless spinning wheel and the error doesn't surface. This PR fixes it.

![Peek 2023-07-11 15-01](https://github.com/SwissDataScienceCenter/renku-ui/assets/43481553/38f41233-a87c-4624-ad45-0bf67c77ebe1)

/deploy #persist #cypress
