### PR TITLE
fix adding files by URL to datasets

### DIFF
--- a/client/src/components/form-field/DropzoneFileUploader.js
+++ b/client/src/components/form-field/DropzoneFileUploader.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect, useState } from "react";
 import {
   Button,
   Card,
@@ -666,6 +666,10 @@ function InputUrl({
   errorUrlInput,
   urlInputValue,
 }) {
+  const onKeyDown = useCallback(
+    (e) => displayFilesHandler.onUrlInputEnter(e, urlInputValue),
+    [displayFilesHandler, urlInputValue]
+  );
   if (displayFilesHandler == null) return null;
   return (
     <>
@@ -682,16 +686,14 @@ function InputUrl({
           disabled={disabled}
           id={URL_FILE_ID}
           placeholder="Upload a file using a URL"
-          onKeyDown={(e) =>
-            displayFilesHandler.onUrlInputEnter(e, urlInputValue)
-          }
+          onKeyDown={onKeyDown}
           onChange={(e) => displayFilesHandler.onUrlInputChange(e)}
           value={urlInputValue}
         />
         <Button
           className="btn-outline-rk-pink"
           id="addFileButton"
-          onClick={(e) => displayFilesHandler.onUrlInputEnter(e)}
+          onClick={onKeyDown}
         >
           Add File from URL
         </Button>

--- a/client/src/features/project/dataset/DatasetModify.tsx
+++ b/client/src/features/project/dataset/DatasetModify.tsx
@@ -244,9 +244,11 @@ function DatasetModifyForm(props: DatasetModifyFormProps) {
         register={register("files", {
           validate: (files: DatasetFormState["form"]["files"]) =>
             files.every((file) =>
-              [FILE_STATUS.ADDED, FILE_STATUS.UPLOADED].includes(
-                file.file_status
-              )
+              [
+                FILE_STATUS.ADDED,
+                FILE_STATUS.PENDING,
+                FILE_STATUS.UPLOADED,
+              ].includes(file.file_status)
             ),
         })}
         value={getValues("files")}


### PR DESCRIPTION
Adding files to a dataset by URL was broken, it should be fixed now

<img width="754" alt="image" src="https://github.com/SwissDataScienceCenter/renku-ui/assets/1196411/bfa2883d-1b35-4eaa-a82f-da434e8dcd57">

<img width="754" alt="image" src="https://github.com/SwissDataScienceCenter/renku-ui/assets/1196411/8b3685c1-c712-4265-b3df-1bd2746075fa">

/deploy #persist