### PR TITLE
fix(client): handle embedded template variables in project creation links

### DIFF
--- a/client/src/project/new/ProjectNew.container.js
+++ b/client/src/project/new/ProjectNew.container.js
@@ -422,6 +422,30 @@ function NewProject(props) {
   const { availableVisibilities, isFetchingVisibilities } =
     useGetVisibilities(namespace);
 
+  const validateForm = useCallback(
+    (newInput = null, newTemplates = null, update = null) => {
+      const projects = {
+        members: projectsMember,
+        fetching: isFetchingProjects,
+      };
+      coordinator?.validate(
+        newInput,
+        newTemplates,
+        update,
+        projects,
+        namespaces,
+        isFetchingVisibilities
+      );
+    },
+    [
+      coordinator,
+      isFetchingProjects,
+      namespaces,
+      projectsMember,
+      isFetchingVisibilities,
+    ]
+  );
+
   /*
    * Start fetching templates and get automatedData. We can execute that only once
    */
@@ -515,30 +539,6 @@ function NewProject(props) {
   const removeAutomated = (manuallyReset = true) => {
     coordinator?.resetAutomated(manuallyReset);
   };
-
-  const validateForm = useCallback(
-    (newInput = null, newTemplates = null, update = null) => {
-      const projects = {
-        members: projectsMember,
-        fetching: isFetchingProjects,
-      };
-      coordinator?.validate(
-        newInput,
-        newTemplates,
-        update,
-        projects,
-        namespaces,
-        isFetchingVisibilities
-      );
-    },
-    [
-      coordinator,
-      isFetchingProjects,
-      namespaces,
-      projectsMember,
-      isFetchingVisibilities,
-    ]
-  );
 
   const createEncodedUrl = (data) => {
     if (!data || !Object.keys(data).length)

--- a/client/src/project/new/ProjectNew.state.js
+++ b/client/src/project/new/ProjectNew.state.js
@@ -162,6 +162,10 @@ class NewProjectCoordinator {
    * @param {object} [setNamespace] - function to set namespace, it is necessary to calculate visibilities
    */
   setAutomated(data, error, namespaces, availableVisibilities, setNamespace) {
+    // ? This is a safeguard in case it's accidentally invoked multiple times.
+    const currentStatus = this.model.get("automated");
+    if (currentStatus.received && currentStatus.valid && currentStatus.step > 0)
+      return;
     let automated = newProjectSchema.createInitialized().automated;
     if (error) {
       automated = {

--- a/client/src/project/new/components/Automated.tsx
+++ b/client/src/project/new/components/Automated.tsx
@@ -24,22 +24,33 @@
  */
 import { useState } from "react";
 import { Link } from "react-router-dom";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
 
 import { Col, Row } from "../../../utils/ts-wrappers";
 import {
-  Alert,
   Button,
   Fade,
   Modal,
   ModalBody,
   ModalHeader,
 } from "../../../utils/ts-wrappers";
-import { ErrorAlert, WarnAlert } from "../../../components/Alert";
+import { ErrorAlert, InfoAlert, WarnAlert } from "../../../components/Alert";
 import { Url } from "../../../utils/helpers/url";
 import { Loader } from "../../../components/Loader";
+import { Docs } from "../../../utils/constants/Docs";
+import { ExternalLink } from "../../../components/ExternalLinks";
 
+const docsUrl = Docs.rtdReferencePage(
+  "templates.html#create-shareable-project-creation-links-with-pre-filled-fields"
+);
+const moreInfoLink = (
+  <ExternalLink
+    role="text"
+    iconSup={true}
+    iconAfter={true}
+    url={docsUrl}
+    title="documentation reference"
+  />
+);
 interface Project {
   title?: string;
   description?: string;
@@ -81,68 +92,89 @@ function Automated({ automated, removeAutomated }: AutomatedProps) {
       return <AutomatedModal removeAutomated={removeAutomated} />;
     return null;
   }
+
   // Show a feedback when the automated part has finished
-  // errors
+  // Case 1: errors
   if (automated.error) {
-    const error = <pre>{automated.error}</pre>;
+    const error = (
+      <div className="py-3">
+        <code>{automated.error}</code>
+      </div>
+    );
     return (
       <ErrorAlert key="alert">
-        <p>
-          We could not pre-fill the fields with the information provided in the
-          RenkuLab project-creation link.
-        </p>
-        <p>
-          It is possible that the link is outdated or not valid. Please contact
-          the source of the RenkuLab link and ask for a new one.
-        </p>
+        <div data-cy="project-creation-embedded-error">
+          <p>
+            You used a RenkuLab project-creation link containing embedded data (
+            {moreInfoLink}). There was an error while pre-filling the fields.
+            This is usually a sign of a wrong link or outdated information (E.G:
+            outdated template links).
+          </p>
+          <p>
+            We used the default settings instead, but that might not lead to the
+            expected results.
+          </p>
 
-        <Button
-          color="link"
-          style={{ fontSize: "smaller" }}
-          className="font-italic"
-          onClick={() => toggleError()}
-        >
-          {showError ? "Hide error details" : "Show error details"}
-        </Button>
-        <Fade in={showError} tag="div">
-          {showError ? error : null}
-        </Fade>
+          <Button
+            color="danger"
+            className="btn-sm"
+            onClick={() => toggleError()}
+          >
+            {showError ? "Hide error details" : "Show error details"}
+          </Button>
+          <Fade in={showError} tag="div">
+            {showError ? error : null}
+          </Fade>
+        </div>
       </ErrorAlert>
     );
   }
-  // warnings
+  // Case 2: warnings
   else if (automated.warnings.length) {
-    const warnings = <pre>{automated.warnings.join("\n")}</pre>;
+    const warnings = (
+      <div className="py-3">
+        <code>{automated.warnings.join("\n")}</code>
+      </div>
+    );
     return (
       <WarnAlert>
-        <p>
-          Some fields could not be pre-filled with the information provided in
-          the RenkuLab project-creation link.
-        </p>
-        <Button
-          color="link"
-          style={{ fontSize: "smaller" }}
-          className="font-italic"
-          onClick={() => toggleWarn()}
-        >
-          {showWarnings ? "Hide warnings" : "Show warnings"}
-        </Button>
-        <Fade in={showWarnings} tag="div">
-          {showWarnings ? warnings : null}
-        </Fade>
+        <div data-cy="project-creation-embedded-warning">
+          <p>
+            You used a RenkuLab project-creation link containing embedded data (
+            {moreInfoLink}). Some fields could not be pre-filled, likely because
+            data is missing or outdated.
+          </p>
+          <p>
+            We used the default settings instead, but that might not lead to the
+            expected results.
+          </p>
+          <Button
+            color="warning"
+            className="btn-sm"
+            onClick={() => toggleWarn()}
+          >
+            {showWarnings ? "Hide warnings" : "Show warnings"}
+          </Button>
+          <Fade in={showWarnings} tag="div">
+            {showWarnings ? warnings : null}
+          </Fade>
+        </div>
       </WarnAlert>
     );
   }
-  // all good
+  // Case 2: all good, just show a feedback
   return (
-    <Alert color="primary">
-      <p className="mb-0">
-        <FontAwesomeIcon icon={faInfoCircle} />
-        &nbsp; Some fields were pre-filled.
-        <br />
-        You can still change any values before you create the project.
-      </p>
-    </Alert>
+    <InfoAlert dismissible={false} timeout={0}>
+      <div data-cy="project-creation-embedded-info">
+        <p>
+          Some fields are pre-filled because you used a RenkuLab
+          project-creation link containing embedded data ({moreInfoLink}).
+        </p>
+        <p className="mb-0">
+          You can still change any value before creating a new project.
+        </p>
+      </div>
+    </InfoAlert>
   );
 }
 
@@ -154,19 +186,14 @@ function AutomatedModal(props: AutomatedModalProps) {
   const toggle = () => setShowFadeIn(!showFadeIn);
 
   const button = showFadeIn ? null : (
-    <Button
-      color="link"
-      style={{ fontSize: "smaller" }}
-      className="font-italic"
-      onClick={() => toggle()}
-    >
+    <Button className="btn btn-sm" onClick={() => toggle()}>
       Taking too long?
     </Button>
   );
 
   const to = Url.get(Url.pages.project.new);
   const fadeInContent = (
-    <p className="mt-3">
+    <p className="my-3">
       If pre-filling the new project form is taking too long, you can
       <Link
         className="btn btn-primary btn-sm"
@@ -175,22 +202,27 @@ function AutomatedModal(props: AutomatedModalProps) {
           removeAutomated();
         }}
       >
-        use a blank form
+        Start from scratch
       </Link>
     </p>
   );
   return (
     <Modal isOpen={true} centered={true} keyboard={false} backdrop="static">
-      <ModalHeader>Fetching initialization data</ModalHeader>
+      <ModalHeader data-cy="project-creation-embedded-fetching">
+        Fetching initialization data
+      </ModalHeader>
       <ModalBody>
         <Row>
           <Col>
-            <p>You entered a url containing information to pre-fill.</p>
-            <span>
-              Please wait while we fetch the required metadata...&nbsp;
+            <p>
+              You used a RenkuLab project-creation link containing embedded data
+              ({moreInfoLink})
+            </p>
+            <p>
+              Please wait while we fetch the required resources...{" "}
               <Loader inline size={16} />
-            </span>
-            <div className="mt-2">
+            </p>
+            <div className="my-3">
               {button}
               <Fade in={showFadeIn} tag="div">
                 {showFadeIn ? fadeInContent : null}

--- a/tests/cypress/e2e/newProject.spec.ts
+++ b/tests/cypress/e2e/newProject.spec.ts
@@ -122,7 +122,7 @@ describe("Add new project", () => {
     cy.get_cy("url-repository").clear().type("valid-url");
     cy.get_cy("fetch-templates-button").click();
     cy.wait("@getCustomTemplatesValid");
-    cy.get_cy("project-template-card").should("have.length", 5);
+    cy.get_cy("project-template-card").should("have.length", 6);
 
     // cannot submit the form if the title and template are missing
     cy.get_cy("create-project-button").click();
@@ -175,9 +175,11 @@ describe("Add new project shared link", () => {
   });
 
   it("prefill values all values (custom template)", () => {
-    // eslint-disable-next-line max-len
     const customValues =
-      "?data=eyJ0aXRsZSI6Im5ldyBwcm9qZWN0IiwiZGVzY3JpcHRpb24iOiIgdGhpcyBhIGN1c3RvbSBkZXNjcmlwdGlvbiIsIm5hbWVzcGFjZSI6ImUyZSIsInZpc2liaWxpdHkiOiJpbnRlcm5hbCIsInVybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9Td2lzc0RhdGFTY2llbmNlQ2VudGVyL3Jlbmt1LXByb2plY3QtdGVtcGxhdGUiLCJyZWYiOiJtYXN0ZXIiLCJ0ZW1wbGF0ZSI6IkN1c3RvbS9SLW1pbmltYWwifQ%3D%3D";
+      "?data=eyJ0aXRsZSI6Im5ldyBwcm9qZWN0IiwiZGVzY3JpcHRpb24iOiIgdGhpcyBhIGN1c3RvbSBkZXNjcml" +
+      "wdGlvbiIsIm5hbWVzcGFjZSI6ImUyZSIsInZpc2liaWxpdHkiOiJpbnRlcm5hbCIsInVybCI6Imh0dHBzOi8v" +
+      "Z2l0aHViLmNvbS9Td2lzc0RhdGFTY2llbmNlQ2VudGVyL3Jlbmt1LXByb2plY3QtdGVtcGxhdGUiLCJyZWYiO" +
+      "iJtYXN0ZXIiLCJ0ZW1wbGF0ZSI6IkN1c3RvbS9SLW1pbmltYWwifQ%3D%3D";
     fixtures
       .templates(false, "*", "getTemplates")
       .getNamespace(
@@ -188,38 +190,38 @@ describe("Add new project shared link", () => {
     cy.visit(`projects/new${customValues}`);
     cy.wait("@getTemplates");
 
-    // check title
+    // Check feedback messages
+    cy.get_cy("project-creation-embedded-fetching").should("be.visible");
+    cy.get_cy("project-creation-embedded-info").should("be.visible", {
+      timeout: 20_000,
+    });
+
+    // Check the prefill values
     cy.get_cy("field-group-title").should("contain.value", "new project");
-    // check description
     cy.get_cy("field-group-description").should(
       "contain.text",
       "this a custom description"
     );
-    // check namespace
     cy.get_cy("project-slug").should("contain.value", "e2e/new-project");
-    // check visibility
     cy.get_cy("visibility-public").should("not.be.checked");
     cy.get_cy("visibility-internal").should("be.checked");
     cy.get_cy("visibility-private").should("not.be.checked");
-
-    // check custom template source
-    // eslint-disable-next-line max-len
     cy.get_cy("url-repository").should(
       "contain.value",
       "https://github.com/SwissDataScienceCenter/renku-project-template"
     );
     cy.get_cy("ref-repository").should("contain.value", "master");
-
-    // check selected template
     cy.get_cy("project-template-card")
       .get(".selected")
       .should("contain.text", "Basic R (4.1.2) Project");
   });
 
   it("prefill values custom template", () => {
-    // eslint-disable-next-line max-len
     const customValues =
-      "?data=eyJ0aXRsZSI6Im5ldyBwcm9qZWN0IiwiZGVzY3JpcHRpb24iOiIgdGhpcyBhIGN1c3RvbSBkZXNjcmlwdGlvbiIsIm5hbWVzcGFjZSI6ImUyZSIsInZpc2liaWxpdHkiOiJpbnRlcm5hbCIsInVybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9Td2lzc0RhdGFTY2llbmNlQ2VudGVyL3Jlbmt1LXByb2plY3QtdGVtcGxhdGUiLCJyZWYiOiJtYXN0ZXIifQ%3D%3D";
+      "?data=eyJ0aXRsZSI6Im5ldyBwcm9qZWN0IiwiZGVzY3JpcHRpb24iOiIgdGhpcyBhIGN1c3RvbSBkZXNjcml" +
+      "wdGlvbiIsIm5hbWVzcGFjZSI6ImUyZSIsInZpc2liaWxpdHkiOiJpbnRlcm5hbCIsInVybCI6Imh0dHBzOi8v" +
+      "Z2l0aHViLmNvbS9Td2lzc0RhdGFTY2llbmNlQ2VudGVyL3Jlbmt1LXByb2plY3QtdGVtcGxhdGUiLCJyZWYiO" +
+      "iJtYXN0ZXIifQ%3D%3D";
     const templateUrl =
       "https://github.com/SwissDataScienceCenter/renku-project-template";
     const templateRef = "master";
@@ -233,13 +235,18 @@ describe("Add new project shared link", () => {
     cy.visit(`projects/new${customValues}`);
     cy.wait("@getTemplates");
 
-    // check custom templates
+    // Check feedback messages
+    cy.get_cy("project-creation-embedded-fetching").should("be.visible");
+    cy.get_cy("project-creation-embedded-info").should("be.visible", {
+      timeout: 20_000,
+    });
+
+    // Check custom templates
     cy.get_cy("url-repository").should("contain.value", templateUrl);
     cy.get_cy("ref-repository").should("contain.value", templateRef);
   });
 
   it("prefill values renkuLab template", () => {
-    // eslint-disable-next-line max-len
     const customValues =
       "?data=eyJ0ZW1wbGF0ZSI6IlJlbmt1L2p1bGlhLW1pbmltYWwifQ%3D%3D";
     fixtures
@@ -252,9 +259,110 @@ describe("Add new project shared link", () => {
     cy.visit(`projects/new${customValues}`);
     cy.wait("@getTemplates");
 
-    // check selected template
+    // Check feedback messages
+    cy.get_cy("project-creation-embedded-fetching").should("be.visible");
+    cy.get_cy("project-creation-embedded-info").should("be.visible", {
+      timeout: 20_000,
+    });
+
+    // Check selected template
     cy.get_cy("project-template-card")
       .get(".selected")
       .should("contain.text", "Basic Julia (1.7.1) Project");
+  });
+
+  it("use the target template and select the custom variables", () => {
+    const customValues =
+      "?data=eyJ1cmwiOiJodHRwczovL2dpdGh1Yi5jb20vb21uaWJlbmNobWFyay9jb250cmlidXRlZC1wcm9qZWN" +
+      "0LXRlbXBsYXRlcyIsInJlZiI6Im1haW4iLCJ0ZW1wbGF0ZSI6IkN1c3RvbS9vbW5pLWRhdGEtcHkiLCJ2YXJp" +
+      "YWJsZXMiOnsiYmVuY2htYXJrX25hbWUiOiJvbW5pX2NsdXN0ZXJpbmciLCJkYXRhc2V0X2tleXdvcmQiOiJ0Z" +
+      "XN0IHZhbHVlIiwibWV0YWRhdGFfZGVzY3JpcHRpb24iOiIiLCJwcm9qZWN0X3RpdGxlIjoiYW5vdGhlciByYW" +
+      "5kb20gdmFsdWUiLCJzdHVkeV9saW5rIjoiIiwic3R1ZHlfbm90ZSI6IiIsInN0dWR5X3Rpc3N1ZSI6IiJ9fQ";
+    fixtures
+      .templates(false, "*", "getTemplates")
+      .getNamespace(
+        "internal-space",
+        "getInternalNamespace",
+        "projects/namespace-128.json"
+      );
+    cy.visit(`projects/new${customValues}`);
+    cy.wait("@getTemplates");
+
+    // Check feedback messages
+    cy.get_cy("project-creation-embedded-fetching").should("be.visible");
+    cy.get_cy("project-creation-embedded-info").should("be.visible", {
+      timeout: 20_000,
+    });
+
+    // Check selected template
+    cy.get_cy("project-template-card")
+      .get(".selected")
+      .should("contain.text", "Omnibenchmark dataset");
+    cy.get("#parameter-benchmark_name").should("have.value", "omni_clustering");
+    cy.get("#parameter-dataset_keyword").should("have.value", "test value");
+    cy.get("#parameter-project_title").should(
+      "have.value",
+      "another random value"
+    );
+  });
+
+  it("display warning on non-essential fields", () => {
+    const customValues =
+      "?data=eyJ0aXRsZSI6Im5ldyBwcm9qZWN0IiwibmFtZXNwYWNlIjoiZmFrZSJ9";
+    fixtures
+      .templates(false, "*", "getTemplates")
+      .getNamespace(
+        "internal-space",
+        "getInternalNamespace",
+        "projects/namespace-128.json"
+      );
+    cy.visit(`projects/new${customValues}`);
+    cy.wait("@getTemplates");
+
+    // Check feedback messages
+    cy.get_cy("project-creation-embedded-fetching").should("be.visible");
+    cy.get_cy("project-creation-embedded-warning")
+      .should("be.visible", {
+        timeout: 20_000,
+      })
+      .contains("button", "Show warnings")
+      .click();
+    cy.get_cy("project-creation-embedded-warning")
+      .contains(`The namespace "fake" is not available.`)
+      .should("be.visible");
+    cy.get_cy("project-creation-embedded-info").should("not.exist");
+
+    // Other valid fields should be filled in correctly
+    cy.get_cy("field-group-title").should("contain.value", "new project");
+  });
+
+  it("display errors on essential fields", () => {
+    const customValues =
+      "?data=eyJ0aXRsZSI6Im5ldyBwcm9qZWN0IiwidGVtcGxhdGUiOiJmYWtlIn0=";
+    fixtures
+      .templates(false, "*", "getTemplates")
+      .getNamespace(
+        "internal-space",
+        "getInternalNamespace",
+        "projects/namespace-128.json"
+      );
+    cy.visit(`projects/new${customValues}`);
+    cy.wait("@getTemplates");
+
+    // Check feedback messages
+    cy.get_cy("project-creation-embedded-fetching").should("be.visible");
+    cy.get_cy("project-creation-embedded-error")
+      .should("be.visible", {
+        timeout: 20_000,
+      })
+      .contains("button", "Show error")
+      .click();
+    cy.get_cy("project-creation-embedded-error")
+      .contains(`The template "fake" is not available.`)
+      .should("be.visible");
+    cy.get_cy("project-creation-embedded-info").should("not.exist");
+
+    // Other valid fields should be filled in correctly
+    cy.get_cy("field-group-title").should("contain.value", "new project");
   });
 });

--- a/tests/cypress/fixtures/templates.json
+++ b/tests/cypress/fixtures/templates.json
@@ -31,6 +31,48 @@
         "description": "The simplest renku project template with files for renku CLI and launching projects on renkulab.",
         "folder": "minimal",
         "variables": {}
+      },
+      {
+        "description": "A simple Renku project with a basic directory structure to add a dataset to an omnibenchmark project.",
+        "folder": "omni-data-py",
+        "name": "Omnibenchmark dataset",
+        "variables": {
+          "benchmark_name": {
+            "default_value": "omni_batch_py",
+            "description": "Name of the omnibenchmark to link this project with.",
+            "enum": [
+              "terraform",
+              "omniclustering",
+              "bc2_2023",
+              "omni_clustering",
+              "iris_example",
+              "CCC_benchmark",
+              "spatial-clustering",
+              "omni_batch_py",
+              "omniclustering_pinned",
+              "iris_versioned"
+            ],
+            "type": "enum"
+          },
+          "dataset_keyword": {
+            "description": "Dataset keyword to make this dataset reachable for other projects/ omnibenchmarks components."
+          },
+          "metadata_description": {
+            "description": "(optional) A complete description of the experimental design, for e.g. the treatment, condition, specificities, etc."
+          },
+          "project_title": {
+            "description": "Long, human readable project title."
+          },
+          "study_link": {
+            "description": "(optional) If any, link to the original study (zenodo, GEO,...)."
+          },
+          "study_note": {
+            "description": "(optional) Any additional notes about the dataset."
+          },
+          "study_tissue": {
+            "description": "(optional) Tissue/ cell line used to generate the data."
+          }
+        }
       }
     ]
   }


### PR DESCRIPTION
There was a rather annoying bug causing an infinite loop when using project creation links embedding custom variables.
Actually, some of the `useEffect` hooks in the ProjectNew container were triggered indefinitely (it would have been easier to spot if we didn't explicitly ignore the `react-hooks/exhaustive-deps` warnings...) but that was not causing issues in most other cases.

This PR also introduces better feedback messages when using the project creation links (see Cypress tests for examples).

Cypress tests were added to be sure we don't accidentally introduce further regressions on the feedback messages or the optional template variables.

/deploy #persist
