### PR TITLE
fix(client): resize feedback badge in session settings

### DIFF
--- a/client/src/project/components/ProjectSettingsSessions.tsx
+++ b/client/src/project/components/ProjectSettingsSessions.tsx
@@ -360,12 +360,14 @@ const SessionsDiv = ({
   children,
 }: SessionsDivProps) => (
   <div className="mt-2">
-    <h3 className="d-flex align-items-center">
-      Session settings
+    <div className={cx("d-flex", "align-items-center", "gap-1")}>
+      <h3>Session settings</h3>
       {enableSavingBadge && (
-        <SavingBadge projectConfigIsFetching={projectConfigIsFetching} />
+        <div>
+          <SavingBadge projectConfigIsFetching={projectConfigIsFetching} />
+        </div>
       )}
-    </h3>
+    </div>
     <div className="row form-rk-green">{children}</div>
   </div>
 );

--- a/client/src/project/components/ProjectSettingsSessions.tsx
+++ b/client/src/project/components/ProjectSettingsSessions.tsx
@@ -360,14 +360,12 @@ const SessionsDiv = ({
   children,
 }: SessionsDivProps) => (
   <div className="mt-2">
-    <div className={cx("d-flex", "align-items-center", "gap-1")}>
-      <h3>Session settings</h3>
+    <h3 className={cx("d-flex", "align-items-center", "gap-1")}>
+      Session settings
       {enableSavingBadge && (
-        <div>
-          <SavingBadge projectConfigIsFetching={projectConfigIsFetching} />
-        </div>
+        <SavingBadge projectConfigIsFetching={projectConfigIsFetching} />
       )}
-    </div>
+    </h3>
     <div className="row form-rk-green">{children}</div>
   </div>
 );
@@ -410,7 +408,9 @@ const SavingBadge = ({ projectConfigIsFetching }: SavingBadgeProps) => {
   }, [saved, updating]);
 
   return (
-    <div className={cx("d-flex", "fade", (updating || saved) && "show")}>
+    <div
+      className={cx("d-flex", "fs-6", "fade", (updating || saved) && "show")}
+    >
       <Badge className="btn-outline-rk-green text-white ms-1">{content}</Badge>
     </div>
   );


### PR DESCRIPTION
While testing other PRs, I noticed the badge in the project's session settings shown as feedback to the user's action has become _very_ big.

![Peek 2024-01-08 14-50](https://github.com/SwissDataScienceCenter/renku-ui/assets/43481553/b04559cc-68b6-4b8d-9f86-80db354a4b03)

I assume that was not intentional; this PR brings it back to the default size.

![Peek 2024-01-08 15-25](https://github.com/SwissDataScienceCenter/renku-ui/assets/43481553/c60d7ac5-ca0f-4292-8f86-72837bf70ca2)

/deploy