### PR TITLE
chore(client): update the session start warning

### DIFF
--- a/client/src/features/project/GitLab.types.ts
+++ b/client/src/features/project/GitLab.types.ts
@@ -48,6 +48,7 @@ export interface GitLabPipelineJob {
   status:
     | "success"
     | "running"
+    | "created"
     | "pending"
     | "stopping"
     | "failed"

--- a/client/src/features/project/projectGitLab.api.ts
+++ b/client/src/features/project/projectGitLab.api.ts
@@ -82,6 +82,7 @@ const projectGitLabApi = createApi({
 
           const jobs = result.data as GitLabPipelineJob[];
           const found = jobs.find(({ name }) => name === jobName);
+          console.log({ jobs, found });
           if (found) {
             return { data: found };
           }
@@ -90,7 +91,7 @@ const projectGitLabApi = createApi({
         return { data: null };
       },
       providesTags: (result) =>
-        result ? [{ id: result.id, type: "Job" }] : [],
+        result ? [{ id: result.id, type: "Job" }] : ["Job"],
     }),
     getPipelines: builder.query<GitLabPipeline[], GetPipelinesParams>({
       query: ({ commit, projectId }) => ({
@@ -116,6 +117,7 @@ const projectGitLabApi = createApi({
       }),
       invalidatesTags: (_result, _error, { pipelineId }) => [
         { id: pipelineId, type: "Pipeline" },
+        "Job",
       ],
     }),
     runPipeline: builder.mutation<GitLabPipeline, RunPipelineParams>({

--- a/client/src/features/project/projectGitLab.api.ts
+++ b/client/src/features/project/projectGitLab.api.ts
@@ -82,7 +82,6 @@ const projectGitLabApi = createApi({
 
           const jobs = result.data as GitLabPipelineJob[];
           const found = jobs.find(({ name }) => name === jobName);
-          console.log({ jobs, found });
           if (found) {
             return { data: found };
           }

--- a/client/src/features/session/components/StartNewSession.tsx
+++ b/client/src/features/session/components/StartNewSession.tsx
@@ -266,10 +266,14 @@ function SessionStartError() {
     return null;
   }
 
+  // Handle `docker-image-building` as a special case
+  if (error === "docker-image-building") {
+    return <SessionStartErrorImageBuilding />;
+  }
+
   const color =
-    error === "docker-image-building" ||
-    error === "session-class" ||
-    error === "cloud-storage-credentials"
+    // error === "docker-image-building" ||
+    error === "session-class" || error === "cloud-storage-credentials"
       ? "warning"
       : "danger";
 
@@ -283,12 +287,13 @@ function SessionStartError() {
       <>
         Starting a session is not possible because this project has no commit.
       </>
-    ) : error === "docker-image-building" ? (
-      <>
-        The session could not start because the image is still building. Please
-        wait for the build to finish, or start the session with the base image.
-      </>
-    ) : error === "docker-image-not-available" ? (
+    ) : // error === "docker-image-building" ? (
+    //   <>
+    //     The session could not start because the image is still building. Please
+    //     wait for the build to finish, or start the session with the base image.
+    //   </>
+    // ) :
+    error === "docker-image-not-available" ? (
       <>
         The session could not start because no image is available. Please select
         a different commit or start the session with the base image.
@@ -324,6 +329,29 @@ function SessionStartError() {
   return (
     <RenkuAlert color={color} timeout={0}>
       <p className="mb-0">{content}</p>
+    </RenkuAlert>
+  );
+}
+
+function SessionStartErrorImageBuilding() {
+  const dockerImageStatus = useAppSelector(
+    ({ startSessionOptions }) => startSessionOptions.dockerImageStatus
+  );
+
+  const color = "warning";
+  const content = (
+    <>
+      The session could not start because the image is still building. Please
+      wait for the build to finish, or start the session with the base image.
+    </>
+  );
+
+  return (
+    <RenkuAlert color={color} timeout={0}>
+      <p className="mb-0">{content}</p>
+      <p>
+        <code>{dockerImageStatus}</code>
+      </p>
     </RenkuAlert>
   );
 }

--- a/client/src/features/session/components/StartNewSession.tsx
+++ b/client/src/features/session/components/StartNewSession.tsx
@@ -337,14 +337,34 @@ function SessionStartErrorImageBuilding() {
   const dockerImageStatus = useAppSelector(
     ({ startSessionOptions }) => startSessionOptions.dockerImageStatus
   );
+  /*
+   | "unknown"
+  | "available"
+  | "not-available"
+  | "building";
+   */
 
-  const color = "warning";
-  const content = (
-    <>
-      The session could not start because the image is still building. Please
-      wait for the build to finish, or start the session with the base image.
-    </>
-  );
+  const color = dockerImageStatus === "not-available" ? "danger" : "warning";
+  const content =
+    dockerImageStatus === "available" ? (
+      <>
+        The session could not start because the image was still building when
+        the session was requested. You can now try to start the session:
+        <StartSessionButton />
+      </>
+    ) : dockerImageStatus === "not-available" ? (
+      <>
+        The session could not start because the image was building when the
+        session was requested. The image build failed and the image is not
+        available. Please select a different commit or start the session with
+        the base image.
+      </>
+    ) : (
+      <>
+        The session could not start because the image is still building. Please
+        wait for the build to finish, or start the session with the base image.
+      </>
+    );
 
   return (
     <RenkuAlert color={color} timeout={0}>

--- a/client/src/features/session/components/StartNewSession.tsx
+++ b/client/src/features/session/components/StartNewSession.tsx
@@ -335,30 +335,34 @@ function SessionStartErrorImageBuilding() {
   const content =
     dockerImageStatus === "available" ? (
       <>
-        The session could not start because the image was still building when
-        the session was requested. You can now try to start the session:
+        <p>
+          The session could not start because the image was still building when
+          the session was requested.
+        </p>
+        <p className="mb-0">You can now try to start the session:</p>
         <StartSessionButton />
       </>
     ) : dockerImageStatus === "not-available" ? (
-      <>
+      <p className="mb-0">
         The session could not start because the image was building when the
         session was requested. The image build failed and the image is not
         available. Please select a different commit or start the session with
         the base image.
-      </>
+      </p>
     ) : (
-      <>
+      <p className="mb-0">
         The session could not start because the image is still building. Please
         wait for the build to finish, or start the session with the base image.
-      </>
+      </p>
     );
 
   return (
-    <RenkuAlert color={color} timeout={0}>
-      <p className="mb-0">{content}</p>
-      <p>
-        <code>{dockerImageStatus}</code>
-      </p>
+    <RenkuAlert
+      className={dockerImageStatus === "available" && "pb-1"}
+      color={color}
+      timeout={0}
+    >
+      {content}
     </RenkuAlert>
   );
 }

--- a/client/src/features/session/components/StartNewSession.tsx
+++ b/client/src/features/session/components/StartNewSession.tsx
@@ -272,7 +272,6 @@ function SessionStartError() {
   }
 
   const color =
-    // error === "docker-image-building" ||
     error === "session-class" || error === "cloud-storage-credentials"
       ? "warning"
       : "danger";
@@ -287,13 +286,7 @@ function SessionStartError() {
       <>
         Starting a session is not possible because this project has no commit.
       </>
-    ) : // error === "docker-image-building" ? (
-    //   <>
-    //     The session could not start because the image is still building. Please
-    //     wait for the build to finish, or start the session with the base image.
-    //   </>
-    // ) :
-    error === "docker-image-not-available" ? (
+    ) : error === "docker-image-not-available" ? (
       <>
         The session could not start because no image is available. Please select
         a different commit or start the session with the base image.
@@ -337,12 +330,6 @@ function SessionStartErrorImageBuilding() {
   const dockerImageStatus = useAppSelector(
     ({ startSessionOptions }) => startSessionOptions.dockerImageStatus
   );
-  /*
-   | "unknown"
-  | "available"
-  | "not-available"
-  | "building";
-   */
 
   const color = dockerImageStatus === "not-available" ? "danger" : "warning";
   const content =

--- a/client/src/features/session/components/options/SessionProjectDockerImage.tsx
+++ b/client/src/features/session/components/options/SessionProjectDockerImage.tsx
@@ -588,11 +588,14 @@ function useDockerImageStatusStateMachine() {
       return;
     }
     const tag = commit.slice(0, 7);
-    getRegistryTag({
-      projectId: gitLabProjectId,
-      registryId: registry.id,
-      tag,
-    });
+    getRegistryTag(
+      {
+        projectId: gitLabProjectId,
+        registryId: registry.id,
+        tag,
+      },
+      /*preferCacheValue=*/ false
+    );
   }, [commit, getRegistryTag, gitLabProjectId, registry, status]);
 
   // Handle checking the Docker image

--- a/client/src/features/session/components/options/SessionProjectDockerImage.tsx
+++ b/client/src/features/session/components/options/SessionProjectDockerImage.tsx
@@ -332,10 +332,6 @@ function useDockerImageStatusStateMachine() {
   );
   const dispatch = useAppDispatch();
 
-  useEffect(() => {
-    console.log({ dockerImageBuildStatus: status });
-  }, [status]);
-
   const [
     getRenkuRegistry,
     {
@@ -495,13 +491,6 @@ function useDockerImageStatusStateMachine() {
 
   // Handle checking the CI/CD pipeline job
   useEffect(() => {
-    console.log({
-      status,
-      pipelineJobIsFetching,
-      pipelineJobIsSuccess,
-      pipelineJobError,
-      pipelineJob,
-    });
     if (
       status !== "checking-ci-jobs" ||
       pipelineJobIsFetching ||

--- a/client/src/features/session/components/options/SessionProjectDockerImage.tsx
+++ b/client/src/features/session/components/options/SessionProjectDockerImage.tsx
@@ -23,7 +23,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import cx from "classnames";
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Badge, Button, UncontrolledTooltip } from "reactstrap";
 
 import { ACCESS_LEVELS } from "../../../../api-client";
@@ -338,6 +338,7 @@ function useDockerImageStatusStateMachine() {
       currentData: registry,
       error: renkuRegistryError,
       isFetching: renkuRegistryIsFetching,
+      requestId: renkuRegistryRequestId,
     },
   ] = projectGitLabApi.useLazyGetRenkuRegistryQuery();
 
@@ -347,6 +348,7 @@ function useDockerImageStatusStateMachine() {
       currentData: registryTag,
       error: registryTagError,
       isFetching: registryTagIsFetching,
+      requestId: registryTagRequestId,
     },
   ] = projectGitLabApi.useLazyGetRegistryTagQuery();
 
@@ -356,6 +358,7 @@ function useDockerImageStatusStateMachine() {
       currentData: pipelines,
       error: pipelinesError,
       isFetching: pipelinesIsFetching,
+      requestId: pipelinesRequestId,
     },
   ] = projectGitLabApi.useLazyGetPipelinesQuery();
 
@@ -366,8 +369,11 @@ function useDockerImageStatusStateMachine() {
       error: pipelineJobError,
       isFetching: pipelineJobIsFetching,
       isSuccess: pipelineJobIsSuccess,
+      requestId: pipelineJobRequestId,
     },
   ] = projectGitLabApi.useLazyGetPipelineJobByNameQuery();
+
+  const [currentRequestId, setCurrentRequestId] = useState("");
 
   // Start checking for Docker images in CI/CD
   useEffect(() => {
@@ -389,15 +395,17 @@ function useDockerImageStatusStateMachine() {
     if (status !== "checking-ci-registry" || !gitLabProjectId) {
       return;
     }
-    getRenkuRegistry({
+    const action = getRenkuRegistry({
       projectId: `${gitLabProjectId}`,
     });
+    setCurrentRequestId(action.requestId);
   }, [getRenkuRegistry, gitLabProjectId, status]);
 
   // Handle checking the registry
   useEffect(() => {
     if (
       status !== "checking-ci-registry" ||
+      renkuRegistryRequestId !== currentRequestId ||
       renkuRegistryIsFetching ||
       (registry == null && renkuRegistryError == null)
     ) {
@@ -408,7 +416,15 @@ function useDockerImageStatusStateMachine() {
       return;
     }
     dispatch(setDockerImageBuildStatus("checking-ci-image"));
-  }, [dispatch, registry, renkuRegistryError, renkuRegistryIsFetching, status]);
+  }, [
+    currentRequestId,
+    dispatch,
+    registry,
+    renkuRegistryError,
+    renkuRegistryIsFetching,
+    renkuRegistryRequestId,
+    status,
+  ]);
 
   // Check the Docker image
   useEffect(() => {
@@ -416,17 +432,19 @@ function useDockerImageStatusStateMachine() {
       return;
     }
     const tag = commit.slice(0, 7);
-    getRegistryTag({
+    const action = getRegistryTag({
       projectId: gitLabProjectId,
       registryId: registry.id,
       tag,
     });
+    setCurrentRequestId(action.requestId);
   }, [commit, getRegistryTag, gitLabProjectId, registry, status]);
 
   // Handle checking the Docker image
   useEffect(() => {
     if (
       status !== "checking-ci-image" ||
+      registryTagRequestId !== currentRequestId ||
       registryTagIsFetching ||
       (registryTag == null && registryTagError == null)
     ) {
@@ -438,23 +456,33 @@ function useDockerImageStatusStateMachine() {
     }
     dispatch(setDockerImageBuildStatus("available"));
     dispatch(setDockerImageStatus("available"));
-  }, [dispatch, registryTag, registryTagError, registryTagIsFetching, status]);
+  }, [
+    currentRequestId,
+    dispatch,
+    registryTag,
+    registryTagError,
+    registryTagIsFetching,
+    registryTagRequestId,
+    status,
+  ]);
 
   // Check the CI/CD pipelines
   useEffect(() => {
     if (status !== "checking-ci-pipelines" || !gitLabProjectId) {
       return;
     }
-    getPipelines({
+    const action = getPipelines({
       commit,
       projectId: gitLabProjectId,
     });
+    setCurrentRequestId(action.requestId);
   }, [commit, getPipelines, gitLabProjectId, status]);
 
   // Handle checking the CI/CD pipelines
   useEffect(() => {
     if (
       status !== "checking-ci-pipelines" ||
+      pipelinesRequestId !== currentRequestId ||
       pipelinesIsFetching ||
       (pipelines == null && pipelinesError == null)
     ) {
@@ -475,24 +503,34 @@ function useDockerImageStatusStateMachine() {
       };
     }
     dispatch(setDockerImageBuildStatus("checking-ci-jobs"));
-  }, [dispatch, pipelines, pipelinesError, pipelinesIsFetching, status]);
+  }, [
+    currentRequestId,
+    dispatch,
+    pipelines,
+    pipelinesError,
+    pipelinesIsFetching,
+    pipelinesRequestId,
+    status,
+  ]);
 
   // Check the CI/CD pipeline job
   useEffect(() => {
     if (status !== "checking-ci-jobs" || !gitLabProjectId || !pipelines) {
       return;
     }
-    getPipelineJobByName({
+    const action = getPipelineJobByName({
       jobName: SESSION_CI_IMAGE_BUILD_JOB,
       pipelineIds: pipelines.map(({ id }) => id),
       projectId: gitLabProjectId,
     });
+    setCurrentRequestId(action.requestId);
   }, [getPipelineJobByName, gitLabProjectId, pipelines, status]);
 
   // Handle checking the CI/CD pipeline job
   useEffect(() => {
     if (
       status !== "checking-ci-jobs" ||
+      pipelineJobRequestId !== currentRequestId ||
       pipelineJobIsFetching ||
       (!pipelineJobIsSuccess && pipelineJobError == null)
     ) {
@@ -534,11 +572,13 @@ function useDockerImageStatusStateMachine() {
     dispatch(setDockerImageBuildStatus("error"));
     dispatch(setDockerImageStatus("not-available"));
   }, [
+    currentRequestId,
     dispatch,
     pipelineJob,
     pipelineJobError,
     pipelineJobIsFetching,
     pipelineJobIsSuccess,
+    pipelineJobRequestId,
     status,
   ]);
 
@@ -560,15 +600,17 @@ function useDockerImageStatusStateMachine() {
     if (status !== "checking-ci-done-registry" || !gitLabProjectId) {
       return;
     }
-    getRenkuRegistry({
+    const action = getRenkuRegistry({
       projectId: `${gitLabProjectId}`,
     });
+    setCurrentRequestId(action.requestId);
   }, [getRenkuRegistry, gitLabProjectId, status]);
 
   // Handle checking the registry
   useEffect(() => {
     if (
       status !== "checking-ci-done-registry" ||
+      renkuRegistryRequestId !== currentRequestId ||
       renkuRegistryIsFetching ||
       (registry == null && renkuRegistryError == null)
     ) {
@@ -580,7 +622,15 @@ function useDockerImageStatusStateMachine() {
       return;
     }
     dispatch(setDockerImageBuildStatus("checking-ci-done-image"));
-  }, [dispatch, registry, renkuRegistryError, renkuRegistryIsFetching, status]);
+  }, [
+    currentRequestId,
+    dispatch,
+    registry,
+    renkuRegistryError,
+    renkuRegistryIsFetching,
+    renkuRegistryRequestId,
+    status,
+  ]);
 
   // Check the Docker image, the CI/CD job is done, so it is supposed to exist
   useEffect(() => {
@@ -588,7 +638,7 @@ function useDockerImageStatusStateMachine() {
       return;
     }
     const tag = commit.slice(0, 7);
-    getRegistryTag(
+    const action = getRegistryTag(
       {
         projectId: gitLabProjectId,
         registryId: registry.id,
@@ -596,12 +646,14 @@ function useDockerImageStatusStateMachine() {
       },
       /*preferCacheValue=*/ false
     );
+    setCurrentRequestId(action.requestId);
   }, [commit, getRegistryTag, gitLabProjectId, registry, status]);
 
   // Handle checking the Docker image
   useEffect(() => {
     if (
       status !== "checking-ci-done-image" ||
+      registryTagRequestId !== currentRequestId ||
       registryTagIsFetching ||
       (registryTag == null && registryTagError == null)
     ) {
@@ -614,7 +666,15 @@ function useDockerImageStatusStateMachine() {
     }
     dispatch(setDockerImageBuildStatus("available"));
     dispatch(setDockerImageStatus("available"));
-  }, [dispatch, registryTag, registryTagError, registryTagIsFetching, status]);
+  }, [
+    currentRequestId,
+    dispatch,
+    registryTag,
+    registryTagError,
+    registryTagIsFetching,
+    registryTagRequestId,
+    status,
+  ]);
 
   // Periodically check the registry for the Docker image
   useEffect(() => {


### PR DESCRIPTION
Fixes #2906.

Update the session start warning when the image has finished building.

![Screenshot from 2023-12-11 13-14-05](https://github.com/SwissDataScienceCenter/renku-ui/assets/951086/d5743c67-839b-4a92-adbc-ca1cc8ed0f41)
![Screenshot from 2023-12-11 13-16-04](https://github.com/SwissDataScienceCenter/renku-ui/assets/951086/c33fc20d-a7cc-4748-83ab-712a120e91a1)
![Screenshot from 2023-12-11 13-18-58](https://github.com/SwissDataScienceCenter/renku-ui/assets/951086/b7b1b4ea-f1a5-4b9b-9437-000b3573cbd2)

/deploy