### PR TITLE
chore(client): remove unused dependencies

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -38,7 +38,6 @@
         "luxon": "^3.3.0",
         "mermaid": "^9.1.3",
         "pica": "^9.0.1",
-        "popper.js": "^1.16.0",
         "query-string": "^6.14.1",
         "react": "^18.2.0",
         "react-autosuggest": "^10.1.0",
@@ -76,7 +75,6 @@
         "showdown-mermaid": "^0.0.1",
         "styled-jsx": "^5.1.0",
         "swiper": "^9.4.1",
-        "uuid": "^3.3.3",
         "xregexp": "^4.4.0"
       },
       "devDependencies": {
@@ -35321,16 +35319,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
-    },
     "node_modules/portfinder": {
       "version": "1.0.32",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.32.tgz",
@@ -40279,15 +40267,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "bin": {
-        "uuid": "bin/uuid"
       }
     },
     "node_modules/uvu": {

--- a/client/package.json
+++ b/client/package.json
@@ -55,7 +55,6 @@
     "luxon": "^3.3.0",
     "mermaid": "^9.1.3",
     "pica": "^9.0.1",
-    "popper.js": "^1.16.0",
     "query-string": "^6.14.1",
     "react": "^18.2.0",
     "react-autosuggest": "^10.1.0",
@@ -93,7 +92,6 @@
     "showdown-mermaid": "^0.0.1",
     "styled-jsx": "^5.1.0",
     "swiper": "^9.4.1",
-    "uuid": "^3.3.3",
     "xregexp": "^4.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
See #3006.

Removes `popper.js` and `uuid`.

/deploy