### PR TITLE
fix(client): adjust dropdown menus  with anchors nested in buttons

### DIFF
--- a/client/src/components/ssh/ssh.tsx
+++ b/client/src/components/ssh/ssh.tsx
@@ -65,7 +65,7 @@ function SshDropdown({ fullPath, gitUrl }: SshDropdownProps) {
   };
 
   return (
-    <DropdownItem onClick={() => handleClick()}>
+    <DropdownItem onClick={handleClick}>
       <img src={rkIconSsh} className="rk-icon rk-icon-md me-2 filter-green" />
       Connect with SSH
     </DropdownItem>

--- a/client/src/components/ssh/ssh.tsx
+++ b/client/src/components/ssh/ssh.tsx
@@ -66,10 +66,7 @@ function SshDropdown({ fullPath, gitUrl }: SshDropdownProps) {
 
   return (
     <DropdownItem onClick={() => handleClick()}>
-      <img
-        src={rkIconSsh}
-        className="rk-icon rk-icon-md btn-with-menu-margin filter-green"
-      />
+      <img src={rkIconSsh} className="rk-icon rk-icon-md me-2 filter-green" />
       Connect with SSH
     </DropdownItem>
   );

--- a/client/src/features/session/components/SessionButton.tsx
+++ b/client/src/features/session/components/SessionButton.tsx
@@ -118,20 +118,20 @@ export default function SessionButton({
         isPrincipal
         size="sm"
       >
-        <DropdownItem>
-          <Link className="text-decoration-none" to={sessionStartUrl}>
+        <li>
+          <Link className="dropdown-item" to={sessionStartUrl}>
             <img
               src={rkIconStartWithOptions}
-              className="rk-icon rk-icon-md btn-with-menu-margin"
+              className="rk-icon rk-icon-md me-2"
             />
             Start with options
           </Link>
-        </DropdownItem>
+        </li>
         {gitUrl && <SshDropdown fullPath={fullPath} gitUrl={gitUrl} />}
         <DropdownItem divider />
-        <DropdownItem>
+        <li>
           <Link
-            className="text-decoration-none"
+            className="dropdown-item"
             to={{
               pathname: sessionStartUrl,
               search: new URLSearchParams({
@@ -146,7 +146,7 @@ export default function SessionButton({
             />
             Create session link
           </Link>
-        </DropdownItem>
+        </li>
       </ButtonWithMenu>
     );
   }
@@ -399,9 +399,9 @@ function SessionActions({ className, session }: SessionActionsProps) {
   );
 
   const createSessionLinkAction = (
-    <DropdownItem>
+    <li>
       <Link
-        className="text-decoration-none"
+        className="dropdown-item"
         to={{
           pathname: sessionStartUrl,
           search: new URLSearchParams({
@@ -416,7 +416,7 @@ function SessionActions({ className, session }: SessionActionsProps) {
         />
         Create session link
       </Link>
-    </DropdownItem>
+    </li>
   );
 
   const logsAction = status !== "hibernated" && (

--- a/client/src/project/components/GitLabConnect.tsx
+++ b/client/src/project/components/GitLabConnect.tsx
@@ -1,4 +1,3 @@
-import { DropdownItem } from "reactstrap";
 import { ExternalLink } from "../../components/ExternalLinks";
 import { ButtonWithMenu } from "../../components/buttons/Button";
 import { ThrottledTooltip } from "../../components/Tooltip";
@@ -14,16 +13,20 @@ function externalUrlToGitLabIdeUrl(externalUrl: string) {
 }
 
 type GitLabLinkItemProps = {
-  size: string;
   text: string;
   url: string;
 };
 
-function GitLabLinkItem({ size, text, url }: GitLabLinkItemProps) {
+function GitLabLinkItem({ text, url }: GitLabLinkItemProps) {
   return (
-    <DropdownItem size={size}>
-      <ExternalLink className="nav-link" role="text" title={text} url={url} />
-    </DropdownItem>
+    <li>
+      <ExternalLink
+        className="dropdown-item"
+        role="text"
+        title={text}
+        url={url}
+      />
+    </li>
   );
 }
 
@@ -54,7 +57,7 @@ function GitLabConnectButton(props: GitLabConnectButtonProps) {
 
   const gitlabIDEButton =
     userLogged && gitlabIdeUrl ? (
-      <GitLabLinkItem size={size} text="Web IDE" url={gitlabIdeUrl} />
+      <GitLabLinkItem text="Web IDE" url={gitlabIdeUrl} />
     ) : null;
 
   return (
@@ -64,8 +67,8 @@ function GitLabConnectButton(props: GitLabConnectButtonProps) {
         default={gitlabProjectButton}
         size={size}
       >
-        <GitLabLinkItem size={size} text="Issues" url={gitLabIssuesUrl} />
-        <GitLabLinkItem size={size} text="Merge Requests" url={gitLabMrUrl} />
+        <GitLabLinkItem text="Issues" url={gitLabIssuesUrl} />
+        <GitLabLinkItem text="Merge Requests" url={gitLabMrUrl} />
         {gitlabIDEButton}
       </ButtonWithMenu>
       <ThrottledTooltip

--- a/client/src/styles/bootstrap_ext/_button.scss
+++ b/client/src/styles/bootstrap_ext/_button.scss
@@ -36,13 +36,6 @@ $borderRadius: 1000px;
   border-left: 1px solid;
 }
 
-.btn-with-menu-options {
-  svg,
-  .btn-with-menu-margin {
-    margin-right: 12px;
-  }
-}
-
 .input-group .btn {
   border-radius: 0;
   padding: 5px 10px;


### PR DESCRIPTION
The `DropdownItem` component should render either a button or a link based on its properties.
Since we use `Link` lo link local resources, we ended up nesting the 2 components instead of using `<DropdownItem href=...>`. That renders an anchor inside a button, with some undesired side effects, like making the areas next to the borders clickable but with no effect (in the gif, the fixed version is on the right).

![Peek 2023-11-20 16-01](https://github.com/SwissDataScienceCenter/renku-ui/assets/43481553/6830eaba-949a-44f4-8484-d261fae190cf)

/deploy
