### PR TITLE
fix(server): save lower case project path for last-visited

### DIFF
--- a/server/src/utils/middlewares/lastProjectsMiddleware.ts
+++ b/server/src/utils/middlewares/lastProjectsMiddleware.ts
@@ -51,13 +51,18 @@ const lastProjectsMiddleware =
         }
 
         const userId = getUserIdFromToken(token);
+        const normalizedProjectName = projectName.toLowerCase();
         // Save as ordered collection
         storage
-          .save(`${config.data.projectsStoragePrefix}${userId}`, projectName, {
-            type: TypeData.Collections,
-            limit: config.data.projectsDefaultLength,
-            score: Date.now(),
-          })
+          .save(
+            `${config.data.projectsStoragePrefix}${userId}`,
+            normalizedProjectName,
+            {
+              type: TypeData.Collections,
+              limit: config.data.projectsDefaultLength,
+              score: Date.now(),
+            }
+          )
           .then((value) => {
             if (!value) {
               const errorMessage = `Error saving project ${projectName} for user ${userId}`;


### PR DESCRIPTION
The full path for a project is case-insensitive (e.g. foo/bar is equivalent to FOO/bar), so we should normalize project paths before saving.

/deploy