### PR TITLE
chore(ci/cd): add a timeout for the unit tests

### DIFF
--- a/.github/workflows/test-and-ci.yml
+++ b/.github/workflows/test-and-ci.yml
@@ -27,6 +27,7 @@ jobs:
         run: npm run test
         env:
           CI: true
+        timeout-minutes: 1
       - name: Run format client
         run: npm run format-check
       - name: Run lint client


### PR DESCRIPTION
The current client unit tests (`npm run test`) usually run in ~11 seconds, but in some cases the test is stuck and takes more than 10 minutes (e.g. https://github.com/SwissDataScienceCenter/renku-ui/actions/runs/7727771816/attempts/1?pr=3011).

This adds a timeout to the corresponding step so that it fails fast and can be re-tried if needed.