### PR TITLE
fix: align font size and text color with rest of the home page

### DIFF
--- a/client/src/landing/SectionShowcase.tsx
+++ b/client/src/landing/SectionShowcase.tsx
@@ -209,7 +209,7 @@ export default function SectionShowcase({
         className={cx("rk-anon-home-section-content", styles.sectionShowcase)}
       >
         <Row className="rk-pt-m">
-          <Col md={10}>
+          <Col id={styles.sectionShowcaseHeader} md={10}>
             <h3 className="text-rk-green">{title}</h3>
             <LazyRenkuMarkdown markdownText={description} />
           </Col>

--- a/client/src/landing/SectionShowcase.tsx
+++ b/client/src/landing/SectionShowcase.tsx
@@ -209,7 +209,7 @@ export default function SectionShowcase({
         className={cx("rk-anon-home-section-content", styles.sectionShowcase)}
       >
         <Row className="rk-pt-m">
-          <Col id={styles.sectionShowcaseHeader} md={10}>
+          <Col className={styles.sectionShowcaseHeader} md={10}>
             <h3 className="text-rk-green">{title}</h3>
             <LazyRenkuMarkdown markdownText={description} />
           </Col>

--- a/client/src/landing/sectionShowcase.module.scss
+++ b/client/src/landing/sectionShowcase.module.scss
@@ -36,50 +36,50 @@
   --swiper-theme-color: #01192d;
 }
 
-#sectionShowcaseHeader {
+.sectionShowcaseHeader {
   // Match WhatIsRenku/WhatIsRenku.module.scss #featContainer
   h3 {
-    font-size: 40px;
-    margin: 40px 0;
-    line-height: normal;
+    font-size: 40px !important;
+    margin: 40px 0 !important;
+    line-height: normal !important;
   }
 
   p {
-    line-height: normal;
+    line-height: normal !important;
   }
 
   @include media-breakpoint-up(xs) {
     h3 {
-      font-size: 24px;
-      font-weight: bold;
+      font-size: 24px !important;
+      font-weight: bold !important;
     }
     p {
-      font-size: 20px;
+      font-size: 20px !important;
     }
   }
 
   @include media-breakpoint-up(md) {
     h3 {
-      font-size: 32px;
+      font-size: 32px !important;
     }
 
     p {
-      font-size: 20px;
+      font-size: 20px !important;
     }
   }
 
   @include media-breakpoint-up(lg) {
     h3 {
-      font-size: 40px;
+      font-size: 40px !important;
     }
     p {
-      font-size: 24px;
+      font-size: 24px !important;
     }
   }
 
   @include media-breakpoint-down(lg) {
     h3 {
-      padding-top: 0;
+      padding-top: 0 !important;
     }
   }
 }

--- a/client/src/landing/sectionShowcase.module.scss
+++ b/client/src/landing/sectionShowcase.module.scss
@@ -1,3 +1,7 @@
+@import "~bootstrap/scss/functions";
+@import "~bootstrap/scss/variables";
+@import "~bootstrap/scss/mixins";
+
 .sectionShowcase {
   --swiper-pagination-bullet-size: 16px;
   --swiper-pagination-bottom: 1px;
@@ -30,4 +34,52 @@
 .sectionShowcaseSwiper {
   --swiper-navigation-sides-offset: 0px;
   --swiper-theme-color: #01192d;
+}
+
+#sectionShowcaseHeader {
+  // Match WhatIsRenku/WhatIsRenku.module.scss #featContainer
+  h3 {
+    font-size: 40px;
+    margin: 40px 0;
+    line-height: normal;
+  }
+
+  p {
+    line-height: normal;
+  }
+
+  @include media-breakpoint-up(xs) {
+    h3 {
+      font-size: 24px;
+      font-weight: bold;
+    }
+    p {
+      font-size: 20px;
+    }
+  }
+
+  @include media-breakpoint-up(md) {
+    h3 {
+      font-size: 32px;
+    }
+
+    p {
+      font-size: 20px;
+    }
+  }
+
+  @include media-breakpoint-up(lg) {
+    h3 {
+      font-size: 40px;
+    }
+    p {
+      font-size: 24px;
+    }
+  }
+
+  @include media-breakpoint-down(lg) {
+    h3 {
+      padding-top: 0;
+    }
+  }
 }

--- a/client/src/styles/components/_renku_home.scss
+++ b/client/src/styles/components/_renku_home.scss
@@ -218,7 +218,7 @@ nav.rk-anon-home .nav-link,
 #rk-anon-home-section-showcase {
   @extend .section-content;
   background-color: var(--bs-rk-background-0);
-  color: $rk-dark;
+  color: black;
   min-height: 600px;
 
   h3 {
@@ -231,7 +231,7 @@ nav.rk-anon-home .nav-link,
 #rk-anon-home-section-showcase-empty {
   @extend .section-content;
   background-color: var(--bs-rk-background-0);
-  color: $rk-dark;
+  color: black;
   height: 200px;
 }
 


### PR DESCRIPTION
Match the font size and color in the showcase section with the rest of the homepage.

**Large viewport**
<img width="801" alt="image" src="https://github.com/SwissDataScienceCenter/renku-ui/assets/1196411/3439b679-60fc-499d-b3c0-369bf0c03e81">

<img width="801" alt="image" src="https://github.com/SwissDataScienceCenter/renku-ui/assets/1196411/0ec1006f-8410-4313-8dcb-fad084d0cf74">


**Small viewport**
<img width="468" alt="image" src="https://github.com/SwissDataScienceCenter/renku-ui/assets/1196411/33bd5135-44e1-4899-996f-62dfa660b9d7">

<img width="468" alt="image" src="https://github.com/SwissDataScienceCenter/renku-ui/assets/1196411/a59cb69f-7076-4fc3-8504-29b1622cb286">


Fix #2963

/deploy extra-values=ui.homepage.showcase.enabled=true,ui.homepage.showcase.title=Renku,ui.homepage.showcase.description=Description,ui.homepage.showcase.projects[0].identifier=hdbi/data-management/cccooci