### PR TITLE
chore(client): fix eslint config with vite

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -27,6 +27,7 @@
     }
   },
   "overrides": [
+    { "files": ["**/*.,s", "**/*.jsx"] },
     {
       "files": ["**/*.ts", "**/*.tsx"],
       "plugins": [

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -80,6 +80,7 @@
         "xregexp": "^4.4.0"
       },
       "devDependencies": {
+        "@nabla/vite-plugin-eslint": "^2.0.2",
         "@storybook/addon-actions": "^7.6.0",
         "@storybook/addon-essentials": "^7.6.0",
         "@storybook/addon-interactions": "^7.6.0",
@@ -5505,6 +5506,90 @@
       },
       "peerDependencies": {
         "react": ">=16"
+      }
+    },
+    "node_modules/@nabla/vite-plugin-eslint": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@nabla/vite-plugin-eslint/-/vite-plugin-eslint-2.0.2.tgz",
+      "integrity": "sha512-bwOAkO3kdDyNvGNbIls9bLQHR1t/NKyCd/CSCP89rbmgmxScORq9O84TBc5t1Bh64UWSYmYM5j5HIjwuiVgtGQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/eslint": "*",
+        "chalk": "^4"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "vite": "^4 || ^5"
+      }
+    },
+    "node_modules/@nabla/vite-plugin-eslint/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@nabla/vite-plugin-eslint/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@nabla/vite-plugin-eslint/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@nabla/vite-plugin-eslint/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@nabla/vite-plugin-eslint/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@nabla/vite-plugin-eslint/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@ndelangen/get-tarball": {
@@ -16991,7 +17076,6 @@
     "node_modules/@types/eslint": {
       "version": "8.4.10",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -17008,8 +17092,7 @@
     },
     "node_modules/@types/estree": {
       "version": "0.0.39",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/express": {
       "version": "4.17.14",

--- a/client/package.json
+++ b/client/package.json
@@ -97,6 +97,7 @@
     "xregexp": "^4.4.0"
   },
   "devDependencies": {
+    "@nabla/vite-plugin-eslint": "^2.0.2",
     "@storybook/addon-actions": "^7.6.0",
     "@storybook/addon-essentials": "^7.6.0",
     "@storybook/addon-interactions": "^7.6.0",

--- a/client/src/project/overview/ProjectOverview.present.jsx
+++ b/client/src/project/overview/ProjectOverview.present.jsx
@@ -35,7 +35,7 @@ import {
   Table,
   UncontrolledTooltip,
 } from "reactstrap";
-import { filesize } from "filesize";
+import { filesize as fileSize } from "filesize"; // eslint-disable-line spellcheck/spell-checker
 import qs from "query-string";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
@@ -53,7 +53,7 @@ class OverviewStats extends Component {
     if (fetching) return <Loader inline size={16} />;
     if (value === 0) return 0;
     if (value !== null && !isNaN(value))
-      return readableSize ? filesize(value) : value;
+      return readableSize ? fileSize(value) : value;
     return "";
   }
 

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,3 +1,4 @@
+import eslintPlugin from "@nabla/vite-plugin-eslint";
 import react from "@vitejs/plugin-react";
 import { resolve } from "path";
 import { defineConfig } from "vite";
@@ -8,7 +9,7 @@ export default defineConfig({
     outDir: "build",
     sourcemap: true,
   },
-  plugins: [react({ include: "/index.html" })],
+  plugins: [react({ include: "/index.html" }), eslintPlugin()],
   resolve: {
     alias: {
       "~bootstrap": resolve(__dirname, "node_modules/bootstrap"),


### PR DESCRIPTION
* Add a plugin to run eslint with the dev server to print linting warnings during development
* Fix eslint rules to have `.jsx` files linted (they were previously skipped)