### PR TITLE
fix(clent): restore logged in/out notifications

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -328,6 +328,7 @@ function App(props) {
         notificationManager
       )
     );
+    // ! Ignoring the rule of hooks creates issues, we should refactor this hook
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Avoid rendering the application while authenticating the user

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -312,7 +312,7 @@ function App(props) {
 
     // Setup authentication listeners and notifications
     LoginHelper.setupListener();
-    LoginHelper.triggerNotifications(notifications);
+    LoginHelper.triggerNotifications(notificationManager);
 
     // Setup WebSocket channel
     let webSocketUrl = props.client.uiserverUrl + "/ws";
@@ -328,7 +328,7 @@ function App(props) {
         notificationManager
       )
     );
-  }, []); // eslint-disable-line
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Avoid rendering the application while authenticating the user
   const user = useLegacySelector((state) => state.stateModel.user);


### PR DESCRIPTION
Restore logged in and out notifications in the UI.

![Screenshot 2024-02-01 at 10 35 29](https://github.com/SwissDataScienceCenter/renku-ui/assets/951086/f993629f-8f92-4245-ac4d-370ccdc3417c)

/deploy