### PR TITLE
build: prevent memory heap error when building locally

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "start": "vite --port 3000",
     "start:strict-port": "vite --port 3000 --strictPort",
-    "build": "tsc && vite build",
-    "build:analyze": "vite-bundle-visualizer",
+    "build": "tsc && NODE_OPTIONS=--max-old-space-size=4096 vite build",
+    "build:analyze": "NODE_OPTIONS=--max-old-space-size=4096 vite-bundle-visualizer",
     "preview": "vite preview --port 3000 --strictPort",
     "optimize": "vite optimize",
     "test": "vitest",


### PR DESCRIPTION
This prevents a memory error when building locally through `npm run build`:

```
<--- JS stacktrace --->

FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
 1: 0xb83f50 node::Abort() [node]
 2: 0xa94834  [node]
 3: 0xd647c0 v8::Utils::ReportOOMFailure(v8::internal::Isolate*, char const*, bool) [node]
 4: 0xd64b67 v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, bool) [node]
 5: 0xf42265  [node]
 6: 0xf5474d v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace, v8::internal::GarbageCollectionReason, v8::GCCallbackFlags) [node]
 7: 0xf2ee4e v8::internal::HeapAllocator::AllocateRawWithLightRetrySlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [node]
 8: 0xf30217 v8::internal::HeapAllocator::AllocateRawWithRetryOrFailSlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [node]
 9: 0xf113ea v8::internal::Factory::NewFillerObject(int, v8::internal::AllocationAlignment, v8::internal::AllocationType, v8::internal::AllocationOrigin) [node]
10: 0x12d690d v8::internal::Runtime_AllocateInOldGeneration(int, unsigned long*, v8::internal::Isolate*) [node]
11: 0x17035b9  [node]
Aborted (core dumped)
```

The setting went lost during the conversion from Create React App to Vite
