### PR TITLE
[WIP]feat: use new project api

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -39,6 +39,7 @@ import { Dashboard } from "./features/dashboard/Dashboard";
 import InactiveKGProjectsPage from "./features/inactiveKgProjects/InactiveKgProjects";
 import SearchPage from "./features/kgSearch/KgSearchPage";
 import { Unavailable } from "./features/maintenance/Maintenance";
+import { NewProject } from "./features/project/editNew/NewProject";
 import AnonymousSessionsList from "./features/session/components/AnonymousSessionsList";
 import { useGetUserInfoQuery } from "./features/user/keycloakUser.api";
 import Help from "./help";
@@ -48,7 +49,6 @@ import { NotificationsManager, NotificationsPage } from "./notifications";
 import { Cookie, Privacy } from "./privacy";
 import { Project } from "./project";
 import { ProjectList } from "./project/list";
-import { NewProject } from "./project/new";
 import { StyleGuide } from "./styleguide";
 import AppContext from "./utils/context/appContext";
 import useLegacySelector from "./utils/customHooks/useLegacySelector.hook";
@@ -187,15 +187,9 @@ function CentralContentContainer(props) {
           <Route
             exact
             path={Url.get(Url.pages.project.new)}
-            render={(p) => (
+            render={() => (
               <ContainerWrap>
-                <NewProject
-                  key="newProject"
-                  model={props.model}
-                  user={props.user}
-                  client={props.client}
-                  {...p}
-                />
+                <NewProject />
               </ContainerWrap>
             )}
           />

--- a/client/src/components/form-field/TextInput.tsx
+++ b/client/src/components/form-field/TextInput.tsx
@@ -30,6 +30,7 @@ type TextInputProps = {
   name: string;
   register: UseFormRegisterReturn;
   required: boolean;
+  readOnly?: boolean;
 };
 
 function TextInput(props: TextInputProps) {
@@ -44,6 +45,7 @@ function TextInput(props: TextInputProps) {
         className="form-control"
         data-cy={props.dataCy}
         id={props.name}
+        readOnly={props.readOnly}
         {...props.register}
       />
       {props.help && <FormText color="muted">{props.help}</FormText>}

--- a/client/src/components/templateSelector/TemplateSelector.stories.tsx
+++ b/client/src/components/templateSelector/TemplateSelector.stories.tsx
@@ -17,8 +17,9 @@
  */
 
 import { Meta, StoryObj } from "@storybook/react";
-import { NewProjectTemplate, Repository } from "../../model/RenkuModels";
+import { Repository } from "../../model/RenkuModels";
 import TemplateSelector from "./TemplateSelector";
+import { Templates } from "../../features/templates/templates.api";
 
 const meta: Meta<typeof TemplateSelector> = {
   title: "Components/Forms/Template Selector",
@@ -75,7 +76,7 @@ const repositories: Repository[] = [
     url: "https://github.com/SwissDataScienceCenter/renku-project-template",
   },
 ];
-const templates: NewProjectTemplate[] = [
+const templates: Templates[] = [
   {
     description:
       "The simplest Python-3.9-based renku " +
@@ -87,50 +88,55 @@ const templates: NewProjectTemplate[] = [
     parentRepo: "Renku",
     parentTemplate: "python-minimal",
     variables: {},
+    isSSHSupported: true,
   },
   {
     description:
       "The simplest R-4.1.2-based renku project with a basic directory structure " +
       "and necessary supporting files.",
-    icon: undefined,
+    icon: "",
     id: "Renku/R-minimal",
     name: "Basic R (4.1.2) Project",
     parentRepo: "Renku",
     parentTemplate: "R-minimal",
     variables: {},
+    isSSHSupported: true,
   },
   {
     description:
       "The simplest R bioconductor-3.14-based renku project with a " +
       "basic directory structure and necessary supporting files.",
-    icon: undefined,
+    icon: "",
     id: "Renku/bioc-minimal",
     name: "R-Bioconductor (3.14) Project",
     parentRepo: "Renku",
     parentTemplate: "bioc-minimal", // eslint-disable-line spellcheck/spell-checker
     variables: {},
+    isSSHSupported: true,
   },
   {
     description:
       "The simplest Julia 1.7.1-based renku project with a basic " +
       "directory structure and necessary supporting files.",
-    icon: undefined,
+    icon: "",
     id: "Renku/julia-minimal",
     name: "Basic Julia (1.7.1) Project",
     parentRepo: "Renku",
     parentTemplate: "julia-minimal", // eslint-disable-line spellcheck/spell-checker
     variables: {},
+    isSSHSupported: true,
   },
   {
     description:
       "The simplest renku project template with files for renku CLI and " +
       "launching projects on renkulab.",
-    icon: undefined,
+    icon: "",
     id: "Renku/minimal",
     name: "Minimal Renku",
     parentRepo: "Renku",
     parentTemplate: "minimal",
     variables: {},
+    isSSHSupported: true,
   },
 ];
 
@@ -170,7 +176,7 @@ export const Selected: Story = {
   args: {
     repositories,
     templates,
-    selected: "Renku/python-minimal",
+    selected: templates[0],
     isRequired: true,
     isInvalid: false,
     isDisabled: false,

--- a/client/src/features/project/Project.d.ts
+++ b/client/src/features/project/Project.d.ts
@@ -357,6 +357,20 @@ export interface EditProjectParams {
   projectId: number;
 }
 
+export interface NewProject {
+  avatar?: File;
+  description?: string;
+  keywords?: string[];
+  namespaceId?: number;
+  templateId: string;
+  templateRepositoryUrl: string;
+  name: string;
+  visibility: "public" | "internal" | "private";
+}
+export interface CreateProjectParams {
+  project: NewProject;
+}
+
 export interface EditAvatarProjectParams {
   projectPathWithNamespace: string;
   avatar: File;
@@ -367,6 +381,12 @@ interface UpdateProjectResponse {
   message: string;
   severity: string;
   branch?: string;
+}
+
+interface CreateProjectResponse {
+  message: string;
+  severity: string;
+  slug?: string;
 }
 
 export interface GitlabProjectResponse {

--- a/client/src/features/project/components/form/AvatarInput.tsx
+++ b/client/src/features/project/components/form/AvatarInput.tsx
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2020 - Swiss Data Science Center (SDSC)
+ * Copyright 2024 - Swiss Data Science Center (SDSC)
  * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
  * Eidgenössische Technische Hochschule Zürich (ETHZ).
  *
@@ -16,13 +16,23 @@
  * limitations under the License.
  */
 
-/**
- *  renku-ui
- *
- *  project/new
- *  Components for the new project page
- */
+import { Control, Controller, UseFormRegisterReturn } from "react-hook-form";
+import { NewProjectFormFields } from "../../projectKg.types";
+import NewProjectAvatar from "../../../../project/new/components/NewProjectAvatar";
 
-import { NewProject, ForkProject } from "./ProjectNew.container";
+interface AvatarInputProps {
+  register: UseFormRegisterReturn;
+  control: Control<NewProjectFormFields>;
+}
 
-export { NewProject, ForkProject };
+export default function AvatarInput({ control }: AvatarInputProps) {
+  return (
+    <Controller
+      control={control}
+      name="avatar"
+      render={({ field }) => (
+        <NewProjectAvatar onAvatarChange={field.onChange} />
+      )}
+    />
+  );
+}

--- a/client/src/features/project/components/form/NamespaceInput.tsx
+++ b/client/src/features/project/components/form/NamespaceInput.tsx
@@ -1,0 +1,58 @@
+/*!
+ * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Control, Controller, UseFormRegisterReturn } from "react-hook-form";
+import Namespaces from "../../../../project/new/components/Namespaces";
+import useGetNamespaces from "../../../../utils/customHooks/UseGetNamespaces";
+import useLegacySelector from "../../../../utils/customHooks/useLegacySelector.hook";
+import { NewProjectFormFields } from "../../projectKg.types";
+import { Namespace } from "../../../projects/projects.api";
+
+interface NamespaceInputProps {
+  register: UseFormRegisterReturn;
+  namespaceValue?: Namespace;
+  isAutomated: boolean;
+  control: Control<NewProjectFormFields>;
+}
+
+export default function NamespaceInput({
+  namespaceValue,
+  isAutomated,
+  control,
+}: NamespaceInputProps) {
+  const namespaces = useGetNamespaces(true);
+  const user = useLegacySelector((state) => state.stateModel.user);
+
+  return (
+    <Controller
+      control={control}
+      name="namespace"
+      render={({ field }) => (
+        <Namespaces
+          namespaces={namespaces}
+          namespaceValue={namespaceValue}
+          setNamespace={field.onChange}
+          user={user}
+          automated={isAutomated}
+          control={control}
+        />
+      )}
+      rules={{ required: true }}
+    />
+  );
+}

--- a/client/src/features/project/components/form/TemplateVariablesInput.tsx
+++ b/client/src/features/project/components/form/TemplateVariablesInput.tsx
@@ -1,0 +1,52 @@
+/*!
+ * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Control, Controller, UseFormRegisterReturn } from "react-hook-form";
+import { NewProjectFormFields } from "../../projectKg.types";
+import TemplateVariables from "../../../../project/new/components/TemplateVariables";
+import { Templates } from "../../../templates/templates.api";
+
+interface TemplateVariablesInputProps {
+  register: UseFormRegisterReturn;
+  control: Control<NewProjectFormFields>;
+  template?: Templates;
+  templateVariables?: Record<string, unknown>;
+}
+
+export default function TemplateVariablesInput({
+  template,
+  templateVariables,
+  control,
+}: TemplateVariablesInputProps) {
+  if (!template) return null;
+
+  return (
+    <Controller
+      control={control}
+      name="templateVariables"
+      render={({ field }) => (
+        <TemplateVariables
+          template={template}
+          templateVariables={templateVariables}
+          setVariable={field.onChange}
+        />
+      )}
+      rules={{ required: true }}
+    />
+  );
+}

--- a/client/src/features/project/components/form/UserTemplateInput.tsx
+++ b/client/src/features/project/components/form/UserTemplateInput.tsx
@@ -1,0 +1,84 @@
+/*!
+ * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Control, Controller, UseFormRegisterReturn } from "react-hook-form";
+import { NewProjectFormFields } from "../../projectKg.types";
+import UserTemplate from "../../../../project/new/components/UserTemplate";
+import useLegacySelector from "../../../../utils/customHooks/useLegacySelector.hook";
+import { RepositoriesParams } from "../../../templates/templates.types";
+import { CustomUserTemplate } from "../../editNew/NewProject.types";
+import { ControllerRenderProps } from "react-hook-form/dist/types/controller";
+
+interface UserTemplateInputProps {
+  register: UseFormRegisterReturn;
+  control: Control<NewProjectFormFields>;
+  userTemplate?: CustomUserTemplate;
+  templateVariables?: Record<string, unknown>;
+  setUserRepositories: (repositories: RepositoriesParams[] | null) => void;
+}
+
+export default function UserTemplateInput({
+  userTemplate,
+  control,
+  setUserRepositories,
+}: UserTemplateInputProps) {
+  const config = useLegacySelector(
+    (state) => state.stateModel.newProject.config
+  );
+  const getUserTemplates = () => {
+    if (userTemplate && userTemplate?.url && userTemplate?.reference) {
+      setUserRepositories([
+        {
+          url: userTemplate.url,
+          ref: userTemplate.reference,
+          name: "Custom",
+        },
+      ]);
+    }
+  };
+
+  const setTemplateProperty = (
+    property: string,
+    value: string,
+    field: ControllerRenderProps<NewProjectFormFields, "userTemplate">
+  ) => {
+    setUserRepositories(null);
+    if (property === "ref") {
+      field.onChange({ url: field.value?.url || "", reference: value });
+    } else if (property === "url") {
+      field.onChange({ url: value, reference: field.value?.reference || "" });
+    }
+  };
+
+  return (
+    <Controller
+      control={control}
+      name="userTemplate"
+      render={({ field }) => (
+        <UserTemplate
+          userTemplate={userTemplate}
+          getUserTemplates={getUserTemplates}
+          config={config}
+          setTemplateProperty={(property: string, value: string) =>
+            setTemplateProperty(property, value, field)
+          }
+        />
+      )}
+    />
+  );
+}

--- a/client/src/features/project/editNew/NewProject.tsx
+++ b/client/src/features/project/editNew/NewProject.tsx
@@ -1,0 +1,107 @@
+/*!
+ * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import LoginAlert from "../../../components/loginAlert/LoginAlert";
+import useLegacySelector from "../../../utils/customHooks/useLegacySelector.hook";
+import { NewProjectForm } from "./NewProjectForm";
+import useAppSelector from "../../../utils/customHooks/useAppSelector.hook";
+import useAppDispatch from "../../../utils/customHooks/useAppDispatch.hook";
+import { setFormValues } from "./projectForm.slice";
+import React from "react";
+import { useCreateProjectMutation } from "../projectKg.api";
+import { SubmitHandler } from "react-hook-form";
+import { NewProjectFormFields } from "../projectKg.types";
+import { CreateProjectParams } from "../Project";
+import FormSchema from "../../../components/formschema/FormSchema";
+import { useLocation } from "react-router-dom";
+import { redirectAfterSubmit } from "./NewProject.utils";
+import { useHistory } from "react-router";
+
+export function NewProject() {
+  const [submitting, setSubmitting] = React.useState(false);
+  const dispatch = useAppDispatch();
+  const [createProjectMutation] = useCreateProjectMutation();
+  const formState = useAppSelector(({ projectForm }) => projectForm);
+  const user = useLegacySelector((state) => state.stateModel.user);
+  const location = useLocation();
+  const history = useHistory();
+  const onSubmit: SubmitHandler<NewProjectFormFields> = React.useCallback(
+    async (data: NewProjectFormFields) => {
+      setSubmitting(true);
+      dispatch(setFormValues(data));
+      const submitData = { ...data };
+
+      try {
+        // step 1: prepare the project
+        const newProjectBody: CreateProjectParams = {
+          project: {
+            avatar: submitData.avatar,
+            description: submitData.description,
+            keywords: submitData.keywords,
+            namespaceId: submitData.namespace?.id,
+            templateId: submitData.template?.id || "",
+            templateRepositoryUrl: submitData.userTemplate?.url || "",
+            name: submitData.name,
+            visibility: submitData.visibility,
+          },
+        };
+
+        const response = await createProjectMutation(newProjectBody);
+        // TODO: Use progress component and show success or error message
+        setSubmitting(false);
+        if ("data" in response && response.data.message === "Project created") {
+          const projectPathWithNamespace = response.data.slug || "";
+          redirectAfterSubmit(history, projectPathWithNamespace, undefined);
+        } else {
+          return;
+        }
+      } catch (error) {
+        setSubmitting(false);
+      }
+    },
+    [dispatch, setSubmitting, createProjectMutation, history]
+  );
+
+  if (!user.logged) {
+    const textIntro = "Only authenticated users can create new projects.";
+    const textPost = "to create a new project.";
+    return (
+      <LoginAlert
+        logged={user.logged}
+        textIntro={textIntro}
+        textPost={textPost}
+      />
+    );
+  }
+  const desc =
+    "Create a project to house your files, include datasets, " +
+    "plan your work, and collaborate on code, among other things.";
+
+  return (
+    <FormSchema showHeader={!submitting} title="New Project" description={desc}>
+      <NewProjectForm
+        formState={formState}
+        importingDataset={false}
+        location={location}
+        onSubmit={onSubmit}
+        submitButtonText="Create Project"
+        submitLoaderText="Creating Project"
+      />
+    </FormSchema>
+  );
+}

--- a/client/src/features/project/editNew/NewProject.types.ts
+++ b/client/src/features/project/editNew/NewProject.types.ts
@@ -1,0 +1,46 @@
+import { NewProjectFormFields } from "../projectKg.types";
+import { FieldErrors } from "react-hook-form";
+import { Namespace } from "../../projects/projects.api";
+import { Templates } from "../../templates/templates.api";
+
+export type ProjectFormFieldKey = keyof NewProjectFormFields;
+export type ProjectFormErrorsProps = {
+  errors: FieldErrors<NewProjectFormFields>;
+};
+
+export type ProjectDisplayProps = {
+  submitButtonText: string;
+  submitLoaderText: string;
+};
+
+export interface CustomUserTemplate {
+  url: string;
+  reference: string;
+}
+export interface UserTemplateVariables {
+  name: string;
+  value: unknown;
+  type: string;
+  description: string;
+}
+
+export interface TemplateVariable {
+  description: string;
+  default_value?: any;
+}
+
+export type NewProjectFormState = {
+  form: {
+    avatar?: File;
+    description: string;
+    keywords: string[];
+    namespace?: Namespace;
+    slug: string;
+    isCustomTemplate: boolean;
+    template?: Templates;
+    templateVariables?: Record<string, any>;
+    name: string;
+    userTemplate?: CustomUserTemplate;
+    visibility: "public" | "internal" | "private";
+  };
+};

--- a/client/src/features/project/editNew/NewProject.utils.ts
+++ b/client/src/features/project/editNew/NewProject.utils.ts
@@ -1,0 +1,136 @@
+import { Url } from "../../../utils/helpers/url";
+import { btoaUTF8 } from "../../../utils/helpers/Encoding";
+import { TemplateVariable } from "./NewProject.types";
+import {
+  slugFromTitle,
+  verifyTitleCharacters,
+} from "../../../utils/helpers/HelperFunctions";
+import { GitlabProjectResponse } from "../Project";
+import { NewProjectFormFields } from "../projectKg.types";
+import { UseFormSetError } from "react-hook-form";
+import { useHistory } from "react-router-dom";
+
+// ? reference https://docs.gitlab.com/ce/user/reserved_names.html#reserved-project-names
+const RESERVED_TITLE_NAMES = [
+  "badges",
+  "blame",
+  "blob",
+  "builds",
+  "commits",
+  "create",
+  "create_dir",
+  "edit",
+  "sessions/folders",
+  "files",
+  "find_file",
+  "gitlab-lfs/objects",
+  "info/lfs/objects",
+  "new",
+  "preview",
+  "raw",
+  "refs",
+  "tree",
+  "update",
+  "wikis",
+];
+
+export async function redirectAfterSubmit(
+  history: ReturnType<typeof useHistory>,
+  projectPathWithNamespace: string,
+  state: unknown
+) {
+  history.push({
+    pathname: `/projects/${projectPathWithNamespace}`,
+    state,
+  });
+}
+
+export const createEncodedNewProjectUrl = (data: Record<string, unknown>) => {
+  if (!data || !Object.keys(data).length)
+    return Url.get(Url.pages.project.new, {}, true);
+  const encodedContent = btoaUTF8(JSON.stringify(data));
+  return Url.get(Url.pages.project.new, { data: encodedContent }, true);
+};
+
+export function getDefaultTemplateVariables(
+  variables: Record<string, TemplateVariable>
+) {
+  const defaultValues: Record<string, unknown> = {};
+  Object.keys(variables).map((variableKey) => {
+    defaultValues[variableKey] =
+      variables && variables[variableKey].default_value;
+  });
+  return defaultValues;
+}
+
+/**
+ * Verify whether the title is valid.
+ *
+ * @param {string} title - title to validate.
+ * @returns {string} error description or null if the string is valid.
+ */
+export function validateTitle(title: string) {
+  if (!title || !title.length) return "Title is missing.";
+  else if (RESERVED_TITLE_NAMES.includes(title)) return "Reserved title name.";
+  else if (title.length && ["_", "-", " ", "."].includes(title[0]))
+    return "Title must start with a letter or a number.";
+  else if (!verifyTitleCharacters(title))
+    return "Title can contain only letters, digits, '_', '.', '-' or spaces.";
+  else if (title && !slugFromTitle(title, true))
+    return "Title must contain at least one letter (without any accents) or a number.";
+  return null;
+}
+
+/**
+ * Verify whether the title and namespace will produce a duplicate.
+ *
+ * @param {string} title - current title.
+ * @param {string} namespace - current namespace.
+ * @param {string[]} projectsPaths - list of current own projects paths.
+ * @returns {boolean} whether the title would create a duplicate or not.
+ */
+export function checkTitleDuplicates(
+  title: string,
+  namespace: string,
+  projectsPaths: string[]
+) {
+  if (!title || !namespace || !projectsPaths || !projectsPaths.length)
+    return false;
+
+  const expectedTitle = slugFromTitle(title, true);
+  const expectedSlug = `${namespace}/${expectedTitle}`;
+  if (projectsPaths.includes(expectedSlug)) return true;
+
+  return false;
+}
+
+export function validateNewProjectName(
+  name: string,
+  namespace: string,
+  userProjects: GitlabProjectResponse[],
+  setError: UseFormSetError<NewProjectFormFields>
+) {
+  const titleNotValid = validateTitle(name);
+  if (titleNotValid) {
+    setError("name", { type: "custom", message: titleNotValid });
+  } else {
+    const projectWithFullPaths = userProjects?.map(
+      (p: GitlabProjectResponse) => p.path_with_namespace
+    );
+    const isDuplicate = checkTitleDuplicates(
+      name,
+      namespace,
+      projectWithFullPaths
+    );
+    if (isDuplicate) {
+      setError("name", {
+        type: "custom",
+        message:
+          "Title produces a project identifier (" +
+          slugFromTitle(name, true) +
+          ") that is already taken in the selected namespace. " +
+          "Please select a different title or namespace.",
+      });
+    }
+  }
+}

--- a/client/src/features/project/editNew/NewProjectForm.tsx
+++ b/client/src/features/project/editNew/NewProjectForm.tsx
@@ -1,0 +1,233 @@
+/*!
+ * Copyright 2023 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useContext, useState } from "react";
+import { SubmitHandler, useForm } from "react-hook-form";
+import { NewProjectFormFields } from "../projectKg.types";
+import { NewProjectFormState, ProjectDisplayProps } from "./NewProject.types";
+
+import { slugFromTitle } from "../../../utils/helpers/HelperFunctions";
+import TextInput from "../../../components/form-field/TextInput";
+import TextAreaInput from "../../../components/form-field/TextAreaInput";
+import { ExternalLink } from "../../../components/ExternalLinks";
+import useGetNamespaces from "../../../utils/customHooks/UseGetNamespaces";
+import Visibility from "../../../project/new/components/Visibility";
+import { Visibilities } from "../../../components/visibility/Visibility";
+import TemplateSource from "../../../project/new/components/TemplateSource";
+import { Template } from "../../../project/new/components/Template";
+import SubmitFormButton from "../../../project/new/components/SubmitFormButton";
+import useGetUserProjects from "../../../utils/customHooks/UseGetProjects";
+import NamespaceInput from "../components/form/NamespaceInput";
+import { DEFAULT_APP_PARAMS } from "../../../utils/context/appParams.constants";
+import AppContext from "../../../utils/context/appContext";
+import { RepositoriesParams } from "../../templates/templates.types";
+import TemplateVariablesInput from "../components/form/TemplateVariablesInput";
+import UserTemplateInput from "../components/form/UserTemplateInput";
+import {
+  getDefaultTemplateVariables,
+  validateNewProjectName,
+} from "./NewProject.utils";
+import AvatarInput from "../components/form/AvatarInput";
+
+interface NewProjectFormProps extends ProjectDisplayProps {
+  formState: NewProjectFormState;
+  location: unknown;
+  onSubmit: SubmitHandler<NewProjectFormFields>;
+  importingDataset: boolean;
+}
+
+export function NewProjectForm(props: NewProjectFormProps) {
+  const {
+    control,
+    formState,
+    handleSubmit,
+    getValues,
+    getFieldState,
+    register,
+    setValue,
+    setError,
+    clearErrors,
+    watch,
+  } = useForm<NewProjectFormFields>({
+    defaultValues: props.formState.form,
+  });
+  const { params } = useContext(AppContext);
+  const { onSubmit, importingDataset } = props;
+  const [userRepositories, setUserRepositories] = useState<
+    RepositoriesParams[] | null
+  >(null);
+
+  const { fetched: fetchedNamespace } = useGetNamespaces(true);
+  const { isFetchingProjects, projectsMember } = useGetUserProjects();
+  const createDataAvailable = !isFetchingProjects && fetchedNamespace;
+  const renkuLabRepositories =
+    params?.TEMPLATES?.repositories ??
+    DEFAULT_APP_PARAMS.TEMPLATES.repositories;
+  const name = watch("name");
+  const namespace = watch("namespace");
+  const template = watch("template");
+  const templateVariables = watch("templateVariables");
+  const isCustomTemplate = watch("isCustomTemplate");
+  const userTemplate = watch("userTemplate");
+
+  React.useEffect(() => {
+    if (template?.variables) {
+      setValue(
+        "templateVariables",
+        getDefaultTemplateVariables(template.variables || {})
+      );
+    } else {
+      setValue("templateVariables", {});
+    }
+  }, [template, setValue]);
+
+  React.useEffect(() => {
+    setValue("template", undefined);
+  }, [setValue, isCustomTemplate]);
+
+  React.useEffect(() => {
+    const nameState = getFieldState("name");
+    if (nameState.isDirty || nameState.isTouched) {
+      clearErrors("name");
+      validateNewProjectName(
+        name,
+        namespace?.full_path || "",
+        projectsMember,
+        setError
+      );
+    }
+  }, [
+    setError,
+    clearErrors,
+    name,
+    namespace?.full_path,
+    projectsMember,
+    getFieldState,
+  ]);
+
+  React.useEffect(() => {
+    setValue(
+      "slug",
+      `${namespace?.full_path}/${
+        name ? slugFromTitle(name, true) : "<no title>"
+      }`
+    );
+  }, [setValue, name, namespace]);
+
+  // registers
+  register("avatar");
+
+  const isAutomated = false; // TODO
+
+  return (
+    <form className="form-rk-green" onSubmit={handleSubmit(props.onSubmit)}>
+      <TextInput
+        error={formState.errors.name}
+        dataCy="input-name"
+        help={
+          <span>
+            A brief name to identify the project. There are a few{" "}
+            <ExternalLink
+              url="https://docs.gitlab.com/ce/user/reserved_names.html#reserved-project-names"
+              title="reserved names"
+              role="link"
+            />{" "}
+            you cannot use
+          </span>
+        }
+        label="Name"
+        name="name"
+        required={true}
+        register={register("name", { required: "A name is required" })}
+      />
+      <NamespaceInput
+        control={control}
+        namespaceValue={getValues("namespace")}
+        isAutomated={isAutomated}
+        register={register("namespace", {
+          required: "A namespace is required",
+        })}
+      />
+      <TextInput
+        error={formState.errors.slug}
+        help="This is automatically derived from Namespace and Title"
+        label="Slug"
+        name="slug"
+        required={true}
+        readOnly={true}
+        register={register("slug", {
+          required:
+            "A slug is required; a default is derived from the name, but it can be modified",
+        })}
+      />
+      <TextAreaInput<NewProjectFormFields>
+        control={control}
+        help="Let people know what the project is about"
+        getValue={() => getValues("description")}
+        label="Description"
+        name="description"
+        register={register("description")}
+      />
+      <Visibility
+        namespace={namespace}
+        isInvalid={getFieldState("visibility").invalid}
+        customVisibility={undefined} // TODO ANDREA get this from params
+        register={register("visibility")}
+        control={control}
+        visibilityValue={getValues("visibility") as Visibilities}
+      />
+      <AvatarInput register={register("avatar")} control={control} />
+      <TemplateSource
+        register={register("isCustomTemplate")}
+        value={getValues("isCustomTemplate")}
+        isRequired={true}
+        control={control}
+      />
+      {isCustomTemplate ? (
+        <UserTemplateInput
+          register={register("userTemplate")}
+          userTemplate={userTemplate}
+          control={control}
+          setUserRepositories={setUserRepositories}
+        />
+      ) : null}
+      <Template
+        control={control}
+        register={register("template")}
+        template={template}
+        isCustomTemplate={getValues("isCustomTemplate")}
+        userRepositories={userRepositories}
+        renkuLabRepositories={renkuLabRepositories}
+      />
+      <TemplateVariablesInput
+        control={control}
+        register={register("templateVariables")}
+        template={template}
+        templateVariables={templateVariables}
+      />
+      <SubmitFormButton
+        createDataAvailable={createDataAvailable}
+        onSubmit={onSubmit}
+        importingDataset={importingDataset}
+        getValues={getValues}
+      />
+      {/*<FormWarnings meta={meta} /> TODO: use formState.errors to get fields with errors  */}
+      {/*<FormErrors meta={meta} input={input} /> TODO: use formState.errors to get fields with errors */}
+    </form>
+  );
+}

--- a/client/src/features/project/editNew/ProjectFromErrors.tsx
+++ b/client/src/features/project/editNew/ProjectFromErrors.tsx
@@ -1,0 +1,21 @@
+import {
+  ProjectFormErrorsProps,
+  ProjectFormFieldKey,
+} from "./NewProject.types";
+import { FormErrorFields } from "../../../project/new/components/FormValidations";
+
+export default function ProjectFormErrors({ errors }: ProjectFormErrorsProps) {
+  function fieldNameToLabel(fieldName: string) {
+    return fieldName.charAt(0).toUpperCase() + fieldName.slice(1);
+  }
+  const formFields = Object.keys(errors) as unknown as ProjectFormFieldKey[];
+  const errorFields = formFields
+    .filter((field) => errors[field])
+    .map(fieldNameToLabel);
+  if (errorFields.length == 0) return null;
+  return (
+    <div className="mb-2">
+      <FormErrorFields errorFields={errorFields} />
+    </div>
+  );
+}

--- a/client/src/features/project/editNew/projectForm.slice.ts
+++ b/client/src/features/project/editNew/projectForm.slice.ts
@@ -1,0 +1,49 @@
+/*!
+ * Copyright 2023 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { NewProjectFormState } from "./NewProject.types";
+
+const initialState: NewProjectFormState = {
+  form: {
+    description: "",
+    isCustomTemplate: false,
+    keywords: [],
+    slug: "",
+    name: "",
+    visibility: "public",
+    templateVariables: {},
+    template: undefined,
+  },
+};
+
+export const newProjectFormSlide = createSlice({
+  name: "projectForm",
+  initialState,
+  reducers: {
+    setFormValues: (
+      state,
+      action: PayloadAction<NewProjectFormState["form"]>
+    ) => {
+      state.form = { ...action.payload, ...state.form };
+    },
+    reset: () => initialState,
+  },
+});
+
+export const { setFormValues, reset } = newProjectFormSlide.actions;

--- a/client/src/features/project/projectKg.api.ts
+++ b/client/src/features/project/projectKg.api.ts
@@ -23,6 +23,8 @@ import {
 } from "@reduxjs/toolkit/query/react";
 
 import {
+  CreateProjectParams,
+  CreateProjectResponse,
   DatasetKg,
   DeleteProjectParams,
   DeleteProjectResponse,
@@ -180,6 +182,19 @@ export const projectKgApi = createApi({
         { type: "project-kg-metadata", id: args.projectId },
       ],
     }),
+    createProject: builder.mutation<CreateProjectResponse, CreateProjectParams>(
+      {
+        query: ({ project }) => {
+          return {
+            method: "POST",
+            url: `projects`,
+            body: {
+              ...project,
+            },
+          };
+        },
+      }
+    ),
     updateAvatarProject: builder.mutation<
       UpdateProjectResponse,
       EditAvatarProjectParams
@@ -210,4 +225,5 @@ export const {
   useProjectMetadataQuery,
   useUpdateProjectMutation,
   useUpdateAvatarProjectMutation,
+  useCreateProjectMutation,
 } = projectKgApi;

--- a/client/src/features/project/projectKg.types.ts
+++ b/client/src/features/project/projectKg.types.ts
@@ -1,4 +1,5 @@
 import { ProjectKgParams } from "./Project";
+import { NewProjectFormState } from "./editNew/NewProject.types";
 
 export interface JsonLdValue<T> {
   "@value": T;
@@ -9,6 +10,7 @@ export interface JsonLdDate {
   "@value": string;
 }
 
+export type NewProjectFormFields = NewProjectFormState["form"];
 export interface KgJsonLdResponse {
   "@id": string;
   "@type": string[];

--- a/client/src/features/projects/projects.api.ts
+++ b/client/src/features/projects/projects.api.ts
@@ -36,7 +36,7 @@ interface MemberProjectResponse {
   hasNextPage: boolean;
 }
 
-type Namespace = {
+export type Namespace = {
   id: number;
   name: string;
   path: string;

--- a/client/src/features/templates/templates.api.ts
+++ b/client/src/features/templates/templates.api.ts
@@ -1,0 +1,131 @@
+/*!
+ * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/dist/query/react";
+import { FetchArgs, FetchBaseQueryError } from "@reduxjs/toolkit/query";
+import { GetTemplatesParams, RepositoriesParams } from "./templates.types";
+import { TemplateVariable } from "../project/editNew/NewProject.types";
+
+type GetTemplatesResponse = {
+  data?: {
+    result?: { templates: TemplateResponse[] };
+    error?: { userMessage?: string; reason: string };
+  };
+};
+interface TemplateResponse {
+  description: string;
+  folder: string;
+  name: string;
+  variables?: Record<string, TemplateVariable>;
+  icon: string;
+  ssh_supported: boolean;
+}
+
+export interface Templates {
+  parentRepo: string;
+  parentTemplate: string;
+  id: string;
+  name: string;
+  description: string;
+  variables?: Record<string, TemplateVariable>;
+  icon: string;
+  isSSHSupported: boolean;
+}
+export const templatesApi = createApi({
+  reducerPath: "templates",
+  baseQuery: fetchBaseQuery({ baseUrl: "/ui-server/api/renku" }),
+  endpoints: (builder) => ({
+    getTemplatesRepositories: builder.query<Templates[], GetTemplatesParams>({
+      async queryFn({ repositories }, _queryApi, _extraOptions, fetchWithBQ) {
+        return fetchTemplatesRepositories({ fetchWithBQ, repositories });
+      },
+    }),
+  }),
+  refetchOnMountOrArgChange: 3,
+});
+
+type PromiseInfo = {
+  promise: ReturnType<ReturnType<typeof fetchBaseQuery>>;
+  sourceName: string;
+};
+interface FetchTemplatesRepositoriesArgs {
+  fetchWithBQ: (
+    arg: string | FetchArgs
+  ) => ReturnType<ReturnType<typeof fetchBaseQuery>>;
+  repositories: RepositoriesParams[];
+}
+async function fetchTemplatesRepositories({
+  fetchWithBQ,
+  repositories,
+}: FetchTemplatesRepositoriesArgs) {
+  if (repositories.length > 0) {
+    const templateRequests: PromiseInfo[] = [];
+    for (const repository of repositories) {
+      templateRequests.push({
+        promise: fetchWithBQ(
+          `/templates.read_manifest?url=${encodeURIComponent(
+            repository.url
+          )}&ref=${encodeURIComponent(repository.ref)}`
+        ),
+        sourceName: repository.name,
+      });
+    }
+
+    try {
+      const resultAllTemplatesData = await Promise.allSettled(
+        templateRequests.map(({ promise }) => promise)
+      );
+      const templatesList: Templates[] = [];
+
+      resultAllTemplatesData.forEach((templateData, index) => {
+        const response =
+          templateData.status === "fulfilled" &&
+          (templateData?.value as GetTemplatesResponse);
+        if (response && !response?.data?.error) {
+          const templates = response.data?.result
+            ?.templates as TemplateResponse[];
+          const sourceName = templateRequests[index].sourceName;
+          templates.map((template) => {
+            templatesList.push({
+              parentRepo: sourceName,
+              parentTemplate: template.folder,
+              id: `${sourceName}/${template.folder}`,
+              name: template.name,
+              description: template.description,
+              variables: template.variables,
+              icon: template.icon,
+              isSSHSupported: template.ssh_supported,
+            });
+          });
+        } else if (response && response.data?.error) {
+          return {
+            error: response.data.error as unknown as FetchBaseQueryError,
+          };
+        }
+      });
+
+      return { data: templatesList };
+    } catch (e) {
+      return { error: e as FetchBaseQueryError };
+    }
+  } else {
+    return { data: [] };
+  }
+}
+
+export const { useGetTemplatesRepositoriesQuery } = templatesApi;

--- a/client/src/features/templates/templates.types.ts
+++ b/client/src/features/templates/templates.types.ts
@@ -1,0 +1,8 @@
+export interface RepositoriesParams {
+  ref: string;
+  url: string;
+  name: string;
+}
+export interface GetTemplatesParams {
+  repositories: RepositoriesParams[];
+}

--- a/client/src/project/new/ProjectNew.container.js
+++ b/client/src/project/new/ProjectNew.container.js
@@ -35,6 +35,10 @@ import { useHistory } from "react-router";
 import { useLocation } from "react-router-dom";
 
 import { Loader } from "../../components/Loader";
+import {
+  checkTitleDuplicates,
+  validateTitle,
+} from "../../features/project/editNew/NewProject.utils";
 import { newProjectSchema } from "../../model/RenkuModels";
 import AppContext from "../../utils/context/appContext";
 import { DEFAULT_APP_PARAMS } from "../../utils/context/appParams.constants";
@@ -53,11 +57,7 @@ import {
   ForkProject as ForkProjectPresent,
   NewProject as NewProjectPresent,
 } from "./ProjectNew.present";
-import {
-  NewProjectCoordinator,
-  checkTitleDuplicates,
-  validateTitle,
-} from "./ProjectNew.state";
+import { NewProjectCoordinator } from "./ProjectNew.state";
 
 const CUSTOM_REPO_NAME = "Custom";
 
@@ -347,7 +347,7 @@ function getDataFromParams(params) {
   return data;
 }
 
-// temporal solution to include coordinator
+// TODO: Remove this when finish refactot
 class NewProjectWrapper extends Component {
   constructor(props) {
     super(props);

--- a/client/src/project/new/ProjectNew.present.js
+++ b/client/src/project/new/ProjectNew.present.js
@@ -50,7 +50,6 @@ import Description from "./components/Description";
 import Namespaces from "./components/Namespaces";
 import ProjectIdentifier from "./components/ProjectIdentifier";
 import Visibility from "./components/Visibility";
-import TemplateSource from "./components/TemplateSource";
 import UserTemplate, { ErrorTemplateFeedback } from "./components/UserTemplate";
 import { Template } from "./components/Template";
 import TemplateVariables from "./components/TemplateVariables";
@@ -257,6 +256,7 @@ const isFormProcessingOrFinished = (meta) => {
   return meta.creation.projectError || meta.creation.kgError;
 };
 
+// TODO: Remove this when finish refactor
 const NewProjectForm = ({
   automated,
   config,
@@ -265,7 +265,7 @@ const NewProjectForm = ({
   isFetchingProjects,
   meta,
   namespaces,
-  namespace,
+  // namespace,
   user,
   importingDataset,
   userRepo,
@@ -291,16 +291,15 @@ const NewProjectForm = ({
         handlers={handlers}
         automated={automated}
         input={input}
-        namespace={namespace}
         user={user}
       />
       <ProjectIdentifier input={input} isRequired={true} />
       <Description handlers={handlers} meta={meta} input={input} />
       <Visibility handlers={handlers} meta={meta} input={input} />
       <NewProjectAvatar onAvatarChange={handlers.onAvatarChange} />
-      {config.custom ? (
-        <TemplateSource handlers={handlers} input={input} isRequired={true} />
-      ) : null}
+      {/*{config.custom ? (*/}
+      {/*  <TemplateSource handlers={handlers} input={input} isRequired={true} />*/}
+      {/*) : null}*/}
       {userRepo ? (
         <UserTemplate
           meta={meta}
@@ -339,6 +338,7 @@ const NewProjectForm = ({
   );
 };
 
+// TODO: remove when finish refactor
 class NewProject extends Component {
   static contextType = AppContext;
 

--- a/client/src/project/new/ProjectNew.state.js
+++ b/client/src/project/new/ProjectNew.state.js
@@ -23,76 +23,16 @@
  *  New project controller code.
  */
 
+import {
+  checkTitleDuplicates,
+  validateTitle,
+} from "../../features/project/editNew/NewProject.utils";
 import { projectKgApi } from "../../features/project/projectKg.api";
 import { newProjectSchema } from "../../model/RenkuModels";
-import {
-  sleep,
-  slugFromTitle,
-  verifyTitleCharacters,
-} from "../../utils/helpers/HelperFunctions";
+import { sleep, slugFromTitle } from "../../utils/helpers/HelperFunctions";
 import { CUSTOM_REPO_NAME } from "./ProjectNew.container";
 
-// ? reference https://docs.gitlab.com/ce/user/reserved_names.html#reserved-project-names
-const RESERVED_TITLE_NAMES = [
-  "badges",
-  "blame",
-  "blob",
-  "builds",
-  "commits",
-  "create",
-  "create_dir",
-  "edit",
-  "sessions/folders",
-  "files",
-  "find_file",
-  "gitlab-lfs/objects",
-  "info/lfs/objects",
-  "new",
-  "preview",
-  "raw",
-  "refs",
-  "tree",
-  "update",
-  "wikis",
-];
-
-/**
- * Verify whether the title is valid.
- *
- * @param {string} title - title to validate.
- * @returns {string} error description or null if the string is valid.
- */
-function validateTitle(title) {
-  if (!title || !title.length) return "Title is missing.";
-  else if (RESERVED_TITLE_NAMES.includes(title)) return "Reserved title name.";
-  else if (title.length && ["_", "-", " ", "."].includes(title[0]))
-    return "Title must start with a letter or a number.";
-  else if (!verifyTitleCharacters(title))
-    return "Title can contain only letters, digits, '_', '.', '-' or spaces.";
-  else if (title && !slugFromTitle(title, true))
-    return "Title must contain at least one letter (without any accents) or a number.";
-  return null;
-}
-
-/**
- * Verify whether the title and namespace will produce a duplicate.
- *
- * @param {string} title - current title.
- * @param {string} namespace - current namespace.
- * @param {string[]} projectsPaths - list of current own projects paths.
- * @returns {boolean} whether the title would create a duplicate or not.
- */
-function checkTitleDuplicates(title, namespace, projectsPaths) {
-  if (!title || !namespace || !projectsPaths || !projectsPaths.length)
-    return false;
-
-  const expectedTitle = slugFromTitle(title, true);
-  const expectedSlug = `${namespace}/${expectedTitle}`;
-  if (projectsPaths.includes(expectedSlug)) return true;
-
-  return false;
-}
-
+// TODO: Remove this when finish refactor
 class NewProjectCoordinator {
   constructor(client, model, projectsModel) {
     this.client = client;
@@ -872,7 +812,4 @@ class NewProjectCoordinator {
   }
 }
 
-export { NewProjectCoordinator, checkTitleDuplicates, validateTitle };
-
-// test only
-export { RESERVED_TITLE_NAMES };
+export { NewProjectCoordinator };

--- a/client/src/project/new/components/Description.tsx
+++ b/client/src/project/new/components/Description.tsx
@@ -24,6 +24,7 @@
  */
 import FieldGroup from "../../../components/FieldGroups";
 import { NewProjectInputs, NewProjectMeta } from "./newProject.d";
+import { UseFormRegisterReturn } from "react-hook-form";
 
 interface DescriptionProps {
   handlers: {
@@ -31,6 +32,7 @@ interface DescriptionProps {
   };
   meta: NewProjectMeta;
   input: NewProjectInputs;
+  register: UseFormRegisterReturn;
 }
 
 function Description({ handlers, meta, input }: DescriptionProps) {

--- a/client/src/project/new/components/NewProjectAvatar.tsx
+++ b/client/src/project/new/components/NewProjectAvatar.tsx
@@ -43,7 +43,7 @@ type ArtificialEvent = {
 };
 
 type NewProjectAvatarProps = {
-  onAvatarChange: (arg: File) => void;
+  onAvatarChange: (file: File) => void;
 };
 function NewProjectAvatar({ onAvatarChange }: NewProjectAvatarProps) {
   const initial: ArtificialEventTargetValue = { options: [], selected: -1 };

--- a/client/src/project/new/components/ProjectIdentifier.tsx
+++ b/client/src/project/new/components/ProjectIdentifier.tsx
@@ -30,6 +30,7 @@ import {
 } from "../../../components/formlabels/FormLabels";
 import { NewProjectInputs } from "./newProject.d";
 
+// TODO: REMOVE THIS COMPONENT WHEN FINISH REFACTOR
 interface ProjectIdentifierProps {
   input: NewProjectInputs;
   isRequired: boolean;

--- a/client/src/project/new/components/ShareLinkModal.js
+++ b/client/src/project/new/components/ShareLinkModal.js
@@ -38,7 +38,6 @@ import { CommandCopy } from "../../../components/commandCopy/CommandCopy";
 
 function ShareLinkModal(props) {
   const { createUrl, input } = props;
-  const { userTemplates } = props.meta;
 
   const defaultObj = {
     title: false,
@@ -77,15 +76,15 @@ function ShareLinkModal(props) {
       visibility: true,
       templateRepo:
         input.userRepo &&
-        userTemplates.fetched &&
-        userTemplates.url &&
-        userTemplates.ref
+        input.userRepositories !== null &&
+        input.userTemplate.url &&
+        input.userTemplates.reference
           ? true
           : false,
       template: input.template ? true : false,
       variables: variablesAvailable,
     });
-  }, [input, userTemplates]);
+  }, [input]);
 
   // Update selected params
   useEffect(() => {
@@ -108,8 +107,8 @@ function ShareLinkModal(props) {
     if (include.namespace) dataObject.namespace = input.namespace;
     if (include.visibility) dataObject.visibility = input.visibility;
     if (include.templateRepo) {
-      dataObject.url = userTemplates.url;
-      dataObject.ref = userTemplates.ref;
+      dataObject.url = input.userTemplates.url;
+      dataObject.ref = input.userTemplates.reference;
     }
     if (include.template) dataObject.template = input.template;
     if (include.variables) {
@@ -122,7 +121,7 @@ function ShareLinkModal(props) {
     }
 
     setUrl(createUrl(dataObject));
-  }, [createUrl, include, input, userTemplates]);
+  }, [createUrl, include, input]);
 
   const handleCheckbox = (target, event) => {
     // select the template source if is selected a custom template

--- a/client/src/project/new/components/SubmitFormButton.tsx
+++ b/client/src/project/new/components/SubmitFormButton.tsx
@@ -22,28 +22,26 @@
  *  SubmitFormButton.tsx
  *  Submit Button create new project
  */
-import { MouseEventHandler, useState } from "react";
+import { useState } from "react";
 import ShareLinkModal from "./ShareLinkModal";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faLink } from "@fortawesome/free-solid-svg-icons";
 import { ButtonWithMenu } from "../../../components/buttons/Button";
 import { Button, DropdownItem } from "../../../utils/ts-wrappers";
-import { NewProjectInputs, NewProjectMeta } from "./newProject.d";
+import { SubmitHandler, UseFormGetValues } from "react-hook-form";
+import { NewProjectFormFields } from "../../../features/project/projectKg.types";
+import { createEncodedNewProjectUrl } from "../../../features/project/editNew/NewProject.utils";
 
 interface SubmitFormButtonProps {
   createDataAvailable: boolean;
-  handlers: {
-    createEncodedUrl: Function; // eslint-disable-line @typescript-eslint/ban-types
-    onSubmit: MouseEventHandler<HTMLButtonElement>;
-  };
+  onSubmit: SubmitHandler<NewProjectFormFields>;
   importingDataset: boolean;
-  input: NewProjectInputs;
-  meta: NewProjectMeta;
+  getValues: UseFormGetValues<NewProjectFormFields>;
 }
 
 function ImportSubmitFormButton({
-  handlers,
-}: Pick<SubmitFormButtonProps, "handlers">) {
+  onSubmit,
+}: Pick<SubmitFormButtonProps, "onSubmit">) {
   return (
     <>
       <div className="mt-4 d-flex justify-content-end">
@@ -51,7 +49,7 @@ function ImportSubmitFormButton({
           data-cy="add-dataset-submit-button"
           id="create-new-project"
           color="rk-pink"
-          onClick={handlers.onSubmit}
+          onClick={onSubmit}
         >
           Add Dataset New Project
         </Button>
@@ -62,21 +60,23 @@ function ImportSubmitFormButton({
 
 function StandardSubmitFormButton({
   createDataAvailable,
-  handlers,
-  input,
-  meta,
+  onSubmit,
+  getValues,
 }: Omit<SubmitFormButtonProps, "importingDataset">) {
   const [showModal, setShotModal] = useState(false);
   const toggleModal = () => {
     setShotModal((showModal) => !showModal);
   };
+
+  const input = getValues();
+  // TODO: Set all values needed for ShareLinkModal
+
   const shareLinkModal = (
     <ShareLinkModal
       show={showModal}
       toggle={toggleModal}
       input={input}
-      meta={meta}
-      createUrl={handlers.createEncodedUrl}
+      createUrl={createEncodedNewProjectUrl}
     />
   );
 
@@ -86,7 +86,7 @@ function StandardSubmitFormButton({
       color="secondary"
       data-cy="create-project-button"
       disabled={!createDataAvailable}
-      onClick={handlers.onSubmit}
+      onClick={onSubmit}
     >
       {" "}
       Create project
@@ -117,17 +117,16 @@ function StandardSubmitFormButton({
 
 function SubmitFormButton({
   createDataAvailable,
-  handlers,
-  input,
+  onSubmit,
   importingDataset,
-  meta,
+  getValues,
 }: SubmitFormButtonProps) {
   if (importingDataset) {
-    return <ImportSubmitFormButton handlers={handlers} />;
+    return <ImportSubmitFormButton onSubmit={onSubmit} />;
   }
   return (
     <StandardSubmitFormButton
-      {...{ createDataAvailable, handlers, input, meta }}
+      {...{ createDataAvailable, onSubmit, getValues }}
     />
   );
 }

--- a/client/src/project/new/components/TemplateSource.tsx
+++ b/client/src/project/new/components/TemplateSource.tsx
@@ -24,40 +24,54 @@
  */
 import { Button, ButtonGroup, FormGroup } from "../../../utils/ts-wrappers";
 import { InputLabel } from "../../../components/formlabels/FormLabels";
-import { NewProjectInputs } from "./newProject.d";
+import { Control, Controller, UseFormRegisterReturn } from "react-hook-form";
+import { NewProjectFormFields } from "../../../features/project/projectKg.types";
 
 interface TemplateSourceProps {
-  handlers: {
-    setProperty: Function; // eslint-disable-line @typescript-eslint/ban-types
-  };
-  input: NewProjectInputs;
+  value: boolean;
   isRequired: boolean;
+  register: UseFormRegisterReturn;
+  control: Control<NewProjectFormFields>;
 }
 
 const TemplateSource = ({
-  handlers,
-  input,
+  value,
   isRequired,
+  control,
 }: TemplateSourceProps) => {
   return (
     <FormGroup className="field-group">
       <InputLabel text="Template source" isRequired={isRequired} />
       <br />
       <ButtonGroup size="sm">
-        <Button
-          active={!input.userRepo}
-          data-cy="renkulab-source-button"
-          onClick={() => handlers.setProperty("userRepo", false)}
-        >
-          RenkuLab
-        </Button>
-        <Button
-          active={!!input.userRepo}
-          data-cy="custom-source-button"
-          onClick={() => handlers.setProperty("userRepo", true)}
-        >
-          Custom
-        </Button>
+        <Controller
+          control={control}
+          name="isCustomTemplate"
+          render={({ field }) => (
+            <Button
+              active={!value}
+              data-cy="renkulab-source-button"
+              onClick={() => field.onChange(false)}
+            >
+              RenkuLab
+            </Button>
+          )}
+          rules={{ required: true }}
+        />
+        <Controller
+          control={control}
+          name="isCustomTemplate"
+          render={({ field }) => (
+            <Button
+              active={value}
+              data-cy="custom-source-button"
+              onClick={() => field.onChange(true)}
+            >
+              Custom
+            </Button>
+          )}
+          rules={{ required: true }}
+        />
       </ButtonGroup>
     </FormGroup>
   );

--- a/client/src/project/new/components/newProject.d.tsx
+++ b/client/src/project/new/components/newProject.d.tsx
@@ -24,6 +24,7 @@
  */
 
 import { Visibilities } from "../../../components/visibility/Visibility";
+import { Namespace } from "../../../features/projects/projects.api";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/ban-types */
@@ -52,10 +53,10 @@ interface NewProjectMeta {
 interface NewProjectInputs {
   descriptionPristine?: boolean;
   description?: string;
-  namespace?: string;
+  namespace?: Namespace;
   title?: string;
   titlePristine?: boolean;
-  userRepo?: string;
+  userRepo?: boolean;
   visibility?: Visibilities;
   visibilityPristine?: boolean;
 }

--- a/client/src/utils/context/appParams.types.ts
+++ b/client/src/utils/context/appParams.types.ts
@@ -78,7 +78,7 @@ export interface TemplatesParams {
   repositories: TemplatesRepositories[];
 }
 
-interface TemplatesRepositories {
+export interface TemplatesRepositories {
   name: string;
   ref: string;
   url: string;

--- a/client/src/utils/customHooks/UseGetVisibilities.ts
+++ b/client/src/utils/customHooks/UseGetVisibilities.ts
@@ -18,7 +18,8 @@
 
 import { useEffect, useState } from "react";
 import { useGetGroupByPathQuery } from "../../features/projects/projects.api";
-import { computeVisibilities } from "../helpers/HelperFunctions";
+import { getComputeVisibilities } from "../helpers/VisibilitiesUtils";
+import { Visibilities } from "../../components/visibility/Visibility";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -28,7 +29,7 @@ import { computeVisibilities } from "../helpers/HelperFunctions";
  *  UseGetVisibilities.ts
  *  hook to get visibilities and fetch groups if the namespace is of type group
  */
-function useGetVisibilities(namespace: any, bound: string | undefined) {
+function useGetVisibilities(namespace: any, bound: Visibilities | undefined) {
   const { data, isFetching, isLoading } = useGetGroupByPathQuery(
     namespace?.full_path,
     {
@@ -40,15 +41,15 @@ function useGetVisibilities(namespace: any, bound: string | undefined) {
   useEffect(() => {
     if (isFetching || isLoading || !namespace) return;
 
-    const options: string[] = [];
+    const options: Visibilities[] = [];
     if (bound) options.push(bound);
 
     if (namespace?.kind === "user") {
-      options.push("public");
-      setAvailableVisibilities(computeVisibilities(options));
+      options.push(Visibilities.Public);
+      setAvailableVisibilities(getComputeVisibilities(options));
     } else if (namespace?.kind === "group") {
       options.push(data.visibility);
-      setAvailableVisibilities(computeVisibilities(options));
+      setAvailableVisibilities(getComputeVisibilities(options));
     }
   }, [bound, isFetching, isLoading, data, namespace]);
 

--- a/client/src/utils/helpers/EnhancedState.ts
+++ b/client/src/utils/helpers/EnhancedState.ts
@@ -53,6 +53,8 @@ import userPreferencesApi from "../../features/user/userPreferences.api";
 import { versionsApi } from "../../features/versions/versions.api";
 import { workflowsApi } from "../../features/workflows/WorkflowsApi";
 import { workflowsSlice } from "../../features/workflows/WorkflowsSlice";
+import { templatesApi } from "../../features/templates/templates.api";
+import { newProjectFormSlide } from "../../features/project/editNew/projectForm.slice";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const createStore = <S = any, A extends Action = AnyAction>(
@@ -64,6 +66,7 @@ export const createStore = <S = any, A extends Action = AnyAction>(
     // Slices
     [dashboardMessageSlice.name]: dashboardMessageSlice.reducer,
     [datasetFormSlice.name]: datasetFormSlice.reducer,
+    [newProjectFormSlide.name]: newProjectFormSlide.reducer,
     [displaySlice.name]: displaySlice.reducer,
     [kgInactiveProjectsSlice.name]: kgInactiveProjectsSlice.reducer,
     [startSessionSlice.name]: startSessionSlice.reducer,
@@ -88,6 +91,7 @@ export const createStore = <S = any, A extends Action = AnyAction>(
     [userPreferencesApi.reducerPath]: userPreferencesApi.reducer,
     [versionsApi.reducerPath]: versionsApi.reducer,
     [workflowsApi.reducerPath]: workflowsApi.reducer,
+    [templatesApi.reducerPath]: templatesApi.reducer,
   };
 
   // For the moment, disable the custom middleware, since it causes problems for our app.
@@ -116,6 +120,7 @@ export const createStore = <S = any, A extends Action = AnyAction>(
         .concat(sessionSidecarApi.middleware)
         .concat(userPreferencesApi.middleware)
         .concat(versionsApi.middleware)
+        .concat(templatesApi.middleware)
         .concat(workflowsApi.middleware),
     enhancers,
   });

--- a/client/src/utils/helpers/VisibilitiesUtils.ts
+++ b/client/src/utils/helpers/VisibilitiesUtils.ts
@@ -1,0 +1,51 @@
+/*!
+ * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Visibilities } from "../../components/visibility/Visibility";
+
+interface ComputeVisibilities {
+  visibilities: Visibilities[];
+  disabled: Visibilities[];
+  default: Visibilities;
+}
+export const getComputeVisibilities = (
+  options: Visibilities[]
+): ComputeVisibilities => {
+  if (options.includes(Visibilities.Private)) {
+    return {
+      visibilities: [Visibilities.Private],
+      disabled: [Visibilities.Public, Visibilities.Internal],
+      default: Visibilities.Private,
+    };
+  } else if (options.includes(Visibilities.Internal)) {
+    return {
+      visibilities: [Visibilities.Private, Visibilities.Internal],
+      disabled: [Visibilities.Public],
+      default: Visibilities.Internal,
+    };
+  }
+  return {
+    visibilities: [
+      Visibilities.Private,
+      Visibilities.Internal,
+      Visibilities.Public,
+    ],
+    disabled: [],
+    default: Visibilities.Public,
+  };
+};


### PR DESCRIPTION
This PR includes only adapting the current "create new project" form to use react-hook-form and fetch data using redux-toolkit. 

Features:
- [x] Set name, namespace, description, avatar, visibility, user template, and template.
- [x] Fetch/refetch namespaces.
- [x] Calculate slug by name and namespace.
- [x] Set visibility by namespace.
- [x] Fetch custom and RenkuLab templates.
- [x] Set template variables (e.g., Pinned image template).
- [x] Restore default template variable.

Form validations:
- [x] Invalid project name.
- [x] Duplicated project name.

Pending to include in this PR:
- [ ] Show a message fetching data next to the submit button.
- [ ] Show errors fetching templates.
- [ ] Validate required fields (title, namespace, template) and display them at the end of the form.

/deploy #persist