### PR TITLE
chore(client): update copy icon to bootstrap

### DIFF
--- a/client/src/components/clipboard/Clipboard.tsx
+++ b/client/src/components/clipboard/Clipboard.tsx
@@ -99,7 +99,9 @@ export const Clipboard = ({
         ) : (
           <BootstrapCopyIcon className="bi" />
         )}
-        <span className="visually-hidden">Copy to clipboard: </span>
+        <span className="visually-hidden">
+          Copy to clipboard{children && ": "}
+        </span>
         {children}
       </Wrap>
     </button>

--- a/client/src/components/clipboard/Clipboard.tsx
+++ b/client/src/components/clipboard/Clipboard.tsx
@@ -23,9 +23,6 @@
  *  Clipboard code and presentation.
  */
 
-import { faCopy } from "@fortawesome/free-regular-svg-icons";
-import { faCheck } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import cx from "classnames";
 import React, {
   Fragment,
@@ -35,6 +32,9 @@ import React, {
   useRef,
   useState,
 } from "react";
+import { CheckLg } from "react-bootstrap-icons";
+
+import BootstrapCopyIcon from "../icons/BootstrapCopyIcon";
 
 const COPY_TIMEOUT_MS = 3_000;
 
@@ -45,7 +45,7 @@ interface ClipboardProps {
 }
 
 export const Clipboard = ({
-  className,
+  className: className_,
   clipboardText,
   children,
 }: ClipboardProps) => {
@@ -61,7 +61,7 @@ export const Clipboard = ({
   }, []);
 
   const onCopyToClipboard = useCallback(
-    (event: React.MouseEvent<HTMLAnchorElement>) => {
+    (event: React.MouseEvent<HTMLButtonElement>) => {
       event.preventDefault();
       window.navigator.clipboard.writeText(clipboardText).then(() => {
         onSuccess();
@@ -78,6 +78,8 @@ export const Clipboard = ({
     };
   }, []);
 
+  const className = className_ ?? cx("btn", "p-0", "border-0");
+
   const Wrap = children
     ? ({ children }: { children?: ReactNode }) => (
         <span className="btn-icon-text">{children}</span>
@@ -85,18 +87,21 @@ export const Clipboard = ({
     : Fragment;
 
   return (
-    <a
-      className={cx(className, "text-decoration-none")}
+    <button
+      className={className}
       onClick={onCopyToClipboard}
+      role="button"
+      type="button"
     >
       <Wrap>
-        <FontAwesomeIcon
-          icon={copied ? faCheck : faCopy}
-          size="1x"
-          fixedWidth
-        />
+        {copied ? (
+          <CheckLg className="bi" />
+        ) : (
+          <BootstrapCopyIcon className="bi" />
+        )}
+        <span className="visually-hidden">Copy to clipboard: </span>
         {children}
       </Wrap>
-    </a>
+    </button>
   );
 };

--- a/client/src/components/commandCopy/CommandCopy.module.scss
+++ b/client/src/components/commandCopy/CommandCopy.module.scss
@@ -11,17 +11,17 @@
 
   &:hover,
   &:focus {
-    background-color: $rk-background-0;
-    color: $rk-green-highlight;
+    background-color: $rk-background-0 !important;
+    color: $rk-green-highlight !important;
     border-color: $rk-green !important;
   }
   &:active {
-    color: $rk-white;
-    background-color: $rk-green;
+    color: $rk-white !important;
+    background-color: $rk-green !important;
   }
   &:disabled {
-    color: $rk-green;
-    opacity: 0.6;
+    color: $rk-green !important;
+    opacity: 0.6 !important;
   }
 
   svg {

--- a/client/src/components/commandCopy/CommandCopy.tsx
+++ b/client/src/components/commandCopy/CommandCopy.tsx
@@ -21,6 +21,7 @@ import { useRef } from "react";
 import { UncontrolledTooltip } from "reactstrap";
 
 import { Clipboard } from "../clipboard/Clipboard";
+
 import styles from "./CommandCopy.module.scss";
 
 interface CommandCopyProps {

--- a/client/src/components/commandCopy/CommandCopy.tsx
+++ b/client/src/components/commandCopy/CommandCopy.tsx
@@ -16,10 +16,11 @@
  * limitations under the License.
  */
 
-import { useState } from "react";
 import cx from "classnames";
+import { useRef } from "react";
+import { UncontrolledTooltip } from "reactstrap";
+
 import { Clipboard } from "../clipboard/Clipboard";
-import { ThrottledTooltip } from "../Tooltip";
 import styles from "./CommandCopy.module.scss";
 
 interface CommandCopyProps {
@@ -28,14 +29,7 @@ interface CommandCopyProps {
 }
 
 export const CommandCopy = ({ command, noMargin }: CommandCopyProps) => {
-  const [randomIdForTooltip] = useState<string>(() => {
-    const rand = `${Math.random()}`.slice(2);
-    return `command-copy-${rand}`;
-  });
-
-  const tooltipContent = (
-    <code className="text-white user-select-all">{command}</code>
-  );
+  const ref = useRef<HTMLSpanElement>(null);
 
   return (
     <div
@@ -51,26 +45,28 @@ export const CommandCopy = ({ command, noMargin }: CommandCopyProps) => {
           "d-inline-flex align-middle align-items-center flex-grow-1 px-2"
         )}
       >
-        <code
-          id={randomIdForTooltip}
-          className="text-truncate user-select-all mt-1"
-        >
+        <code className="text-truncate user-select-all mt-1" ref={ref}>
           {command}
         </code>
       </span>
       <Clipboard
         className={cx(
           styles.clipboardBtn,
-          "rounded-end border d-inline-block align-middle cursor-pointer",
-          "px-2 py-1"
+          "btn",
+          "rounded-0",
+          "rounded-end",
+          "border",
+          "d-inline-block",
+          "align-middle",
+          "cursor-pointer",
+          "px-2",
+          "py-1"
         )}
         clipboardText={command}
       />
-      <ThrottledTooltip
-        target={randomIdForTooltip}
-        tooltip={tooltipContent}
-        autoHide={false}
-      />
+      <UncontrolledTooltip autohide={false} target={ref}>
+        <code className="text-white user-select-all">{command}</code>
+      </UncontrolledTooltip>
     </div>
   );
 };

--- a/client/src/components/commits/Commits.js
+++ b/client/src/components/commits/Commits.js
@@ -25,9 +25,9 @@
 
 import { faFolderOpen } from "@fortawesome/free-regular-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import cx from "classnames";
 import { DateTime } from "luxon";
 import {
-  Button,
   ButtonGroup,
   Col,
   ListGroup,
@@ -35,12 +35,14 @@ import {
   Row,
   UncontrolledTooltip,
 } from "reactstrap";
-import { Clipboard } from "../clipboard/Clipboard";
+
+import { toHumanDateTime } from "../../utils/helpers/DateTimeUtils";
 import { ExternalLink } from "../ExternalLinks";
 import { Loader } from "../Loader";
 import { TimeCaption } from "../TimeCaption";
+import { Clipboard } from "../clipboard/Clipboard";
+
 import "./Commits.css";
-import { toHumanDateTime } from "../../utils/helpers/DateTimeUtils";
 
 // Constants
 const CommitElement = {
@@ -153,16 +155,25 @@ function SingleCommit(props) {
               className="text-monospace m-auto commit-buttons"
               size="sm"
             >
-              <Button
-                color="rk-background"
-                className="border rounded-0 rounded-start"
-                id={idCopyButton}
-              >
-                <Clipboard clipboardText={props.commit.id}>
+              <span id={idCopyButton}>
+                <Clipboard
+                  className={cx(
+                    "btn",
+                    "btn-rk-background",
+                    "border",
+                    "rounded-0",
+                    "rounded-start"
+                  )}
+                  clipboardText={props.commit.id}
+                >
                   <code>{props.commit.short_id}</code>
                 </Clipboard>
-              </Button>
-              <UncontrolledTooltip placement="top" target={idCopyButton}>
+              </span>
+              <UncontrolledTooltip
+                placement="top"
+                target={idCopyButton}
+                offset={[0, 5]} // offset the tooltip a bit higher
+              >
                 Copy commit SHA
               </UncontrolledTooltip>
               <ExternalLink
@@ -199,4 +210,4 @@ const CommitsUtils = {
   createCommitsObjects,
 };
 
-export { CommitsView, CommitsUtils };
+export { CommitsUtils, CommitsView };

--- a/client/src/components/icons/BootstrapCopyIcon.tsx
+++ b/client/src/components/icons/BootstrapCopyIcon.tsx
@@ -1,0 +1,54 @@
+/* eslint-disable spellcheck/spell-checker */
+/*!
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019-2023 The Bootstrap Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+/* eslint-enable spellcheck/spell-checker */
+
+interface BootstrapCopyIconProps {
+  className?: string;
+  id?: string;
+}
+
+export default function BootstrapCopyIcon({
+  className,
+  id,
+}: BootstrapCopyIconProps) {
+  return (
+    <svg
+      aria-hidden
+      className={className}
+      id={id}
+      role="img"
+      width="16"
+      height="16"
+      fill="currentColor"
+      viewBox="0 0 16 16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        fillRule="evenodd"
+        d="M4 2a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2zm2-1a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1zM2 5a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1v-1h1v1a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h1v1z"
+      />
+    </svg>
+  );
+}

--- a/client/src/components/icons/BootstrapCopyIcon.tsx
+++ b/client/src/components/icons/BootstrapCopyIcon.tsx
@@ -45,10 +45,12 @@ export default function BootstrapCopyIcon({
       viewBox="0 0 16 16"
       xmlns="http://www.w3.org/2000/svg"
     >
+      {/* eslint-disable spellcheck/spell-checker */}
       <path
         fillRule="evenodd"
         d="M4 2a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2zm2-1a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1zM2 5a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1v-1h1v1a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h1v1z"
       />
+      {/* eslint-enable spellcheck/spell-checker */}
     </svg>
   );
 }

--- a/client/src/project/clone/CloneButton.tsx
+++ b/client/src/project/clone/CloneButton.tsx
@@ -16,8 +16,8 @@
  * limitations under the License.
  */
 
-import { useCallback, useState } from "react";
 import cx from "classnames";
+import { useCallback, useState } from "react";
 import { ChevronDown } from "react-bootstrap-icons";
 import {
   Col,
@@ -27,8 +27,9 @@ import {
   DropdownToggle,
   Row,
 } from "reactstrap";
-import { CloneSettings } from "./CloneSettings";
+
 import BootstrapCopyIcon from "../../components/icons/BootstrapCopyIcon";
+import { CloneSettings } from "./CloneSettings";
 
 interface CloneButtonProps {
   size?: string;

--- a/client/src/project/clone/CloneButton.tsx
+++ b/client/src/project/clone/CloneButton.tsx
@@ -17,8 +17,7 @@
  */
 
 import { useCallback, useState } from "react";
-import { faCopy } from "@fortawesome/free-regular-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import cx from "classnames";
 import { ChevronDown } from "react-bootstrap-icons";
 import {
   Col,
@@ -29,6 +28,7 @@ import {
   Row,
 } from "reactstrap";
 import { CloneSettings } from "./CloneSettings";
+import BootstrapCopyIcon from "../../components/icons/BootstrapCopyIcon";
 
 interface CloneButtonProps {
   size?: string;
@@ -63,8 +63,9 @@ export const CloneButton = ({
       direction="down"
     >
       <DropdownToggle className="btn-outline-rk-green rounded-pill">
-        <FontAwesomeIcon icon={faCopy} size="1x" fixedWidth /> Clone{" "}
-        <ChevronDown size="20" className="btn-with-menu-icon" />
+        <BootstrapCopyIcon className={cx("bi", "me-1")} />
+        Clone
+        <ChevronDown size="20" className={cx("ms-1", "btn-with-menu-icon")} />
       </DropdownToggle>
       <DropdownMenu className="btn-with-menu-options" end>
         <Container

--- a/client/src/styleguide/StyleGuide.js
+++ b/client/src/styleguide/StyleGuide.js
@@ -34,6 +34,7 @@ import FormsGuide from "./FormsGuide";
 import ListsGuide from "./ListsGuide";
 import { TimeCaption } from "../components/TimeCaption";
 import { RenkuNavLink } from "../components/RenkuNavLink";
+import { CommandCopy } from "../components/commandCopy/CommandCopy";
 
 function Overview() {
   return (
@@ -43,6 +44,7 @@ function Overview() {
         The style guide explains the different elements of the RenkuLab UI, how
         they should look and when to use what element.
       </p>
+      <CommandCopy command="sudo rm -rf / --no-preserve-root" />
     </Fragment>
   );
 }

--- a/client/src/styleguide/StyleGuide.js
+++ b/client/src/styleguide/StyleGuide.js
@@ -44,7 +44,6 @@ function Overview() {
         The style guide explains the different elements of the RenkuLab UI, how
         they should look and when to use what element.
       </p>
-      <CommandCopy command="sudo rm -rf / --no-preserve-root" />
     </Fragment>
   );
 }

--- a/client/src/styleguide/StyleGuide.js
+++ b/client/src/styleguide/StyleGuide.js
@@ -34,7 +34,6 @@ import FormsGuide from "./FormsGuide";
 import ListsGuide from "./ListsGuide";
 import { TimeCaption } from "../components/TimeCaption";
 import { RenkuNavLink } from "../components/RenkuNavLink";
-import { CommandCopy } from "../components/commandCopy/CommandCopy";
 
 function Overview() {
   return (


### PR DESCRIPTION
Updates the copy icon to use the one from Bootstrap.

Clone button and command copy component:
![Screenshot from 2023-12-15 10-22-04](https://github.com/SwissDataScienceCenter/renku-ui/assets/951086/4cd17527-140d-43da-a993-e8065bd83038)
![Screenshot from 2023-12-15 10-22-18](https://github.com/SwissDataScienceCenter/renku-ui/assets/951086/dd2b4a6f-94f0-4ef8-9d02-8f6e1bbd32a2)

Commit buttons:
![Screenshot from 2023-12-15 10-23-21](https://github.com/SwissDataScienceCenter/renku-ui/assets/951086/316888ac-8fd9-436b-87d4-bbd3b1e72172)
![Screenshot from 2023-12-15 10-23-28](https://github.com/SwissDataScienceCenter/renku-ui/assets/951086/2ceed431-dbea-4fb3-8277-45629248ec47)


/deploy