### PR TITLE
Always specify the branch when dealing with datasets

### DIFF
--- a/client/src/api-client/dataset.js
+++ b/client/src/api-client/dataset.js
@@ -114,7 +114,12 @@ export default function addDatasetMethods(client) {
     });
   };
 
-  client.datasetImport = (projectUrl, datasetUrl, versionUrl = null) => {
+  client.datasetImport = (
+    projectUrl,
+    datasetUrl,
+    versionUrl = null,
+    branch
+  ) => {
     let headers = client.getBasicHeaders();
     headers.append("Content-Type", "application/json");
     headers.append("X-Requested-With", "XMLHttpRequest");
@@ -127,6 +132,7 @@ export default function addDatasetMethods(client) {
       body: JSON.stringify({
         dataset_uri: datasetUrl,
         git_url: projectUrl,
+        branch,
       }),
     });
   };
@@ -134,14 +140,14 @@ export default function addDatasetMethods(client) {
   client.listProjectDatasetsFromCoreService = (
     git_url,
     versionUrl = null,
-    defaultBranch
+    branch
   ) => {
     let headers = client.getBasicHeaders();
     headers.append("Content-Type", "application/json");
     headers.append("X-Requested-With", "XMLHttpRequest");
 
     const url = client.versionedCoreUrl("datasets.list", versionUrl);
-    const queryParams = { git_url };
+    const queryParams = { git_url, branch };
 
     return client
       .clientFetch(url, {
@@ -152,7 +158,7 @@ export default function addDatasetMethods(client) {
       .then((response) => {
         if (response.data.result && response.data.result.datasets.length > 0) {
           response.data.result.datasets.map((d) =>
-            addMarqueeImageToDataset(git_url, cleanDatasetId(d), defaultBranch)
+            addMarqueeImageToDataset(git_url, cleanDatasetId(d), branch)
           );
         }
 
@@ -166,14 +172,15 @@ export default function addDatasetMethods(client) {
   client.fetchDatasetFilesFromCoreService = (
     slug,
     git_url,
-    versionUrl = null
+    versionUrl = null,
+    branch
   ) => {
     let headers = client.getBasicHeaders();
     headers.append("Content-Type", "application/json");
     headers.append("X-Requested-With", "XMLHttpRequest");
 
     const url = client.versionedCoreUrl("datasets.files_list", versionUrl);
-    const queryParams = { git_url, slug };
+    const queryParams = { git_url, slug, branch };
 
     const filesPromise = client
       .clientFetch(url, {

--- a/client/src/dataset/Dataset.container.jsx
+++ b/client/src/dataset/Dataset.container.jsx
@@ -79,11 +79,12 @@ export default function ShowDataset(props) {
 
   // use effect to calculate files
   useEffect(() => {
-    const fetchFiles = (slug, externalUrl, versionUrl) => {
+    const fetchFiles = (slug, externalUrl, versionUrl, branch) => {
       props.datasetCoordinator.fetchDatasetFilesFromCoreService(
         slug,
         externalUrl,
-        versionUrl
+        versionUrl,
+        branch
       );
     };
 
@@ -100,7 +101,7 @@ export default function ShowDataset(props) {
         backendAvailable &&
         !isFilesFetching
       ) {
-        fetchFiles(dataset?.slug, externalUrl, versionUrl);
+        fetchFiles(dataset?.slug, externalUrl, versionUrl, defaultBranch);
       }
     }
   }, [
@@ -112,6 +113,7 @@ export default function ShowDataset(props) {
     props.datasetCoordinator,
     datasetFiles,
     versionUrl,
+    defaultBranch,
   ]);
 
   const currentDataset = useLegacySelector(

--- a/client/src/dataset/Dataset.present.jsx
+++ b/client/src/dataset/Dataset.present.jsx
@@ -44,6 +44,7 @@ import {
   getUpdatedDatasetImage,
 } from "./DatasetFunctions";
 import { getEntityImageUrl } from "../utils/helpers/HelperFunctions";
+import useLegacySelector from "../utils/customHooks/useLegacySelector.hook";
 
 function DisplayFiles(props) {
   if (!props.files || !props.files?.hasPart) return null;
@@ -405,6 +406,10 @@ function getLinksDatasetHeader(projects) {
 
 export default function DatasetView(props) {
   const [deleteDatasetModalOpen, setDeleteDatasetModalOpen] = useState(false);
+  const { defaultBranch } = useLegacySelector(
+    (state) => state.stateModel.project.metadata
+  );
+
   const dataset = props.dataset;
   // We only get the locked prop if we are inside a project
   const locked = props.insideProject && props.lockStatus?.locked === true;
@@ -523,7 +528,7 @@ export default function DatasetView(props) {
           projectId={props.projectId}
           description={dataset.description}
           insideProject={props.insideProject}
-          defaultBranch={props.defaultBranch}
+          defaultBranch={props.defaultBranch ?? defaultBranch}
         />
         <DisplayFiles
           projectsUrl={props.projectsUrl}
@@ -587,6 +592,7 @@ export default function DatasetView(props) {
             setModalOpen={setDeleteDatasetModalOpen}
             user={props.user}
             versionUrl={props.versionUrl}
+            branch={defaultBranch}
           />
         ) : null}
       </Col>

--- a/client/src/dataset/Dataset.state.js
+++ b/client/src/dataset/Dataset.state.js
@@ -121,12 +121,17 @@ class DatasetCoordinator {
       });
   }
 
-  fetchDatasetFilesFromCoreService(name, httpProjectUrl, versionUrl) {
+  fetchDatasetFilesFromCoreService(name, httpProjectUrl, versionUrl, branch) {
     if (!name || !httpProjectUrl || !versionUrl) return;
 
     this.set("files.fetching", true);
     return this.client
-      .fetchDatasetFilesFromCoreService(name, httpProjectUrl, versionUrl)
+      .fetchDatasetFilesFromCoreService(
+        name,
+        httpProjectUrl,
+        versionUrl,
+        branch
+      )
       .then((response) => {
         if (response.data.result) {
           const files = response.data.result.files.map((file) => ({

--- a/client/src/dataset/addtoproject/DatasetAddToProject.tsx
+++ b/client/src/dataset/addtoproject/DatasetAddToProject.tsx
@@ -255,7 +255,10 @@ function DatasetAddToProject({
       .datasetImport(
         cleanGitUrl(selectedProject.value),
         dataset.url,
-        versionUrl // this will be undefined for a new project, so the latest version will be used
+        versionUrl, // this will be undefined for a new project, so the latest version will be used
+        selectedProject.default_branch
+          ? selectedProject.default_branch
+          : dstProjectDetails?.branch
       )
       .then((response: DatasetImportResponse) => {
         if (response?.data?.error !== undefined) {

--- a/client/src/features/datasets/datasetsCore.api.ts
+++ b/client/src/features/datasets/datasetsCore.api.ts
@@ -60,8 +60,8 @@ export const datasetsCoreApi = createApi({
       },
     }),
     deleteDataset: builder.mutation<DeleteDataset, DeleteDatasetParams>({
-      query: ({ apiVersion, gitUrl, metadataVersion, slug }) => {
-        const body = { git_url: gitUrl, slug };
+      query: ({ apiVersion, gitUrl, metadataVersion, slug, branch }) => {
+        const body = { git_url: gitUrl, slug, branch };
         return {
           body,
           method: "POST",

--- a/client/src/features/project/Project.d.ts
+++ b/client/src/features/project/Project.d.ts
@@ -34,6 +34,7 @@ type DatasetImage = {
 export interface GetDatasetFilesParams extends CoreVersionUrl {
   git_url: string;
   slug: string;
+  branch: string;
 }
 
 export interface GetDatasetFilesResponse {
@@ -103,6 +104,7 @@ interface IDataset extends DatasetAbstract {
   sameAs?: string;
   url?: string;
   usedIn?: UsedIn;
+  branch?: string;
 }
 
 export type IDatasetFiles = {

--- a/client/src/features/project/dataset/ProjectDatasetShow.tsx
+++ b/client/src/features/project/dataset/ProjectDatasetShow.tsx
@@ -38,7 +38,8 @@ type IDatasetCoordinator = {
   fetchDatasetFilesFromCoreService: (
     id: string,
     httpProjectUrl: string,
-    versionUrl: string
+    versionUrl: string,
+    branch: string
   ) => void;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   get(key: string): any;
@@ -156,6 +157,7 @@ function ProjectDatasetView(props: ProjectDatasetViewProps) {
       git_url: props.externalUrl,
       slug: datasetSlug ?? "",
       metadataVersion,
+      branch: defaultBranch,
     },
     { skip: !datasetSlug }
   );

--- a/client/src/features/project/projectCoreApi.ts
+++ b/client/src/features/project/projectCoreApi.ts
@@ -103,7 +103,11 @@ export const projectCoreApi = createApi({
   endpoints: (builder) => ({
     getDatasetFiles: builder.query<IDatasetFiles, GetDatasetFilesParams>({
       query: (params: GetDatasetFilesParams) => {
-        const queryParams = { git_url: params.git_url, slug: params.slug };
+        const queryParams = {
+          git_url: params.git_url,
+          slug: params.slug,
+          branch: params.branch,
+        };
         const headers = {
           Accept: "application/json",
           "Content-Type": "application/json",

--- a/client/src/project/datasets/delete/DeleteDataset.tsx
+++ b/client/src/project/datasets/delete/DeleteDataset.tsx
@@ -147,6 +147,7 @@ export interface DeleteDatasetProps extends CoreVersionUrl {
   modalOpen: boolean;
   projectPathWithNamespace: string;
   setModalOpen: (modalOpen: boolean) => void;
+  branch: string;
 }
 
 function DeleteDataset(props: DeleteDatasetProps) {
@@ -196,6 +197,7 @@ function DeleteDataset(props: DeleteDatasetProps) {
       gitUrl: props.externalUrl,
       metadataVersion: props.metadataVersion,
       slug: props.dataset.slug ?? "",
+      branch: props.branch,
     });
   };
 

--- a/client/src/project/datasets/import/DatasetImport.tsx
+++ b/client/src/project/datasets/import/DatasetImport.tsx
@@ -46,7 +46,8 @@ type DatasetImportClient = {
   datasetImport: (
     httpProjectUrl: string,
     uri: string,
-    versionUrl: string
+    versionUrl: string,
+    branch: string
   ) => Promise<DatasetImportResult>;
   getJobStatus: (job_id: string, versionUrl: string) => Promise<JobStatus>;
 };
@@ -195,6 +196,7 @@ function DatasetImportForm(
 
 type ImportDatasetArgs = {
   client: DatasetImportClient;
+  branch: string;
   externalUrl: string;
   formValues: DatasetInputFormFields;
   handlers: {
@@ -216,11 +218,13 @@ async function importDatasetAndWaitForResult({
   handlers,
   redirectUser,
   versionUrl,
+  branch,
 }: ImportDatasetArgs) {
   const response = await client.datasetImport(
     externalUrl,
     formValues.uri,
-    versionUrl
+    versionUrl,
+    branch
   );
   if (response.data.error !== undefined) {
     const error = response.data.error;
@@ -294,7 +298,7 @@ async function importDatasetAndWaitForResult({
 }
 
 function DatasetImportContainer(
-  props: DatasetImportProps & { versionUrl: string }
+  props: DatasetImportProps & { branch: string; versionUrl: string }
 ) {
   const {
     externalUrl,
@@ -342,6 +346,7 @@ function DatasetImportContainer(
       };
       try {
         await importDatasetAndWaitForResult({
+          branch: props.branch,
           client,
           externalUrl,
           formValues,
@@ -357,6 +362,7 @@ function DatasetImportContainer(
     [
       externalUrl,
       client,
+      props.branch,
       redirectUser,
       setServerErrors,
       setSubmitLoader,
@@ -447,7 +453,13 @@ function DatasetImport(props: DatasetImportProps) {
     );
   }
 
-  return <DatasetImportContainer {...props} versionUrl={versionUrl} />;
+  return (
+    <DatasetImportContainer
+      {...props}
+      branch={defaultBranch}
+      versionUrl={versionUrl}
+    />
+  );
 }
 
 export default DatasetImport;


### PR DESCRIPTION
There is a breaking change from the renku-core APIs that requires the clients to either _always_ or _never_ specify the branch name. The reason is that the branch is used for caching, and not sending one results in falling back to a default name instead of picking the default branch name.

Since we know the default branch and we are already using it somewhere, this PR updates the code to always pass the default branch name.

/deploy renku=remove-v9 renku-core=develop