### PR TITLE
fix: unzip multiple dataset files (#2754)

### DIFF
--- a/client/src/components/FileExplorer.tsx
+++ b/client/src/components/FileExplorer.tsx
@@ -337,9 +337,18 @@ function FileExplorer(props: FileExplorerProps) {
   const setOpenFolder = React.useCallback(
     (filePath: string) => {
       if (filesTree == null) return;
-      filesTree.hash[filePath].childrenOpen =
-        !filesTree.hash[filePath].childrenOpen;
-      setFilesTree(filesTree);
+      const updatedFilesTree = {
+        ...filesTree,
+        hash: {
+          ...filesTree.hash,
+          [filePath]: {
+            ...filesTree.hash[filePath],
+            childrenOpen: !filesTree.hash[filePath].childrenOpen,
+          },
+        },
+      };
+
+      setFilesTree(updatedFilesTree);
     },
     [filesTree]
   );

--- a/client/src/components/form-field/DropzoneFileUploader.js
+++ b/client/src/components/form-field/DropzoneFileUploader.js
@@ -773,7 +773,7 @@ function FileStatusComp({ file, uploadCompressedFile, uploadThresholdSoft }) {
           icon={faExclamationTriangle}
         />
         <span className="mb-1">&nbsp;Unzip on upload?</span>
-        <span className="me-1">
+        <span className="me-1 d-flex  gap-2">
           <span
             data-cy="upload-compressed-yes"
             className="text-primary text-button"
@@ -786,7 +786,7 @@ function FileStatusComp({ file, uploadCompressedFile, uploadThresholdSoft }) {
             }
           >
             Yes
-          </span>{" "}
+          </span>
           or
           <span
             data-cy="upload-compressed-no"

--- a/client/src/components/form-field/DropzoneFileUploader.js
+++ b/client/src/components/form-field/DropzoneFileUploader.js
@@ -773,7 +773,7 @@ function FileStatusComp({ file, uploadCompressedFile, uploadThresholdSoft }) {
           icon={faExclamationTriangle}
         />
         <span className="mb-1">&nbsp;Unzip on upload?</span>
-        <span className="me-1 d-flex  gap-2">
+        <span className="me-1 d-flex gap-2">
           <span
             data-cy="upload-compressed-yes"
             className="text-primary text-button"

--- a/client/src/features/project/dataset/datasetCore.api.ts
+++ b/client/src/features/project/dataset/datasetCore.api.ts
@@ -21,6 +21,7 @@ import type { ImageInputImage } from "../../../components/form-field/ImageInput"
 import type { Creator } from "../Project";
 import type { DatasetFormState } from "./datasetForm.slice";
 import type { DatasetImage } from "./dataset.types";
+import { DatasetUploaderFile } from "./datasetForm.slice";
 
 export type DatasetFormFields = DatasetFormState["form"];
 
@@ -102,20 +103,27 @@ function getCreator(creator: Creator) {
   return newCreator;
 }
 
+function getFileIds(
+  files: Omit<DatasetUploaderFile, "file">[]
+): { file_id: string }[] {
+  return files.flatMap((file) => {
+    if (Array.isArray(file.file_id))
+      return file.file_id.map((id) => ({ file_id: id as string }));
+    return { file_id: file.file_id as string };
+  });
+}
 function gatherDatasetFilesForSubmit(datasetInput: DatasetFormFields) {
   // TODO: make sure file_status is kept in the form
   const pendingFiles = datasetInput.files
     .filter((f) => f.file_status === FILE_STATUS.PENDING)
     .map((f) => ({ file_url: f.file_name }));
-  const readyFiles = datasetInput.files
-    .filter(
-      (f) =>
-        f.file_status !== FILE_STATUS.PENDING &&
-        f.file_status !== FILE_STATUS.ADDED &&
-        f.file_id !== undefined
-    )
-    .map((f) => ({ file_id: f.file_id }));
-  return { readyFiles, pendingFiles };
+  const readyFiles = datasetInput.files.filter(
+    (f) =>
+      f.file_status !== FILE_STATUS.PENDING &&
+      f.file_status !== FILE_STATUS.ADDED &&
+      f.file_id !== undefined
+  );
+  return { readyFiles: getFileIds(readyFiles), pendingFiles };
 }
 
 async function getDatasetImagesForSubmit(


### PR DESCRIPTION
Pull request for resolving the issue with uploading dataset files in the "Add/Modify Dataset" form. 

1. Issue with displaying subfolders in unzipped dataset files.

* Before
![expand files Error](https://github.com/SwissDataScienceCenter/renku-ui/assets/43388408/90b8e6e4-423c-4f9e-b86c-644ff2b5f7c4)
* After
![expand files OK](https://github.com/SwissDataScienceCenter/renku-ui/assets/43388408/043e8c1e-ca73-4f48-b20a-3bf92d3cd194)

2. Error when sending several dataset files
* Before
![send files error](https://github.com/SwissDataScienceCenter/renku-ui/assets/43388408/96512ed9-6d8b-4786-bc55-bfbab793f017)

* After
![send files ok](https://github.com/SwissDataScienceCenter/renku-ui/assets/43388408/33b0f6f2-0af4-4ef3-9af6-e0c6eb82801e)

Fix #2754 

/deploy #persist 