### PR TITLE
[ShapeUp] improve UX when adding/editing storage

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -36,7 +36,7 @@ jobs:
       extra-values: ${{ steps.deploy-comment.outputs.extra-values}}
     steps:
       - id: deploy-comment
-        uses: SwissDataScienceCenter/renku-actions/check-pr-description@amalthea-deploy
+        uses: SwissDataScienceCenter/renku-actions/check-pr-description@v1.9.0
         with:
           string: /deploy
           pr_ref: ${{ github.event.number }}
@@ -66,7 +66,7 @@ jobs:
           body: |
             You can access the deployment of this PR at https://renku-ci-ui-${{ github.event.number }}.dev.renku.ch
       - name: Build and deploy
-        uses: SwissDataScienceCenter/renku-actions/deploy-renku@amalthea-deploy
+        uses: SwissDataScienceCenter/renku-actions/deploy-renku@v1.9.0
         env:
           RANCHER_PROJECT_ID: ${{ secrets.CI_RANCHER_PROJECT }}
           DOCKER_PASSWORD: ${{ secrets.RENKU_DOCKER_PASSWORD }}
@@ -97,7 +97,7 @@ jobs:
     if: github.event.action != 'closed' && needs.check-deploy.outputs.pr-contains-string == 'true' && needs.check-deploy.outputs.test-enabled == 'true'
     runs-on: ubuntu-22.04
     steps:
-      - uses: SwissDataScienceCenter/renku-actions/test-renku@amalthea-deploy
+      - uses: SwissDataScienceCenter/renku-actions/test-renku@v1.9.0
         with:
           kubeconfig: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
           renku-release: renku-ci-ui-${{ github.event.number }}
@@ -126,7 +126,7 @@ jobs:
     steps:
       - name: Extract Renku repository reference
         run: echo "RENKU_REFERENCE=`echo '${{ needs.check-deploy.outputs.renku }}' | cut -d'@' -f2`" >> $GITHUB_ENV
-      - uses: SwissDataScienceCenter/renku-actions/test-renku-cypress@amalthea-deploy
+      - uses: SwissDataScienceCenter/renku-actions/test-renku-cypress@v1.9.0
         with:
           e2e-target: ${{ matrix.tests }}
           renku-reference: ${{ env.RENKU_REFERENCE }}
@@ -154,7 +154,7 @@ jobs:
           body: |
             Tearing down the temporary RenkuLab deplyoment for this PR.
       - name: renku teardown
-        uses: SwissDataScienceCenter/renku-actions/cleanup-renku-ci-deployments@amalthea-deploy
+        uses: SwissDataScienceCenter/renku-actions/cleanup-renku-ci-deployments@v1.9.0
         env:
           HELM_RELEASE_REGEX: "^renku-ci-ui-${{ github.event.number }}$"
           GITLAB_TOKEN: ${{ secrets.DEV_GITLAB_TOKEN }}

