### PR TITLE
fix(client): use the migrations_check endpoint on the latest core version

### DIFF
--- a/client/src/features/project/projectCoreApi.ts
+++ b/client/src/features/project/projectCoreApi.ts
@@ -147,7 +147,7 @@ export const projectCoreApi = createApi({
         };
         if (migrationParams.branch) params.branch = migrationParams.branch;
         return {
-          url: getCoreVersionedUrl("/cache.migrations_check"), // ? migrations always uses the last renku version
+          url: "/cache.migrations_check", // ? migrations always uses the last renku version
           params,
         };
       },


### PR DESCRIPTION
This fixes a bug accidentally introduced in #2717 
/deploy #persist
