### PR TITLE
fix(client): temporarily fix search bar styles

### DIFF
--- a/client/src/components/quicknav/QuickNav.container.jsx
+++ b/client/src/components/quicknav/QuickNav.container.jsx
@@ -72,7 +72,7 @@ export const defaultAnonymousSuggestionQuickBar = {
   ],
 };
 
-const QuickNavContainerWithRouter = ({ user }) => {
+export function QuickNavContainer({ user }) {
   const history = useHistory();
 
   const {
@@ -187,7 +187,4 @@ const QuickNavContainerWithRouter = ({ user }) => {
       suggestions={lastQueriesSuggestions}
     />
   );
-};
-
-const QuickNavContainer = withRouter(QuickNavContainerWithRouter);
-export { QuickNavContainer };
+}

--- a/client/src/components/quicknav/QuickNav.container.jsx
+++ b/client/src/components/quicknav/QuickNav.container.jsx
@@ -17,14 +17,14 @@
  */
 
 import { useEffect, useState } from "react";
-import { useHistory, withRouter } from "react-router-dom";
+import { useHistory } from "react-router-dom";
 
-import { QuickNavPresent } from "./QuickNav.present";
+import { useKgSearchContext } from "../../features/kgSearch/KgSearchContext";
 import {
   TOTAL_QUERIES,
   useSearchLastQueriesQuery,
 } from "../../features/recentUserActivity/RecentUserActivityApi";
-import { useKgSearchContext } from "../../features/kgSearch/KgSearchContext";
+import { QuickNavPresent } from "./QuickNav.present";
 
 export const defaultSuggestionQuickBar = {
   title: "",

--- a/client/src/components/quicknav/QuickNav.present.jsx
+++ b/client/src/components/quicknav/QuickNav.present.jsx
@@ -22,7 +22,11 @@ import Autosuggest from "react-autosuggest";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSearch } from "@fortawesome/free-solid-svg-icons";
 
+// ? react-autosuggest styles are defined there q_q
+// ? also, the order of import matters here q_q
+import "../../project/new/Project.style.css";
 import "./QuickNav.style.css";
+
 class QuickNavPresent extends Component {
   constructor(props) {
     super(props);

--- a/client/src/landing/AnonymousHome.tsx
+++ b/client/src/landing/AnonymousHome.tsx
@@ -51,6 +51,9 @@ import WhoWeAre from "./WhoWeAre/WhoWeAre";
 import type { AnonymousHomeConfig } from "./anonymousHome.types";
 import { BottomNav, TopNav } from "./anonymousHomeNav";
 
+// ? the "quick-nav" class is used in this file
+import "../components/quicknav/QuickNav.style.css";
+
 export default function AnonymousHome() {
   const { client, model, params } = useContext(AppContext);
 

--- a/client/src/landing/AnonymousHome.tsx
+++ b/client/src/landing/AnonymousHome.tsx
@@ -51,6 +51,9 @@ import WhoWeAre from "./WhoWeAre/WhoWeAre";
 import type { AnonymousHomeConfig } from "./anonymousHome.types";
 import { BottomNav, TopNav } from "./anonymousHomeNav";
 
+// ? react-autosuggest styles are defined there q_q
+// ? also, the order of import matters here q_q
+import "../project/new/Project.style.css";
 // ? the "quick-nav" class is used in this file
 import "../components/quicknav/QuickNav.style.css";
 


### PR DESCRIPTION
Component styles which leaked global classes where used in other places; now that pages are loaded lazily, this breaks styling for components which used to rely on "hidden" global styles.

Before:
![Screenshot 2024-02-07 at 10 24 46](https://github.com/SwissDataScienceCenter/renku-ui/assets/951086/a88071ab-aa3b-43a8-9536-7192b1926cc4)
![Screenshot 2024-02-07 at 10 25 02](https://github.com/SwissDataScienceCenter/renku-ui/assets/951086/73df124d-7ead-464b-a6e8-322917990215)

After:
![Screenshot 2024-02-07 at 10 27 38](https://github.com/SwissDataScienceCenter/renku-ui/assets/951086/b13a2a3c-db95-4a5b-b646-fafd2a73a8b2)
![Screenshot 2024-02-07 at 10 29 20](https://github.com/SwissDataScienceCenter/renku-ui/assets/951086/6e333c37-7b98-40fb-8419-67e132168543)