--- a/client/src/features/project/components/cloudStorage/AddOrEditCloudStorage.tsx
+++ b/client/src/features/project/components/cloudStorage/AddOrEditCloudStorage.tsx
@@ -583,9 +583,14 @@ function OptionDataList({ examples, listId }: OptionDataListProps) {
 
 interface TruncatedTextProps {
   collapsedLines?: number;
+  linesTolerance?: number;
   text: string;
 }
-function TruncatedText({ collapsedLines = 3, text }: TruncatedTextProps) {
+function TruncatedText({
+  collapsedLines = 2,
+  linesTolerance = 1,
+  text,
+}: TruncatedTextProps) {
   const [isTruncated, setIsTruncated] = useState(true);
   const contentRef = useRef<HTMLDivElement>(null);
 
@@ -599,9 +604,12 @@ function TruncatedText({ collapsedLines = 3, text }: TruncatedTextProps) {
       const containerHeight = contentRef.current.clientHeight;
       const contentHeight = contentRef.current.scrollHeight;
 
-      setIsTruncated(contentHeight > containerHeight);
+      const lineHeight = containerHeight / collapsedLines;
+      const tolerance = lineHeight * (linesTolerance + 0.5);
+
+      setIsTruncated(contentHeight > containerHeight + tolerance);
     }
-  }, [collapsedLines, text]);
+  }, [collapsedLines, linesTolerance, text]);
 
   const textStyle = {
     maxHeight: isTruncated ? `${collapsedLines * 1.5}em` : "none",

--- a/client/src/features/project/components/cloudStorage/AddOrEditCloudStorage.tsx
+++ b/client/src/features/project/components/cloudStorage/AddOrEditCloudStorage.tsx
@@ -559,8 +559,8 @@ function SecretOptionWarning({
       </div>
       <UncontrolledTooltip placement="top" target={id}>
         This field contains sensitive data (E.G. password, access token, ...).
-        We currently cannot store it safely, so you might be asked this value
-        again when starting a session.
+        RenkuLab does not store passwords, so you will be asked this value again
+        when starting a session.
       </UncontrolledTooltip>
     </>
   );
@@ -979,7 +979,7 @@ function AddStorageMount({ setStorage, storage }: AddStorageStepProps) {
         </div>
         <div className={cx("form-text", "text-muted")}>
           This name will help you identify the storage. It should be unique for
-          this project and it can only contains letter, numbers, $, _.
+          this project and can only contain letters, numbers, _, -.
         </div>
       </div>
 
@@ -1008,8 +1008,8 @@ function AddStorageMount({ setStorage, storage }: AddStorageStepProps) {
         <div className="invalid-feedback">Please provide a mount point.</div>
         <div className={cx("form-text", "text-muted")}>
           This is the name of the folder where you will find your external
-          storage in the sessions. You should pick something different from the
-          folders used in the projects repository, and from folder mounted by
+          storage in sessions. You should pick something different from the
+          folders used in the projects repository, and from folders mounted by
           other storage services.
         </div>
       </div>

--- a/client/src/features/project/components/cloudStorage/AddOrEditCloudStorage.tsx
+++ b/client/src/features/project/components/cloudStorage/AddOrEditCloudStorage.tsx
@@ -406,7 +406,7 @@ function OptionTruncatedText({
 }
 
 interface CheckboxOptionItemProps {
-  control: Control<FieldValues, any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+  control: Control<FieldValues, void>;
   defaultValue: boolean | undefined;
   onFieldValueChange: (option: string, value: boolean) => void;
   option: CloudStorageSchemaOptions;
@@ -454,7 +454,7 @@ function PasswordOptionItem({
   option,
 }: PasswordOptionItemProps) {
   const [showPassword, setShowPassword] = useState(false);
-  const swapShowPassword = useCallback(() => {
+  const toggleShowPassword = useCallback(() => {
     setShowPassword((showPassword) => !showPassword);
   }, []);
 
@@ -498,7 +498,7 @@ function PasswordOptionItem({
         <Button
           className="rounded-end"
           id={`show-password-${option.name}`}
-          onClick={() => swapShowPassword()}
+          onClick={() => toggleShowPassword()}
         >
           {showPassword ? (
             <EyeFill className="bi" />
@@ -531,10 +531,9 @@ function InputOptionItem({
   onFieldValueChange,
   option,
 }: InputOptionItemProps) {
-  const additionalProps: Record<string, string> = {};
-  if (inputType === "dropdown") {
-    additionalProps.list = `${option.name}__list`;
-  }
+  const additionalProps: Record<string, string> = {
+    ...(inputType === "dropdown" ? { list: `${option.name}__list` } : {}),
+  };
   return (
     <>
       <label htmlFor={option.name}>{option.friendlyName ?? option.name}</label>

--- a/client/src/features/project/components/cloudStorage/CloudStorageItem.tsx
+++ b/client/src/features/project/components/cloudStorage/CloudStorageItem.tsx
@@ -230,7 +230,7 @@ function CloudStorageDetails({
             <div className="text-rk-text-light">
               <small className="text-capitalize">{key}</small>
             </div>
-            <div>{configuration[key]}</div>
+            <div>{configuration[key]?.toString()}</div>
           </div>
         ))}
         <div className="mt-2">

--- a/client/src/features/project/components/cloudStorage/projectCloudStorage.api.ts
+++ b/client/src/features/project/components/cloudStorage/projectCloudStorage.api.ts
@@ -77,7 +77,7 @@ const projectCloudStorageApi = createApi({
     >({
       query: ({ storage_id, ...params }) => {
         return {
-          method: "PATCH",
+          method: "PUT",
           url: `storage/${storage_id}`,
           body: { ...params },
         };

--- a/client/src/features/project/components/cloudStorage/projectCloudStorage.constants.ts
+++ b/client/src/features/project/components/cloudStorage/projectCloudStorage.constants.ts
@@ -58,6 +58,8 @@ export const CLOUD_STORAGE_OVERRIDE = {
       },
     },
     webdav: {
+      description:
+        "WebDAV compatible services, including PolyBox and SwitchDrive",
       position: 2,
     },
   } as Record<string, Partial<CloudStorageOverride>>,

--- a/client/src/features/project/components/cloudStorage/projectCloudStorage.constants.ts
+++ b/client/src/features/project/components/cloudStorage/projectCloudStorage.constants.ts
@@ -66,6 +66,11 @@ export const CLOUD_STORAGE_OVERRIDE = {
 };
 
 export const CLOUD_OPTIONS_OVERRIDE = {
+  azureblob: {
+    client_certificate_path: { advanced: true },
+    client_certificate_password: { advanced: true },
+    env_auth: { hide: true },
+  },
   s3: {
     env_auth: { hide: true }, // ? uses the ENV variables
     location_constraint: { hide: true }, // ? only for creating buckets
@@ -80,6 +85,15 @@ export const CLOUD_OPTIONS_OVERRIDE = {
       friendlyName: "Endpoint",
       help: "Endpoint for S3 API. You should leave this blank if you entered the region already.",
     },
+  },
+  webdav: {
+    pass: {
+      friendlyName: "Token (or password)",
+      help: "This is the token to access the WebDAV service. Mind that providing the user's password directly here won't usually work.",
+    },
+    bearer_token: { friendlyName: "Bearer Token" },
+    url: { friendlyName: "URL" },
+    user: { friendlyName: "Username" },
   },
 } as Record<string, Record<string, Partial<CloudStorageSchemaOptions>>>;
 

--- a/client/src/features/project/components/cloudStorage/projectCloudStorage.constants.ts
+++ b/client/src/features/project/components/cloudStorage/projectCloudStorage.constants.ts
@@ -67,9 +67,18 @@ export const CLOUD_STORAGE_OVERRIDE = {
 
 export const CLOUD_OPTIONS_OVERRIDE = {
   azureblob: {
+    account: {
+      friendlyName: "Account Name",
+      help: "Set this to the Azure Storage Account Name in use. Leave blank to use SAS URL or Emulator, otherwise it needs to be set.",
+    },
     client_certificate_path: { advanced: true },
     client_certificate_password: { advanced: true },
     env_auth: { hide: true },
+    key: { friendlyName: "Shared Key" },
+    sas_url: { advanced: true },
+    tenant: { friendlyName: "Tenant ID", advanced: true },
+    client_id: { friendlyName: "Client ID", advanced: true },
+    client_secret: { friendlyName: "Client Secret", advanced: true },
   },
   s3: {
     env_auth: { hide: true }, // ? uses the ENV variables
@@ -94,6 +103,7 @@ export const CLOUD_OPTIONS_OVERRIDE = {
     bearer_token: { friendlyName: "Bearer Token" },
     url: { friendlyName: "URL" },
     user: { friendlyName: "Username" },
+    vendor: { advanced: true },
   },
 } as Record<string, Record<string, Partial<CloudStorageSchemaOptions>>>;
 

--- a/client/src/features/project/components/cloudStorage/projectCloudStorage.constants.ts
+++ b/client/src/features/project/components/cloudStorage/projectCloudStorage.constants.ts
@@ -30,6 +30,23 @@ export const CLOUD_STORAGE_CONFIGURATION_PLACEHOLDER =
 
 export const CLOUD_STORAGE_OVERRIDE = {
   storage: {
+    azureblob: {
+      position: 3,
+    },
+    drive: {
+      hide: true,
+    },
+    gcs: {
+      hide: true,
+    },
+    // eslint-disable-next-line spellcheck/spell-checker
+    dropbox: {
+      hide: true,
+    },
+    // eslint-disable-next-line spellcheck/spell-checker
+    onedrive: {
+      hide: true,
+    },
     s3: {
       description:
         "Amazon S3 Compliant Storage Providers including AWS, CloudFlare, DigitalOcean and many others",
@@ -40,14 +57,8 @@ export const CLOUD_STORAGE_OVERRIDE = {
         },
       },
     },
-    drive: {
-      position: 2,
-    },
     webdav: {
-      position: 3,
-    },
-    azureblob: {
-      position: 4,
+      position: 2,
     },
   } as Record<string, Partial<CloudStorageOverride>>,
 };

--- a/client/src/features/project/components/cloudStorage/projectCloudStorage.types.ts
+++ b/client/src/features/project/components/cloudStorage/projectCloudStorage.types.ts
@@ -114,6 +114,7 @@ export interface CloudStorageSchemaOptions {
 export interface CloudStorageSchema {
   name: string;
   description: string;
+  hide?: boolean;
   prefix: string; // ? weird naming; it's the machine readable name
   position?: number;
   options: CloudStorageSchemaOptions[];

--- a/client/src/features/project/components/cloudStorage/projectCloudStorage.types.ts
+++ b/client/src/features/project/components/cloudStorage/projectCloudStorage.types.ts
@@ -82,6 +82,12 @@ export type CloudStorageOptionTypes =
   | "number"
   | "secret";
 
+export type CloudStorageSchemaOptionExample = {
+  value: string; // ? Potential value for the option
+  help: string; // ? Help text for the _value_
+  provider: string; // ? empty for "all providers"
+};
+
 export interface CloudStorageSchemaOptions {
   name: string;
   help: string;
@@ -89,16 +95,10 @@ export interface CloudStorageSchemaOptions {
   default: number | string | boolean;
   default_str: string;
   value: null | number | string | boolean;
-  examples: [
-    {
-      value: string; // ? Potential value for the option
-      help: string; // ? Help text for the _value_
-      provider: string; // ? empty for "all providers"
-    }
-  ];
+  examples: CloudStorageSchemaOptionExample[];
   required: boolean;
   ispassword: boolean; // eslint-disable-line spellcheck/spell-checker
-  sensitive: boolean; // ? The service doesn't store it -- "more" sensitive? 😁
+  sensitive: boolean;
   advanced: boolean; // ? Only shown when advanced options are enabled
   exclusive: boolean; // ? Only one of the examples can be used when this is true
   datatype: string;
@@ -107,6 +107,7 @@ export interface CloudStorageSchemaOptions {
   convertedType?: CloudStorageOptionTypes;
   convertedDefault?: number | string | boolean;
   convertedHide?: boolean;
+  filteredExamples: CloudStorageSchemaOptionExample[];
   friendlyName?: string;
 }
 

--- a/client/src/features/project/utils/projectCloudStorage.utils.ts
+++ b/client/src/features/project/utils/projectCloudStorage.utils.ts
@@ -118,12 +118,14 @@ export function getSchemaStorage(
         Object.keys(CLOUD_STORAGE_OVERRIDE.storage).includes(element.prefix)
       ) {
         const override = CLOUD_STORAGE_OVERRIDE.storage[element.prefix];
-        current.push({
-          ...element,
-          name: override.name ?? element.name,
-          description: override.description ?? element.description,
-          position: override.position ?? element.position,
-        });
+        if (!override.hide) {
+          current.push({
+            ...element,
+            name: override.name ?? element.name,
+            description: override.description ?? element.description,
+            position: override.position ?? element.position,
+          });
+        }
       } else {
         current.push(element);
       }


### PR DESCRIPTION
This PR fixes a few issues when adding/editing storage:
- Prevents a bunch of default values to be set automatically, especially when many advanced options exist.
- Correct use of placeholders for default values and examples.
- Remove values correctly when editing an existing storage.
- Handles non-stringy values correctly when listing the storage options in the storage list.
- Use `<datalist>` to pick values from the examples list.
    - Mind that examples from the backend are not 100% reliable; we can't use a `<select>` here, and I would rather keep a simple solution than mess up with autocomplete examples and "use-react-form." Support for the datalist tag is pretty good on Firefox, while the UX on Chrome is still not that good, especially for longer lists.

/deploy renku=rclone-sessions renku-notebooks=rclone-csi amalthea=main renku-data-services=main extra-values=notebooks.cloudstorage.enabled=true,notebooks.cloudstorage.storageClass=csi-rclone-test,notebooks.cloudstorage.installRCloneCSI=false
