### PR TITLE
chore: always use read-only for cloud storage

### DIFF
--- a/client/src/features/project/components/AddCloudStorageButton.tsx
+++ b/client/src/features/project/components/AddCloudStorageButton.tsx
@@ -321,7 +321,7 @@ function AdvancedAddCloudStorage({
               </FormText>
             </div>
 
-            { !CLOUD_STORAGE_READWRITE_ENABLED ? null :
+            {!CLOUD_STORAGE_READWRITE_ENABLED ? null : (
               <div className="mb-3">
                 <div className="form-label">Mode</div>
                 <Controller
@@ -369,7 +369,7 @@ function AdvancedAddCloudStorage({
                   )}
                 />
               </div>
-            }
+            )}
 
             <div className="mb-3">
               <Label className="form-label" for="addCloudStorageSourcePath">
@@ -675,7 +675,7 @@ function SimpleAddCloudStorage({
               </FormText>
             </div>
 
-            { !CLOUD_STORAGE_READWRITE_ENABLED ? null :
+            {!CLOUD_STORAGE_READWRITE_ENABLED ? null : (
               <div>
                 <div className="form-label">Mode</div>
                 <Controller
@@ -723,7 +723,7 @@ function SimpleAddCloudStorage({
                   )}
                 />
               </div>
-            }
+            )}
           </div>
         </Form>
       </ModalBody>

--- a/client/src/features/project/components/AddCloudStorageButton.tsx
+++ b/client/src/features/project/components/AddCloudStorageButton.tsx
@@ -47,6 +47,7 @@ import {
 import {
   CLOUD_STORAGE_CONFIGURATION_PLACEHOLDER,
   CLOUD_STORAGE_SENSITIVE_FIELD_TOKEN,
+  CLOUD_STORAGE_READWRITE_ENABLED,
 } from "../projectCloudStorage.constants";
 import {
   CloudStorage,
@@ -320,53 +321,55 @@ function AdvancedAddCloudStorage({
               </FormText>
             </div>
 
-            <div className="mb-3">
-              <div className="form-label">Mode</div>
-              <Controller
-                control={control}
-                name="readonly"
-                render={({ field }) => (
-                  <>
-                    <div className="form-check">
-                      <Input
-                        type="radio"
-                        className="form-check-input"
-                        name="readonlyRadio"
-                        id="addCloudStorageReadOnly"
-                        autoComplete="off"
-                        checked={field.value}
-                        onBlur={field.onBlur}
-                        onChange={() => field.onChange(true)}
-                      />
-                      <Label
-                        className={cx("form-check-label", "ms-2")}
-                        for="addCloudStorageReadOnly"
-                      >
-                        Read-only
-                      </Label>
-                    </div>
-                    <div className="form-check">
-                      <Input
-                        type="radio"
-                        className="form-check-input"
-                        name="readonlyRadio"
-                        id="addCloudStorageReadWrite"
-                        autoComplete="off"
-                        checked={!field.value}
-                        onBlur={field.onBlur}
-                        onChange={() => field.onChange(false)}
-                      />
-                      <Label
-                        className={cx("form-check-label", "ms-2")}
-                        for="addCloudStorageReadWrite"
-                      >
-                        Read/Write
-                      </Label>
-                    </div>
-                  </>
-                )}
-              />
-            </div>
+            { !CLOUD_STORAGE_READWRITE_ENABLED ? null :
+              <div className="mb-3">
+                <div className="form-label">Mode</div>
+                <Controller
+                  control={control}
+                  name="readonly"
+                  render={({ field }) => (
+                    <>
+                      <div className="form-check">
+                        <Input
+                          type="radio"
+                          className="form-check-input"
+                          name="readonlyRadio"
+                          id="addCloudStorageReadOnly"
+                          autoComplete="off"
+                          checked={field.value}
+                          onBlur={field.onBlur}
+                          onChange={() => field.onChange(true)}
+                        />
+                        <Label
+                          className={cx("form-check-label", "ms-2")}
+                          for="addCloudStorageReadOnly"
+                        >
+                          Read-only
+                        </Label>
+                      </div>
+                      <div className="form-check">
+                        <Input
+                          type="radio"
+                          className="form-check-input"
+                          name="readonlyRadio"
+                          id="addCloudStorageReadWrite"
+                          autoComplete="off"
+                          checked={!field.value}
+                          onBlur={field.onBlur}
+                          onChange={() => field.onChange(false)}
+                        />
+                        <Label
+                          className={cx("form-check-label", "ms-2")}
+                          for="addCloudStorageReadWrite"
+                        >
+                          Read/Write
+                        </Label>
+                      </div>
+                    </>
+                  )}
+                />
+              </div>
+            }
 
             <div className="mb-3">
               <Label className="form-label" for="addCloudStorageSourcePath">
@@ -672,53 +675,55 @@ function SimpleAddCloudStorage({
               </FormText>
             </div>
 
-            <div>
-              <div className="form-label">Mode</div>
-              <Controller
-                control={control}
-                name="readonly"
-                render={({ field }) => (
-                  <>
-                    <div className="form-check">
-                      <Input
-                        type="radio"
-                        className="form-check-input"
-                        name="addCloudStorageReadOnlyRadio"
-                        id="addCloudStorageReadOnly"
-                        autoComplete="off"
-                        checked={field.value}
-                        onBlur={field.onBlur}
-                        onChange={() => field.onChange(true)}
-                      />
-                      <Label
-                        className={cx("form-check-label", "ms-2")}
-                        for="addCloudStorageReadOnly"
-                      >
-                        Read-only
-                      </Label>
-                    </div>
-                    <div className="form-check">
-                      <Input
-                        type="radio"
-                        className="form-check-input"
-                        name="addCloudStorageReadOnlyRadio"
-                        id="addCloudStorageReadWrite"
-                        autoComplete="off"
-                        checked={!field.value}
-                        onBlur={field.onBlur}
-                        onChange={() => field.onChange(false)}
-                      />
-                      <Label
-                        className={cx("form-check-label", "ms-2")}
-                        for="addCloudStorageReadWrite"
-                      >
-                        Read/Write
-                      </Label>
-                    </div>
-                  </>
-                )}
-              />
-            </div>
+            { !CLOUD_STORAGE_READWRITE_ENABLED ? null :
+              <div>
+                <div className="form-label">Mode</div>
+                <Controller
+                  control={control}
+                  name="readonly"
+                  render={({ field }) => (
+                    <>
+                      <div className="form-check">
+                        <Input
+                          type="radio"
+                          className="form-check-input"
+                          name="addCloudStorageReadOnlyRadio"
+                          id="addCloudStorageReadOnly"
+                          autoComplete="off"
+                          checked={field.value}
+                          onBlur={field.onBlur}
+                          onChange={() => field.onChange(true)}
+                        />
+                        <Label
+                          className={cx("form-check-label", "ms-2")}
+                          for="addCloudStorageReadOnly"
+                        >
+                          Read-only
+                        </Label>
+                      </div>
+                      <div className="form-check">
+                        <Input
+                          type="radio"
+                          className="form-check-input"
+                          name="addCloudStorageReadOnlyRadio"
+                          id="addCloudStorageReadWrite"
+                          autoComplete="off"
+                          checked={!field.value}
+                          onBlur={field.onBlur}
+                          onChange={() => field.onChange(false)}
+                        />
+                        <Label
+                          className={cx("form-check-label", "ms-2")}
+                          for="addCloudStorageReadWrite"
+                        >
+                          Read/Write
+                        </Label>
+                      </div>
+                    </>
+                  )}
+                />
+              </div>
+            }
           </div>
         </Form>
       </ModalBody>

--- a/client/src/features/project/components/ProjectSettingsCloudStorage.tsx
+++ b/client/src/features/project/components/ProjectSettingsCloudStorage.tsx
@@ -646,7 +646,7 @@ function EditCloudStorage({
           </div>
         )}
 
-        { !CLOUD_STORAGE_READWRITE_ENABLED ? null :
+        {!CLOUD_STORAGE_READWRITE_ENABLED ? null : (
           <div className="mb-3">
             <div className="form-label">Mode</div>
             <Controller
@@ -694,7 +694,7 @@ function EditCloudStorage({
               )}
             />
           </div>
-        }
+        )}
         <div className="mb-3">
           <Label
             className="form-label"

--- a/client/src/features/project/components/ProjectSettingsCloudStorage.tsx
+++ b/client/src/features/project/components/ProjectSettingsCloudStorage.tsx
@@ -70,6 +70,7 @@ import {
 import {
   CLOUD_STORAGE_CONFIGURATION_PLACEHOLDER,
   CLOUD_STORAGE_SENSITIVE_FIELD_TOKEN,
+  CLOUD_STORAGE_READWRITE_ENABLED,
 } from "../projectCloudStorage.constants";
 import {
   CloudStorage,
@@ -645,54 +646,55 @@ function EditCloudStorage({
           </div>
         )}
 
-        <div className="mb-3">
-          <div className="form-label">Mode</div>
-          <Controller
-            control={control}
-            name="readonly"
-            render={({ field }) => (
-              <>
-                <div className="form-check">
-                  <Input
-                    type="radio"
-                    className="form-check-input"
-                    name={`updateCloudStorageReadOnlyRadio-${name}`}
-                    id={`updateCloudStorageReadOnly-${name}`}
-                    autoComplete="off"
-                    checked={field.value}
-                    onBlur={field.onBlur}
-                    onChange={() => field.onChange(true)}
-                  />
-                  <Label
-                    className={cx("form-check-label", "ms-2")}
-                    for={`updateCloudStorageReadOnly-${name}`}
-                  >
-                    Read-only
-                  </Label>
-                </div>
-                <div className="form-check">
-                  <Input
-                    type="radio"
-                    className="form-check-input"
-                    name={`updateCloudStorageReadOnlyRadio-${name}`}
-                    id={`updateCloudStorageReadWrite-${name}`}
-                    autoComplete="off"
-                    checked={!field.value}
-                    onBlur={field.onBlur}
-                    onChange={() => field.onChange(false)}
-                  />
-                  <Label
-                    className={cx("form-check-label", "ms-2")}
-                    for={`updateCloudStorageReadWrite-${name}`}
-                  >
-                    Read/Write
-                  </Label>
-                </div>
-              </>
-            )}
-          />
-        </div>
-
+        { !CLOUD_STORAGE_READWRITE_ENABLED ? null :
+          <div className="mb-3">
+            <div className="form-label">Mode</div>
+            <Controller
+              control={control}
+              name="readonly"
+              render={({ field }) => (
+                <>
+                  <div className="form-check">
+                    <Input
+                      type="radio"
+                      className="form-check-input"
+                      name={`updateCloudStorageReadOnlyRadio-${name}`}
+                      id={`updateCloudStorageReadOnly-${name}`}
+                      autoComplete="off"
+                      checked={field.value}
+                      onBlur={field.onBlur}
+                      onChange={() => field.onChange(true)}
+                    />
+                    <Label
+                      className={cx("form-check-label", "ms-2")}
+                      for={`updateCloudStorageReadOnly-${name}`}
+                    >
+                      Read-only
+                    </Label>
+                  </div>
+                  <div className="form-check">
+                    <Input
+                      type="radio"
+                      className="form-check-input"
+                      name={`updateCloudStorageReadOnlyRadio-${name}`}
+                      id={`updateCloudStorageReadWrite-${name}`}
+                      autoComplete="off"
+                      checked={!field.value}
+                      onBlur={field.onBlur}
+                      onChange={() => field.onChange(false)}
+                    />
+                    <Label
+                      className={cx("form-check-label", "ms-2")}
+                      for={`updateCloudStorageReadWrite-${name}`}
+                    >
+                      Read/Write
+                    </Label>
+                  </div>
+                </>
+              )}
+            />
+          </div>
+        }
         <div className="mb-3">
           <Label
             className="form-label"

--- a/client/src/features/project/projectCloudStorage.constants.ts
+++ b/client/src/features/project/projectCloudStorage.constants.ts
@@ -20,3 +20,5 @@ export const CLOUD_STORAGE_SENSITIVE_FIELD_TOKEN = "<sensitive>";
 
 export const CLOUD_STORAGE_CONFIGURATION_PLACEHOLDER =
   "[example]\ntype = s3\nprovider = AWS\nregion = us-east-1";
+
+export const CLOUD_STORAGE_READWRITE_ENABLED: boolean = false;

--- a/client/src/features/project/projectCloudStorage.constants.ts
+++ b/client/src/features/project/projectCloudStorage.constants.ts
@@ -21,4 +21,4 @@ export const CLOUD_STORAGE_SENSITIVE_FIELD_TOKEN = "<sensitive>";
 export const CLOUD_STORAGE_CONFIGURATION_PLACEHOLDER =
   "[example]\ntype = s3\nprovider = AWS\nregion = us-east-1";
 
-export const CLOUD_STORAGE_READWRITE_ENABLED: boolean = false;
+export const CLOUD_STORAGE_READWRITE_ENABLED = false;

--- a/client/src/features/session/components/options/SessionCloudStorageOption.tsx
+++ b/client/src/features/session/components/options/SessionCloudStorageOption.tsx
@@ -72,6 +72,7 @@ import {
 import {
   CLOUD_STORAGE_CONFIGURATION_PLACEHOLDER,
   CLOUD_STORAGE_SENSITIVE_FIELD_TOKEN,
+  CLOUD_STORAGE_READWRITE_ENABLED,
 } from "../../../project/projectCloudStorage.constants";
 import {
   formatCloudStorageConfiguration,
@@ -631,44 +632,45 @@ function CloudStorageDetails({ index, storage }: CloudStorageItemProps) {
         />
       </div>
 
-      <div className="mb-3">
-        <div className="form-label">Mode</div>
-        <div className="form-check">
-          <Input
-            type="radio"
-            className="form-check-input"
-            name={`updateCloudStorageReadOnlyRadio-${index}`}
-            id={`updateCloudStorageReadOnly-${index}`}
-            autoComplete="off"
-            checked={!!readonly}
-            onChange={onChangeReadWriteMode}
-          />
-          <Label
-            className={cx("form-check-label", "ms-2")}
-            for={`updateCloudStorageReadOnly-${index}`}
-          >
-            Read-only
-          </Label>
+      { !CLOUD_STORAGE_READWRITE_ENABLED ? null :
+        <div className="mb-3">
+          <div className="form-label">Mode</div>
+          <div className="form-check">
+            <Input
+              type="radio"
+              className="form-check-input"
+              name={`updateCloudStorageReadOnlyRadio-${index}`}
+              id={`updateCloudStorageReadOnly-${index}`}
+              autoComplete="off"
+              checked={!!readonly}
+              onChange={onChangeReadWriteMode}
+            />
+            <Label
+              className={cx("form-check-label", "ms-2")}
+              for={`updateCloudStorageReadOnly-${index}`}
+            >
+              Read-only
+            </Label>
+          </div>
+          <div className="form-check">
+            <Input
+              type="radio"
+              className="form-check-input"
+              name={`updateCloudStorageReadOnlyRadio-${index}`}
+              id={`updateCloudStorageReadWrite-${index}`}
+              autoComplete="off"
+              checked={!readonly}
+              onChange={onChangeReadWriteMode}
+            />
+            <Label
+              className={cx("form-check-label", "ms-2")}
+              for={`updateCloudStorageReadWrite-${index}`}
+            >
+              Read/Write
+            </Label>
+          </div>
         </div>
-        <div className="form-check">
-          <Input
-            type="radio"
-            className="form-check-input"
-            name={`updateCloudStorageReadOnlyRadio-${index}`}
-            id={`updateCloudStorageReadWrite-${index}`}
-            autoComplete="off"
-            checked={!readonly}
-            onChange={onChangeReadWriteMode}
-          />
-          <Label
-            className={cx("form-check-label", "ms-2")}
-            for={`updateCloudStorageReadWrite-${index}`}
-          >
-            Read/Write
-          </Label>
-        </div>
-      </div>
-
+      }
       <div>
         <Label className="form-label" for={`updateCloudStorageConfig-${index}`}>
           Configuration
@@ -856,54 +858,55 @@ function AddTemporaryCloudStorageModal({
             <div className="invalid-feedback">Please provide a name</div>
           </div>
 
-          <div className="mb-3">
-            <div className="form-label">Mode</div>
-            <Controller
-              control={control}
-              name="readonly"
-              render={({ field }) => (
-                <>
-                  <div className="form-check">
-                    <Input
-                      type="radio"
-                      className="form-check-input"
-                      name="readonlyRadio"
-                      id="addCloudStorageReadOnly"
-                      autoComplete="off"
-                      checked={field.value}
-                      onBlur={field.onBlur}
-                      onChange={() => field.onChange(true)}
-                    />
-                    <Label
-                      className={cx("form-check-label", "ms-2")}
-                      for="addCloudStorageReadOnly"
-                    >
-                      Read-only
-                    </Label>
-                  </div>
-                  <div className="form-check">
-                    <Input
-                      type="radio"
-                      className="form-check-input"
-                      name="readonlyRadio"
-                      id="addCloudStorageReadWrite"
-                      autoComplete="off"
-                      checked={!field.value}
-                      onBlur={field.onBlur}
-                      onChange={() => field.onChange(false)}
-                    />
-                    <Label
-                      className={cx("form-check-label", "ms-2")}
-                      for="addCloudStorageReadWrite"
-                    >
-                      Read/Write
-                    </Label>
-                  </div>
-                </>
-              )}
-            />
-          </div>
-
+          { !CLOUD_STORAGE_READWRITE_ENABLED ? null : 
+            <div className="mb-3">
+              <div className="form-label">Mode</div>
+              <Controller
+                control={control}
+                name="readonly"
+                render={({ field }) => (
+                  <>
+                    <div className="form-check">
+                      <Input
+                        type="radio"
+                        className="form-check-input"
+                        name="readonlyRadio"
+                        id="addCloudStorageReadOnly"
+                        autoComplete="off"
+                        checked={field.value}
+                        onBlur={field.onBlur}
+                        onChange={() => field.onChange(true)}
+                      />
+                      <Label
+                        className={cx("form-check-label", "ms-2")}
+                        for="addCloudStorageReadOnly"
+                      >
+                        Read-only
+                      </Label>
+                    </div>
+                    <div className="form-check">
+                      <Input
+                        type="radio"
+                        className="form-check-input"
+                        name="readonlyRadio"
+                        id="addCloudStorageReadWrite"
+                        autoComplete="off"
+                        checked={!field.value}
+                        onBlur={field.onBlur}
+                        onChange={() => field.onChange(false)}
+                      />
+                      <Label
+                        className={cx("form-check-label", "ms-2")}
+                        for="addCloudStorageReadWrite"
+                      >
+                        Read/Write
+                      </Label>
+                    </div>
+                  </>
+                )}
+              />
+            </div>
+          }
           <div className="mb-3">
             <Label className="form-label" for="addCloudStorageSourcePath">
               Source Path

--- a/client/src/features/session/components/options/SessionCloudStorageOption.tsx
+++ b/client/src/features/session/components/options/SessionCloudStorageOption.tsx
@@ -632,7 +632,7 @@ function CloudStorageDetails({ index, storage }: CloudStorageItemProps) {
         />
       </div>
 
-      { !CLOUD_STORAGE_READWRITE_ENABLED ? null :
+      {!CLOUD_STORAGE_READWRITE_ENABLED ? null : (
         <div className="mb-3">
           <div className="form-label">Mode</div>
           <div className="form-check">
@@ -670,7 +670,7 @@ function CloudStorageDetails({ index, storage }: CloudStorageItemProps) {
             </Label>
           </div>
         </div>
-      }
+      )}
       <div>
         <Label className="form-label" for={`updateCloudStorageConfig-${index}`}>
           Configuration
@@ -858,7 +858,7 @@ function AddTemporaryCloudStorageModal({
             <div className="invalid-feedback">Please provide a name</div>
           </div>
 
-          { !CLOUD_STORAGE_READWRITE_ENABLED ? null : 
+          {!CLOUD_STORAGE_READWRITE_ENABLED ? null : (
             <div className="mb-3">
               <div className="form-label">Mode</div>
               <Controller
@@ -906,7 +906,7 @@ function AddTemporaryCloudStorageModal({
                 )}
               />
             </div>
-          }
+          )}
           <div className="mb-3">
             <Label className="form-label" for="addCloudStorageSourcePath">
               Source Path

--- a/tests/cypress.config.ts
+++ b/tests/cypress.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "cypress";
 export default defineConfig({
   env: {
     USE_FIXTURES: true,
+    CLOUD_STORAGE_READWRITE_ENABLED: false,
   },
 
   video: false,

--- a/tests/cypress/e2e/newSession.spec.ts
+++ b/tests/cypress/e2e/newSession.spec.ts
@@ -203,6 +203,6 @@ describe("launch sessions", () => {
         .contains("Read/Write")
         .siblings("input")
         .should("not.be.checked");
-    } 
+    }
   });
 });

--- a/tests/cypress/e2e/newSession.spec.ts
+++ b/tests/cypress/e2e/newSession.spec.ts
@@ -197,10 +197,12 @@ describe("launch sessions", () => {
       .should("have.value", "mount/path")
       .should("be.visible");
 
-    cy.contains("Read-only").siblings("input").should("be.checked");
-    cy.get("label")
-      .contains("Read/Write")
-      .siblings("input")
-      .should("not.be.checked");
+    if (Cypress.env("CLOUD_STORAGE_READWRITE_ENABLED")) {
+      cy.contains("Read-only").siblings("input").should("be.checked");
+      cy.get("label")
+        .contains("Read/Write")
+        .siblings("input")
+        .should("not.be.checked");
+    } 
   });
 });

--- a/tests/cypress/e2e/projectSettings.spec.ts
+++ b/tests/cypress/e2e/projectSettings.spec.ts
@@ -353,7 +353,7 @@ describe("Cloud storage settings page", () => {
 
       expect(name).to.equal("My special storage");
       expect(isPrivate).to.be.false;
-      expect(readonly).to.be.false;
+      expect(readonly).to.be.undefined;
       expect(source_path).to.equal("bucket/source/subfolder");
       expect(target_path).to.equal("/mnt/special");
     });
@@ -447,7 +447,9 @@ describe("Cloud storage settings page", () => {
 
       expect(name).to.equal("My new storage");
       expect(isPrivate).to.be.true;
-      expect(readonly).to.be.false;
+      expect(readonly).to.equal(
+        !Cypress.env("CLOUD_STORAGE_READWRITE_ENABLED")
+      );
       expect(target_path).to.equal("My new storage");
     });
 

--- a/tests/cypress/e2e/projectSettings.spec.ts
+++ b/tests/cypress/e2e/projectSettings.spec.ts
@@ -324,15 +324,17 @@ describe("Cloud storage settings page", () => {
       .siblings("input")
       .should("not.be.checked");
 
-    cy.get("label")
-      .contains("Read/Write")
-      .click()
-      .siblings("input")
-      .should("be.checked");
-    cy.get("label")
-      .contains("Read-only")
-      .siblings("input")
-      .should("not.be.checked");
+    if (Cypress.env("CLOUD_STORAGE_READWRITE_ENABLED")) {
+      cy.get("label")
+        .contains("Read/Write")
+        .click()
+        .siblings("input")
+        .should("be.checked");
+      cy.get("label")
+        .contains("Read-only")
+        .siblings("input")
+        .should("not.be.checked");
+    }
 
     cy.get("button[type='submit']")
       .contains("Save changes")
@@ -422,15 +424,17 @@ describe("Cloud storage settings page", () => {
       .siblings("input")
       .should("be.checked");
 
-    cy.get("label")
-      .contains("Read/Write")
-      .click()
-      .siblings("input")
-      .should("be.checked");
-    cy.get("label")
-      .contains("Read-only")
-      .siblings("input")
-      .should("not.be.checked");
+    if (Cypress.env("CLOUD_STORAGE_READWRITE_ENABLED")) {
+      cy.get("label")
+        .contains("Read/Write")
+        .click()
+        .siblings("input")
+        .should("be.checked");
+      cy.get("label")
+        .contains("Read-only")
+        .siblings("input")
+        .should("not.be.checked");
+    }
 
     cy.get("button[type='submit']")
       .contains("Add Storage")


### PR DESCRIPTION
The 3rd party library we use for mounting cloud storage breaks down when in read/write mode.

We will swap this for a better library. But we want to release this with read-only support and not delay the feature further. Because swapping this library cannot be done that quickly and it needs some testing to make sure it works well.

You can see this deployed at https://github.com/SwissDataScienceCenter/renku/pull/3214