### PR TITLE
fix(client): fix z-index clash in the search page

### DIFF
--- a/client/src/components/navbar/NavBarItem.module.scss
+++ b/client/src/components/navbar/NavBarItem.module.scss
@@ -1,0 +1,3 @@
+.dropdownMenu {
+  z-index: 1100;
+}

--- a/client/src/components/navbar/NavBarItems.tsx
+++ b/client/src/components/navbar/NavBarItems.tsx
@@ -44,6 +44,8 @@ import { Loader } from "../Loader";
 import { RenkuNavLink } from "../RenkuNavLink";
 import BootstrapGitLabIcon from "../icons/BootstrapGitLabIcon";
 
+import styles from "./NavBarItem.module.scss";
+
 export function RenkuToolbarItemPlus() {
   const location = useLocation();
 
@@ -75,7 +77,7 @@ export function RenkuToolbarItemPlus() {
   );
 
   return (
-    <UncontrolledDropdown className="nav-item dropdown">
+    <UncontrolledDropdown className="nav-item">
       <DropdownToggle
         className={cx("nav-link", "fs-5", "ps-sm-2", "pe-2")}
         nav
@@ -86,7 +88,11 @@ export function RenkuToolbarItemPlus() {
       </DropdownToggle>
       <DropdownMenu
         aria-labelledby="plus-menu"
-        className="plus-menu btn-with-menu-options"
+        className={cx(
+          "plus-menu",
+          "btn-with-menu-options",
+          styles.dropdownMenu
+        )}
         end
       >
         {projectDropdown}
@@ -126,7 +132,11 @@ export function RenkuToolbarGitLabMenu() {
         <BootstrapGitLabIcon className="bi" id="gitLabDropdownToggle" />
       </DropdownToggle>
       <DropdownMenu
-        className="gitLab-menu btn-with-menu-options"
+        className={cx(
+          "gitLab-menu",
+          "btn-with-menu-options",
+          styles.dropdownMenu
+        )}
         end
         key="gitLab-bar"
         aria-labelledby="gitLab-menu"
@@ -188,7 +198,11 @@ export function RenkuToolbarHelpMenu({ firstItem }: RenkuToolbarHelpMenuProps) {
         <QuestionCircle className="bi" id="helpDropdownToggle" />
       </DropdownToggle>
       <DropdownMenu
-        className="help-menu btn-with-menu-options"
+        className={cx(
+          "help-menu",
+          "btn-with-menu-options",
+          styles.dropdownMenu
+        )}
         key="help-bar"
         aria-labelledby="help-menu"
       >
@@ -291,7 +305,11 @@ export function RenkuToolbarItemUser({ params }: RenkuToolbarItemUserProps) {
         <Person className="bi" id="userIcon" />
       </DropdownToggle>
       <DropdownMenu
-        className="user-menu btn-with-menu-options"
+        className={cx(
+          "user-menu",
+          "btn-with-menu-options",
+          styles.dropdownMenu
+        )}
         end
         key="user-bar"
         aria-labelledby="user-menu"


### PR DESCRIPTION
Fixes #2934.

Use `1100` as a z-index for the dropdown content of the top bar menu items.

![Screenshot 2024-01-23 at 11 37 58](https://github.com/SwissDataScienceCenter/renku-ui/assets/951086/4c143fe1-c353-4e9d-bfcf-60475aa8ac3c)

/deploy