### PR TITLE
build: release 3.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@
 ### Features
 
 - Show a confirmation text when saving a session ([#2856](https://github.com/SwissDataScienceCenter/renku-ui/pull/2856)).
-- Add an admin interface for resource pools ([#2726](https://github.com/SwissDataScienceCenter/renku-ui/issues/2726)).
+- Add an admin interface for resource pools ([#2752](https://github.com/SwissDataScienceCenter/renku-ui/pull/2752), [#2726](https://github.com/SwissDataScienceCenter/renku-ui/issues/2726)).
 
 ### Bug Fixes
 
-- Merge implementations of KG API ([#2829](https://github.com/SwissDataScienceCenter/renku-ui/issues/2829)).
+- Merge implementations of KG API ([#2859](https://github.com/SwissDataScienceCenter/renku-ui/pull/2859), [#2829](https://github.com/SwissDataScienceCenter/renku-ui/issues/2829)).
 - Properly close all WebSocket connections upon shutdown ([#2861](https://github.com/SwissDataScienceCenter/renku-ui/pull/2861)).
-- Update the session notebook icon to use RTK query ([#2759](https://github.com/SwissDataScienceCenter/renku-ui/issues/2759)).
+- Update the session notebook icon to use RTK query ([#2842](https://github.com/SwissDataScienceCenter/renku-ui/pull/2842), [#2759](https://github.com/SwissDataScienceCenter/renku-ui/issues/2759)).
 
 ## [3.14.0](https://github.com/SwissDataScienceCenter/renku-ui/compare/3.13.1...3.14.0) (2023-10-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [3.15.0](https://github.com/SwissDataScienceCenter/renku-ui/compare/3.14.0...3.15.0) (2023-10-27)
+
 ## [3.14.0](https://github.com/SwissDataScienceCenter/renku-ui/compare/3.13.1...3.14.0) (2023-10-24)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [3.15.0](https://github.com/SwissDataScienceCenter/renku-ui/compare/3.14.0...3.15.0) (2023-10-27)
 
+### Features
+
+- Show a confirmation text when saving a session ([#2856](https://github.com/SwissDataScienceCenter/renku-ui/pull/2856)).
+- Add an admin interface for resource pools ([#2726](https://github.com/SwissDataScienceCenter/renku-ui/issues/2726)).
+
+### Bug Fixes
+
+- Merge implementations of KG API ([#2829](https://github.com/SwissDataScienceCenter/renku-ui/issues/2829)).
+- Properly close all WebSocket connections upon shutdown ([#2861](https://github.com/SwissDataScienceCenter/renku-ui/pull/2861)).
+- Update the session notebook icon to use RTK query ([#2759](https://github.com/SwissDataScienceCenter/renku-ui/issues/2759)).
+
 ## [3.14.0](https://github.com/SwissDataScienceCenter/renku-ui/compare/3.13.1...3.14.0) (2023-10-24)
 
 ### Features

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "renku-ui",
-  "version": "3.14.0",
+  "version": "3.15.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "renku-ui",
-      "version": "3.14.0",
+      "version": "3.15.0",
       "dependencies": {
         "@ckeditor/ckeditor5-react": "^5.1.0",
         "@fortawesome/fontawesome-svg-core": "^1.2.35",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "renku-ui",
-  "version": "3.14.0",
+  "version": "3.15.0",
   "private": true,
   "dependencies": {
     "@ckeditor/ckeditor5-react": "^5.1.0",

--- a/helm-chart/renku-ui/Chart.yaml
+++ b/helm-chart/renku-ui/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: "1.0"
 description: A Helm chart for the Renku UI
 name: renku-ui
 icon: https://github.com/SwissDataScienceCenter/renku-sphinx-theme/raw/master/renku_sphinx_theme/static/favicon.png
-version: 3.14.0
+version: 3.15.0

--- a/helm-chart/renku-ui/values.yaml
+++ b/helm-chart/renku-ui/values.yaml
@@ -2,9 +2,9 @@ ui:
   client:
     image:
       repository: renku/renku-ui
-      tag: "3.14.0"
+      tag: "3.15.0"
 
   server:
     image:
       repository: renku/renku-ui-server
-      tag: "3.14.0"
+      tag: "3.15.0"

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "renku-ui-server",
-  "version": "3.14.0",
+  "version": "3.15.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "renku-ui-server",
-      "version": "3.14.0",
+      "version": "3.15.0",
       "dependencies": {
         "@sentry/node": "^7.60.1",
         "cookie-parser": "^1.4.6",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "renku-ui-server",
-  "version": "3.14.0",
+  "version": "3.15.0",
   "description": "Server for renku API",
   "private": true,
   "main": "dist/index.js",


### PR DESCRIPTION
/deploy renku=leafty/feat-admin-panel renku-gateway=master renku-data-services=main extra-values=global.gitlab.url=https://gitlab.dev.renku.ch,dataService.image.pullPolicy=Always,notebooks.cloudstorage.s3.enabled=true,amalthea.extraChildResources[0].group=com.ie.ibm.hpsys,amalthea.extraChildResources[0].name=datasets,notebooks.cloudstorage.s3.installDatashim=false