### PR TITLE
chore: prevent swallowing session errors

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -19,7 +19,7 @@
         "morgan": "^1.10.0",
         "openid-client": "^4.9.1",
         "uuid": "^8.3.2",
-        "winston": "^3.8.2",
+        "winston": "^3.10.0",
         "ws": "^7.5.9"
       },
       "devDependencies": {
@@ -7856,9 +7856,9 @@
       }
     },
     "node_modules/winston": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.8.2.tgz",
-      "integrity": "sha512-MsE1gRx1m5jdTTO9Ld/vND4krP2To+lgDoMEHGGa4HIlAUyXJtfc7CxQcGXVyz2IBpw5hbFkj2b/AtUdQwyRew==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.10.0.tgz",
+      "integrity": "sha512-nT6SIDaE9B7ZRO0u3UvdrimG0HkB7dSTAgInQnNR2SOPJ4bvq5q79+pXLftKmP52lJGW15+H5MCK0nM9D3KB/g==",
       "dependencies": {
         "@colors/colors": "1.5.0",
         "@dabh/diagnostics": "^2.0.2",
@@ -14075,9 +14075,9 @@
       }
     },
     "winston": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.8.2.tgz",
-      "integrity": "sha512-MsE1gRx1m5jdTTO9Ld/vND4krP2To+lgDoMEHGGa4HIlAUyXJtfc7CxQcGXVyz2IBpw5hbFkj2b/AtUdQwyRew==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.10.0.tgz",
+      "integrity": "sha512-nT6SIDaE9B7ZRO0u3UvdrimG0HkB7dSTAgInQnNR2SOPJ4bvq5q79+pXLftKmP52lJGW15+H5MCK0nM9D3KB/g==",
       "requires": {
         "@colors/colors": "1.5.0",
         "@dabh/diagnostics": "^2.0.2",

--- a/server/package.json
+++ b/server/package.json
@@ -36,7 +36,7 @@
     "morgan": "^1.10.0",
     "openid-client": "^4.9.1",
     "uuid": "^8.3.2",
-    "winston": "^3.8.2",
+    "winston": "^3.10.0",
     "ws": "^7.5.9"
   },
   "devDependencies": {

--- a/server/src/websocket/handlers/sessions.ts
+++ b/server/src/websocket/handlers/sessions.ts
@@ -82,6 +82,7 @@ function heartbeatRequestSessionStatus(
     })
     .catch((e) => {
       logger.warn("There was a problem while trying to fetch sessions");
+      if (e.message) logger.warn(e.message);
       logger.warn(e);
     });
 }


### PR DESCRIPTION
There seems to be an [annoying error with Winston](https://github.com/winstonjs/winston/issues/1338) that results in non-expanded errors when logging.

![image](https://github.com/SwissDataScienceCenter/renku-ui/assets/43481553/7376f5b0-0d62-4099-bc1f-c44964ecf60f)

This PR updates the library. Since it's unclear from the linked issues/PRs whether _all_ errors are handled correctly, I also added a log to print the error message for sessions.

/deploy #persist renku=renku-ui-3.10-tests
