### PR TITLE
chore(build): update acceptance-tests.yml

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -47,6 +47,7 @@ jobs:
     runs-on: ubuntu-22.04
     environment:
       name: renku-ci-ui-${{ github.event.number }}
+      url: https://renku-ci-ui-${{ github.event.number }}.dev.renku.ch
     steps:
       - uses: actions/checkout@v3
       - name: Find deplyoment url


### PR DESCRIPTION
Add the URL of the deployment to the `environment` section.

This adds a button in GitHub:
![Screenshot 2023-08-09 at 14 50 25](https://github.com/SwissDataScienceCenter/renku-ui/assets/951086/e2bf4c3f-288a-4347-b17f-38bb8ec03b9b)

Clicking "View deployment" opens the Renku UI in a new tab.

/deploy #notest #persist

