### PR TITLE
fix(client): hide button to add storage when the feature is turned off

### DIFF
--- a/client/src/features/project/components/ProjectSettingsCloudStorage.tsx
+++ b/client/src/features/project/components/ProjectSettingsCloudStorage.tsx
@@ -110,11 +110,13 @@ export default function ProjectSettingsCloudStorage() {
       )}
       <CloudStorageSupportNotice notebooksVersion={notebooksVersion} />
 
-      <Row>
-        <Col>
-          <AddOrEditCloudStorageButton devAccess={devAccess} />
-        </Col>
-      </Row>
+      {notebooksVersion.cloudStorageEnabled && (
+        <Row>
+          <Col>
+            <AddOrEditCloudStorageButton devAccess={devAccess} />
+          </Col>
+        </Row>
+      )}
 
       <CloudStorageList
         devAccess={devAccess}


### PR DESCRIPTION
We should not show the button to add a new storage service in deployments that do not support it

![image](https://github.com/SwissDataScienceCenter/renku-ui/assets/43481553/bef0ba8c-ffd0-49ad-9f6a-9e1bd31a5b20)

/deploy renku=000-cypress-storage-off
