### PR TITLE
Persistent sessions: small UI updates

### DIFF
--- a/client/src/components/entityHeader/EntityHeader.tsx
+++ b/client/src/components/entityHeader/EntityHeader.tsx
@@ -106,11 +106,7 @@ function EntityHeader({
   // Set the main button based on running sessions
   const mainButton =
     fullPath && gitUrl ? (
-      <SessionButton
-        enableCreateSessionLink
-        fullPath={fullPath}
-        gitUrl={gitUrl}
-      />
+      <SessionButton fullPath={fullPath} gitUrl={gitUrl} />
     ) : null;
 
   // Set up support for logs modal

--- a/client/src/components/list/ListBarSessions.tsx
+++ b/client/src/components/list/ListBarSessions.tsx
@@ -278,6 +278,7 @@ function ListBarSession({
       </div>
       <div className="session-icon">
         <SessionStatusBadge
+          annotations={notebook.annotations}
           defaultImage={notebook.annotations["default_image_used"]}
           name={notebook.name}
           status={notebook.status}

--- a/client/src/components/shareLinkSession/ShareLinkSession.tsx
+++ b/client/src/components/shareLinkSession/ShareLinkSession.tsx
@@ -283,12 +283,6 @@ const ShareLinkSessionOpenFileModal = ({
   }, [filters, filePath]);
 
   const goToSpecifyCommit = () => {
-    // const state = {
-    //   filePath,
-    //   showShareLinkModal: true,
-    //   from: location.pathname,
-    // };
-    // history.push({ pathname: launchNotebookUrl, search: "", state });
     const search = new URLSearchParams({ filePath, showCreateLink: "1" });
     const state = { from: location.pathname };
     history.push({

--- a/client/src/components/shareLinkSession/ShareLinkSession.tsx
+++ b/client/src/components/shareLinkSession/ShareLinkSession.tsx
@@ -283,12 +283,19 @@ const ShareLinkSessionOpenFileModal = ({
   }, [filters, filePath]);
 
   const goToSpecifyCommit = () => {
-    const state = {
-      filePath,
-      showShareLinkModal: true,
-      from: location.pathname,
-    };
-    history.push({ pathname: launchNotebookUrl, search: "", state });
+    // const state = {
+    //   filePath,
+    //   showShareLinkModal: true,
+    //   from: location.pathname,
+    // };
+    // history.push({ pathname: launchNotebookUrl, search: "", state });
+    const search = new URLSearchParams({ filePath, showCreateLink: "1" });
+    const state = { from: location.pathname };
+    history.push({
+      pathname: launchNotebookUrl,
+      search: search.toString(),
+      state,
+    });
   };
 
   const markdown = `[![launch - renku](${Url.get(

--- a/client/src/features/session/components/SessionButton.tsx
+++ b/client/src/features/session/components/SessionButton.tsx
@@ -60,7 +60,6 @@ import SimpleSessionButton from "./SimpleSessionButton";
 
 interface SessionButtonProps {
   className?: string;
-  enableCreateSessionLink?: boolean;
   fullPath: string;
   gitUrl?: string;
   runningSessionName?: string;
@@ -68,7 +67,6 @@ interface SessionButtonProps {
 
 export default function SessionButton({
   className,
-  enableCreateSessionLink,
   fullPath,
   gitUrl,
   runningSessionName,
@@ -125,53 +123,38 @@ export default function SessionButton({
           </Link>
         </DropdownItem>
         {gitUrl && <SshDropdown fullPath={fullPath} gitUrl={gitUrl} />}
-        {enableCreateSessionLink && (
-          <>
-            <DropdownItem divider />
-            <DropdownItem>
-              <Link
-                className="text-decoration-none"
-                to={{
-                  pathname: sessionStartUrl,
-                  search: new URLSearchParams({
-                    showCreateLink: "1",
-                  }).toString(),
-                }}
-              >
-                <FontAwesomeIcon
-                  className={cx("text-rk-green", "fa-w-14", "me-2")}
-                  fixedWidth
-                  icon={faLink}
-                />
-                Create session link
-              </Link>
-            </DropdownItem>
-          </>
-        )}
+        <DropdownItem divider />
+        <DropdownItem>
+          <Link
+            className="text-decoration-none"
+            to={{
+              pathname: sessionStartUrl,
+              search: new URLSearchParams({
+                showCreateLink: "1",
+              }).toString(),
+            }}
+          >
+            <FontAwesomeIcon
+              className={cx("text-rk-green", "fa-w-14", "me-2")}
+              fixedWidth
+              icon={faLink}
+            />
+            Create session link
+          </Link>
+        </DropdownItem>
       </ButtonWithMenu>
     );
   }
 
-  return (
-    <SessionActions
-      className={className}
-      enableCreateSessionLink={enableCreateSessionLink}
-      session={runningSession}
-    />
-  );
+  return <SessionActions className={className} session={runningSession} />;
 }
 
 interface SessionActionsProps {
   className?: string;
-  enableCreateSessionLink?: boolean;
   session: Session;
 }
 
-function SessionActions({
-  className,
-  enableCreateSessionLink,
-  session,
-}: SessionActionsProps) {
+function SessionActions({ className, session }: SessionActionsProps) {
   const history = useHistory();
 
   const logged = useSelector<RootStateOrAny, User["logged"]>(
@@ -371,7 +354,7 @@ function SessionActions({
     </DropdownItem>
   );
 
-  const createSessionLinkAction = enableCreateSessionLink && (
+  const createSessionLinkAction = (
     <>
       <DropdownItem divider />
       <DropdownItem>

--- a/client/src/features/session/components/SessionButton.tsx
+++ b/client/src/features/session/components/SessionButton.tsx
@@ -20,6 +20,7 @@ import React, { useCallback, useEffect, useState } from "react";
 import {
   faExternalLinkAlt,
   faFileAlt,
+  faLink,
   faPlay,
   faTrash,
 } from "@fortawesome/free-solid-svg-icons";
@@ -127,7 +128,24 @@ export default function SessionButton({
         {enableCreateSessionLink && (
           <>
             <DropdownItem divider />
-            <DropdownItem>TODO: Create session link</DropdownItem>
+            <DropdownItem>
+              <Link
+                className="text-decoration-none"
+                to={{
+                  pathname: sessionStartUrl,
+                  search: new URLSearchParams({
+                    showCreateLink: "1",
+                  }).toString(),
+                }}
+              >
+                <FontAwesomeIcon
+                  className={cx("text-rk-green", "fa-w-14", "me-2")}
+                  fixedWidth
+                  icon={faLink}
+                />
+                Create session link
+              </Link>
+            </DropdownItem>
           </>
         )}
       </ButtonWithMenu>
@@ -172,6 +190,10 @@ function SessionActions({
     namespace: annotations.namespace,
     path: annotations.projectName,
     server: session.name,
+  });
+  const sessionStartUrl = Url.get(Url.pages.project.session.new, {
+    namespace: annotations.namespace,
+    path: annotations.projectName,
   });
 
   // Handle resuming session
@@ -352,7 +374,24 @@ function SessionActions({
   const createSessionLinkAction = enableCreateSessionLink && (
     <>
       <DropdownItem divider />
-      <DropdownItem>TODO: Create session link</DropdownItem>
+      <DropdownItem>
+        <Link
+          className="text-decoration-none"
+          to={{
+            pathname: sessionStartUrl,
+            search: new URLSearchParams({
+              showCreateLink: "1",
+            }).toString(),
+          }}
+        >
+          <FontAwesomeIcon
+            className={cx("text-rk-green", "fa-w-14", "me-2")}
+            fixedWidth
+            icon={faLink}
+          />
+          Create session link
+        </Link>
+      </DropdownItem>
     </>
   );
 

--- a/client/src/features/session/components/SessionHibernated.tsx
+++ b/client/src/features/session/components/SessionHibernated.tsx
@@ -73,7 +73,6 @@ export default function SessionHibernated({ session }: SessionHibernatedProps) {
 
   // Resume session if opening a notebook from the file explorer
   useEffect(() => {
-    console.log({ locationFilePath });
     if (locationFilePath) {
       onResumeSession();
     }

--- a/client/src/features/session/components/SessionHibernated.tsx
+++ b/client/src/features/session/components/SessionHibernated.tsx
@@ -23,7 +23,7 @@ import { SerializedError } from "@reduxjs/toolkit";
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 import cx from "classnames";
 import { RootStateOrAny, useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { Alert, Button } from "reactstrap";
 import { Loader } from "../../../components/Loader";
 import { NOTIFICATION_TOPICS } from "../../../notifications/Notifications.constants";
@@ -38,6 +38,9 @@ interface SessionHibernatedProps {
 }
 
 export default function SessionHibernated({ session }: SessionHibernatedProps) {
+  const location = useLocation<{ filePath?: string } | undefined>();
+  const locationFilePath = location.state?.filePath;
+
   const pathWithNamespace = useSelector<RootStateOrAny, string>(
     (state) => state.stateModel.project.metadata.pathWithNamespace
   );
@@ -67,6 +70,14 @@ export default function SessionHibernated({ session }: SessionHibernatedProps) {
       });
     }
   }, [error, notifications]);
+
+  // Resume session if opening a notebook from the file explorer
+  useEffect(() => {
+    console.log({ locationFilePath });
+    if (locationFilePath) {
+      onResumeSession();
+    }
+  }, [locationFilePath, onResumeSession]);
 
   return (
     <div className={cx("p-2", "p-lg-3", "text-nowrap", "container-lg")}>

--- a/client/src/features/session/components/StopSessionModal.tsx
+++ b/client/src/features/session/components/StopSessionModal.tsx
@@ -219,13 +219,6 @@ function HibernateSessionModal({
               Please note that paused session are deleted after 30 days of
               inactivity.
             </InfoAlert>
-            {isStopping ? (
-              <FormText color="primary">
-                <Loader className="me-1" inline size={16} />
-                Pausing Session
-                <br />
-              </FormText>
-            ) : null}
             <div className="d-flex justify-content-end">
               <Button
                 className={cx("float-right", "mt-1", "btn-outline-rk-green")}
@@ -241,7 +234,14 @@ function HibernateSessionModal({
                 type="submit"
                 onClick={onHibernateSession}
               >
-                Pause Session
+                {isStopping ? (
+                  <>
+                    <Loader className="me-2" inline size={16} />
+                    Pausing session
+                  </>
+                ) : (
+                  <>Pause Session</>
+                )}
               </Button>
             </div>
           </Col>

--- a/client/src/features/session/components/status/SessionHibernationStatusDetails.tsx
+++ b/client/src/features/session/components/status/SessionHibernationStatusDetails.tsx
@@ -1,0 +1,96 @@
+/*!
+ * Copyright 2023 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import cx from "classnames";
+import { NotebookAnnotations } from "../../../../notebooks/components/Session";
+import { TimeCaption } from "../../../../components/TimeCaption";
+import { faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+interface SessionHibernationStatusDetailsProps {
+  annotations: NotebookAnnotations;
+}
+
+export default function SessionHibernationStatusDetails({
+  annotations,
+}: SessionHibernationStatusDetailsProps) {
+  const hasHibernationInfo = !!annotations["hibernation-date"];
+
+  return (
+    <>
+      {hasHibernationInfo ? (
+        <>
+          <p className="mb-0">
+            <span className="fw-bold">Paused:</span>{" "}
+            <TimeCaption
+              datetime={annotations["hibernation-date"]}
+              enableTooltip
+              noCaption
+            />
+          </p>
+          <p className="mb-0">
+            <span className="fw-bold">Current commit:</span>{" "}
+            <code>{annotations["hibernation-commit-sha"].slice(0, 8)}</code>
+          </p>
+          <p className="mb-0">
+            <span className="fw-bold">
+              {annotations["hibernation-dirty"] ? (
+                <>
+                  <FontAwesomeIcon
+                    className={cx("text-warning", "me-1")}
+                    icon={faExclamationTriangle}
+                  />
+                  Uncommitted files
+                </>
+              ) : (
+                "No uncommitted files"
+              )}
+            </span>
+          </p>
+          <p className="mb-2">
+            <span className="fw-bold">
+              {!annotations["hibernation-synchronized"] ? (
+                <>
+                  <FontAwesomeIcon
+                    className={cx("text-warning", "me-1")}
+                    icon={faExclamationTriangle}
+                  />
+                  Some commits are not synced to the remote
+                </>
+              ) : (
+                "All commits pushed to remote"
+              )}
+            </span>
+          </p>
+        </>
+      ) : (
+        <p className="mb-2">
+          <span className="fw-bold">
+            <FontAwesomeIcon
+              className={cx("text-warning", "me-1")}
+              icon={faExclamationTriangle}
+            />
+            Could not retrieve session information before the session was
+            paused. There may be uncommitted files or unsynced commits.
+          </span>
+        </p>
+      )}
+    </>
+  );
+}

--- a/client/src/features/session/components/status/SessionStatusBadge.tsx
+++ b/client/src/features/session/components/status/SessionStatusBadge.tsx
@@ -23,17 +23,22 @@ import {
   PopoverHeader,
   UncontrolledPopover,
 } from "reactstrap";
+import cx from "classnames";
 import { SessionStatus, SessionStatusState } from "../../sessions.types";
 import { getSessionStatusColor } from "../../utils/sessionStatus.utils";
 import SessionStatusIcon from "./SessionStatusIcon";
+import SessionHibernationStatusDetails from "./SessionHibernationStatusDetails";
+import { NotebookAnnotations } from "../../../../notebooks/components/Session";
 
 interface SessionStatusBadgeProps {
+  annotations: NotebookAnnotations;
   defaultImage: boolean;
   name: string;
   status: SessionStatus;
 }
 
 export default function SessionStatusBadge({
+  annotations,
   defaultImage,
   name,
   status: statusObject,
@@ -42,14 +47,22 @@ export default function SessionStatusBadge({
 
   const color = getSessionStatusColor({ defaultImage, status });
   const popover = (status === "failed" ||
-    (status === "running" && defaultImage)) && (
+    (status === "running" && defaultImage) ||
+    status === "hibernated") && (
     <UncontrolledPopover target={name} trigger="hover" placement="bottom">
       <PopoverHeader>
-        {status === "failed" ? "Error Details" : "Warning Details"}
+        {status === "failed"
+          ? "Error Details"
+          : status === "running"
+          ? "Warning Details"
+          : "Paused Session"}
       </PopoverHeader>
       <PopoverBody>
         {message}
         {defaultImage && <div>A fallback image was used.</div>}
+        {status === "hibernated" && (
+          <SessionHibernationStatusDetails annotations={annotations} />
+        )}
       </PopoverBody>
     </UncontrolledPopover>
   );
@@ -57,9 +70,12 @@ export default function SessionStatusBadge({
   return (
     <div
       id={name}
-      className={`d-flex align-items-center gap-1 ${
-        status === "failed" ? "cursor-pointer" : ""
-      }`}
+      className={cx(
+        "d-flex",
+        "align-items-center",
+        "gap-1",
+        popover && "cursor-pointer"
+      )}
     >
       <Badge className="p-1" color={color}>
         <SessionStatusIcon defaultImage={defaultImage} status={status} />

--- a/client/src/features/session/components/status/SessionStatusText.tsx
+++ b/client/src/features/session/components/status/SessionStatusText.tsx
@@ -50,13 +50,12 @@ export default function SessionStatusText({
   ) : status === "hibernated" && hibernationTimestamp ? (
     <>
       Paused{" "}
-      <TimeCaption datetime={hibernationTimestamp} enableTooltip noCaption />,
-      created {startTimeText}
+      <TimeCaption datetime={hibernationTimestamp} enableTooltip noCaption />
     </>
   ) : status === "hibernated" ? (
     <>
       Paused
-      <MissingHibernationInfo />, created {startTimeText}
+      <MissingHibernationInfo />
     </>
   ) : status === "failed" ? (
     <>

--- a/client/src/notebooks/NotebookStart.present.js
+++ b/client/src/notebooks/NotebookStart.present.js
@@ -1529,7 +1529,10 @@ const CheckNotebookIcon = ({
     aligner = null;
   if (notebook) {
     const status = notebook.status?.state;
-    if (status === SessionStatusStateEnum.running) {
+    if (
+      status === SessionStatusStateEnum.running ||
+      status === SessionStatusStateEnum.hibernated
+    ) {
       const annotations = NotebooksHelper.cleanAnnotations(
         notebook.annotations
       );

--- a/client/src/notebooks/components/SessionListStatus.tsx
+++ b/client/src/notebooks/components/SessionListStatus.tsx
@@ -17,10 +17,7 @@
  */
 
 import React from "react";
-import {
-  faExclamationTriangle,
-  faInfoCircle,
-} from "@fortawesome/free-solid-svg-icons";
+import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import cx from "classnames";
 import {
@@ -30,12 +27,12 @@ import {
   UncontrolledPopover,
 } from "reactstrap";
 import { Clipboard } from "../../components/Clipboard";
+import SessionHibernationStatusDetails from "../../features/session/components/status/SessionHibernationStatusDetails";
 import SessionStatusIcon from "../../features/session/components/status/SessionStatusIcon";
 import SessionStatusText from "../../features/session/components/status/SessionStatusText";
 import { SessionStatusState } from "../../features/session/sessions.types";
 import { getSessionStatusColor } from "../../features/session/utils/sessionStatus.utils";
 import type { NotebookAnnotations } from "./Session";
-import { TimeCaption } from "../../components/TimeCaption";
 
 interface SessionListRowCoreProps {
   annotations: NotebookAnnotations;
@@ -131,8 +128,6 @@ function SessionListRowStatusIconPopover({
   id,
   status,
 }: SessionListRowStatusIconPopoverProps) {
-  // TODO: handle showing hibernating data in popover
-
   if (status !== "running" && status !== "failed" && status !== "hibernated") {
     return null;
   }
@@ -156,71 +151,13 @@ function SessionListRowStatusIconPopover({
     </span>
   );
 
-  const hasHibernationInfo = !!annotations["hibernation-date"];
-
   if (status === "hibernated") {
     return (
       <UncontrolledPopover placement="bottom" target={id} trigger="legacy">
         <PopoverHeader>Details</PopoverHeader>
         <PopoverBody>
           <h3 className="fs-6 fw-bold">Paused session</h3>
-          {hasHibernationInfo ? (
-            <>
-              <p className="mb-0">
-                <span className="fw-bold">Paused:</span>{" "}
-                <TimeCaption
-                  datetime={annotations["hibernation-date"]}
-                  enableTooltip
-                  noCaption
-                />
-              </p>
-              <p className="mb-0">
-                <span className="fw-bold">Current commit:</span>{" "}
-                <code>{annotations["hibernation-commit-sha"].slice(0, 8)}</code>
-              </p>
-              <p className="mb-0">
-                <span className="fw-bold">
-                  {annotations["hibernation-dirty"] ? (
-                    <>
-                      <FontAwesomeIcon
-                        className={cx("text-warning", "me-1")}
-                        icon={faExclamationTriangle}
-                      />
-                      Uncommitted files
-                    </>
-                  ) : (
-                    "No uncommitted files"
-                  )}
-                </span>
-              </p>
-              <p className="mb-2">
-                <span className="fw-bold">
-                  {!annotations["hibernation-synchronized"] ? (
-                    <>
-                      <FontAwesomeIcon
-                        className={cx("text-warning", "me-1")}
-                        icon={faExclamationTriangle}
-                      />
-                      Some commits are not synced to the remote
-                    </>
-                  ) : (
-                    "All commits pushed to remote"
-                  )}
-                </span>
-              </p>
-            </>
-          ) : (
-            <p className="mb-2">
-              <span className="fw-bold">
-                <FontAwesomeIcon
-                  className={cx("text-warning", "me-1")}
-                  icon={faExclamationTriangle}
-                />
-                Could not retrieve session information before the session was
-                paused. There may be uncommitted files or unsynced commits.
-              </span>
-            </p>
-          )}
+          <SessionHibernationStatusDetails annotations={annotations} />
 
           {image && (
             <>

--- a/tests/cypress/e2e/project.spec.ts
+++ b/tests/cypress/e2e/project.spec.ts
@@ -196,7 +196,7 @@ describe("display a project", () => {
   });
 
   it("displays project file > notebook with python output", () => {
-    fixtures.projectFiles().getSessions;
+    fixtures.projectFiles().getSessions();
     cy.visit("/projects/e2e/local-test-project/files");
     cy.wait("@getProjectFilesRoot");
     cy.contains("01-CountFlights.ipynb").scrollIntoView();

--- a/tests/cypress/support/renkulab-fixtures/projects.ts
+++ b/tests/cypress/support/renkulab-fixtures/projects.ts
@@ -288,6 +288,11 @@ function Projects<T extends FixturesConstructor>(Parent: T) {
         "/ui-server/api/projects/*/repository/branches?page=1&per_page=100",
         { fixture: "project/test-project-branches.json" }
       ).as(projectBranchesName);
+      // Intercepting with swapped pagination params is necessary because of the legacy API client
+      cy.intercept(
+        "/ui-server/api/projects/*/repository/branches?per_page=100&page=1",
+        { fixture: "project/test-project-branches.json" }
+      ).as(projectBranchesName);
       cy.intercept("/ui-server/api/kg/webhooks/projects/*/events/status", {
         fixture: "project/kgStatus/kgStatusIndexing.json",
       });


### PR DESCRIPTION
* Fix the share session link functionality
* Update the paused session status in the dashboard
* Update the pause session modal

Dashboard info:
![Screenshot 2023-08-17 at 13 16 51](https://github.com/SwissDataScienceCenter/renku-ui/assets/951086/f33acd04-e95b-44b9-892b-bb88dec52e04)

Pause session modal:
![image](https://github.com/SwissDataScienceCenter/renku-ui/assets/951086/69e680dc-983f-4d91-b321-fb3ba5f265ed)

/deploy #persist extra-values=notebooks.userSessionPersistentVolumes.enabled=true,notebooks.amalthea.image.repository=renku/amalthea,notebooks.amalthea.image.tag=db70f80ef1983d49a1b167faa57d02d9d8b9554f renku-notebooks=pitch/session-persistence