### PR TITLE
build: release 3.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changes
 
+## [3.12.1](https://github.com/SwissDataScienceCenter/renku-ui/compare/3.12.0...3.12.1) (2023-09-07)
+
+This release includes relevant changes non-visible to the users. It also includes the urgent bugfix from version 3.11.1
+
+- Take advantage of Core Service API versions ([#2718](https://github.com/SwissDataScienceCenter/renku-ui/issues/2718), [#2755](https://github.com/SwissDataScienceCenter/renku-ui/issues/2755), [#2764](https://github.com/SwissDataScienceCenter/renku-ui/issues/2764))
+- Fix bootstrap icons ([#2772](https://github.com/SwissDataScienceCenter/renku-ui/issues/2772))
+
 ## [3.12.0](https://github.com/SwissDataScienceCenter/renku-ui/compare/3.11.0...3.12.0) (2023-08-31)
 
 ### Features
@@ -10,6 +17,12 @@
 
 - Use the migrations endpoint correctly -- we were accidentally routing older projects to the wrong backend version ([#2766](https://github.com/SwissDataScienceCenter/renku-ui/issues/2766)).
 - Use the "dev" label properly on the footer in the Renku version section ([#2776](https://github.com/SwissDataScienceCenter/renku-ui/issues/2776)).
+
+## [3.11.1](https://github.com/SwissDataScienceCenter/renku-ui/compare/3.11.0...3.11.1) (2023-09-07)
+
+### Bug Fixes
+
+- Handle embedded template variables in project creation links ([#2789](https://github.com/SwissDataScienceCenter/renku-ui/issues/2789))
 
 ## [3.11.0](https://github.com/SwissDataScienceCenter/renku-ui/compare/3.10.0...3.11.0) (2023-08-22)
 

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "renku-ui",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "renku-ui",
-      "version": "3.12.0",
+      "version": "3.12.1",
       "dependencies": {
         "@ckeditor/ckeditor5-react": "^5.1.0",
         "@fortawesome/fontawesome-svg-core": "^1.2.35",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "renku-ui",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "private": true,
   "dependencies": {
     "@ckeditor/ckeditor5-react": "^5.1.0",

--- a/helm-chart/renku-ui/Chart.yaml
+++ b/helm-chart/renku-ui/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: "1.0"
 description: A Helm chart for the Renku UI
 name: renku-ui
 icon: https://github.com/SwissDataScienceCenter/renku-sphinx-theme/raw/master/renku_sphinx_theme/static/favicon.png
-version: 3.12.0
+version: 3.12.1

--- a/helm-chart/renku-ui/values.yaml
+++ b/helm-chart/renku-ui/values.yaml
@@ -57,7 +57,7 @@ client:
 
   image:
     repository: renku/renku-ui
-    tag: "3.12.0"
+    tag: "3.12.1"
     pullPolicy: IfNotPresent
 
     ## Optionally specify an array of imagePullSecrets.
@@ -215,7 +215,7 @@ server:
 
   image:
     repository: renku/renku-ui-server
-    tag: "3.12.0"
+    tag: "3.12.1"
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "renku-ui-server",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "renku-ui-server",
-      "version": "3.12.0",
+      "version": "3.12.1",
       "dependencies": {
         "@sentry/node": "^7.60.1",
         "cookie-parser": "^1.4.6",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "renku-ui-server",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "description": "Server for renku API",
   "private": true,
   "main": "dist/index.js",


### PR DESCRIPTION
This is a bugfix release including the fix from 3.11.1
Using the renku-core versioning is also included, but that's probably not enough to mark this as a full release: the change is nothing visible to users, more of a refactoring on how we invoke renku-core APIs.

/deploy #persist
