### PR TITLE
chore: update the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Here are the folders in `/client/src` where to place new components:
 - `features`: create/use sub-folders to contain files identifying single features.
   These sometimes correspond to Renku abstractions, like "Projects", "Datasets",
   "Sessions", or to cross-entity features such as "Search" and "Dashboard".
-  Wherever relevant, please add `*Api.ts` files containg the RTK queries and `*Slice.ts`
+  Wherever relevant, please add `*.api.ts` files containg the RTK queries and `*.slice.ts`
   files for slices.
 - `components`: add here components that can be reused in different contexts. If
   something is clearly a shared component (E.G. `RenkuAlert`), put it here. If it's

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ In short:
   [slices](https://redux-toolkit.js.org/usage/usage-with-typescript#createslice) that
   encapsulate the state they need and add the slices into the
   [global store](https://redux-toolkit.js.org/api/configureStore).
-- Use slice-specific selector hooks (E.G.
+- Use slice-specific selector hooks (e.g.
   [useWorkflowsSelector](https://github.com/SwissDataScienceCenter/renku-ui/blob/master/client/src/features/workflows/WorkflowsSlice.ts)),
   or the `useSelector` hook to access global state.
 - Use the `useDispatch` hook to make changes to the state in components.
@@ -161,13 +161,13 @@ Here are the folders in `/client/src` where to place new components:
   Wherever relevant, please add `*.api.ts` files containg the RTK queries and `*.slice.ts`
   files for slices.
 - `components`: add here components that can be reused in different contexts. If
-  something is clearly a shared component (E.G. `RenkuAlert`), put it here. If it's
+  something is clearly a shared component (e.g. `RenkuAlert`), put it here. If it's
   not obvious, and currently used by just one component, you can leave it in the
   `feature` folder (follow the principle: do not over-engineer it too early).
   Mind that we also store most of the temporary values in the Redux store, so you
   can define actions here if necessary.
 - `utils`: put here anything generic that doesn't fall into the previous categories
-  (E.G. constants, helper functions, wrappers).
+  (e.g. constants, helper functions, wrappers).
 
 Picking the perfect place isn't always straightforward and our current folder structure
 still has many outdated components that don't follow the convention. We plan to move
@@ -402,7 +402,7 @@ The main responsibilities of the server include:
 
 - Managing access tokens.
 - Creating a WebSocket client that can invoke APIs on behalf of the user.
-- Storing temporary data for the client (E.G. recent searches and recently
+- Storing temporary data for the client (e.g. recent searches and recently
   visited projects or).
 
 Though the server is the first recipient of service requests from the client,

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Development started in 2017, and we have striven to change our development style
 to reflect the evolving best practices around the tools we use.
 
 Not all code conforms to the guidelines and best practices laid out in this
-document and you might find older code using deprecated technologies. that will
+document and you might find older code using deprecated technologies. That will
 be refactored in the future.
 
 We use [TypeScript](https://www.typescriptlang.org) in all new code but we still
@@ -140,7 +140,9 @@ In short:
   [slices](https://redux-toolkit.js.org/usage/usage-with-typescript#createslice) that
   encapsulate the state they need and add the slices into the
   [global store](https://redux-toolkit.js.org/api/configureStore).
-- Use the `useSelector` hook to access information from slices in components.
+- Use slice-specific selector hooks (E.G.
+  [useWorkflowsSelector](https://github.com/SwissDataScienceCenter/renku-ui/blob/master/client/src/features/workflows/WorkflowsSlice.ts)),
+  or the `useSelector` hook to access global state.
 - Use the `useDispatch` hook to make changes to the state in components.
 
 Also, please use [RTK Query](https://redux-toolkit.js.org/tutorials/rtk-query) to
@@ -153,13 +155,25 @@ Based on [these suggestions from Redux](https://redux.js.org/faq/code-structure)
 
 Here are the folders in `/client/src` where to place new components:
 
-- `features`: create/use sub-folders to contain files identifying single features. These sometimes correspond to Renku abstractions, like "Projects", "Datasets", "Sessions", or to cross-entity features such as "Search" and "Dashboard". All RTK queries should be triggered by components in this folder. Most of the actions to save data in the Redux store slices should be defined here as well.
-- `components`: add here components that can be reused in different contexts. If something is clearly a shared component (E.G. `RenkuAlert`), put it here. If it's not obvious, and currently used by just one component, you can leave it in the `feature` folder (follow the principle: do not over-engineer it too early). Mind that we also store most of the temporary values in the Redux store, so you can define actions here if necessary.
-- `utils`: put here anything generic that doesn't fall into the previous categories (E.G. constants, helper functions, wrappers).
+- `features`: create/use sub-folders to contain files identifying single features.
+  These sometimes correspond to Renku abstractions, like "Projects", "Datasets",
+  "Sessions", or to cross-entity features such as "Search" and "Dashboard".
+  Wherever relevant, please add `*Api.ts` files containg the RTK queries and `*Slice.ts`
+  files for slices.
+- `components`: add here components that can be reused in different contexts. If
+  something is clearly a shared component (E.G. `RenkuAlert`), put it here. If it's
+  not obvious, and currently used by just one component, you can leave it in the
+  `feature` folder (follow the principle: do not over-engineer it too early).
+  Mind that we also store most of the temporary values in the Redux store, so you
+  can define actions here if necessary.
+- `utils`: put here anything generic that doesn't fall into the previous categories
+  (E.G. constants, helper functions, wrappers).
 
-Picking the perfect place isn't always straightforward and our current folder structure still has many outdated components that don't follow the convention. We plan to move them when already touching the code for other changes.
+Picking the perfect place isn't always straightforward and our current folder structure
+still has many outdated components that don't follow the convention. We plan to move
+them when already touching the code for other changes.
 
-#### **Use CSS modules**
+#### **Use CSS modules for local styles**
 
 We use [CSS modules](https://github.com/css-modules/css-modules) to apply CSS styles
 locally and avoid leaking styles to the whole web application.

--- a/README.md
+++ b/README.md
@@ -4,46 +4,84 @@
 
 # Renku UI
 
-The web-based UI for [Renku](https://github.com/SwissDataScienceCenter/renku).
+The Renku UI is the web-based UI for [Renku](https://github.com/SwissDataScienceCenter/renku)
+and it requires a RenkuLab deployment. You can check the
+[Administrator's Guide](https://renku.readthedocs.io/en/latest/how-to-guides/admin/deploying-renku.html)
+to get more information.
 
-This README contains information relevant to contributors to the renku-ui component. To deploy RenkuLab, including the UI, see the [Administrator's Guide](https://renku.readthedocs.io/en/latest/how-to-guides/admin/deploying-renku.html).
-
-# Architecture
+## Architecture
 
 The Renku UI is made up of two subcomponents, which are each packaged as [Docker](https://www.docker.com) containers and are deployed using [Kubernetes](https://kubernetes.io).
 
-|        |                                                 |
-| ------ | ----------------------------------------------- |
-| client | [React-based](https://reactjs.org) front-end    |
-| server | [Express-based](https://expressjs.com) back-end |
-
-Below, we explain each of those components in greater detail and guidelines for developing code within them.
-
-# Prerequisites
+|                         |                                                 |
+| ----------------------- | ----------------------------------------------- |
+| [UI Client](#ui-client) | [React-based](https://reactjs.org) front-end    |
+| [UI Server](#ui-server) | [Express-based](https://expressjs.com) back-end |
 
 To develop on this codebase, you will want the following tools installed.
 
 |                                      |                                                     |
 | ------------------------------------ | --------------------------------------------------- |
-| [node](https://nodejs.org/en/)       | Node JavaScript execution environment               |
+| [node](https://nodejs.org)           | Node JavaScript execution environment               |
 | [npm](https://github.com/npm/cli)    | Node package manager                                |
-| [nvm](https://github.com/nvm-sh/nvm) | NVM or some similar tool for managing node versions |
+| [nvm](https://github.com/nvm-sh/nvm) | NVM or some similar tool for managing Node versions |
 
-Node is a requirement; when you install node, you will probably also get npm automatically. Though not absolutely necessary, we recommend using a **node version manager** like nvm to manage node/npm installations.
+Node is a requirement; when you install node, you will probably also get npm
+automatically. Though not absolutely necessary, we recommend using a node version
+manager like nvm to manage node/npm installations.
 
 However you get it, you need the node version specified in the [Dockerfile](https://github.com/SwissDataScienceCenter/renku-ui/blob/master/client/Dockerfile).
 
-## Git hooks
+## Development
 
-This project uses [husky](https://typicode.github.io/husky) to handle git hooks.
+You don't need much to start developing, at least for the
+[UI Client](#ui-client). If you are content with testing your changes using
+[Cypress](https://www.cypress.io), no additional tools are strictly needed.
+The [UI Server](#ui-server) requires a full RenkuLab deployment. You can
+find more information in the UI server section.
+
+To start your journey, clone this repository and install the dependencies
+using npm:
 
     $ npm install
 
-This will install husky and the git hooks.
+### Coding guidelines
 
-## Recommended tools
+We have a [coding guidelines](CODING_GUIDELINES.md) document that explains how
+to write code for this repository. We suggest you read it before starting to
+develop.
 
-If you are content with testing your changes using Cypress, all you need is node. If you want to develop and test your changes against a real RenkuLab deployment, then you will need a few more tools.
+Please note that not all the code in the repository follows the guidelines
+since they were introduced later in the project. We are working on refactoring
+the codebase to make it consistent, and guidelines will be enforced for all new
+code.
+
+### Code Formating
+
+We use [Prettier](https://prettier.io) to format the codebase to
+keep the syntax consistent. We enforce that by checking every pull request
+and the CI pipelines will fail in case of formatting issues.
+
+You can manually format the code by running `npm run format` in the `client`,
+`server` or `tests` folder.
+
+This repository is configured to automatically format the files on
+commit through [git hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks).
+To set them up, we use [Husky](https://typicode.github.io/husky).
+You can install Husky and the git hooks by running `npm install` from the
+base folder on this repository.
+
+If you use [VS Code](https://code.visualstudio.com), you can also install the
+`esbenp.prettier-vscode` extension to run Prettier each time you save files.
+After installing it, go to the workspace settings, search for
+`editor.defaultFormatter` and set it to `Prettier`, then search for
+`editor.formatOnSave` and turn on "Format on save".
+
+### Additional tools
+
+If you want to develop and test your changes against a real RenkuLab deployment
+or if you wish to develop on the [UI Server](#ui-server), then you will need a
+few more tools to deal with the infrastructure.
 
 |                                                                      |                                                                     |
 | -------------------------------------------------------------------- | ------------------------------------------------------------------- |
@@ -57,195 +95,59 @@ Kubectl and telepresence will allow you to inject code running on your developme
 | [docker](https://www.docker.com) | For building containers      |
 | [helm](https://helm.sh)          | For packaging things for K8s |
 
-# Client
+## UI Client
 
-The client is the [React-based](https://reactjs.org) front-end for RenkuLab. Development started in 2017, and, in the intervening years, we have striven to change our development style to reflect the evolving best practices around the tools we use. You will see that not all code conforms to the guidelines laid out in this document, but **new code** should follow these guidelines, and older code should be refactored at opportune moments, whenever possible, to conform as well.
+The UI client is the [React-based](https://reactjs.org) front-end for RenkuLab.
+Development started in 2017, and we have striven to change our development style
+to reflect the evolving best practices around the tools we use.
 
-Further technical details are available in [README file in the `client` folder](./client/README.md).
+Not all code conforms to the guidelines and best practices laid out in this
+document and you might find older code using deprecated technologies. that will
+be refactored in the future.
 
-## Tool Stack
+We use [TypeScript](https://www.typescriptlang.org) in all new code but we still
+have a lot of JavaScript code.
 
-| Framework                                     | Purpose                                       |
-| --------------------------------------------- | --------------------------------------------- |
-| [Bootstrap](https://getbootstrap.com)         | Responsive grid, HTML styling, and components |
-| [Cypress](https://www.cypress.io)             | UI testing framework                          |
-| [React](https://reactjs.org)                  | Reactive component framework                  |
-| [Reactstrap](https://reactstrap.github.io/)   | React bindings for Bootstrap                  |
-| [Redux Toolkit](https://redux-toolkit.js.org) | State and React-integration components        |
-| [Storybook](https://storybook.js.org)         | UI component documentation                    |
-| [TypeScript](https://www.typescriptlang.org)  | JavaScript extension with static typing       |
+### Tool Stack
 
-## Code Formating
+This is a list of the main tools we use in the client and you need to know to
+develop it.
 
-We use [prettier](https://prettier.io/docs/en/) to format the client codebase.
+| Framework                                     | Purpose                                      |
+| --------------------------------------------- | -------------------------------------------- |
+| [React](https://reactjs.org)                  | Reactive component framework                 |
+| [Redux](https://redux.js.org)                 | Centralized state management                 |
+| [Redux Toolkit](https://redux-toolkit.js.org) | State integration and fetching/caching tools |
+| [Bootstrap](https://getbootstrap.com)         | CSS framework based on a responsive grid     |
 
-You can manually run formatting with the following:
+Mind that we try to take advantage of the latest features of React and Redux,
+and to integrate the two tools as seamlessly as possible.
 
-    $ cd client
-    $ npm run format
-
-This repository is configured to automatically format the client files on
-commit.
-
-To automatically format on save in VS Code, you can install the
-`esbenp.prettier-vscode` extension then open your workspace settings.
-First, search for `editor.defaultFormatter` and set it to `Prettier`, then
-search for `editor.formatOnSave` and turn on "Format on save".
-
-## Unit Tests and Linting
-
-We use [jest](https://jestjs.io) for unit tests and
-[eslint](https://eslint.org/) for linting. We run them in out CI piplines and
-require both to pass without warnings before we merge a PR. You can manually run
-tests using the following commands:
-
-    $ cd client   # or server if you need to work there
-    $ npm test
-    $ npm run lint
-
-Mind that some linting errors can be automatically fixed by running `npm run lint-fix`.
-
-We suggest using an IDE that supports eslint (like [VS Code](https://code.visualstudio.com) or similar) and configuring your IDE to integrate with our eslint configuration so that any linting errors will be displayed as you develop rather than waiting for the CI pipeline to flag them.
-
-### Utilities
-
-We are using [Craco](https://craco.js.org) to override default settings from
-[Create React App](https://create-react-app.dev).
-This means that Jest cannot be run outside of Craco's context.
-
-If you ever need to debug your tests using advanced features like `node --expose-gc`
-or `node --inspect-brk`, you have to reference jest from
-`./node_modules/@craco/craco/dist/bin/jest`.
-
-The following example shows how to check for memory leaks:
-
-    $ node --expose-gc ./node_modules/@craco/craco/dist/bin/jest --runInBand --logHeapUsage *
-
-## Developing
-
-As you would expect for a React-based project, you can install the client using `npm`.
-
-    $ cd client
-    $ npm install
-
-This will install the toolchain for developing the client as well as any libraries used in the UI.
-
-To run and interact with the UI code on your development machine, you can either use the Cypress tests, which provide mocked responses from the backend, or use telepresence to replace the UI client component in a K8s-based deployment with the component running on your machine.
-
-### Cypress
-
-We have an ever-growing suite of UI tests developed with Cypress. The tests can be run with mock responses from the backend, and can therefore be used to try out changes to the UI without access to a development cluster.
-
-    $ cd tests
-    $ npm install
-    $ npm run e2e:local
-
-### Storybook
-
-We use [Storybook](https://storybook.js.org) to create interactive stories for our UI components.
-Stories provide a visual representation of how our components behave in different scenarios.
-
-#### Run Storybook
-
-Run the following command to start Storybook:
-
-    $ npm run storybook
-
-This should automatically open your browser at http://localhost:6006 where you can see your components in action.
-
-#### Write stories
-
-To create new story files for your components, just add a new `<ComponentName>.stories.tsx` file.
-As an example of a well-structured and documented story, you can check out the Button component
-in `client/src/components/buttons/Buttons.stories.tsx`.
-
-The full documentation for Storybook can be found [here](https://storybook.js.org/docs/react/writing-stories/introduction).
-
-#### Best Practices
-
-- Add stories files in the same directory as your component.
-- Name your story after the target component `<ComponentName>.stories.tsx`. Use the `title` property in the story definition to group related stories by categories. E.G.. `components/buttons/buttonWithMenu`.
-- It's good to showcase different variations of your component. Use multiple stories to demonstrate how props and states affect the component and how that helps in serving different use cases.
-- Provide a clear and concise description for each story. Include details on its purpose, usage, and any relevant notes.
-- Use `Args` to tweak props' values, making the components interactive so that users can play with them.
-- Wherever relevant, please include stories that demonstrate responsive behavior across various devices.
-- You can use `addon-redux` for state management on components that require to get data from the Redis store.
-
-#### Testing Stories:
-
-Storybook's test runner transforms stories into executable tests, supporting Chromium and Firefox browsers. It ensures error-free rendering for non-play stories. For interactive stories with play functions, it validates both play function errors and successful assertions.
-
-    $ npm run storybook-compile-and-test
-
-
-
-#### Deployment
-
-Storybook is deployed at the following location:
-
-- **URL**: `/storybook/`
-
-To access Storybook, visit the specified URL path in your web browser after your application is deployed.
-
-### Telepresence
-
-Telepresence can be used to develop the UI in a realistic setting. The client folder includes a `run-telepresence.sh` script that is tailored for the SDSC development cluster.
-
-    $ cd client
-    $ ./run-telepresence.sh
-
-Telepresence replaces the UI client pod in the target Kubernetes instance. All the traffic is then redirected to a local process, making changes to files almost immediately available in your development RenkuLab instance.
-
-The `run-telepresence.sh` script uses the current K8s context as returned by `kubectl config current-context`. You can deploy your own RenkuLab application (using the helm chart in the renku repository) for development; alternatively the renku-ui repository includes CI tasks that can deploy the code for a PR. To take advantage of this task, add
-
-    $ /deploy #persist
-
-To the body of your PR description.
-
-There are a few environment variables you may want to set when starting telepresence if you are going to to take advantage of the Renku team internal development infrastructure:
-
-- SENTRY: set to 1 to redirect the exceptions to the dev [sentry](https://sentry.dev.renku.ch) deployment
-- PR: set to the target PR number in the [renku-ui](https://github.com/SwissDataScienceCenter/renku-ui/pulls) repo to work in the corresponding CI deployment
-- DEV_NAMESPACE: if you do not target a PR deployment you should specify a value for this to reference the namespace with your development deployment
-
-For example:
-
-    $ SENTRY=0 PR=1166 ./run-telepresence.sh
-
-There are also further configuration possibilities offered by the `run-telepresence.sh` script. For
-specific use cases, you may need to modify the script directly, since not all options are configurable through environment variables.
-
-## Coding Guidelines
-
-The coding guidelines are detailed in full in [CODING_GUIDELINES.md](CODING_GUIDELINES.md).
-
-As explained above, not all the code in the repo conforms to these guidelines, but this section explains how code _should_ be developed in the repo.
-
-### **Use Typescript**
-
-New code should be developed in TypeScript, and older code should be converted to TypeScript whenever feasible.
-
-### **React components should be functional and take advantage of hooks**
+For this reason, please follow these simple best practices when dealing with new
+React components:
 
 - Use `useState` to manage component-local state
 - Use `useEffect` for handling the component lifecycle
 
-### **Application state is managed by Redux**
+When dealing with the state, we follow the
+[redux-toolkit](https://redux-toolkit.js.org/tutorials/typescript) style for interacting
+with Redux. If you are not familiar with this, follow the link to see the tutorial.
 
-We follow the [redux-toolkit](https://redux-toolkit.js.org/tutorials/typescript) style for interacting with Redux. If you are not familiar with this, follow the link to see the tutorial.
+In short:
 
-Key points around this include:
+- Global application state is kept in a single, global [Redux](https://redux.js.org) store.
+- Features should have
+  [slices](https://redux-toolkit.js.org/usage/usage-with-typescript#createslice) that
+  encapsulate the state they need and add the slices into the
+  [global store](https://redux-toolkit.js.org/api/configureStore).
+- Use the `useSelector` hook to access information from slices in components.
+- Use the `useDispatch` hook to make changes to the state in components.
 
-- Global application state is kept in a single, global [Redux](https://redux.js.org) store
-- Features (see below) should make [slices](https://redux-toolkit.js.org/usage/usage-with-typescript#createslice) that encapsulate the state they need and add the slices into the [global store](https://redux-toolkit.js.org/api/configureStore).
-- Use the `useSelector` hook to access information from slices in components
-- Use the `useDispatch` hook to make changes to state in components
+Also, please use [RTK Query](https://redux-toolkit.js.org/tutorials/rtk-query) to
+interact with backend services. It greatly simplifies writing the code to fetch and
+cache data, as well as handling the transitions through the request lifecycle.
 
-### **Interact with backend services using RTK Query**
-
-[RTK Query](https://redux-toolkit.js.org/tutorials/rtk-query) greatly simplifies interacting with other services. It automatically provides integration with the Redux store and handles caching of responses and transitions through the request lifecycle (e.g., _fetching_, etc.).
-
-### **Group shared code into features**
+### Code structure
 
 Based on [these suggestions from Redux](https://redux.js.org/faq/code-structure), we decided to use a few folders to bundle functions and components together, broadly following the "Feature folders" style.
 
@@ -257,13 +159,153 @@ Here are the folders in `/client/src` where to place new components:
 
 Picking the perfect place isn't always straightforward and our current folder structure still has many outdated components that don't follow the convention. We plan to move them when already touching the code for other changes.
 
-### **Use of CSS modules**
+#### **Use CSS modules**
 
-[CSS modules](https://github.com/css-modules/css-modules) can be used to apply CSS styles locally and avoid leaking
-styles to the whole web application.
-[Create React App supports CSS modules out of the box](https://create-react-app.dev/docs/adding-a-css-modules-stylesheet).
+We use [CSS modules](https://github.com/css-modules/css-modules) to apply CSS styles
+locally and avoid leaking styles to the whole web application.
+No additional configuration is needed since Create React App [supports CSS modules out of the box](https://create-react-app.dev/docs/adding-a-css-modules-stylesheet).
 
-## Navigation map
+### Testing
+
+We split testing into multiple categories. All these tests are required to pass
+before we merge a PR.
+
+#### Unit tests
+
+We use [jest](https://jestjs.io) for unit testing.
+
+Unit tests are used to test individual functions. We don't have a fixed rule for
+the amount of coverage we require, but we try to cover all the helper functions and
+the most important functions used by components.
+
+Files containing unit tests are named `*.test.ts`. Usually, they refer to a specific
+file in the `src` folder, so you can find the tests for `src/*/MyComponent.tsx`
+in `src/*/MyComponent.test.ts`.
+
+You can run the unit tests manually using the following command:
+
+    $ cd client
+    $ npm test
+
+#### Component tests
+
+We use [Storybook](https://storybook.js.org) to test single React components in isolation.
+This tool allows us to create interactive stories and to keep track of all the reusable
+components we implemented.
+_Mind that this is a recent introduction so you can expect quite a few components to be
+missing._
+
+Storybook files are named `*.stories.tsx` and refer to specific components.
+The overhead of writing stories is rather low, so we encourage you to write them
+for all new components.
+Whether to write stories for specific components depends on the size and re-usability
+of the component. The more simple and reusable a component is, the more important
+it is to have a story for it.
+Be sure to check out the full documentation [here](https://storybook.js.org/docs/react/writing-stories/introduction).
+
+You can run component tests using the following command:
+
+    $ npm run storybook-compile-and-test
+
+If you wish to check the components, you can use the Storybook interface. To start it,
+run:
+
+    $ npm run storybook
+
+This should also open your browser automatically. If it doesn't, you can visit
+http://localhost:6006 to see the Storybook interface.
+
+> Mind that we deploy Storybook automatically in each RenkuLab deployment. You can
+> access it at `https://<renkulab-url>/storybook/`.
+
+##### Storybook best practices
+
+Here are a few rules to follow when writing new stories:
+
+- Use the `title` property in the story definition to group related stories by categories.
+  You can find an example in `components/buttons/buttonWithMenu`.
+- It's good to showcase different variations of your component. Use multiple stories to demonstrate
+  how props and states affect the component and how that helps in serving different use cases.
+- Provide a clear and concise description for each story; feel free to include details on the usage
+  whenever necessary.
+- Use `Args` to tweak props' values, making the components interactive so that users can play with them.
+- Include stories that demonstrate responsiveness across different devices wherever it's relevant.
+- You can use `addon-redux` for state management on components that require to get data from the
+  Redis store.
+
+#### End-to-end tests
+
+For testing interactions between multiple components or slices of pages, as well as some
+common scenarios (or uncommon, like specific error cases), we use
+[Cypress](https://www.cypress.io).
+
+Cypress tests are located in the `tests` folder and are named `*.spec.ts`. We don't have a
+fixed naming convention for them, but we try to group tests based on features instead of
+single components. For this reason, some components might be tested in multiple spec files,
+while others get less coverage.
+
+Keep in mind we test real scenarios and we try to simulate users interacting with the
+platform. Since our goal is to catch non-obvious regressions, we mock backend
+responses in different scenarios, including errors and other edge cases. They _do_
+occasionally occur in our platform, especially since users can change a lot of things
+in their projects and break them in creative ways, so the best we can do is handle
+errors gracefully and provide meaningful feedback to the user so that they can recover
+whenever possible.
+
+Cypress is also a great tool to run components in the browser and debug them. Most of the
+time, you don't need the whole platform to develop or update a component, so you can
+use Cypress to develop the UI without a dedicated RenkuLab deployment.
+
+You can run Cypress tests using the following command:
+
+    $ cd tests
+    $ npm run e2e:local
+
+### Utilities and additional information
+
+Here are other information that might be useful.
+
+#### Craco
+
+We are using [Craco](https://craco.js.org) to override default settings from
+[Create React App](https://create-react-app.dev).
+Since CRA is not actively maintained, we might move away soon from this stack.
+
+In the meanwhile, mind that Jest cannot be run outside of Craco's context;
+if you ever need to debug your tests using advanced features like `node --expose-gc`
+or `node --inspect-brk`, you have to reference Jest from
+`./node_modules/@craco/craco/dist/bin/jest`.
+
+The following example shows how to check for memory leaks:
+
+    $ node --expose-gc ./node_modules/@craco/craco/dist/bin/jest --runInBand --logHeapUsage *
+
+#### Deployments
+
+As already mentioned, you don't strictly need a full RenkuLab deployment for the client.
+Using Cypress, you can test your changes against a mocked backend; otherwise, you can run
+the client locally and point to a development instance like `https://dev.renku.ch` or one
+of the CI deployments made on each PR.
+
+#### Telepresence
+
+If you are part of the Renku team, you should have full access to the development
+infrastructure.
+
+In this case, you can use [Telepresence](https://www.telepresence.io) to develop the UI
+in a realistic setting. The client folder includes a `run-telepresence.sh` script that
+is tailored for the SDSC development cluster.
+
+Try to run it to get more instructions:
+
+    $ cd client
+    $ ./run-telepresence.sh
+
+Telepresence replaces the UI client pod in the target Kubernetes instance. All the traffic
+is then redirected to a local process, making changes to files almost immediately available
+in your development RenkuLab instance.
+
+### Navigation map
 
 ```mermaid
 flowchart LR
@@ -325,94 +367,80 @@ flowchart LR
     A-->F(https://ethz.ch)
 ```
 
-# Server
+## UI Server
 
-The server is the [Express-based](https://expressjs.com) back-end for the RenkuLab UI. The main responsibilities of the server are managing user tokens acting handling requests for information from other backend services.
+The UI server is the [Express-based](https://expressjs.com) back-end for the UI client.
+All code is written in [TypeScript](https://www.typescriptlang.org).
 
-User access tokens are retrieved, stored, and renewed in the server for reasons of safety and also because this allows the server to interact with and poll other resources on behalf of the user.
+The main responsibilities of the server include:
 
-Though the server is the first receipient of service requests from the client, in many cases, the server just forwards requests to the appropriate service. For this reason, the codebase is much smaller and simpler than the client. In some cases though, the server can implement logic or interact with multiple services to provide a more unified view to the client. The server also manages websockets to send asynchronous notifications to clients when important events occur.
+- Managing access tokens.
+- Creating a WebSocket client that can invoke APIs on behalf of the user.
+- Storing temporary data for the client (E.G. recent searches and recently
+  visited projects or).
 
-## Tool Stack
+Though the server is the first recipient of service requests from the client,
+in most cases the server just forwards requests to the appropriate service with the
+access tokens attached. For this reason, the codebase is much smaller and simpler
+than the client.
 
-| Framework                                                           | Purpose                                 |
-| ------------------------------------------------------------------- | --------------------------------------- |
-| [Express](https://expressjs.com)                                    | Route and respond to HTTP requests      |
-| [Morgan](https://expressjs.com/en/resources/middleware/morgan.html) | Logging middleware for express          |
-| [TypeScript](https://www.typescriptlang.org)                        | JavaScript extension with static typing |
-| [WS](https://www.npmjs.com/package/ws)                              | WebSocket framework                     |
+### Tool Stack
 
-## Unit Tests and Linting
+| Framework                                                           | Purpose                            |
+| ------------------------------------------------------------------- | ---------------------------------- |
+| [Express](https://expressjs.com)                                    | Route and respond to HTTP requests |
+| [Morgan](https://expressjs.com/en/resources/middleware/morgan.html) | Logging middleware for express     |
+| [WS](https://www.npmjs.com/package/ws)                              | WebSocket framework                |
 
-As with the client, we use [jest](https://jestjs.io) as for unit tests and
-[eslint](https://eslint.org/) to detect trivial errors and enforce some coding-style preferences. We require both
-commands to terminate without warnings before we merge a PR. You can
-manually run tests using the following commands:
+We use Express to handle HTTP requests and WS to handle WebSocket connections.
+
+### Code structure
+
+We have an abstraction for storage in the `storage` folder. Currently, we support
+only Redis and we don't plan to use the UI server to store non-volatile data.
+We use Redis to store user tokens and temporary data.
+
+The authentication logic is in the `authentication` folder, including the middleware
+to add tokens to the queries.
+
+The WebSocket logic is in the `websocket` folder. There is a fixed structure for the
+messages between the server and the client. Should you need to add support for new
+messages, please add a new function in the `handlers` section and configure the handler
+in the index file.
+
+Finally, we configure the routes in the `routes` folder. There is little to change
+there since the Server should have very limited logic to handle requests.
+
+### Testing
+
+As with the client, we use [Jest](https://jestjs.io) for unit tests.
+We should improve the coverage since it's pretty low at the moment.
+
+You can manually run tests using the following commands:
 
     $ cd server
     $ npm test
-    $ npm run lint
 
-Some linting errors can be automatically fixed by running
-`npm run lint-fix`.
+### Utilities and additional information
 
-We suggest using an IDE that supports eslint (like [VS Code](https://code.visualstudio.com) or similar) and configuring your IDE to integrate with our eslint configuration so that any linting errors will be displayed as you develop rather than waiting for the CI pipeline to flag them.
+Here are other information that might be useful.
 
-## Developing
+#### Deployments
 
-You can install the server using `npm`.
+We don't have any abstraction of the resources needed by the UI server, so we
+rely on an existing deployment of RenkuLab to run it.
 
-    $ cd server
-    $ npm install
+#### Telepresence
 
-This will install the toolchain for developing the server as well as any libraries used.
+If you are part of the Renku team, you should have full access to the development
+infrastructure and you can use [Telepresence](https://www.telepresence.io) to
+develop the UI server.
 
-To run and interact with the server code on your development machine, you will need to use telepresence to replace the UI server component in a K8s-based deployment with the component running on your machine.
-
-### Telepresence
-
-The server folder includes a `run-telepresence.sh` script that is tailored for the SDSC development cluster.
+Try to run the `run-telepresence.sh` script to get more instructions:
 
     $ cd server
     $ ./run-telepresence.sh
 
-Telepresence replaces the UI server pod in the target Kubernetes instance. All the traffic is then redirected to a local process, making changes to files almost immediately available in your development RenkuLab instance.
-
-The instructions for deploying the renku application into K8s are the same as in the client, so see that section for those details. There are some small differences in how the server `run-telepresence.sh` script works compared to the client.
-
-- In the server, `run-telepresence.sh` will prompt you to provide or override the deployment you want to intercept. You can enter the id of a PR to intercept the deployment associated with a GitHub PR.
-- By default, the script will start the server and wait for a debugger to attach. Instead, you can start in _console mode_ and start the server yourself by running `npm run dev-debug` (within a debugger).
-
-For the default mode of the script, you will need to attach a debugger to finish bringing the server up. In VS Code, you can add a **Node Attach** run configuration for this. It will look something like:
-
-```
-{
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "uiserver",
-            "type": "node",
-            "request": "attach",
-            "address": "localhost",
-            "port": 9229,
-            "protocol": "inspector",
-            "restart": true
-        }
-    ]
-}
-```
-
-With this configuration, after running `run-telepresence.sh` you should invoke the _Run > Start Debugging_ in VS Code to attach the debugger.
-
-# Troubleshooting
-
-## Telepresence
-
-Telepresence 2 has greatly improved robustness to network problems and is much more reliable than the earlier version. Still, sometimes situations arise that cause problems for telepresence. When that happens, the best course of action is to quit and restart telepresence:
-
-```
-$ telepresence quit -ur
-$ telepresence connect
-```
-
-If that is not sufficient, you may need use the activity monitor to find and kill zombie telepresence processes before restarting.
+Telepresence replaces the UI server pod in the target Kubernetes instance. All the traffic
+is then redirected to a local process, making changes to files almost immediately available
+in your development RenkuLab instance.

--- a/README.md
+++ b/README.md
@@ -186,17 +186,21 @@ before we merge a PR.
 
 #### Unit tests
 
-We use [jest](https://jestjs.io) for unit testing.
+We use [jest](https://jestjs.io) _only_ for unit testing.
 
 Unit tests are used to test individual functions. We don't have a fixed rule for
 the amount of coverage we require, but we try to cover all the helper functions and
-the most important functions used by components.
+the most important functions used by components. Note, we do not test components
+using jest/jsdom anymore. Tests that require a browser/DOM environment are implemented
+either in Storybook or Cypress (see below). There might be legacy tests that still
+use `jest` with components.
 
 Files containing unit tests are named `*.test.ts`. Usually, they refer to a specific
 file in the `src` folder, so you can find the tests for `src/*/MyComponent.tsx`
 in `src/*/MyComponent.test.ts`.
 
-You can run the unit tests manually using the following command:
+You can run the unit tests manually using the following command in the client
+subfolder:
 
     $ cd client
     $ npm test
@@ -273,7 +277,7 @@ use Cypress to develop the UI without a dedicated RenkuLab deployment.
 You can run Cypress tests using the following command:
 
     $ cd tests
-    $ npm run e2e:local
+    $ npm run e2e
 
 ### Utilities and additional information
 
@@ -318,6 +322,14 @@ Try to run it to get more instructions:
 Telepresence replaces the UI client pod in the target Kubernetes instance. All the traffic
 is then redirected to a local process, making changes to files almost immediately available
 in your development RenkuLab instance.
+
+##### Configuration
+
+The script allows configuration of certain aspects of the deployment through environment
+variables. Take a look at the script to see all the options that are available.
+The script generates a `config.json` file into the `client/public` folder, and you can
+modify this file with a text editor and reload the browser to test out different
+configuration settings.
 
 ### Navigation map
 
@@ -411,7 +423,7 @@ We use Express to handle HTTP requests and WS to handle WebSocket connections.
 ### Code structure
 
 We have an abstraction for storage in the `storage` folder. Currently, we support
-only Redis and we don't plan to use the UI server to store non-volatile data.
+only Redis, and we do not currently to use the UI server to store non-volatile data.
 We use Redis to store user tokens and temporary data.
 
 The authentication logic is in the `authentication` folder, including the middleware


### PR DESCRIPTION
This PR restructures the Readme file to provide more consistent information to the developers.

* The initial `Development` section explains how to start developing code for the whole UI.
* The `UI client` and `UI server` have been restructured and expanded (especially the Client section). Grouping should be more intuitive going through the "tool stack", then the "code structure", then "testing" and finally mentioning other utilities useful for the development.

fix #2775
