### PR TITLE
Show status banner as loud during major incidents

### DIFF
--- a/client/src/statuspage/Statuspage.present.js
+++ b/client/src/statuspage/Statuspage.present.js
@@ -23,6 +23,7 @@
  *  Components for the displaying information from statuspage.io
  */
 
+import cx from "classnames";
 import { Fragment, useState } from "react";
 import {
   faCheckCircle,
@@ -124,10 +125,12 @@ function SiteStatusLanding(props) {
 
   if (status.indicator === "none") return null;
 
-  const alertStyle = loud ? { fontSize: "larger" } : {};
   return (
-    <WarnAlert className="container-xxl renku-container" dismissible={!loud}>
-      <div style={alertStyle}>
+    <WarnAlert
+      className={cx("container-xxl", "renku-container")}
+      dismissible={!loud}
+    >
+      <div className={cx(loud && "fs-5")}>
         RenkuLab is unstable: {status.description}. See{" "}
         <b>
           <Link to={siteStatusUrl}>RenkuLab Status</Link>
@@ -196,15 +199,14 @@ function MaintenanceSummaryLanding(props) {
   const scheduled = sortedMaintenances(props.statuspage.scheduled_maintenances);
   if (scheduled.length < 1) return <span></span>;
   const loud = props.loud != null ? props.loud : false;
-  const alertStyle = loud ? { fontSize: "larger" } : {};
   const first = scheduled[0];
   // Not use custom Alert due it use a custom icon
   return (
     <Alert color="warning" className="container-xxl renku-container">
-      <div style={alertStyle}>
+      <div className={cx(loud && "fs-5")}>
         <MaintenanceInfo maintenance={first} loud={loud} />
       </div>
-      <div style={alertStyle}>
+      <div className={cx(loud && "fs-5")}>
         See{" "}
         <b>
           <Link to={siteStatusUrl}>details</Link>

--- a/client/src/statuspage/statuspage.css
+++ b/client/src/statuspage/statuspage.css
@@ -1,0 +1,3 @@
+.loud {
+  font-size: "larger";
+}

--- a/tests/cypress/e2e/home.spec.ts
+++ b/tests/cypress/e2e/home.spec.ts
@@ -50,13 +50,12 @@ describe("404 page", () => {
 
 describe("display the maintenance page", () => {
   beforeEach(() => {
-    new Fixtures(cy).config().versions().renkuDown();
-    cy.visit("/");
+    new Fixtures(cy).config().versions();
   });
 
   it("displays an error when trying to get status page information", () => {
     // ! we plan to change this behavior and ignore statuspage info when unavailable #2283
-    new Fixtures(cy).config().versions().renkuDown();
+    new Fixtures(cy).renkuDown();
     cy.visit("/");
     cy.get("h1").should("have.length", 1);
     cy.get("h1").contains("RenkuLab Down").should("be.visible");
@@ -66,7 +65,9 @@ describe("display the maintenance page", () => {
   });
 
   it("displays status page information", () => {
-    new Fixtures(cy).config().versions().getStatuspageInfo();
+    // if the call to get the user fails (e.g., no .userNone() fixture)
+    // then show the status page
+    new Fixtures(cy).getStatuspageInfo();
     cy.visit("/");
     cy.wait("@getStatuspageInfo");
     cy.get("h1").should("have.length", 1);

--- a/tests/cypress/e2e/maintenance.spec.ts
+++ b/tests/cypress/e2e/maintenance.spec.ts
@@ -45,3 +45,60 @@ describe("display the maintenance page", () => {
     cy.get("h1").first().should("not.contain.text", "RenkuLab Down");
   });
 });
+
+describe("display the status page", () => {
+  const fixtures = new Fixtures(cy);
+
+  it("Shows no banner if there is no incident or maintenance", () => {
+    fixtures.config().versions().userNone().getStatuspageInfo();
+    cy.visit("/");
+    cy.wait("@getStatuspageInfo");
+    cy.get(".alert").should("not.exist");
+  });
+
+  it("Shows the banner on the home page if there is a major incident", () => {
+    fixtures
+      .config()
+      .versions()
+      .userNone()
+      .getStatuspageInfo({ fixture: "statuspage-outage.json" });
+    cy.visit("/");
+    cy.wait("@getStatuspageInfo");
+    cy.get(".alert").contains("RenkuLab is unstable").should("be.visible");
+  });
+
+  it("Shows the banner everywhere if there is a major incident", () => {
+    fixtures
+      .config()
+      .versions()
+      .userTest()
+      .getStatuspageInfo({ fixture: "statuspage-outage.json" });
+    cy.visit("/");
+    cy.wait("@getStatuspageInfo");
+    cy.get(".alert").contains("RenkuLab is unstable").should("be.visible");
+    cy.contains("Search").click();
+    cy.get(".alert").contains("RenkuLab is unstable").should("be.visible");
+    cy.get(".btn-close").should("not.exist");
+  });
+
+  it("Shows the banner only on the dashboard if there is a minor incident", () => {
+    fixtures
+      .config()
+      .versions()
+      .userTest()
+      .getStatuspageInfo({
+        overrides: {
+          status: {
+            indicator: "minor",
+            description: "Everything is a little slow, but working",
+          },
+        },
+      });
+    cy.visit("/");
+    cy.wait("@getStatuspageInfo");
+    cy.get(".alert").contains("RenkuLab is unstable").should("be.visible");
+    cy.get(".btn-close").should("be.visible");
+    cy.contains("Search").click();
+    cy.get(".alert").should("not.exist");
+  });
+});

--- a/tests/cypress/fixtures/statuspage/statuspage-outage.json
+++ b/tests/cypress/fixtures/statuspage/statuspage-outage.json
@@ -128,10 +128,64 @@
       "only_show_if_degraded": false
     }
   ],
-  "incidents": [],
+  "incidents": [
+    {
+      "id": "jl5c3h8ts43j",
+      "name": "Having Problems",
+      "status": "investigating",
+      "created_at": "2023-10-17T10:32:48.378Z",
+      "updated_at": "2023-10-17T10:32:48.431Z",
+      "monitoring_at": null,
+      "resolved_at": null,
+      "impact": "critical",
+      "shortlink": "https://stspg.io/g1h503rykdwm",
+      "started_at": "2023-10-17T10:32:48.373Z",
+      "page_id": "abcdef123456",
+      "incident_updates": [
+        {
+          "id": "p7gm97bjydq9",
+          "status": "investigating",
+          "body": "We are currently investigating this issue.",
+          "incident_id": "jl5c3h8ts43j",
+          "created_at": "2023-10-17T10:32:48.429Z",
+          "updated_at": "2023-10-17T10:32:48.429Z",
+          "display_at": "2023-10-17T10:32:48.429Z",
+          "affected_components": [
+            {
+              "code": "8vycwk1lgw9b",
+              "name": "renku-gateway",
+              "old_status": "operational",
+              "new_status": "major_outage"
+            }
+          ],
+          "deliver_notifications": false,
+          "custom_tweet": null,
+          "tweet_id": null
+        }
+      ],
+      "components": [
+        {
+          "id": "8vycwk1lgw9b",
+          "name": "renku-gateway",
+          "status": "major_outage",
+          "created_at": "2020-08-07T18:03:08.541+02:00",
+          "updated_at": "2022-11-21T20:39:00.092+01:00",
+          "position": 8,
+          "description": null,
+          "showcase": true,
+          "start_date": null,
+          "group_id": null,
+          "page_id": "abcdef123456",
+          "group": false,
+          "only_show_if_degraded": false
+        }
+      ],
+      "reminder_intervals": "[]"
+    }
+  ],
   "scheduled_maintenances": [],
   "status": {
-    "indicator": "none",
-    "description": "All Systems Operational"
+    "indicator": "major",
+    "description": "Partial System Outage"
   }
 }

--- a/tests/cypress/support/renkulab-fixtures/global.ts
+++ b/tests/cypress/support/renkulab-fixtures/global.ts
@@ -24,17 +24,30 @@ import { FixturesConstructor } from "./fixtures";
 
 function Global<T extends FixturesConstructor>(Parent: T) {
   return class NewSessionFixtures extends Parent {
-    getStatuspageInfo(
+    getStatuspageInfo({
       name = "getStatuspageInfo",
-      fixture = "statuspage-operational.json"
-    ) {
-      const interceptResponse = fixture
-        ? { fixture: `statuspage/${fixture}` }
-        : { body: {} };
-      cy.intercept(
-        "https://*.statuspage.io/api/v2/summary.json",
-        interceptResponse
-      ).as(name);
+      fixture = "statuspage-operational.json",
+      overrides,
+    }: {
+      name?: string;
+      fixture?: string;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      overrides?: any;
+    } = {}) {
+      if (overrides == null) {
+        const interceptResponse = { fixture: `statuspage/${fixture}` };
+        cy.intercept(
+          "https://*.statuspage.io/api/v2/summary.json",
+          interceptResponse
+        ).as(name);
+        return this;
+      }
+      cy.fixture(`statuspage/${fixture}`).then((baseResponse) => {
+        const combinedResponse = { ...baseResponse, ...overrides };
+        cy.intercept("https://*.statuspage.io/api/v2/summary.json", {
+          body: combinedResponse,
+        }).as(name);
+      });
       return this;
     }
 


### PR DESCRIPTION
If there is a major or critical incident reported on the statuspage, show information about it in a banner.

<img width="824" alt="image" src="https://github.com/SwissDataScienceCenter/renku-ui/assets/1196411/d054890d-5fd4-4650-b13a-f25f9017c7ae">


Fix #2767

/deploy