### PR TITLE
fix: correctly determine if a deployment is a dev deployment

### DIFF
--- a/client/src/landing/NavBar.js
+++ b/client/src/landing/NavBar.js
@@ -545,9 +545,9 @@ function FooterNavbar({ location, params }) {
   const displayVersion =
     taggedVersion == null
       ? "unknown"
-      : isDevVersion == null
-      ? taggedVersion
-      : `${taggedVersion} (dev)`;
+      : isDevVersion
+      ? `${taggedVersion} (dev)`
+      : taggedVersion;
 
   const footer = (
     <footer className="footer">


### PR DESCRIPTION
There is a mistake in the logic to determine if a deployment is a dev deployment.

**Before**

![image](https://github.com/SwissDataScienceCenter/renku-ui/assets/1196411/5394d598-4975-496e-a927-69473ee84564)

**After**

![image](https://github.com/SwissDataScienceCenter/renku-ui/assets/1196411/6d61ea5c-ae09-476d-af9c-34ae2b6734bb)
