### PR TITLE
Take advantage of Core Service API versions

### DIFF
--- a/client/docker-entrypoint.sh
+++ b/client/docker-entrypoint.sh
@@ -39,6 +39,7 @@ echo " TEMPLATES=${TEMPLATES}"
 echo " PREVIEW_THRESHOLD=${PREVIEW_THRESHOLD}"
 echo " UPLOAD_THRESHOLD=${UPLOAD_THRESHOLD}"
 echo " HOMEPAGE=${HOMEPAGE}"
+echo " CORE_API_VERSION_CONFIG=${CORE_API_VERSION_CONFIG}"
 echo "==================================================="
 
 echo "Privacy file contains the following markdown (first 5 lines):"
@@ -67,7 +68,8 @@ tee > "${NGINX_PATH}/config.json" << EOF
   "PREVIEW_THRESHOLD": ${PREVIEW_THRESHOLD},
   "UPLOAD_THRESHOLD": ${UPLOAD_THRESHOLD},
   "STATUSPAGE_ID": "${STATUSPAGE_ID}",
-  "HOMEPAGE": ${HOMEPAGE}
+  "HOMEPAGE": ${HOMEPAGE},
+  "CORE_API_VERSION_CONFIG": ${CORE_API_VERSION_CONFIG}
 }
 EOF
 echo "config.json created in ${NGINX_PATH}"

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -64,7 +64,7 @@ export const ContainerWrap = ({ children, fullSize = false }) => {
 };
 
 function CentralContentContainer(props) {
-  const { coreApiVersionedUrlHelper, notifications, socket, user } = props;
+  const { coreApiVersionedUrlConfig, notifications, socket, user } = props;
 
   if (
     !props.user.logged &&
@@ -89,7 +89,7 @@ function CentralContentContainer(props) {
     client: props.client,
     params: props.params,
     location: props.location,
-    coreApiVersionedUrlHelper,
+    coreApiVersionedUrlConfig,
   };
 
   return (

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -64,7 +64,7 @@ export const ContainerWrap = ({ children, fullSize = false }) => {
 };
 
 function CentralContentContainer(props) {
-  const { notifications, user, socket } = props;
+  const { coreApiVersionedUrlHelper, notifications, socket, user } = props;
 
   if (
     !props.user.logged &&
@@ -89,6 +89,7 @@ function CentralContentContainer(props) {
     client: props.client,
     params: props.params,
     location: props.location,
+    coreApiVersionedUrlHelper,
   };
 
   return (

--- a/client/src/App.test.js
+++ b/client/src/App.test.js
@@ -8,6 +8,7 @@ import App from "./App";
 import { testClient as client } from "./api-client";
 import { StateModel, globalSchema } from "./model";
 import { generateFakeUser } from "./user/User.test";
+import { createCoreApiVersionedUrlConfig } from "./utils/helpers/url";
 
 describe("rendering", () => {
   const model = new StateModel(globalSchema);
@@ -47,12 +48,16 @@ describe("rendering", () => {
     const div = document.createElement("div");
     const root = createRoot(div);
     const user = generateFakeUser();
+    const coreApiVersionedUrlConfig = createCoreApiVersionedUrlConfig({
+      coreApiVersion: "/",
+    });
     await act(async () => {
       root.render(
         <Provider store={model.reduxStore}>
           <Router>
             <App
               client={client}
+              coreApiVersionedUrlConfig={coreApiVersionedUrlConfig}
               model={model}
               user={user}
               location={fakeLocation}

--- a/client/src/api-client/index.js
+++ b/client/src/api-client/index.js
@@ -55,10 +55,12 @@ class APIClient {
   /**
    * @param {string} apiUrl - base API url
    * @param {string} uiserverUrl - UI server base url, mainly used for authentication
+   * @param {CoreApiVersionedUrlHelper} coreApiVersionedUrlHelper - helper object for computing versioned URLs.
    */
-  constructor(apiUrl, uiserverUrl) {
+  constructor(apiUrl, uiserverUrl, coreApiVersionedUrlHelper) {
     this.baseUrl = apiUrl;
     this.uiserverUrl = uiserverUrl;
+    this.coreApiVersionedUrlHelper = coreApiVersionedUrlHelper;
     this.returnTypes = RETURN_TYPES;
 
     addDatasetMethods(this);
@@ -228,6 +230,7 @@ class APIClient {
    * @returns string
    */
   versionedCoreUrl(endpoint, version) {
+    // TODO: read the coreApiVersion variable or override and insert it between the urlAddition and the endpoint
     const urlAddition = version ? version : "";
     return `${this.baseUrl}/renku${urlAddition}/${endpoint}`;
   }

--- a/client/src/api-client/index.js
+++ b/client/src/api-client/index.js
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { CoreApiVersionedUrlHelper } from "../utils/helpers/url";
 
 import addDatasetMethods from "./dataset";
 import addGraphMethods from "./graph";
@@ -55,12 +56,14 @@ class APIClient {
   /**
    * @param {string} apiUrl - base API url
    * @param {string} uiserverUrl - UI server base url, mainly used for authentication
-   * @param {CoreApiVersionedUrlHelper} coreApiVersionedUrlHelper - helper object for computing versioned URLs.
+   * @param {CoreApiVersionedUrlConfig} coreApiVersionedUrlConfig - helper object for computing versioned URLs.
    */
-  constructor(apiUrl, uiserverUrl, coreApiVersionedUrlHelper) {
+  constructor(apiUrl, uiserverUrl, coreApiVersionedUrlConfig) {
     this.baseUrl = apiUrl;
     this.uiserverUrl = uiserverUrl;
-    this.coreApiVersionedUrlHelper = coreApiVersionedUrlHelper;
+    this.coreApiVersionedUrlHelper = new CoreApiVersionedUrlHelper(
+      coreApiVersionedUrlConfig
+    );
     this.returnTypes = RETURN_TYPES;
 
     addDatasetMethods(this);

--- a/client/src/api-client/index.js
+++ b/client/src/api-client/index.js
@@ -229,13 +229,15 @@ class APIClient {
   /**
    * Return a versioned endpoint url for the core service.
    * @param {string} endpoint
-   * @param {string or null} version
+   * @param {string or null} metadataVersion
    * @returns string
    */
-  versionedCoreUrl(endpoint, version) {
-    // TODO: read the coreApiVersion variable or override and insert it between the urlAddition and the endpoint
-    const urlAddition = version ? version : "";
-    return `${this.baseUrl}/renku${urlAddition}/${endpoint}`;
+  versionedCoreUrl(endpoint, metadataVersion) {
+    const path = this.coreApiVersionedUrlHelper.urlForEndpoint(
+      endpoint,
+      metadataVersion
+    );
+    return `${this.baseUrl}/renku${path}`;
   }
 
   /**

--- a/client/src/components/ssh/ssh.tsx
+++ b/client/src/components/ssh/ssh.tsx
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+import { useContext } from "react";
 import { Link } from "react-router-dom";
 import { useDispatch } from "react-redux";
 import { DropdownItem, Modal, ModalBody, ModalHeader } from "reactstrap";
@@ -28,7 +29,9 @@ import {
   toggleSshModal,
   useDisplaySelector,
 } from "../../features/display";
+import AppContext from "../../utils/context/appContext";
 import { Url } from "../../utils/helpers/url";
+
 import { InfoAlert } from "../Alert";
 import { ExternalDocsLink } from "../ExternalLinks";
 import { Docs } from "../../utils/constants/Docs";
@@ -37,6 +40,7 @@ import rkIconSshTicked from "../../styles/icons/ssh-ticked.svg";
 import rkIconSshCross from "../../styles/icons/ssh-cross.svg";
 import { CommandCopy } from "../commandCopy/CommandCopy";
 import { projectCoreApi } from "../../features/project/projectCoreApi";
+import { apiVersionForMetadataVersion } from "../../utils/helpers/url";
 import { cleanGitUrl } from "../../utils/helpers/ProjectFunctions";
 
 const docsIconStyle = {
@@ -77,8 +81,15 @@ function SshModal() {
   const gitUrl = cleanGitUrl(displayModal.gitUrl);
 
   const notebooksSupport = useGetNotebooksVersionsQuery();
+  const { coreApiVersionedUrlConfig } = useContext(AppContext);
+  const migrationStatusApiVersion = apiVersionForMetadataVersion(
+    coreApiVersionedUrlConfig,
+    undefined,
+    undefined // do not use the override for getting migration status
+  );
   const coreSupport = projectCoreApi.useGetMigrationStatusQuery(
     {
+      apiVersion: migrationStatusApiVersion,
       gitUrl,
     },
     { skip: !gitUrl }

--- a/client/src/dataset/Dataset.present.js
+++ b/client/src/dataset/Dataset.present.js
@@ -579,10 +579,12 @@ export default function DatasetView(props) {
         ) : null}
         {props.insideProject && props.maintainer ? (
           <DeleteDataset
+            apiVersion={props.apiVersion}
             client={props.client}
             dataset={dataset}
             externalUrl={props.externalUrl}
             history={props.history}
+            metadataVersion={props.metadataVersion}
             modalOpen={deleteDatasetModalOpen}
             projectPathWithNamespace={props.projectPathWithNamespace}
             setModalOpen={setDeleteDatasetModalOpen}

--- a/client/src/features/project/Project.d.ts
+++ b/client/src/features/project/Project.d.ts
@@ -160,7 +160,8 @@ export interface CoreSectionError extends CoreErrorContent {
   type: "error";
 }
 
-export interface MigrationStatusParams {
+export interface MigrationStatusParams
+  extends Pick<CoreVersionUrl, "apiVersion"> {
   branch?: string;
   gitUrl: string;
 }
@@ -230,7 +231,8 @@ export interface ProjectActivateIndexingResponse {
   message: string;
 }
 
-export interface MigrationStartParams {
+export interface MigrationStartParams
+  extends Pick<CoreVersionUrl, "apiVersion"> {
   branch?: string;
   gitUrl: string;
   scope?: MigrationStartScopes;

--- a/client/src/features/project/Project.d.ts
+++ b/client/src/features/project/Project.d.ts
@@ -322,7 +322,7 @@ export interface ProjectConfigSection {
   };
 }
 
-export interface UpdateDescriptionParams {
+export interface UpdateDescriptionParams extends CoreVersionUrl {
   description: string;
   gitUrl: string;
   projectId: number;

--- a/client/src/features/project/components/ProjectSettings.tsx
+++ b/client/src/features/project/components/ProjectSettings.tsx
@@ -33,6 +33,7 @@ import { Visibilities } from "../../../components/visibility/Visibility";
 // ****** SETTINGS COMPONENTS ****** //
 
 interface ProjectSettingsGeneralProps {
+  apiVersion?: string;
   client: unknown;
   forkedFromProject?: {
     id: number;
@@ -48,6 +49,7 @@ interface ProjectSettingsGeneralProps {
     visibility: Visibilities;
     [key: string]: unknown;
   };
+  metadataVersion?: number;
   notifications: Notifications;
   projectPathWithNamespace: string;
   user: {
@@ -74,8 +76,10 @@ export function ProjectSettingsGeneral(props: ProjectSettingsGeneralProps) {
         projectId={props.metadata?.id}
       />
       <ProjectSettingsDescription
+        apiVersion={props.apiVersion}
         gitUrl={props.metadata?.externalUrl}
         isMaintainer={isMaintainer}
+        metadataVersion={props.metadataVersion}
         projectId={props.metadata?.id}
         projectFullPath={props.projectPathWithNamespace}
       />

--- a/client/src/features/project/components/ProjectSettingsDescription.tsx
+++ b/client/src/features/project/components/ProjectSettingsDescription.tsx
@@ -26,17 +26,22 @@ import { useProjectMetadataQuery } from "../../projects/projectsKgApi";
 import { useUpdateDescriptionMutation } from "../projectCoreApi";
 import { CoreErrorAlert } from "../../../components/errors/CoreErrorAlert";
 import { SettingRequiresKg } from "./ProjectSettingsUtils";
-import { CoreErrorContent } from "../../../utils/types/coreService.types";
+import {
+  CoreErrorContent,
+  CoreVersionUrl,
+} from "../../../utils/types/coreService.types";
 
-interface ProjectSettingsDescriptionProps {
+interface ProjectSettingsDescriptionProps extends CoreVersionUrl {
   gitUrl: string;
   isMaintainer: boolean;
   projectFullPath: string;
   projectId: number;
 }
 export function ProjectSettingsDescription({
+  apiVersion,
   gitUrl,
   isMaintainer,
+  metadataVersion,
   projectFullPath,
   projectId,
 }: ProjectSettingsDescriptionProps) {
@@ -57,11 +62,20 @@ export function ProjectSettingsDescription({
     useUpdateDescriptionMutation();
   const onSubmit = useCallback(() => {
     updateDescriptionMutation({
+      apiVersion,
       description,
       gitUrl,
+      metadataVersion,
       projectId,
     });
-  }, [description, gitUrl, projectId, updateDescriptionMutation]);
+  }, [
+    apiVersion,
+    description,
+    gitUrl,
+    metadataVersion,
+    projectId,
+    updateDescriptionMutation,
+  ]);
 
   const setDescriptionAndReset = (newDescription: string) => {
     setDescription(newDescription);

--- a/client/src/features/project/components/migrations/ProjectCoreMigrations.tsx
+++ b/client/src/features/project/components/migrations/ProjectCoreMigrations.tsx
@@ -77,21 +77,26 @@ export function ProjectMigrationStatus({
     gitUrl,
     branch,
   });
-  const { backendAvailable, computed: coreSupportComputed } = coreSupport;
+  const {
+    apiVersion,
+    backendAvailable,
+    computed: coreSupportComputed,
+  } = coreSupport;
   const isSupported = coreSupportComputed && backendAvailable;
   const checkingSupport = !coreSupportComputed;
 
   const skip = !gitUrl || !branch;
   const { data, isLoading, isFetching, error } =
     projectCoreApi.useGetMigrationStatusQuery(
-      { gitUrl, branch },
+      { apiVersion, gitUrl, branch },
       { refetchOnMountOrArgChange: 60 * 5, skip }
     );
   const [startMigration, migrationStatus] =
     projectCoreApi.useStartMigrationMutation();
   const updateProject = useCallback(
-    (scope: MigrationStartScopes) => startMigration({ branch, gitUrl, scope }),
-    [branch, gitUrl, startMigration]
+    (scope: MigrationStartScopes) =>
+      startMigration({ apiVersion, branch, gitUrl, scope }),
+    [apiVersion, branch, gitUrl, startMigration]
   );
 
   const sectionCyId = "project-version";

--- a/client/src/features/project/dataset/DatasetModify.tsx
+++ b/client/src/features/project/dataset/DatasetModify.tsx
@@ -346,6 +346,7 @@ function formatServerError(error: ServerError) {
   );
 }
 export interface DatasetModifyProps extends DatasetModifyDisplayProps {
+  apiVersion: string | undefined;
   client: DatasetPostClient;
   dataset: DatasetModifyFormProps["dataset"];
   defaultBranch: string;
@@ -355,6 +356,7 @@ export interface DatasetModifyProps extends DatasetModifyDisplayProps {
   history: ReturnType<typeof useHistory>;
   initialized: boolean;
   location: { pathname: string };
+  metadataVersion: number | undefined;
   notifications: unknown;
   onCancel: () => void;
   overviewCommitsUrl: string;
@@ -366,6 +368,7 @@ export interface DatasetModifyProps extends DatasetModifyDisplayProps {
 export default function DatasetModify(props: DatasetModifyProps) {
   const dispatch = useDispatch();
   const {
+    apiVersion,
     client,
     dataset,
     defaultBranch,
@@ -373,6 +376,7 @@ export default function DatasetModify(props: DatasetModifyProps) {
     fetchDatasets,
     history,
     location,
+    metadataVersion,
     overviewCommitsUrl,
     projectPathWithNamespace,
     setSubmitting,
@@ -441,11 +445,12 @@ export default function DatasetModify(props: DatasetModifyProps) {
 
         // step 2: create or modify the dataset metadata -- no files
         const datasetMutationParams: PostDatasetParams = {
+          apiVersion,
           branch: defaultBranch,
           dataset: groomedDataset as PostDataset,
           edit,
           gitUrl: externalUrl,
-          versionUrl,
+          metadataVersion,
         };
         // ? this was a quick fix; we should _not_ use then/catch but rather rely on postDatasetStatus
         postDatasetMutation(datasetMutationParams)
@@ -490,11 +495,12 @@ export default function DatasetModify(props: DatasetModifyProps) {
 
             // step 3: add the files (if any)
             const addFilesParams: AddFilesParams = {
+              apiVersion,
               branch: response.data.remoteBranch ?? defaultBranch,
               files: groomedDataset.files,
               gitUrl: externalUrl,
+              metadataVersion,
               name: groomedDataset.name,
-              versionUrl,
             };
             addFilesMutation(addFilesParams)
               .then(async (filesResponse) => {
@@ -578,6 +584,7 @@ export default function DatasetModify(props: DatasetModifyProps) {
       }
     },
     [
+      apiVersion,
       addFilesMutation,
       client,
       dataset?.name,
@@ -587,6 +594,7 @@ export default function DatasetModify(props: DatasetModifyProps) {
       externalUrl,
       fetchDatasets,
       history,
+      metadataVersion,
       name,
       postDatasetMutation,
       projectPathWithNamespace,

--- a/client/src/features/project/dataset/ProjectDatasetNewEdit.tsx
+++ b/client/src/features/project/dataset/ProjectDatasetNewEdit.tsx
@@ -50,12 +50,14 @@ import { SerializedError } from "@reduxjs/toolkit";
 import { Loader } from "../../../components/Loader";
 
 type ChangeDatasetProps = {
+  apiVersion: string | undefined;
   client: DatasetPostClient;
   fetchDatasets: PostSubmitProps["fetchDatasets"];
   history: ReturnType<typeof useHistory>;
   location: { pathname: string };
   model: unknown;
   notifications: unknown;
+  metadataVersion: number | undefined;
   params: unknown;
   submitting: boolean;
   setSubmitting: (submitting: boolean) => void;
@@ -172,6 +174,7 @@ function ProjectDatasetNewEdit(props: ProjectDatasetNewEditProps) {
 
   return (
     <DatasetModify
+      apiVersion={props.apiVersion}
       client={props.client}
       dataset={props.dataset}
       defaultBranch={projectMetadata.defaultBranch}
@@ -181,6 +184,7 @@ function ProjectDatasetNewEdit(props: ProjectDatasetNewEditProps) {
       initialized={true}
       history={props.history}
       location={props.location}
+      metadataVersion={props.metadataVersion}
       notifications={props.notifications}
       onCancel={onCancel}
       overviewCommitsUrl={overviewCommitsUrl}
@@ -225,10 +229,12 @@ function ProjectDatasetNew(
         />
         <ProjectDatasetNewEdit
           key="datasetCreate"
+          apiVersion={props.apiVersion}
           client={props.client}
           fetchDatasets={props.fetchDatasets}
           history={props.history}
           location={props.location}
+          metadataVersion={props.metadataVersion}
           model={props.model}
           notifications={props.notifications}
           params={props.params}
@@ -269,6 +275,7 @@ function ProjectDatasetEditForm(
   return (
     <ProjectDatasetNewEdit
       key="datasetModify"
+      apiVersion={props.apiVersion}
       client={props.client}
       dataset={props.dataset}
       datasetId={props.datasetId}
@@ -276,6 +283,7 @@ function ProjectDatasetEditForm(
       files={files}
       history={props.history}
       location={props.location}
+      metadataVersion={props.metadataVersion}
       model={props.model}
       notifications={props.notifications}
       setSubmitting={setSubmitting}
@@ -329,6 +337,7 @@ function ProjectDatasetEdit(props: ProjectDatasetEditProps) {
     >
       <ProjectDatasetEditForm
         key="datasetModify"
+        apiVersion={props.apiVersion}
         client={props.client}
         dataset={dataset}
         datasetId={datasetId}
@@ -336,6 +345,7 @@ function ProjectDatasetEdit(props: ProjectDatasetEditProps) {
         files={props.files}
         history={props.history}
         location={props.location}
+        metadataVersion={props.metadataVersion}
         model={props.model}
         notifications={props.notifications}
         setSubmitting={setSubmitting}

--- a/client/src/features/project/dataset/ProjectDatasetShow.tsx
+++ b/client/src/features/project/dataset/ProjectDatasetShow.tsx
@@ -165,6 +165,7 @@ function ProjectDatasetView(props: ProjectDatasetViewProps) {
     isKgFetching;
   return (
     <DatasetView
+      apiVersion={apiVersion}
       client={client}
       dataset={currentDataset}
       datasets={props.datasets}
@@ -185,6 +186,7 @@ function ProjectDatasetView(props: ProjectDatasetViewProps) {
       lockStatus={props.lockStatus}
       logged={props.logged}
       maintainer={props.maintainer}
+      metadataVersion={metadataVersion}
       model={props.model}
       projectId={props.projectId}
       projectInsideKg={props.projectInsideKg}

--- a/client/src/features/project/dataset/ProjectDatasetShow.tsx
+++ b/client/src/features/project/dataset/ProjectDatasetShow.tsx
@@ -136,7 +136,7 @@ function ProjectDatasetView(props: ProjectDatasetViewProps) {
     gitUrl: externalUrl ?? undefined,
     branch: defaultBranch ?? undefined,
   });
-  const { versionUrl } = coreSupport;
+  const { versionUrl, urlHelper } = coreSupport;
 
   const {
     data: kgDataset,
@@ -150,7 +150,12 @@ function ProjectDatasetView(props: ProjectDatasetViewProps) {
     error: filesFetchError,
     isFetching: isFilesFetching,
   } = useGetDatasetFilesQuery(
-    { git_url: props.externalUrl, name: datasetName ?? "", versionUrl },
+    {
+      git_url: props.externalUrl,
+      helper: urlHelper,
+      name: datasetName ?? "",
+      versionUrl,
+    },
     { skip: !datasetName }
   );
 

--- a/client/src/features/project/dataset/ProjectDatasetShow.tsx
+++ b/client/src/features/project/dataset/ProjectDatasetShow.tsx
@@ -136,7 +136,7 @@ function ProjectDatasetView(props: ProjectDatasetViewProps) {
     gitUrl: externalUrl ?? undefined,
     branch: defaultBranch ?? undefined,
   });
-  const { versionUrl, urlHelper } = coreSupport;
+  const { apiVersion, metadataVersion, versionUrl } = coreSupport;
 
   const {
     data: kgDataset,
@@ -151,10 +151,10 @@ function ProjectDatasetView(props: ProjectDatasetViewProps) {
     isFetching: isFilesFetching,
   } = useGetDatasetFilesQuery(
     {
+      apiVersion,
       git_url: props.externalUrl,
-      helper: urlHelper,
       name: datasetName ?? "",
-      versionUrl,
+      metadataVersion,
     },
     { skip: !datasetName }
   );

--- a/client/src/features/project/dataset/ProjectDatasetsView.tsx
+++ b/client/src/features/project/dataset/ProjectDatasetsView.tsx
@@ -123,10 +123,12 @@ function ProjectAddDataset(props: any) {
     <Col>
       {newDataset ? (
         <ProjectDatasetNew
+          apiVersion={props.apiVersion}
           client={props.client}
           fetchDatasets={props.fetchDatasets}
           history={props.history}
           location={props.location}
+          metadataVersion={props.metadataVersion}
           model={props.model}
           notifications={props.notifications}
           params={props.params}
@@ -200,9 +202,11 @@ function ProjectDatasetsView(props: any) {
     branch: defaultBranch ?? undefined,
   });
   const {
+    apiVersion,
     backendAvailable,
     computed: coreSupportComputed,
     backendErrorMessage,
+    metadataVersion,
     versionUrl,
   } = coreSupport;
 
@@ -381,6 +385,8 @@ function ProjectDatasetsView(props: any) {
               <ProjectAddDataset
                 key="projectsAddDataset"
                 {...props}
+                apiVersion={apiVersion}
+                metadataVersion={metadataVersion}
                 versionUrl={versionUrl}
               />
             </>
@@ -401,6 +407,7 @@ function ProjectDatasetsView(props: any) {
                   />
                 </Col>
                 <ProjectDatasetEdit
+                  apiVersion={apiVersion}
                   client={props.client}
                   dataset={locationState?.dataset}
                   datasetId={decodeURIComponent(p.match.params.datasetId ?? "")}
@@ -410,6 +417,7 @@ function ProjectDatasetsView(props: any) {
                   history={props.history}
                   isFilesFetching={locationState?.isFilesFetching ?? false}
                   location={props.location}
+                  metadataVersion={metadataVersion}
                   model={props.model}
                   notifications={props.notifications}
                   params={props.params}

--- a/client/src/features/project/projectCoreApi.ts
+++ b/client/src/features/project/projectCoreApi.ts
@@ -318,7 +318,11 @@ export const projectCoreApi = createApi({
         return {
           body: { description: data.description, git_url: data.gitUrl },
           method: "POST",
-          url: `/project.edit`,
+          url: versionedPathForEndpoint({
+            endpoint: "project.edit",
+            metadataVersion: data.metadataVersion,
+            apiVersion: data.apiVersion,
+          }),
           validateStatus: (response, body) => {
             return response.status < 400 && !body.error?.code;
           },

--- a/client/src/features/project/projectCoreApi.ts
+++ b/client/src/features/project/projectCoreApi.ts
@@ -119,7 +119,11 @@ export const projectCoreApi = createApi({
         };
         return {
           url: urlWithQueryParams(
-            getCoreVersionedUrl("datasets.files_list", params.versionUrl),
+            getCoreVersionedUrl(
+              "datasets.files_list",
+              params.versionUrl,
+              params.helper
+            ),
             queryParams
           ),
           method: "GET",

--- a/client/src/features/project/projectCoreApi.ts
+++ b/client/src/features/project/projectCoreApi.ts
@@ -39,7 +39,7 @@ import type {
 import { MigrationStartScopes } from "./projectEnums";
 import { projectKgApi } from "./projectKgApi";
 import { projectsKgApi } from "../projects/projectsKgApi";
-import { getCoreVersionedUrl } from "../../utils/helpers/url/versionedUrls";
+import { versionedPathForEndpoint } from "../../utils/helpers/url/versionedUrls";
 import { CoreVersionUrl } from "../../utils/types/coreService.types";
 
 interface GetConfigParams extends CoreVersionUrl {
@@ -119,11 +119,11 @@ export const projectCoreApi = createApi({
         };
         return {
           url: urlWithQueryParams(
-            getCoreVersionedUrl(
-              "datasets.files_list",
-              params.versionUrl,
-              params.helper
-            ),
+            versionedPathForEndpoint({
+              endpoint: "datasets.files_list",
+              metadataVersion: params.metadataVersion,
+              apiVersion: params.apiVersion,
+            }),
             queryParams
           ),
           method: "GET",
@@ -151,11 +151,15 @@ export const projectCoreApi = createApi({
         };
         if (migrationParams.branch) params.branch = migrationParams.branch;
         return {
-          url: "/cache.migrations_check", // ? migrations always uses the last renku version
+          url: versionedPathForEndpoint({
+            endpoint: "cache.migrations_check",
+            metadataVersion: undefined, // ? migrations always uses the last renku metadata version
+            apiVersion: migrationParams.apiVersion,
+          }),
           params,
         };
       },
-      providesTags: (result, error, migrationParams) => [
+      providesTags: (_result, _error, migrationParams) => [
         { type: "project-status", id: migrationParams.gitUrl },
       ],
       transformResponse: (response: MigrationStatusResponse) => {
@@ -227,7 +231,11 @@ export const projectCoreApi = createApi({
         return {
           body,
           method: "POST",
-          url: getCoreVersionedUrl("/cache.migrate"), // ? migrations always uses the last renku version
+          url: versionedPathForEndpoint({
+            endpoint: "cache.migrate",
+            metadataVersion: undefined, // ? migrations always uses the last renku metadata version
+            apiVersion: data.apiVersion,
+          }),
           validateStatus: (response, body) => {
             return response.status < 400 && !body.error?.code;
           },
@@ -238,13 +246,22 @@ export const projectCoreApi = createApi({
       ],
     }),
     getConfig: builder.query<ProjectConfig, GetConfigParams>({
-      query: ({ branch, projectRepositoryUrl, versionUrl }) => {
+      query: ({
+        apiVersion,
+        branch,
+        projectRepositoryUrl,
+        metadataVersion,
+      }) => {
         const params = {
           git_url: projectRepositoryUrl,
           ...(branch ? { branch } : {}),
         };
         return {
-          url: getCoreVersionedUrl("config.show", versionUrl),
+          url: versionedPathForEndpoint({
+            endpoint: "config.show",
+            metadataVersion,
+            apiVersion,
+          }),
           params,
           validateStatus: (response, body) =>
             response.status >= 200 && response.status < 300 && !body.error,
@@ -258,14 +275,24 @@ export const projectCoreApi = createApi({
       ],
     }),
     updateConfig: builder.mutation<UpdateConfigResponse, UpdateConfigParams>({
-      query: ({ branch, projectRepositoryUrl, versionUrl, update }) => {
+      query: ({
+        apiVersion,
+        branch,
+        metadataVersion,
+        projectRepositoryUrl,
+        update,
+      }) => {
         const body = {
           git_url: projectRepositoryUrl,
           ...(branch ? { branch } : {}),
           config: update,
         };
         return {
-          url: getCoreVersionedUrl("config.set", versionUrl),
+          url: versionedPathForEndpoint({
+            endpoint: "config.set",
+            metadataVersion,
+            apiVersion,
+          }),
           method: "POST",
           body,
           validateStatus: (response, body) =>
@@ -320,15 +347,6 @@ export const projectCoreApi = createApi({
     }),
   }),
 });
-
-export const {
-  useGetDatasetFilesQuery,
-  useGetMigrationStatusQuery,
-  useStartMigrationMutation,
-  useGetConfigQuery,
-  useUpdateConfigMutation,
-  useUpdateDescriptionMutation,
-} = projectCoreApi;
 
 const transformGetConfigRawResponse = (
   response: GetConfigRawResponse
@@ -429,3 +447,12 @@ const transformRenkuCoreErrorResponse = (
     data: data.error,
   };
 };
+
+export const {
+  useGetDatasetFilesQuery,
+  useGetMigrationStatusQuery,
+  useStartMigrationMutation,
+  useGetConfigQuery,
+  useUpdateConfigMutation,
+  useUpdateDescriptionMutation,
+} = projectCoreApi;

--- a/client/src/features/project/useProjectCoreSupport.ts
+++ b/client/src/features/project/useProjectCoreSupport.ts
@@ -16,7 +16,9 @@
  * limitations under the License.
  */
 
-import { useMemo } from "react";
+import { useContext, useMemo } from "react";
+import AppContext from "../../utils/context/appContext";
+import type { CoreApiVersionedUrlHelper } from "../../utils/helpers/url";
 import { useGetCoreVersionsQuery } from "../versions/versionsApi";
 import { useGetMigrationStatusQuery } from "./projectCoreApi";
 
@@ -25,24 +27,28 @@ export type CoreSupport =
       backendAvailable: undefined;
       backendErrorMessage: undefined;
       computed: false;
+      urlHelper: undefined;
       versionUrl: undefined;
     }
   | {
       backendAvailable: false;
       backendErrorMessage: string;
       computed: true;
+      urlHelper: undefined;
       versionUrl: undefined;
     }
   | {
       backendAvailable: false;
       backendErrorMessage: undefined;
       computed: true;
+      urlHelper: undefined;
       versionUrl: undefined;
     }
   | {
       backendAvailable: true;
       backendErrorMessage: undefined;
       computed: true;
+      urlHelper: CoreApiVersionedUrlHelper;
       versionUrl: string;
     };
 
@@ -53,6 +59,7 @@ export const useCoreSupport = ({
   gitUrl: string | undefined;
   branch?: string | undefined;
 }) => {
+  const { coreApiVersionedUrlHelper } = useContext(AppContext);
   const getMigrationStatusQuery = useGetMigrationStatusQuery(
     { gitUrl: gitUrl ?? "", branch },
     { skip: !gitUrl || !branch }
@@ -79,8 +86,9 @@ export const useCoreSupport = ({
       availableVersions,
       backendErrorMessage,
       projectVersion,
+      urlHelper: coreApiVersionedUrlHelper,
     });
-  }, [coreVersions, migrationStatus]);
+  }, [coreApiVersionedUrlHelper, coreVersions, migrationStatus]);
 
   return {
     coreSupport,
@@ -93,16 +101,19 @@ export const computeBackendData = ({
   availableVersions,
   backendErrorMessage,
   projectVersion,
+  urlHelper,
 }: {
   availableVersions: number[] | undefined;
   backendErrorMessage: string | undefined;
   projectVersion: number | undefined;
+  urlHelper: CoreApiVersionedUrlHelper;
 }): CoreSupport => {
   if (backendErrorMessage) {
     return {
       backendAvailable: false,
       backendErrorMessage,
       computed: true,
+      urlHelper: undefined,
       versionUrl: undefined,
     };
   }
@@ -111,6 +122,7 @@ export const computeBackendData = ({
       backendAvailable: undefined,
       backendErrorMessage: undefined,
       computed: false,
+      urlHelper: undefined,
       versionUrl: undefined,
     };
   if (availableVersions.includes(projectVersion))
@@ -118,12 +130,14 @@ export const computeBackendData = ({
       backendAvailable: true,
       backendErrorMessage: undefined,
       computed: true,
+      urlHelper,
       versionUrl: `/${projectVersion}`,
     };
   return {
     backendAvailable: false,
     backendErrorMessage: undefined,
     computed: true,
+    urlHelper: undefined,
     versionUrl: undefined,
   };
 };

--- a/client/src/features/workflows/Workflows.d.ts
+++ b/client/src/features/workflows/Workflows.d.ts
@@ -16,6 +16,11 @@
  * limitations under the License.
  */
 
+import {
+  CoreRepositoryParams,
+  CoreVersionUrl,
+} from "../../utils/types/coreService.types";
+
 import { WorkflowType } from "../../components/entities";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -96,9 +101,9 @@ export interface WorkflowsDisplay {
   showInactive: boolean;
 }
 
-export interface WorkflowRequestParams {
-  coreUrl: string;
-  gitUrl: string;
+export interface WorkflowRequestParams
+  extends CoreVersionUrl,
+    CoreRepositoryParams {
   reference: string;
   fullPath: string;
 }

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -18,7 +18,7 @@ import { StateModel, globalSchema } from "./model";
 import { pollStatuspage } from "./statuspage";
 import { UserCoordinator } from "./user";
 import { Sentry } from "./utils/helpers/sentry";
-import { CoreApiVersionedUrlHelper, Url } from "./utils/helpers/url";
+import { Url, createCoreApiVersionedUrlConfig } from "./utils/helpers/url";
 import { AppErrorBoundary } from "./error-boundary/ErrorBoundary";
 
 const configFetch = fetch("/config.json");
@@ -47,12 +47,11 @@ Promise.all([configFetch, privacyFetch]).then((valuesRead) => {
     else params["PRIVACY_STATEMENT"] = privacy;
 
     // configure core api versioned url helper
-    const coreApiVersion = params["CORE_API_VERSION"] ?? "/";
-    const coreApiVersionOverrides = params["CORE_API_VERSION_OVERRIDES"] ?? {};
-    const coreApiVersionedUrlHelper = new CoreApiVersionedUrlHelper({
-      coreApiVersion,
-      overrides: coreApiVersionOverrides,
-    });
+    const coreApiVersionConfig = params["CORE_API_VERSION"] ?? {
+      coreApiVersion: "/",
+    };
+    const coreApiVersionedUrlConfig =
+      createCoreApiVersionedUrlConfig(coreApiVersionConfig);
 
     // configure base url
     Url.setBaseUrl(params["BASE_URL"]);
@@ -61,7 +60,7 @@ Promise.all([configFetch, privacyFetch]).then((valuesRead) => {
     const client = new APIClient(
       params.UISERVER_URL + "/api",
       params.UISERVER_URL,
-      coreApiVersionedUrlHelper
+      coreApiVersionedUrlConfig
     );
 
     // Create the global model containing the formal schema definition and the redux store
@@ -119,7 +118,7 @@ Promise.all([configFetch, privacyFetch]).then((valuesRead) => {
                 return (
                   <VisibleApp
                     client={client}
-                    coreApiVersionedUrlHelper={coreApiVersionedUrlHelper}
+                    coreApiVersionedUrlConfig={coreApiVersionedUrlConfig}
                     params={params}
                     model={model}
                     location={props.location}

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -47,7 +47,7 @@ Promise.all([configFetch, privacyFetch]).then((valuesRead) => {
     else params["PRIVACY_STATEMENT"] = privacy;
 
     // configure core api versioned url helper
-    const coreApiVersionConfig = params["CORE_API_VERSION"] ?? {
+    const coreApiVersionConfig = params["CORE_API_VERSION_CONFIG"] ?? {
       coreApiVersion: "/",
     };
     const coreApiVersionedUrlConfig =

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -18,7 +18,7 @@ import { StateModel, globalSchema } from "./model";
 import { pollStatuspage } from "./statuspage";
 import { UserCoordinator } from "./user";
 import { Sentry } from "./utils/helpers/sentry";
-import { Url } from "./utils/helpers/url";
+import { CoreApiVersionedUrlHelper, Url } from "./utils/helpers/url";
 import { AppErrorBoundary } from "./error-boundary/ErrorBoundary";
 
 const configFetch = fetch("/config.json");
@@ -46,13 +46,22 @@ Promise.all([configFetch, privacyFetch]).then((valuesRead) => {
       params["PRIVACY_STATEMENT"] = null;
     else params["PRIVACY_STATEMENT"] = privacy;
 
+    // configure core api versioned url helper
+    const coreApiVersion = params["CORE_API_VERSION"] ?? "/";
+    const coreApiVersionOverrides = params["CORE_API_VERSION_OVERRIDES"] ?? {};
+    const coreApiVersionedUrlHelper = new CoreApiVersionedUrlHelper({
+      coreApiVersion,
+      overrides: coreApiVersionOverrides,
+    });
+
     // configure base url
     Url.setBaseUrl(params["BASE_URL"]);
 
     // create client to be passed to coordinators
     const client = new APIClient(
       params.UISERVER_URL + "/api",
-      params.UISERVER_URL
+      params.UISERVER_URL,
+      coreApiVersionedUrlHelper
     );
 
     // Create the global model containing the formal schema definition and the redux store
@@ -110,6 +119,7 @@ Promise.all([configFetch, privacyFetch]).then((valuesRead) => {
                 return (
                   <VisibleApp
                     client={client}
+                    coreApiVersionedUrlHelper={coreApiVersionedUrlHelper}
                     params={params}
                     model={model}
                     location={props.location}

--- a/client/src/landing/Landing.test.js
+++ b/client/src/landing/Landing.test.js
@@ -28,6 +28,7 @@ import { createRoot } from "react-dom/client";
 import { act } from "react-dom/test-utils";
 import { MemoryRouter } from "react-router-dom";
 import AppContext from "../utils/context/appContext";
+import { createCoreApiVersionedUrlConfig } from "../utils/helpers/url";
 import { testClient as client } from "../api-client";
 import { generateFakeUser } from "../user/User.test";
 import { StateModel, globalSchema } from "../model";
@@ -38,6 +39,9 @@ import { AnonymousHome } from "./index";
 const appContext = {
   client: client,
   location: { pathname: "" },
+  coreApiVersionedUrlConfig: createCoreApiVersionedUrlConfig({
+    coreApiVersion: "/",
+  }),
 };
 
 describe("rendering", () => {

--- a/client/src/notebooks/Notebooks.container.js
+++ b/client/src/notebooks/Notebooks.container.js
@@ -29,6 +29,7 @@ import {
   CheckNotebookIcon,
 } from "./Notebooks.present";
 import { StatusHelper } from "../model/Model";
+import AppContext from "../utils/context/appContext";
 import { Url } from "../utils/helpers/url";
 import { sleep } from "../utils/helpers/HelperFunctions";
 import ShowSessionFullscreen from "./components/SessionFullScreen";
@@ -289,6 +290,8 @@ class Notebooks extends Component {
  * @param {string} [message] - provide a useful information or warning message
  */
 class StartNotebookServer extends Component {
+  static contextType = AppContext;
+
   constructor(props) {
     super(props);
     this.model = props.model.subModel("notebooks");
@@ -709,8 +712,10 @@ class StartNotebookServer extends Component {
           )
         : undefined;
 
+    const { coreApiVersionedUrlConfig } = this.context;
     const coreSupport = computeBackendData({
       availableVersions,
+      coreApiVersionedUrlConfig,
       projectVersion,
     });
 

--- a/client/src/notebooks/components/StartNotebookServerOptions.tsx
+++ b/client/src/notebooks/components/StartNotebookServerOptions.tsx
@@ -66,11 +66,16 @@ export const StartNotebookServerOptions = () => {
     gitUrl: projectRepositoryUrl ?? undefined,
     branch: defaultBranch ?? undefined,
   });
-  const { computed: coreSupportComputed, versionUrl } = coreSupport;
+  const {
+    apiVersion,
+    computed: coreSupportComputed,
+    metadataVersion,
+  } = coreSupport;
   const { isLoading: projectConfigIsLoading } = useGetConfigQuery(
     {
+      apiVersion,
+      metadataVersion,
       projectRepositoryUrl,
-      versionUrl,
     },
     { skip: !coreSupportComputed }
   );
@@ -119,12 +124,17 @@ const DefaultUrlOption = () => {
     gitUrl: projectRepositoryUrl ?? undefined,
     branch: defaultBranch ?? undefined,
   });
-  const { computed: coreSupportComputed, versionUrl } = coreSupport;
+  const {
+    apiVersion,
+    computed: coreSupportComputed,
+    metadataVersion,
+  } = coreSupport;
   const { data: projectConfig, isLoading: projectConfigIsLoading } =
     useGetConfigQuery(
       {
+        apiVersion,
+        metadataVersion,
         projectRepositoryUrl,
-        versionUrl,
         // ...(branchName ? { branch: branchName } : {}),
       },
       { skip: !coreSupportComputed }
@@ -217,11 +227,16 @@ const AutoFetchLfsOption = () => {
     gitUrl: projectRepositoryUrl ?? undefined,
     branch: defaultBranch ?? undefined,
   });
-  const { computed: coreSupportComputed, versionUrl } = coreSupport;
+  const {
+    apiVersion,
+    computed: coreSupportComputed,
+    metadataVersion,
+  } = coreSupport;
   const { data: projectConfig } = useGetConfigQuery(
     {
+      apiVersion,
+      metadataVersion,
       projectRepositoryUrl,
-      versionUrl,
     },
     { skip: !coreSupportComputed }
   );

--- a/client/src/notebooks/components/options/SessionClassOption.tsx
+++ b/client/src/notebooks/components/options/SessionClassOption.tsx
@@ -65,11 +65,16 @@ export const SessionClassOption = () => {
     gitUrl: projectRepositoryUrl ?? undefined,
     branch: defaultBranch ?? undefined,
   });
-  const { computed: coreSupportComputed, versionUrl } = coreSupport;
+  const {
+    apiVersion,
+    computed: coreSupportComputed,
+    metadataVersion,
+  } = coreSupport;
   const { data: projectConfig } = useGetConfigQuery(
     {
+      apiVersion,
+      metadataVersion,
       projectRepositoryUrl,
-      versionUrl,
     },
     { skip: !coreSupportComputed }
   );

--- a/client/src/notebooks/components/options/SessionStorageOption.tsx
+++ b/client/src/notebooks/components/options/SessionStorageOption.tsx
@@ -54,11 +54,16 @@ export const SessionStorageOption = () => {
     gitUrl: projectRepositoryUrl ?? undefined,
     branch: defaultBranch ?? undefined,
   });
-  const { computed: coreSupportComputed, versionUrl } = coreSupport;
+  const {
+    apiVersion,
+    computed: coreSupportComputed,
+    metadataVersion,
+  } = coreSupport;
   const { data: projectConfig } = useGetConfigQuery(
     {
+      apiVersion,
+      metadataVersion,
       projectRepositoryUrl,
-      versionUrl,
     },
     { skip: !coreSupportComputed }
   );

--- a/client/src/project/Project.present.js
+++ b/client/src/project/Project.present.js
@@ -1198,7 +1198,8 @@ function ProjectView(props) {
     gitUrl,
     branch,
   });
-  const { backendAvailable, versionUrl } = coreSupport;
+  const { apiVersion, backendAvailable, metadataVersion, versionUrl } =
+    coreSupport;
 
   const { datasets, fetchDatasets } = props;
   useEffect(() => {
@@ -1309,7 +1310,14 @@ function ProjectView(props) {
           />
           <Route
             path={props.settingsUrl}
-            render={() => <ProjectSettings key="settings" {...props} />}
+            render={() => (
+              <ProjectSettings
+                key="settings"
+                {...props}
+                apiVersion={apiVersion}
+                metadataVersion={metadataVersion}
+              />
+            )}
           />
           <Route
             path={props.notebookServersUrl}

--- a/client/src/project/components/ProjectSettingsSessions.tsx
+++ b/client/src/project/components/ProjectSettingsSessions.tsx
@@ -74,6 +74,11 @@ import { isFetchBaseQueryError } from "../../utils/helpers/ApiErrors";
 import { Url } from "../../utils/helpers/url";
 import styles from "./ProjectSettingsSessions.module.scss";
 
+type CoreServiceVersionedApiParams = {
+  apiVersion: string | undefined;
+  metadataVersion: number | undefined;
+};
+
 export const ProjectSettingsSessions = () => {
   const logged = useSelector<RootStateOrAny, User["logged"]>(
     (state) => state.stateModel.user.logged
@@ -104,9 +109,10 @@ export const ProjectSettingsSessions = () => {
     branch: defaultBranch ?? undefined,
   });
   const {
+    apiVersion,
     backendAvailable,
     computed: coreSupportComputed,
-    versionUrl,
+    metadataVersion,
   } = coreSupport;
   const {
     data: projectConfig,
@@ -115,8 +121,9 @@ export const ProjectSettingsSessions = () => {
     error,
   } = useGetConfigQuery(
     {
+      apiVersion,
+      metadataVersion,
       projectRepositoryUrl,
-      versionUrl,
     },
     { skip: !coreSupportComputed }
   );
@@ -233,15 +240,18 @@ export const ProjectSettingsSessions = () => {
         <p>Settings can be changed only by developers and maintainers.</p>
       )}
       <DefaultUrlOption
+        apiVersion={apiVersion}
+        metadataVersion={metadataVersion}
         serverOptions={serverOptions}
         projectConfig={projectConfig}
         projectConfigIsFetching={projectConfigIsFetching}
         projectRepositoryUrl={projectRepositoryUrl}
-        versionUrl={versionUrl}
         devAccess={devAccess}
       />
 
       <ComputeResourceOption
+        apiVersion={apiVersion}
+        metadataVersion={metadataVersion}
         devAccess={devAccess}
         optionInputAddon="CPUs"
         optionLabel="Number of CPUs"
@@ -254,9 +264,10 @@ export const ProjectSettingsSessions = () => {
         optionValue={projectConfig.config.sessions?.legacyConfig?.cpuRequest}
         projectConfigIsFetching={projectConfigIsFetching}
         projectRepositoryUrl={projectRepositoryUrl}
-        versionUrl={versionUrl}
       />
       <ComputeResourceOption
+        apiVersion={apiVersion}
+        metadataVersion={metadataVersion}
         devAccess={devAccess}
         optionInputAddon="GB"
         optionInputAddonTooltip="Gigabytes"
@@ -271,9 +282,10 @@ export const ProjectSettingsSessions = () => {
         optionValue={projectConfig.config.sessions?.legacyConfig?.memoryRequest}
         projectConfigIsFetching={projectConfigIsFetching}
         projectRepositoryUrl={projectRepositoryUrl}
-        versionUrl={versionUrl}
       />
       <ComputeResourceOption
+        apiVersion={apiVersion}
+        metadataVersion={metadataVersion}
         devAccess={devAccess}
         optionInputAddon="GB"
         optionInputAddonTooltip="Gigabytes"
@@ -286,9 +298,10 @@ export const ProjectSettingsSessions = () => {
         optionValue={projectConfig.config.sessions?.storage}
         projectConfigIsFetching={projectConfigIsFetching}
         projectRepositoryUrl={projectRepositoryUrl}
-        versionUrl={versionUrl}
       />
       <ComputeResourceOption
+        apiVersion={apiVersion}
+        metadataVersion={metadataVersion}
         devAccess={devAccess}
         optionInputAddon="GPUs"
         optionLabel="Number of GPUs"
@@ -301,30 +314,32 @@ export const ProjectSettingsSessions = () => {
         optionValue={projectConfig.config.sessions?.legacyConfig?.gpuRequest}
         projectConfigIsFetching={projectConfigIsFetching}
         projectRepositoryUrl={projectRepositoryUrl}
-        versionUrl={versionUrl}
       />
 
       <AutoFetchLfsOption
+        apiVersion={apiVersion}
+        metadataVersion={metadataVersion}
         projectConfig={projectConfig}
         projectConfigIsFetching={projectConfigIsFetching}
         projectRepositoryUrl={projectRepositoryUrl}
-        versionUrl={versionUrl}
         devAccess={devAccess}
       />
 
       <ProjectSettingsSessionsAdvanced
+        apiVersion={apiVersion}
+        metadataVersion={metadataVersion}
         projectConfig={projectConfig}
         projectConfigIsFetching={projectConfigIsFetching}
         projectRepositoryUrl={projectRepositoryUrl}
-        versionUrl={versionUrl}
         devAccess={devAccess}
       />
 
       <ProjectSettingsSessionsUnknown
+        apiVersion={apiVersion}
+        metadataVersion={metadataVersion}
         projectConfig={projectConfig}
         projectConfigIsFetching={projectConfigIsFetching}
         projectRepositoryUrl={projectRepositoryUrl}
-        versionUrl={versionUrl}
         devAccess={devAccess}
       />
     </SessionsDiv>
@@ -431,21 +446,21 @@ const UpdateStatus = () => {
   );
 };
 
-interface DefaultUrlOptionProps {
+interface DefaultUrlOptionProps extends CoreServiceVersionedApiParams {
   serverOptions: ServerOptions;
   projectConfig: ProjectConfig;
   projectConfigIsFetching: boolean;
   projectRepositoryUrl: string;
-  versionUrl: string;
   devAccess: boolean;
 }
 
 const DefaultUrlOption = ({
+  apiVersion,
+  metadataVersion,
   serverOptions,
   projectConfig,
   projectConfigIsFetching,
   projectRepositoryUrl,
-  versionUrl,
   devAccess,
 }: DefaultUrlOptionProps) => {
   const defaultUrlOptions = [
@@ -474,26 +489,34 @@ const DefaultUrlOption = ({
     (_event: React.MouseEvent<HTMLElement, MouseEvent>, value: string) => {
       setNewValue(value);
       updateConfig({
+        apiVersion,
+        metadataVersion,
         projectRepositoryUrl,
-        versionUrl,
         update: {
           "interactive.default_url": value,
         },
       });
     },
-    [projectRepositoryUrl, updateConfig, versionUrl]
+    [apiVersion, metadataVersion, projectRepositoryUrl, updateConfig]
   );
 
   const onReset = useCallback(() => {
     setNewValue(defaultValue);
     updateConfig({
+      apiVersion,
+      metadataVersion,
       projectRepositoryUrl,
-      versionUrl,
       update: {
         "interactive.default_url": defaultValue,
       },
     });
-  }, [defaultValue, projectRepositoryUrl, updateConfig, versionUrl]);
+  }, [
+    apiVersion,
+    defaultValue,
+    metadataVersion,
+    projectRepositoryUrl,
+    updateConfig,
+  ]);
 
   // Reset the temporary value when the API responds with an error
   useEffect(() => {
@@ -558,7 +581,7 @@ const ResetOption = ({ optionId, disabled, onReset }: ResetOptionProps) => {
   );
 };
 
-interface ComputeResourceOptionProps {
+interface ComputeResourceOptionProps extends CoreServiceVersionedApiParams {
   devAccess: boolean;
   optionInputAddon?: string;
   optionInputAddonTooltip?: ReactNode;
@@ -572,10 +595,11 @@ interface ComputeResourceOptionProps {
   optionValue: number | undefined;
   projectConfigIsFetching: boolean;
   projectRepositoryUrl: string;
-  versionUrl: string;
 }
 
 function ComputeResourceOption({
+  apiVersion,
+  metadataVersion,
   devAccess,
   optionInputAddon,
   optionInputAddonTooltip,
@@ -589,7 +613,6 @@ function ComputeResourceOption({
   optionValue,
   projectConfigIsFetching,
   projectRepositoryUrl,
-  versionUrl,
 }: ComputeResourceOptionProps) {
   // Temporary value for optimistic UI update
   const [newValue, setNewValue] = useState<number | null>(null);
@@ -609,37 +632,41 @@ function ComputeResourceOption({
       const value = event.target.valueAsNumber;
       setNewValue(value);
       debouncedUpdateConfig({
+        apiVersion,
+        metadataVersion,
         projectRepositoryUrl,
-        versionUrl,
         update: {
           [optionName]: `${value}${optionSuffix}`,
         },
       });
     },
     [
+      apiVersion,
+      metadataVersion,
       debouncedUpdateConfig,
       optionName,
       optionSuffix,
       projectRepositoryUrl,
-      versionUrl,
     ]
   );
 
   const onReset = useCallback(() => {
     setNewValue(optionDefaultValue ?? null);
     updateConfig({
+      apiVersion,
+      metadataVersion,
       projectRepositoryUrl,
-      versionUrl,
       update: {
         [optionName]: null,
       },
     });
   }, [
+    apiVersion,
+    metadataVersion,
     optionDefaultValue,
     optionName,
     projectRepositoryUrl,
     updateConfig,
-    versionUrl,
   ]);
 
   // Reset the temporary value when the API responds with an error
@@ -699,19 +726,19 @@ function ComputeResourceOption({
 
 const INPUT_NUMBER_DEBOUNCE_MS = 1_000;
 
-interface AutoFetchLfsOptionProps {
+interface AutoFetchLfsOptionProps extends CoreServiceVersionedApiParams {
   projectConfig: ProjectConfig;
   projectConfigIsFetching: boolean;
   projectRepositoryUrl: string;
-  versionUrl: string;
   devAccess: boolean;
 }
 
 const AutoFetchLfsOption = ({
+  apiVersion,
+  metadataVersion,
   projectConfig,
   projectConfigIsFetching,
   projectRepositoryUrl,
-  versionUrl,
   devAccess,
 }: AutoFetchLfsOptionProps) => {
   // Temporary value for optimistic UI update
@@ -727,24 +754,32 @@ const AutoFetchLfsOption = ({
   const onChange = useCallback(() => {
     setNewValue(!selectedAutoFetchLfs);
     updateConfig({
+      apiVersion,
+      metadataVersion,
       projectRepositoryUrl,
-      versionUrl,
       update: {
         "interactive.lfs_auto_fetch": `${!selectedAutoFetchLfs}`,
       },
     });
-  }, [projectRepositoryUrl, selectedAutoFetchLfs, updateConfig, versionUrl]);
+  }, [
+    apiVersion,
+    metadataVersion,
+    projectRepositoryUrl,
+    selectedAutoFetchLfs,
+    updateConfig,
+  ]);
 
   const onReset = useCallback(() => {
     setNewValue(false);
     updateConfig({
+      apiVersion,
+      metadataVersion,
       projectRepositoryUrl,
-      versionUrl,
       update: {
         "interactive.lfs_auto_fetch": null,
       },
     });
-  }, [projectRepositoryUrl, updateConfig, versionUrl]);
+  }, [apiVersion, metadataVersion, projectRepositoryUrl, updateConfig]);
 
   // Reset the temporary value when the API responds with an error
   useEffect(() => {
@@ -777,19 +812,20 @@ const AutoFetchLfsOption = ({
   );
 };
 
-interface ProjectSettingsSessionsAdvancedProps {
+interface ProjectSettingsSessionsAdvancedProps
+  extends CoreServiceVersionedApiParams {
   projectConfig: ProjectConfig;
   projectConfigIsFetching: boolean;
   projectRepositoryUrl: string;
-  versionUrl: string;
   devAccess: boolean;
 }
 
 const ProjectSettingsSessionsAdvanced = ({
+  apiVersion,
+  metadataVersion,
   projectConfig,
   projectConfigIsFetching,
   projectRepositoryUrl,
-  versionUrl,
   devAccess,
 }: ProjectSettingsSessionsAdvancedProps) => {
   const imageIsSet = !!projectConfig.config.sessions?.dockerImage;
@@ -830,10 +866,11 @@ const ProjectSettingsSessionsAdvanced = ({
                 </WarnAlert>
               )}
               <PinnedImageOption
+                apiVersion={apiVersion}
+                metadataVersion={metadataVersion}
                 projectConfig={projectConfig}
                 projectConfigIsFetching={projectConfigIsFetching}
                 projectRepositoryUrl={projectRepositoryUrl}
-                versionUrl={versionUrl}
                 devAccess={devAccess}
               />
             </AccordionBody>
@@ -850,19 +887,19 @@ const AccordionFixed = (
   }
 ) => <Accordion {...props} />;
 
-interface PinnedImageOptionProps {
+interface PinnedImageOptionProps extends CoreServiceVersionedApiParams {
   projectConfig: ProjectConfig;
   projectConfigIsFetching: boolean;
   projectRepositoryUrl: string;
-  versionUrl: string;
   devAccess: boolean;
 }
 
 const PinnedImageOption = ({
+  apiVersion,
+  metadataVersion,
   projectConfig,
   projectConfigIsFetching,
   projectRepositoryUrl,
-  versionUrl,
   devAccess,
 }: PinnedImageOptionProps) => {
   const [isEditing, setIsEditing] = useState<boolean>(false);
@@ -890,24 +927,32 @@ const PinnedImageOption = ({
   const onSave = useCallback(() => {
     setIsEditing(false);
     updateConfig({
+      apiVersion,
+      metadataVersion,
       projectRepositoryUrl,
-      versionUrl,
       update: {
         "interactive.image": newValue,
       },
     });
-  }, [newValue, projectRepositoryUrl, updateConfig, versionUrl]);
+  }, [
+    apiVersion,
+    metadataVersion,
+    newValue,
+    projectRepositoryUrl,
+    updateConfig,
+  ]);
 
   const onResetValue = useCallback(() => {
     setNewValue("");
     updateConfig({
+      apiVersion,
+      metadataVersion,
       projectRepositoryUrl,
-      versionUrl,
       update: {
         "interactive.image": null,
       },
     });
-  }, [projectRepositoryUrl, updateConfig, versionUrl]);
+  }, [apiVersion, metadataVersion, projectRepositoryUrl, updateConfig]);
 
   // Reset the temporary value when the API responds with an error
   useEffect(() => {
@@ -1046,19 +1091,20 @@ const PinnedImageOption = ({
   );
 };
 
-interface ProjectSettingsSessionsUnknownProps {
+interface ProjectSettingsSessionsUnknownProps
+  extends CoreServiceVersionedApiParams {
   projectConfig: ProjectConfig;
   projectConfigIsFetching: boolean;
   projectRepositoryUrl: string;
-  versionUrl: string;
   devAccess: boolean;
 }
 
 const ProjectSettingsSessionsUnknown = ({
+  apiVersion,
+  metadataVersion,
   projectConfig,
   projectConfigIsFetching,
   projectRepositoryUrl,
-  versionUrl,
   devAccess,
 }: ProjectSettingsSessionsUnknownProps) => {
   const unknownConfig = projectConfig.config.sessions?.unknownConfig ?? {};
@@ -1094,12 +1140,13 @@ const ProjectSettingsSessionsUnknown = ({
               </p>
               {unknownConfigKeys.map((optionKey) => (
                 <UnknownOption
+                  apiVersion={apiVersion}
+                  metadataVersion={metadataVersion}
                   key={optionKey}
                   optionKey={optionKey}
                   optionValue={unknownConfig[optionKey]}
                   projectConfigIsFetching={projectConfigIsFetching}
                   projectRepositoryUrl={projectRepositoryUrl}
-                  versionUrl={versionUrl}
                   devAccess={devAccess}
                 />
               ))}
@@ -1111,23 +1158,23 @@ const ProjectSettingsSessionsUnknown = ({
   );
 };
 
-interface UnknownOptionProps {
+interface UnknownOptionProps extends CoreServiceVersionedApiParams {
   optionKey: string;
   optionLabel?: string;
   optionValue: string;
   projectConfigIsFetching: boolean;
   projectRepositoryUrl: string;
-  versionUrl: string;
   devAccess: boolean;
 }
 
 const UnknownOption = ({
+  apiVersion,
+  metadataVersion,
   optionKey,
   optionLabel,
   optionValue,
   projectConfigIsFetching,
   projectRepositoryUrl,
-  versionUrl,
   devAccess,
 }: UnknownOptionProps) => {
   const shortKey = optionKey.toLocaleLowerCase().startsWith("interactive")
@@ -1141,13 +1188,20 @@ const UnknownOption = ({
 
   const onResetValue = useCallback(() => {
     updateConfig({
+      apiVersion,
+      metadataVersion,
       projectRepositoryUrl,
-      versionUrl,
       update: {
         [optionKey]: null,
       },
     });
-  }, [optionKey, projectRepositoryUrl, updateConfig, versionUrl]);
+  }, [
+    apiVersion,
+    metadataVersion,
+    optionKey,
+    projectRepositoryUrl,
+    updateConfig,
+  ]);
 
   const disabled = !devAccess || isLoading || projectConfigIsFetching;
 

--- a/client/src/project/datasets/delete/DeleteDataset.tsx
+++ b/client/src/project/datasets/delete/DeleteDataset.tsx
@@ -35,6 +35,7 @@ import { useDeleteDatasetMutation } from "../../../features/datasets/datasetsCor
 import {
   CoreErrorContent,
   CoreErrorResponse,
+  CoreVersionUrl,
 } from "../../../utils/types/coreService.types";
 import { Url } from "../../../utils/helpers/url";
 
@@ -138,20 +139,7 @@ export type DeleteDatasetSuccessResponse = {
   };
 };
 
-type DeleteDatasetResponse = {
-  data: DeleteDatasetErrorResponse | DeleteDatasetSuccessResponse;
-};
-
-type DatasetDeleteClient = {
-  deleteDataset: (
-    projectUrl: string,
-    datasetName: string,
-    versionUrl: string
-  ) => Promise<DeleteDatasetResponse>;
-};
-
-export interface DeleteDatasetProps {
-  client: DatasetDeleteClient;
+export interface DeleteDatasetProps extends CoreVersionUrl {
   dataset: DatasetCore;
   history: ReturnType<typeof useHistory>;
   externalUrl: string;
@@ -159,7 +147,6 @@ export interface DeleteDatasetProps {
   modalOpen: boolean;
   projectPathWithNamespace: string;
   setModalOpen: (modalOpen: boolean) => void;
-  versionUrl: string;
 }
 
 function DeleteDataset(props: DeleteDatasetProps) {
@@ -205,9 +192,10 @@ function DeleteDataset(props: DeleteDatasetProps) {
     setServerErrors(undefined);
     setSubmitLoaderText(undefined);
     deleteDataset({
+      apiVersion: props.apiVersion,
       gitUrl: props.externalUrl,
+      metadataVersion: props.metadataVersion,
       name: props.dataset.name,
-      versionUrl: props.versionUrl,
     });
   };
 

--- a/client/src/utils/context/appContext.ts
+++ b/client/src/utils/context/appContext.ts
@@ -17,15 +17,20 @@
  */
 
 import React from "react";
+import { CoreApiVersionedUrlHelper } from "../helpers/url";
 
 type IAppContext = {
   client: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  coreApiVersionedUrlHelper: CoreApiVersionedUrlHelper;
   params: unknown;
   location: unknown;
 };
 
 const AppContext = React.createContext<IAppContext>({
   client: undefined,
+  coreApiVersionedUrlHelper: new CoreApiVersionedUrlHelper({
+    coreApiVersion: "/",
+  }),
   params: undefined,
   location: undefined,
 });

--- a/client/src/utils/context/appContext.ts
+++ b/client/src/utils/context/appContext.ts
@@ -17,18 +17,19 @@
  */
 
 import React from "react";
-import { CoreApiVersionedUrlHelper } from "../helpers/url";
+import { createCoreApiVersionedUrlConfig } from "../helpers/url";
+import type { CoreApiVersionedUrlConfig } from "../helpers/url";
 
 type IAppContext = {
   client: any; // eslint-disable-line @typescript-eslint/no-explicit-any
-  coreApiVersionedUrlHelper: CoreApiVersionedUrlHelper;
+  coreApiVersionedUrlConfig: CoreApiVersionedUrlConfig;
   params: unknown;
   location: unknown;
 };
 
 const AppContext = React.createContext<IAppContext>({
   client: undefined,
-  coreApiVersionedUrlHelper: new CoreApiVersionedUrlHelper({
+  coreApiVersionedUrlConfig: createCoreApiVersionedUrlConfig({
     coreApiVersion: "/",
   }),
   params: undefined,

--- a/client/src/utils/helpers/url/index.ts
+++ b/client/src/utils/helpers/url/index.ts
@@ -25,4 +25,11 @@
 
 export { appendCustomUrlPath } from "./NotebookUrl";
 export { Url, getSearchParams } from "./Url";
-export { CoreApiVersionedUrlHelper } from "./versionedUrls";
+export {
+  CoreApiVersionedUrlHelper,
+  apiVersionForMetadataVersion,
+  coreVersionedUrl,
+  createCoreApiVersionedUrlConfig,
+  sanitizedVersionedPathParams,
+} from "./versionedUrls";
+export type { CoreApiVersionedUrlConfig } from "./versionedUrls";

--- a/client/src/utils/helpers/url/index.ts
+++ b/client/src/utils/helpers/url/index.ts
@@ -25,3 +25,4 @@
 
 export { appendCustomUrlPath } from "./NotebookUrl";
 export { Url, getSearchParams } from "./Url";
+export { CoreApiVersionedUrlHelper } from "./versionedUrls";

--- a/client/src/utils/helpers/url/versionedUrls.test.ts
+++ b/client/src/utils/helpers/url/versionedUrls.test.ts
@@ -19,29 +19,7 @@
 import {
   coreVersionedUrl,
   createCoreApiVersionedUrlConfig,
-  getCoreVersionedUrl,
 } from "./versionedUrls";
-
-describe("Test versionedUrl", () => {
-  const FAKE_ENDPOINT = "renkuEntity.edit";
-
-  it("Version: number only", () => {
-    const numberedUrl = getCoreVersionedUrl(FAKE_ENDPOINT, "10");
-    expect(numberedUrl).toBe(`/10/${FAKE_ENDPOINT}`);
-  });
-  it("Version: initial slash", () => {
-    const numberedUrl = getCoreVersionedUrl(FAKE_ENDPOINT, "/10");
-    expect(numberedUrl).toBe(`/10/${FAKE_ENDPOINT}`);
-  });
-  it("Version: none", () => {
-    const numberedUrl = getCoreVersionedUrl(FAKE_ENDPOINT, null);
-    expect(numberedUrl).toBe(`/${FAKE_ENDPOINT}`);
-  });
-  it("Endpoint: missing", () => {
-    const numberedUrl = getCoreVersionedUrl("", null);
-    expect(numberedUrl).toBe("/");
-  });
-});
 
 describe("Test versionedUrl config, always latest", () => {
   const FAKE_ENDPOINT = "renkuEntity.edit";
@@ -114,10 +92,10 @@ describe("Test versionedUrl config, default, no overrides", () => {
 describe("Test versionedUrl config, with overrides", () => {
   const FAKE_ENDPOINT = "renkuEntity.edit";
   const config = createCoreApiVersionedUrlConfig({
-    coreApiVersion: "2.0",
+    coreApiVersion: "/2.0",
     overrides: {
       "9": "/",
-      "11": "/3.0",
+      "11": "3.0",
     },
   });
 

--- a/client/src/utils/helpers/url/versionedUrls.test.ts
+++ b/client/src/utils/helpers/url/versionedUrls.test.ts
@@ -43,21 +43,21 @@ describe("Test versionedUrl", () => {
   });
 });
 
-describe("Test versionedUrl helper, always latest", () => {
+describe("Test versionedUrl config, always latest", () => {
   const FAKE_ENDPOINT = "renkuEntity.edit";
   const config = createCoreApiVersionedUrlConfig({ coreApiVersion: "/" });
 
   it("Version: number only", () => {
     const numberedUrl = coreVersionedUrl(config, {
       endpoint: FAKE_ENDPOINT,
-      metadataVersion: "10",
+      metadataVersion: 10,
     });
     expect(numberedUrl).toBe(`/10/${FAKE_ENDPOINT}`);
   });
   it("Version: initial slash", () => {
     const numberedUrl = coreVersionedUrl(config, {
-      endpoint: FAKE_ENDPOINT,
-      metadataVersion: "/10",
+      endpoint: `/${FAKE_ENDPOINT}`,
+      metadataVersion: 10,
     });
     expect(numberedUrl).toBe(`/10/${FAKE_ENDPOINT}`);
   });
@@ -77,21 +77,21 @@ describe("Test versionedUrl helper, always latest", () => {
   });
 });
 
-describe("Test versionedUrl helper, default, no overrides", () => {
+describe("Test versionedUrl config, default, no overrides", () => {
   const FAKE_ENDPOINT = "renkuEntity.edit";
   const config = createCoreApiVersionedUrlConfig({ coreApiVersion: "2.0" });
 
   it("Version: number only", () => {
     const numberedUrl = coreVersionedUrl(config, {
       endpoint: FAKE_ENDPOINT,
-      metadataVersion: "10",
+      metadataVersion: 10,
     });
     expect(numberedUrl).toBe(`/10/2.0/${FAKE_ENDPOINT}`);
   });
   it("Version: initial slash", () => {
     const numberedUrl = coreVersionedUrl(config, {
-      endpoint: FAKE_ENDPOINT,
-      metadataVersion: "/10",
+      endpoint: `/${FAKE_ENDPOINT}`,
+      metadataVersion: 10,
     });
     expect(numberedUrl).toBe(`/10/2.0/${FAKE_ENDPOINT}`);
   });
@@ -111,7 +111,7 @@ describe("Test versionedUrl helper, default, no overrides", () => {
   });
 });
 
-describe("Test versionedUrl helper, with overrides", () => {
+describe("Test versionedUrl config, with overrides", () => {
   const FAKE_ENDPOINT = "renkuEntity.edit";
   const config = createCoreApiVersionedUrlConfig({
     coreApiVersion: "2.0",
@@ -124,66 +124,66 @@ describe("Test versionedUrl helper, with overrides", () => {
   it("Version 10", () => {
     const numberedUrl = coreVersionedUrl(config, {
       endpoint: FAKE_ENDPOINT,
-      metadataVersion: "10",
+      metadataVersion: 10,
     });
     expect(numberedUrl).toBe(`/10/2.0/${FAKE_ENDPOINT}`);
   });
   it("Version 9", () => {
     const numberedUrl = coreVersionedUrl(config, {
       endpoint: FAKE_ENDPOINT,
-      metadataVersion: "9",
+      metadataVersion: 9,
     });
     expect(numberedUrl).toBe(`/9/${FAKE_ENDPOINT}`);
   });
   it("Version 11", () => {
     const numberedUrl = coreVersionedUrl(config, {
       endpoint: FAKE_ENDPOINT,
-      metadataVersion: "11",
+      metadataVersion: 11,
     });
     expect(numberedUrl).toBe(`/11/3.0/${FAKE_ENDPOINT}`);
   });
-  it("Version /10", () => {
+  it("Initial slash, version 10", () => {
     const numberedUrl = coreVersionedUrl(config, {
-      endpoint: FAKE_ENDPOINT,
-      metadataVersion: "/10",
+      endpoint: `/${FAKE_ENDPOINT}`,
+      metadataVersion: 10,
     });
     expect(numberedUrl).toBe(`/10/2.0/${FAKE_ENDPOINT}`);
   });
-  it("Version /9", () => {
+  it("Initial slash, version 9", () => {
     const numberedUrl = coreVersionedUrl(config, {
-      endpoint: FAKE_ENDPOINT,
-      metadataVersion: "/9",
+      endpoint: `/${FAKE_ENDPOINT}`,
+      metadataVersion: 9,
     });
     expect(numberedUrl).toBe(`/9/${FAKE_ENDPOINT}`);
   });
-  it("Version /11", () => {
+  it("Initial slash,version 11", () => {
     const numberedUrl = coreVersionedUrl(config, {
-      endpoint: FAKE_ENDPOINT,
-      metadataVersion: "/11",
+      endpoint: `/${FAKE_ENDPOINT}`,
+      metadataVersion: 11,
     });
     expect(numberedUrl).toBe(`/11/3.0/${FAKE_ENDPOINT}`);
   });
 
-  it("Version /10 locally overridden", () => {
+  it("Version 10 locally overridden", () => {
     const numberedUrl = coreVersionedUrl(config, {
       endpoint: FAKE_ENDPOINT,
-      metadataVersion: "/10",
+      metadataVersion: 10,
       apiVersion: "3.0",
     });
     expect(numberedUrl).toBe(`/10/3.0/${FAKE_ENDPOINT}`);
   });
-  it("Version /9 locally overridden", () => {
+  it("Version 9 locally overridden", () => {
     const numberedUrl = coreVersionedUrl(config, {
       endpoint: FAKE_ENDPOINT,
-      metadataVersion: "/9",
+      metadataVersion: 9,
       apiVersion: "3.0",
     });
     expect(numberedUrl).toBe(`/9/3.0/${FAKE_ENDPOINT}`);
   });
-  it("Version /11 locally overridden", () => {
+  it("Version 11 locally overridden", () => {
     const numberedUrl = coreVersionedUrl(config, {
       endpoint: FAKE_ENDPOINT,
-      metadataVersion: "/11",
+      metadataVersion: 11,
       apiVersion: "/",
     });
     expect(numberedUrl).toBe(`/11/${FAKE_ENDPOINT}`);

--- a/client/src/utils/helpers/url/versionedUrls.test.ts
+++ b/client/src/utils/helpers/url/versionedUrls.test.ts
@@ -16,25 +16,176 @@
  * limitations under the License.
  */
 
-import { getCoreVersionedUrl } from "./versionedUrls";
+import {
+  coreVersionedUrl,
+  createCoreApiVersionedUrlConfig,
+  getCoreVersionedUrl,
+} from "./versionedUrls";
 
 describe("Test versionedUrl", () => {
-  const FAKE_URL = "renkuEntity.edit";
+  const FAKE_ENDPOINT = "renkuEntity.edit";
 
   it("Version: number only", () => {
-    const numberedUrl = getCoreVersionedUrl(FAKE_URL, "10");
-    expect(numberedUrl).toBe(`/10/${FAKE_URL}`);
+    const numberedUrl = getCoreVersionedUrl(FAKE_ENDPOINT, "10");
+    expect(numberedUrl).toBe(`/10/${FAKE_ENDPOINT}`);
   });
-  it("Version: trailing slash", () => {
-    const numberedUrl = getCoreVersionedUrl(FAKE_URL, "/10");
-    expect(numberedUrl).toBe(`/10/${FAKE_URL}`);
+  it("Version: initial slash", () => {
+    const numberedUrl = getCoreVersionedUrl(FAKE_ENDPOINT, "/10");
+    expect(numberedUrl).toBe(`/10/${FAKE_ENDPOINT}`);
   });
   it("Version: none", () => {
-    const numberedUrl = getCoreVersionedUrl(FAKE_URL, null);
-    expect(numberedUrl).toBe(`/${FAKE_URL}`);
+    const numberedUrl = getCoreVersionedUrl(FAKE_ENDPOINT, null);
+    expect(numberedUrl).toBe(`/${FAKE_ENDPOINT}`);
   });
   it("Endpoint: missing", () => {
     const numberedUrl = getCoreVersionedUrl("", null);
     expect(numberedUrl).toBe("/");
+  });
+});
+
+describe("Test versionedUrl helper, always latest", () => {
+  const FAKE_ENDPOINT = "renkuEntity.edit";
+  const config = createCoreApiVersionedUrlConfig({ coreApiVersion: "/" });
+
+  it("Version: number only", () => {
+    const numberedUrl = coreVersionedUrl(config, {
+      endpoint: FAKE_ENDPOINT,
+      metadataVersion: "10",
+    });
+    expect(numberedUrl).toBe(`/10/${FAKE_ENDPOINT}`);
+  });
+  it("Version: initial slash", () => {
+    const numberedUrl = coreVersionedUrl(config, {
+      endpoint: FAKE_ENDPOINT,
+      metadataVersion: "/10",
+    });
+    expect(numberedUrl).toBe(`/10/${FAKE_ENDPOINT}`);
+  });
+  it("Version: none", () => {
+    const numberedUrl = coreVersionedUrl(config, {
+      endpoint: FAKE_ENDPOINT,
+      metadataVersion: null,
+    });
+    expect(numberedUrl).toBe(`/${FAKE_ENDPOINT}`);
+  });
+  it("Endpoint: missing", () => {
+    const numberedUrl = coreVersionedUrl(config, {
+      endpoint: "",
+      metadataVersion: null,
+    });
+    expect(numberedUrl).toBe("/");
+  });
+});
+
+describe("Test versionedUrl helper, default, no overrides", () => {
+  const FAKE_ENDPOINT = "renkuEntity.edit";
+  const config = createCoreApiVersionedUrlConfig({ coreApiVersion: "2.0" });
+
+  it("Version: number only", () => {
+    const numberedUrl = coreVersionedUrl(config, {
+      endpoint: FAKE_ENDPOINT,
+      metadataVersion: "10",
+    });
+    expect(numberedUrl).toBe(`/10/2.0/${FAKE_ENDPOINT}`);
+  });
+  it("Version: initial slash", () => {
+    const numberedUrl = coreVersionedUrl(config, {
+      endpoint: FAKE_ENDPOINT,
+      metadataVersion: "/10",
+    });
+    expect(numberedUrl).toBe(`/10/2.0/${FAKE_ENDPOINT}`);
+  });
+  it("Version: none", () => {
+    const numberedUrl = coreVersionedUrl(config, {
+      endpoint: FAKE_ENDPOINT,
+      metadataVersion: null,
+    });
+    expect(numberedUrl).toBe(`/2.0/${FAKE_ENDPOINT}`);
+  });
+  it("Endpoint: missing", () => {
+    const numberedUrl = coreVersionedUrl(config, {
+      endpoint: "",
+      metadataVersion: null,
+    });
+    expect(numberedUrl).toBe("/2.0/");
+  });
+});
+
+describe("Test versionedUrl helper, with overrides", () => {
+  const FAKE_ENDPOINT = "renkuEntity.edit";
+  const config = createCoreApiVersionedUrlConfig({
+    coreApiVersion: "2.0",
+    overrides: {
+      "9": "/",
+      "11": "/3.0",
+    },
+  });
+
+  it("Version 10", () => {
+    const numberedUrl = coreVersionedUrl(config, {
+      endpoint: FAKE_ENDPOINT,
+      metadataVersion: "10",
+    });
+    expect(numberedUrl).toBe(`/10/2.0/${FAKE_ENDPOINT}`);
+  });
+  it("Version 9", () => {
+    const numberedUrl = coreVersionedUrl(config, {
+      endpoint: FAKE_ENDPOINT,
+      metadataVersion: "9",
+    });
+    expect(numberedUrl).toBe(`/9/${FAKE_ENDPOINT}`);
+  });
+  it("Version 11", () => {
+    const numberedUrl = coreVersionedUrl(config, {
+      endpoint: FAKE_ENDPOINT,
+      metadataVersion: "11",
+    });
+    expect(numberedUrl).toBe(`/11/3.0/${FAKE_ENDPOINT}`);
+  });
+  it("Version /10", () => {
+    const numberedUrl = coreVersionedUrl(config, {
+      endpoint: FAKE_ENDPOINT,
+      metadataVersion: "/10",
+    });
+    expect(numberedUrl).toBe(`/10/2.0/${FAKE_ENDPOINT}`);
+  });
+  it("Version /9", () => {
+    const numberedUrl = coreVersionedUrl(config, {
+      endpoint: FAKE_ENDPOINT,
+      metadataVersion: "/9",
+    });
+    expect(numberedUrl).toBe(`/9/${FAKE_ENDPOINT}`);
+  });
+  it("Version /11", () => {
+    const numberedUrl = coreVersionedUrl(config, {
+      endpoint: FAKE_ENDPOINT,
+      metadataVersion: "/11",
+    });
+    expect(numberedUrl).toBe(`/11/3.0/${FAKE_ENDPOINT}`);
+  });
+
+  it("Version /10 locally overridden", () => {
+    const numberedUrl = coreVersionedUrl(config, {
+      endpoint: FAKE_ENDPOINT,
+      metadataVersion: "/10",
+      apiVersion: "3.0",
+    });
+    expect(numberedUrl).toBe(`/10/3.0/${FAKE_ENDPOINT}`);
+  });
+  it("Version /9 locally overridden", () => {
+    const numberedUrl = coreVersionedUrl(config, {
+      endpoint: FAKE_ENDPOINT,
+      metadataVersion: "/9",
+      apiVersion: "3.0",
+    });
+    expect(numberedUrl).toBe(`/9/3.0/${FAKE_ENDPOINT}`);
+  });
+  it("Version /11 locally overridden", () => {
+    const numberedUrl = coreVersionedUrl(config, {
+      endpoint: FAKE_ENDPOINT,
+      metadataVersion: "/11",
+      apiVersion: "/",
+    });
+    expect(numberedUrl).toBe(`/11/${FAKE_ENDPOINT}`);
   });
 });

--- a/client/src/utils/helpers/url/versionedUrls.ts
+++ b/client/src/utils/helpers/url/versionedUrls.ts
@@ -94,22 +94,6 @@ export function coreVersionedUrl(
   return versionedPathForEndpoint(sanitized);
 }
 
-export function getCoreVersionedUrl(
-  endpoint: string,
-  metadataVersion?: string | null,
-  helper?: CoreApiVersionedUrlHelper,
-  apiVersionOverride?: string
-): string {
-  const helper_ =
-    helper != null
-      ? helper
-      : new CoreApiVersionedUrlHelper({ coreApiVersion: "/" });
-  metadataVersion = metadataVersion
-    ? stripInitialSlash(metadataVersion)
-    : undefined;
-  return helper_.urlForEndpoint(endpoint, metadataVersion, apiVersionOverride);
-}
-
 /**
  * Take a proposed set of endpoint params and remove initial slashes and convert empty string to undefined.
  * @param param Proposed endpoint params to clean up

--- a/client/src/utils/helpers/url/versionedUrls.ts
+++ b/client/src/utils/helpers/url/versionedUrls.ts
@@ -16,14 +16,135 @@
  * limitations under the License.
  */
 
+function stripInitialSlash(
+  path: string | null | undefined
+): string | undefined {
+  if (path == null) return undefined;
+  path = path.startsWith("/") ? path.slice(1) : path;
+  if (path.length < 1) return undefined;
+  return path;
+}
+
+export type CoreApiVersionedUrlConfig = {
+  /** The default version to use. Set to "/" to use the latest API version. */
+  coreApiVersion: string;
+  /** API Version overrides for specific metadata versions. Set to "/" to mean 'latest'. */
+  overrides: Record<string, string>;
+};
+
+/**
+ * Helper class to generate versioned urls for the core api.
+ */
+export class CoreApiVersionedUrlHelper {
+  config: CoreApiVersionedUrlConfig;
+  constructor(
+    config: Pick<CoreApiVersionedUrlConfig, "coreApiVersion"> &
+      Partial<Pick<CoreApiVersionedUrlConfig, "overrides">>
+  ) {
+    this.config = createCoreApiVersionedUrlConfig(config);
+  }
+
+  urlForEndpoint(
+    endpoint: string,
+    metadataVersion: string | undefined | null,
+    apiVersionOverride?: string
+  ): string {
+    return coreVersionedUrl(this.config, {
+      apiVersion: apiVersionOverride,
+      endpoint,
+      metadataVersion,
+    });
+  }
+}
+
+export function apiVersionForMetadataVersion(
+  config: CoreApiVersionedUrlConfig,
+  metadataVersion: string | undefined | null,
+  apiVersionOverride?: string
+) {
+  const apiVersion = apiVersionOverride
+    ? apiVersionOverride
+    : metadataVersion
+    ? config.overrides[metadataVersion] ?? config.coreApiVersion
+    : config.coreApiVersion;
+  return stripInitialSlash(apiVersion);
+}
+
+export function createCoreApiVersionedUrlConfig(
+  config: Partial<CoreApiVersionedUrlConfig>
+) {
+  const overrides = config.overrides ?? {};
+  return {
+    coreApiVersion: config.coreApiVersion ?? "/",
+    overrides,
+  };
+}
+
+export function coreVersionedUrl(
+  config: CoreApiVersionedUrlConfig,
+  params: VersionedPathForEndpointParams
+) {
+  const sanitized = sanitizedVersionedPathParams({
+    endpoint: params.endpoint,
+    metadataVersion: params.metadataVersion,
+  });
+  sanitized.apiVersion = apiVersionForMetadataVersion(
+    config,
+    sanitized.metadataVersion,
+    params.apiVersion ?? undefined
+  );
+  return versionedPathForEndpoint(sanitized);
+}
+
 export function getCoreVersionedUrl(
   endpoint: string,
-  versionUrl?: string | undefined | null
+  metadataVersion?: string | null,
+  helper?: CoreApiVersionedUrlHelper,
+  apiVersionOverride?: string
 ): string {
-  const endpoint_ = endpoint.startsWith("/") ? endpoint.slice(1) : endpoint;
-  const versionUrl_ = versionUrl?.startsWith("/")
-    ? versionUrl.slice(1)
-    : versionUrl;
-  const urlPath = versionUrl_ ? `${versionUrl_}/${endpoint_}` : endpoint_;
-  return `/${urlPath}`;
+  const helper_ =
+    helper != null
+      ? helper
+      : new CoreApiVersionedUrlHelper({ coreApiVersion: "/" });
+  return helper_.urlForEndpoint(endpoint, metadataVersion, apiVersionOverride);
+}
+
+/**
+ * Take a proposed set of endpoint params and remove initial slashes and convert empty string to undefined.
+ * @param param Proposed endpoint params to clean up
+ */
+export function sanitizedVersionedPathParams({
+  apiVersion,
+  endpoint,
+  metadataVersion,
+}: Partial<VersionedPathForEndpointParams>) {
+  endpoint = stripInitialSlash(endpoint);
+  metadataVersion = stripInitialSlash(metadataVersion);
+  apiVersion = stripInitialSlash(apiVersion);
+  return {
+    apiVersion,
+    endpoint,
+    metadataVersion,
+  };
+}
+
+export type VersionedPathForEndpointParams = {
+  /* The API version to use, with any initial slash stripped. undefined/null => latest */
+  apiVersion?: string;
+  /* The endpoint, with any initial slash stripped. undefined/null => root */
+  endpoint: string | undefined | null;
+  /* The metadata version, with any initial slash stripped. undefined/null => latest */
+  metadataVersion: string | undefined | null;
+};
+
+export function versionedPathForEndpoint({
+  apiVersion,
+  endpoint,
+  metadataVersion,
+}: VersionedPathForEndpointParams) {
+  if (endpoint == null) endpoint = "";
+  if (metadataVersion == null && apiVersion == null) return `/${endpoint}`;
+  if (metadataVersion == null) return `/${apiVersion}/${endpoint}`;
+  if (apiVersion == null) return `/${metadataVersion}/${endpoint}`;
+  return `/${metadataVersion}/${apiVersion}/${endpoint}`;
 }

--- a/client/src/utils/types/coreService.types.ts
+++ b/client/src/utils/types/coreService.types.ts
@@ -16,11 +16,9 @@
  * limitations under the License.
  */
 
-import type { CoreApiVersionedUrlHelper } from "../helpers/url";
-
 export interface CoreVersionUrl {
-  helper?: CoreApiVersionedUrlHelper;
-  versionUrl?: string;
+  apiVersion?: string;
+  metadataVersion?: number;
 }
 
 export interface CoreRepositoryParams {

--- a/client/src/utils/types/coreService.types.ts
+++ b/client/src/utils/types/coreService.types.ts
@@ -16,7 +16,10 @@
  * limitations under the License.
  */
 
+import type { CoreApiVersionedUrlHelper } from "../helpers/url";
+
 export interface CoreVersionUrl {
+  helper?: CoreApiVersionedUrlHelper;
   versionUrl?: string;
 }
 

--- a/client/src/workflows/Workflows.container.tsx
+++ b/client/src/workflows/Workflows.container.tsx
@@ -83,13 +83,11 @@ function WorkflowsList({
     branch: defaultBranch,
   });
   const {
+    apiVersion,
     backendAvailable,
     computed: coreSupportComputed,
-    versionUrl,
+    metadataVersion,
   } = coreSupport;
-  const metadataVersion = versionUrl
-    ? parseInt(versionUrl.slice(1))
-    : undefined;
 
   // Verify backend support and availability
   const unsupported =
@@ -112,9 +110,9 @@ function WorkflowsList({
   const workflowsDisplay = useWorkflowsSelector();
 
   // Fetch workflow list
-  const skipList = !versionUrl || !repositoryUrl || unsupported;
+  const skipList = !metadataVersion || !repositoryUrl || unsupported;
   const workflowsQuery = useGetWorkflowListQuery(
-    { coreUrl: versionUrl ?? "", gitUrl: repositoryUrl, reference, fullPath },
+    { apiVersion, gitUrl: repositoryUrl, metadataVersion, reference, fullPath },
     { skip: skipList }
   );
   const workflows = {
@@ -128,14 +126,15 @@ function WorkflowsList({
     orderProperty: workflowsDisplay.orderProperty,
   };
   const waiting =
-    !versionUrl || !coreSupportComputed || workflowsQuery.isLoading;
+    !metadataVersion || !coreSupportComputed || workflowsQuery.isLoading;
 
   // Fetch workflow details
   const skipDetails = skipList || !selected ? true : false;
   const workflowDetailQuery = useGetWorkflowDetailQuery(
     {
-      coreUrl: versionUrl ?? "",
+      apiVersion,
       gitUrl: repositoryUrl,
+      metadataVersion,
       workflowId: selected,
       reference,
       fullPath,

--- a/helm-chart/renku-ui/templates/ui-client-deployment-template.yaml
+++ b/helm-chart/renku-ui/templates/ui-client-deployment-template.yaml
@@ -103,6 +103,8 @@ spec:
                   key: chart_version
             - name: HOMEPAGE
               value: {{ toJson .Values.client.homepage | quote }}
+            - name: CORE_API_VERSION_CONFIG
+              value: {{ toJson .Values.client.coreApiVersionConfig | quote }}
           livenessProbe:
             httpGet:
               path: /

--- a/helm-chart/renku-ui/values.yaml
+++ b/helm-chart/renku-ui/values.yaml
@@ -191,6 +191,16 @@ client:
     tutorialLink: https://renku.readthedocs.io/en/stable/tutorials/01_firststeps.html
     # Projects to highlight on the homepage
     projects: []
+  coreApiVersionConfig:
+    ## Configuration to specify which version of the core-service API should be used
+    # "/" indicates that the latest version should be used
+    # A version number "2.0" can be used to specify one explicitly
+    # The coreApiVersion specifies the default version to use
+    coreApiVersion: "/"
+    # With overrides, the version for a specific metadata version can be changed
+    # overrides:
+    #   9: "/"
+    #   10: "/"
   canary:
     enabled: false
     image:

--- a/tests/cypress/e2e/coreServiceVersion.spec.ts
+++ b/tests/cypress/e2e/coreServiceVersion.spec.ts
@@ -1,0 +1,107 @@
+/// <reference types="cypress" />
+/*!
+ * Copyright 2022 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Fix the core service version to specific values and test a few calls
+ */
+import "../support/utils";
+import Fixtures from "../support/renkulab-fixtures";
+
+const config = {
+  overrides: {
+    CORE_API_VERSION: {
+      coreApiVersion: "2.0",
+      overrides: {
+        "9": "1.0",
+      },
+    },
+  },
+};
+
+describe("display a project", () => {
+  const fixtures = new Fixtures(cy);
+  fixtures.useMockedData = true;
+  beforeEach(() => {
+    fixtures.config(config).versions().userTest();
+    fixtures
+      .projects()
+      .landingUserProjects()
+      .projectTest()
+      .projectById("getProjectsById", 39646);
+    fixtures.projectLockStatus().projectMigrationUpToDate();
+    cy.visit("/projects/e2e/local-test-project");
+  });
+
+  it("displays the project overview page", () => {
+    cy.wait("@getProject");
+    cy.wait("@getReadme");
+    cy.get_cy("header-project").should("be.visible");
+    cy.get_cy("project-readme")
+      .should("be.visible")
+      .should("contain.text", "local test project");
+    cy.get_cy("project-title")
+      .should("be.visible")
+      .should("contain.text", "local-test-project");
+  });
+
+  it("displays lock correctly", () => {
+    fixtures.projectLockStatus({ locked: true });
+    cy.visit("/projects/e2e/local-test-project/settings");
+    cy.get_cy("settings-navbar")
+      .contains("a", "Sessions")
+      .should("exist")
+      .click();
+    cy.get_cy("settings-container")
+      .contains("project is currently being modified")
+      .should("exist");
+  });
+});
+
+describe("Project dataset", () => {
+  const fixtures = new Fixtures(cy);
+  fixtures.useMockedData = Cypress.env("USE_FIXTURES") === true;
+  const projectPath = "e2e/testing-datasets";
+
+  beforeEach(() => {
+    fixtures.config(config).versions().userTest();
+    fixtures.projects().landingUserProjects();
+    fixtures.project(projectPath);
+    fixtures.projectKGDatasetList(projectPath);
+    fixtures.projectDatasetList();
+    fixtures.projectTestContents(undefined, 9);
+    fixtures.projectMigrationUpToDate({
+      queryUrl: "*",
+      fixtureName: "getMigration",
+    });
+    fixtures.projectLockStatus();
+  });
+
+  it("displays project datasets", () => {
+    cy.visit(`projects/${projectPath}/datasets`);
+    cy.wait("@getProject");
+    cy.wait("@datasetList")
+      .its("response.body")
+      .then((data) => {
+        const datasets = data.result.datasets;
+        // all datasets are displayed
+        const totalDatasets = datasets?.length;
+        cy.get_cy("list-card").should("have.length", totalDatasets);
+      });
+  });
+});

--- a/tests/cypress/e2e/coreServiceVersion.spec.ts
+++ b/tests/cypress/e2e/coreServiceVersion.spec.ts
@@ -25,7 +25,7 @@ import Fixtures from "../support/renkulab-fixtures";
 
 const config = {
   overrides: {
-    CORE_API_VERSION: {
+    CORE_API_VERSION_CONFIG: {
       coreApiVersion: "2.0",
       overrides: {
         "9": "1.0",

--- a/tests/cypress/e2e/maintenance.spec.ts
+++ b/tests/cypress/e2e/maintenance.spec.ts
@@ -24,7 +24,7 @@ describe("display the maintenance page", () => {
   fixtures.useMockedData = Cypress.env("USE_FIXTURES") === true;
 
   // e of the resources on RenkuLab are t
-  it("Shows the standard error when UI is down but no maintenace is set", () => {
+  it("Shows the standard error when UI is down but no maintenance is set", () => {
     fixtures.config();
     cy.visit("/");
     cy.get("h1").first().should("contain.text", "RenkuLab Down");
@@ -33,8 +33,11 @@ describe("display the maintenance page", () => {
     cy.get("h1").first().should("not.contain.text", "Maintenance ongoing");
   });
 
-  it("Keep showing the maintenace page on every URL", () => {
-    fixtures.config("getConfigMaintenace", "config_maintenance.json");
+  it("Keep showing the maintenance page on every URL", () => {
+    fixtures.config({
+      name: "getConfigMaintenance",
+      fixture: "config_maintenance.json",
+    });
     cy.visit("/");
     cy.get("h1").first().should("contain.text", "Maintenance ongoing");
     cy.visit("/projects");

--- a/tests/cypress/support/renkulab-fixtures/datasets.ts
+++ b/tests/cypress/support/renkulab-fixtures/datasets.ts
@@ -92,7 +92,7 @@ function Datasets<T extends FixturesConstructor>(Parent: T) {
         const result = process(content);
         const fixture = { body: result };
         cy.intercept(
-          "/ui-server/api/renku/*/datasets.list?git_url=*",
+          "/ui-server/api/renku/**/datasets.list?git_url=*",
           fixture
         ).as(name);
       });

--- a/tests/cypress/support/renkulab-fixtures/global.ts
+++ b/tests/cypress/support/renkulab-fixtures/global.ts
@@ -38,10 +38,29 @@ function Global<T extends FixturesConstructor>(Parent: T) {
       return this;
     }
 
-    config(name = "getConfig", fixture = "config.json") {
-      cy.intercept("/config.json", {
-        fixture,
-      }).as(name);
+    config(params?: {
+      name?: string;
+      fixture?: string;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      overrides?: any;
+    }) {
+      const {
+        name = "getConfig",
+        fixture = "config.json",
+        overrides,
+      } = params || {};
+      if (overrides == null) {
+        cy.intercept("/config.json", {
+          fixture,
+        }).as(name);
+        return this;
+      }
+      cy.fixture("config.json").then((baseConfig) => {
+        const combinedConfig = { ...baseConfig, ...overrides };
+        cy.intercept("/config.json", {
+          body: combinedConfig,
+        }).as(name);
+      });
       return this;
     }
 

--- a/tests/cypress/support/renkulab-fixtures/projects.ts
+++ b/tests/cypress/support/renkulab-fixtures/projects.ts
@@ -184,7 +184,7 @@ function Projects<T extends FixturesConstructor>(Parent: T) {
     }
 
     interceptMigrationCheck(name, fixture, queryUrl = null) {
-      const coreUrl = "/ui-server/api/renku/cache.migrations_check";
+      const coreUrl = "/ui-server/api/renku/**/cache.migrations_check";
       const defaultQuery =
         "git_url=https%3A%2F%2Fdev.renku.ch%2Fgitlab%2Fe2e%2Flocal-test-project&branch=master";
       cy.intercept(`${coreUrl}?${queryUrl || defaultQuery}`, {
@@ -237,7 +237,7 @@ function Projects<T extends FixturesConstructor>(Parent: T) {
       error = false,
       legacyError = false,
     } = {}) {
-      const coreUrl = "/ui-server/api/renku/project.lock_status";
+      const coreUrl = "/ui-server/api/renku/**/project.lock_status";
       const params = "git_url=*";
       const errorFixture = legacyError
         ? "errors/core-error-old.json"
@@ -412,7 +412,7 @@ function Projects<T extends FixturesConstructor>(Parent: T) {
       result = "project/edit/edit-project-confirm.json"
     ) {
       const fixture = this.useMockedData ? { fixture: result } : undefined;
-      cy.intercept("POST", "/ui-server/api/renku/project.edit", fixture).as(
+      cy.intercept("POST", "/ui-server/api/renku/**/project.edit", fixture).as(
         name
       );
       return this;


### PR DESCRIPTION
The Core Service supports API versions, and the UI should take advantage of this feature.

Fix  #2718 
Fix #2755

/deploy #persist extra-values=ui.client.coreApiVersionConfig.coreApiVersion=2.0