### PR TITLE
Adapt test setup for vite-based server

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -6,14 +6,14 @@
   "scripts": {
     "cypress": "cypress open --e2e --browser=chrome --config-file cypress.config.ts",
     "cypress:headless": "cypress run --e2e --headless --config-file cypress.config.ts --spec '**/*'",
-    "e2e": "start-server-and-test start 3000 cypress",
-    "e2e:headless": "start-server-and-test start 3000 cypress:headless",
+    "e2e": "start-server-and-test start http://localhost:3000 cypress",
+    "e2e:headless": "start-server-and-test start http://localhost:3000 cypress:headless",
     "lint": "eslint --max-warnings=0 cypress/",
     "format": "prettier -w .",
     "format-check": "prettier -c .",
     "format-changed": "pretty-quick --pattern \"tests/**/*.*\"",
     "format-commit": "pretty-quick --staged --pattern \"tests/**/*.*\"",
-    "start": "npm --prefix ../client run start-js",
+    "start": "npm --prefix ../client run start:strict-port",
     "client:install": "npm --prefix ../client clean-install",
     "client:build": "npm --prefix ../client run build",
     "client:preview": "npm --prefix ../client run preview"


### PR DESCRIPTION
The change to vite requires changes to how the tests are started.