### PR TITLE
fix(client): prevent endless loader on migration errors

### DIFF
--- a/client/src/features/project/components/migrations/ProjectCoreMigrations.tsx
+++ b/client/src/features/project/components/migrations/ProjectCoreMigrations.tsx
@@ -263,7 +263,7 @@ interface ProjectMigrationStatusDetailsProps {
   buttonDisable: boolean;
   data: MigrationStatus | undefined;
   isMaintainer: boolean;
-  isSupported: boolean;
+  isSupported: boolean | undefined;
   showDetails: boolean;
   updateProject: (scope: MigrationStartScopes) => void;
 }

--- a/client/src/features/project/dataset/ProjectDatasetsView.tsx
+++ b/client/src/features/project/dataset/ProjectDatasetsView.tsx
@@ -197,6 +197,7 @@ function ProjectDatasetsView(props: any) {
   const {
     backendAvailable,
     computed: coreSupportComputed,
+    backendErrorMessage,
     versionUrl,
   } = coreSupport;
 
@@ -232,6 +233,14 @@ function ProjectDatasetsView(props: any) {
     versionUrl,
   ]);
 
+  if (coreSupportComputed && backendErrorMessage)
+    return (
+      <ErrorAlert>
+        <b>There was an error verifying support for this project.</b>
+        <p>{backendErrorMessage}</p>
+      </ErrorAlert>
+    );
+
   if (coreSupportComputed && !backendAvailable) {
     const settingsUrl = Url.get(Url.pages.project.settings, {
       namespace: props.metadata.namespace,
@@ -264,13 +273,6 @@ function ProjectDatasetsView(props: any) {
   }
 
   if (!coreSupportComputed) {
-    if (coreSupport.backendErrorMessage)
-      return (
-        <ErrorAlert>
-          <b>There was an error verifying support for this project.</b>
-          <p>{coreSupport.backendErrorMessage}</p>
-        </ErrorAlert>
-      );
     return (
       <div>
         <p>Checking project version and RenkuLab compatibility...</p>

--- a/client/src/features/project/useProjectCoreSupport.ts
+++ b/client/src/features/project/useProjectCoreSupport.ts
@@ -23,8 +23,14 @@ import { useGetMigrationStatusQuery } from "./projectCoreApi";
 export type CoreSupport =
   | {
       backendAvailable: undefined;
-      backendErrorMessage: string | undefined;
+      backendErrorMessage: undefined;
       computed: false;
+      versionUrl: undefined;
+    }
+  | {
+      backendAvailable: undefined;
+      backendErrorMessage: string;
+      computed: true;
       versionUrl: undefined;
     }
   | {
@@ -92,12 +98,20 @@ export const computeBackendData = ({
   backendErrorMessage: string | undefined;
   projectVersion: number | undefined;
 }): CoreSupport => {
+  if (backendErrorMessage) {
+    return {
+      backendAvailable: undefined,
+      backendErrorMessage,
+      computed: true,
+      versionUrl: undefined,
+    };
+  }
   if (!availableVersions || typeof projectVersion !== "number")
     return {
       backendAvailable: undefined,
+      backendErrorMessage: undefined,
       computed: false,
       versionUrl: undefined,
-      backendErrorMessage,
     };
   if (availableVersions.includes(projectVersion))
     return {

--- a/client/src/features/project/utils/migrations.ts
+++ b/client/src/features/project/utils/migrations.ts
@@ -86,7 +86,7 @@ export function getCompareUrl(
  */
 export function getMigrationLevel(
   migrationStatus: MigrationStatus | undefined,
-  backendAvailable: boolean
+  backendAvailable: boolean | undefined
 ): ProjectMigrationLevel | null {
   // ? REF: https://www.notion.so/Project-status-889f7a0f16574c84a4b7af344683623b
   if (!migrationStatus) return null;


### PR DESCRIPTION
When the check_migrations API errors, we show an endless spinning wheel and the error doesn't surface. This PR fixes it.

This is an alternative implementation to #2649 . Do not merge both!

![Peek 2023-07-11 15-01](https://github.com/SwissDataScienceCenter/renku-ui/assets/43481553/38f41233-a87c-4624-ad45-0bf67c77ebe1)

/deploy #persist #cypress
