### PR TITLE
ci: update Cypress acceptance tests action

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -16,15 +16,11 @@ on:
       - .github/workflows/**
       - chartpress.yaml
 
-jobs:
-  cleanup-previous-runs:
-    runs-on: ubuntu-22.04
-    if: github.event.action != 'closed'
-    steps:
-      - uses: rokroskar/workflow-run-cleanup-action@v0.3.3
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
+jobs:
   check-deploy:
     runs-on: ubuntu-22.04
     outputs:
@@ -46,7 +42,7 @@ jobs:
           pr_ref: ${{ github.event.number }}
 
   deploy-pr:
-    needs: [check-deploy, cleanup-previous-runs]
+    needs: [check-deploy]
     if: github.event.action != 'closed' && needs.check-deploy.outputs.pr-contains-string == 'true'
     runs-on: ubuntu-22.04
     environment:

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -36,7 +36,7 @@ jobs:
       extra-values: ${{ steps.deploy-comment.outputs.extra-values}}
     steps:
       - id: deploy-comment
-        uses: SwissDataScienceCenter/renku-actions/check-pr-description@v1.4.6
+        uses: SwissDataScienceCenter/renku-actions/check-pr-description@v1.5.0
         with:
           string: /deploy
           pr_ref: ${{ github.event.number }}
@@ -65,7 +65,7 @@ jobs:
           body: |
             You can access the deployment of this PR at https://renku-ci-ui-${{ github.event.number }}.dev.renku.ch
       - name: Build and deploy
-        uses: SwissDataScienceCenter/renku-actions/deploy-renku@v1.4.6
+        uses: SwissDataScienceCenter/renku-actions/deploy-renku@v1.5.0
         env:
           RANCHER_PROJECT_ID: ${{ secrets.CI_RANCHER_PROJECT }}
           DOCKER_PASSWORD: ${{ secrets.RENKU_DOCKER_PASSWORD }}
@@ -94,7 +94,7 @@ jobs:
     if: github.event.action != 'closed' && needs.check-deploy.outputs.pr-contains-string == 'true' && needs.check-deploy.outputs.test-enabled == 'true'
     runs-on: ubuntu-22.04
     steps:
-      - uses: SwissDataScienceCenter/renku-actions/test-renku@v1.4.6
+      - uses: SwissDataScienceCenter/renku-actions/test-renku@v1.5.0
         with:
           kubeconfig: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
           renku-release: renku-ci-ui-${{ github.event.number }}
@@ -121,7 +121,7 @@ jobs:
     steps:
       - name: Extract Renku repository reference
         run: echo "RENKU_REFERENCE=`echo '${{ needs.check-deploy.outputs.renku }}' | cut -d'@' -f2`" >> $GITHUB_ENV
-      - uses: SwissDataScienceCenter/renku-actions/test-renku-cypress@renku3150-update-cypress-tests
+      - uses: SwissDataScienceCenter/renku-actions/test-renku-cypress@v1.5.0
         with:
           e2e-target: ${{ matrix.tests }}
           renku-reference: ${{ env.RENKU_REFERENCE }}
@@ -149,7 +149,7 @@ jobs:
           body: |
             Tearing down the temporary RenkuLab deplyoment for this PR.
       - name: renku teardown
-        uses: SwissDataScienceCenter/renku-actions/cleanup-renku-ci-deployments@v1.4.6
+        uses: SwissDataScienceCenter/renku-actions/cleanup-renku-ci-deployments@v1.5.0
         env:
           HELM_RELEASE_REGEX: "^renku-ci-ui-${{ github.event.number }}$"
           GITLAB_TOKEN: ${{ secrets.DEV_GITLAB_TOKEN }}

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -108,7 +108,7 @@ jobs:
     if: |
       github.event.action != 'closed' &&
       needs.check-deploy.outputs.pr-contains-string == 'true' &&
-      (needs.check-deploy.outputs.test-cypress-enabled == 'true' || needs.check-deploy.outputs.test-cypress-enabled == 'true')
+      (needs.check-deploy.outputs.test-enabled == 'true' || needs.check-deploy.outputs.test-cypress-enabled == 'true')
     needs: [check-deploy, deploy-pr]
     runs-on: ubuntu-22.04
 

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -93,7 +93,7 @@ jobs:
           renku_notebooks: "${{ needs.check-deploy.outputs.renku-notebooks }}"
           extra_values: "${{ needs.check-deploy.outputs.extra-values }}"
 
-  run-selenium-acceptance-tests:
+  selenium-acceptance-tests:
     needs: [check-deploy, deploy-pr]
     if: github.event.action != 'closed' && needs.check-deploy.outputs.pr-contains-string == 'true' && needs.check-deploy.outputs.test-enabled == 'true'
     runs-on: ubuntu-22.04
@@ -108,7 +108,7 @@ jobs:
           s3-results-secret-key: ${{ secrets.ACCEPTANCE_TESTS_BUCKET_SECRET_KEY }}
           test-timeout-mins: "60"
 
-  run-cypress-acceptance-tests:
+  cypress-acceptance-tests:
     if: |
       github.event.action != 'closed' &&
       needs.check-deploy.outputs.pr-contains-string == 'true' &&

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -109,18 +109,28 @@ jobs:
           test-timeout-mins: "60"
 
   run-cypress-acceptance-tests:
+    if: |
+      github.event.action != 'closed' &&
+      needs.check-deploy.outputs.pr-contains-string == 'true' &&
+      (needs.check-deploy.outputs.test-cypress-enabled == 'true' || needs.check-deploy.outputs.test-cypress-enabled == 'true')
     needs: [check-deploy, deploy-pr]
-    if: github.event.action != 'closed' && needs.check-deploy.outputs.pr-contains-string == 'true' && needs.check-deploy.outputs.test-cypress-enabled == 'true'
     runs-on: ubuntu-22.04
+
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        tests: [publicProject, updateProjects, useSession]
+
     steps:
-      - name: Extract renku repo ref
-        run: echo "RENKU=`echo '${{ needs.check-deploy.outputs.renku }}' | cut -d'@' -f2`" >> $GITHUB_ENV
-      - uses: SwissDataScienceCenter/renku-actions/test-renku-cypress@v1.4.6
+      - name: Extract Renku repository reference
+        run: echo "RENKU_REFERENCE=`echo '${{ needs.check-deploy.outputs.renku }}' | cut -d'@' -f2`" >> $GITHUB_ENV
+      - uses: SwissDataScienceCenter/renku-actions/test-renku-cypress@renku3150-update-cypress-tests
         with:
-          gitlab-token: ${{ secrets.DEV_GITLAB_TOKEN }}
+          e2e-target: ${{ matrix.tests }}
+          renku-reference: ${{ env.RENKU_REFERENCE }}
           renku-release: renku-ci-ui-${{ github.event.number }}
           test-user-password: ${{ secrets.RENKU_BOT_DEV_PASSWORD }}
-          renku: ${{ env.RENKU }}
 
   cleanup:
     needs: check-deploy

--- a/.github/workflows/test-and-ci.yml
+++ b/.github/workflows/test-and-ci.yml
@@ -171,7 +171,7 @@ jobs:
           echo "GIT_USER=Renku Bot" >> $GITHUB_ENV
           echo "GIT_EMAIL=renku@datascience.ch" >> $GITHUB_ENV
       - name: Push chart and images
-        uses: SwissDataScienceCenter/renku-actions/publish-chart@v1.4.6
+        uses: SwissDataScienceCenter/renku-actions/publish-chart@v1.5.0
         env:
           GITHUB_TOKEN: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
           CHART_NAME: renku-ui
@@ -180,7 +180,7 @@ jobs:
       - name: Wait for chart to get published
         run: sleep 120
       - name: Update ui version
-        uses: SwissDataScienceCenter/renku-actions/update-component-version@v1.4.6
+        uses: SwissDataScienceCenter/renku-actions/update-component-version@v1.5.0
         env:
           GITHUB_TOKEN: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
           CHART_NAME: renku-ui

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -31826,9 +31826,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.26",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.26.tgz",
-      "integrity": "sha512-jrXHFF8iTloAenySjM/ob3gSj7pCu0Ji49hnjqzsgSRa50hkWCKD0HQ+gMNJkW38jBI68MpAAg7ZWwHwX8NMMw==",
+      "version": "8.4.27",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.27.tgz",
+      "integrity": "sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==",
       "dev": true,
       "funding": [
         {
@@ -64655,9 +64655,9 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.4.26",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.26.tgz",
-      "integrity": "sha512-jrXHFF8iTloAenySjM/ob3gSj7pCu0Ji49hnjqzsgSRa50hkWCKD0HQ+gMNJkW38jBI68MpAAg7ZWwHwX8NMMw==",
+      "version": "8.4.27",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.27.tgz",
+      "integrity": "sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==",
       "dev": true,
       "requires": {
         "nanoid": "^3.3.6",


### PR DESCRIPTION
Updating the Cypress acceptance tests action to support changes in https://github.com/SwissDataScienceCenter/renku-actions/pull/54 and https://github.com/SwissDataScienceCenter/renku/pull/3150

/deploy #persist #notest #cypress renku=renku-ui-3.10-tests

