### PR TITLE
refactor: change the url structure for renku-native projects

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -199,17 +199,17 @@ function CentralContentContainer(props) {
               <LazyNotificationsPage />
             </ContainerWrap>
           </Route>{" "}
-          <Route path={Url.get(Url.pages.projectsV2.new)}>
+          <Route path={Url.get(Url.pages.nativeProjects.new)}>
             <ContainerWrap>
               <LazyProjectV2New />
             </ContainerWrap>
           </Route>
-          <Route path="/projectsV2/:id">
+          <Route path={`${Url.get(Url.pages.nativeProjects.list)}/:id`}>
             <ContainerWrap>
               <LazyProjectV2Show />
             </ContainerWrap>
           </Route>
-          <Route path={Url.get(Url.pages.projectsV2.list)}>
+          <Route path={Url.get(Url.pages.nativeProjects.list)}>
             <ContainerWrap>
               <LazyProjectV2List />
             </ContainerWrap>

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -199,17 +199,17 @@ function CentralContentContainer(props) {
               <LazyNotificationsPage />
             </ContainerWrap>
           </Route>{" "}
-          <Route path={Url.get(Url.pages.nativeProjects.new)}>
+          <Route path={Url.get(Url.pages.v2Projects.new)}>
             <ContainerWrap>
               <LazyProjectV2New />
             </ContainerWrap>
           </Route>
-          <Route path={`${Url.get(Url.pages.nativeProjects.list)}/:id`}>
+          <Route path={`${Url.get(Url.pages.v2Projects.list)}/:id`}>
             <ContainerWrap>
               <LazyProjectV2Show />
             </ContainerWrap>
           </Route>
-          <Route path={Url.get(Url.pages.nativeProjects.list)}>
+          <Route path={Url.get(Url.pages.v2Projects.list)}>
             <ContainerWrap>
               <LazyProjectV2List />
             </ContainerWrap>

--- a/client/src/features/projectsV2/list/ProjectV2List.tsx
+++ b/client/src/features/projectsV2/list/ProjectV2List.tsx
@@ -35,7 +35,7 @@ interface ProjectV2ListProjectProps {
   project: Project;
 }
 function ProjectV2ListProject({ project }: ProjectV2ListProjectProps) {
-  const projectUrl = Url.get(Url.pages.nativeProjects.show, { id: project.id });
+  const projectUrl = Url.get(Url.pages.v2Projects.show, { id: project.id });
   return (
     <div
       data-cy="list-card"
@@ -99,7 +99,7 @@ function ProjectList() {
 }
 
 export default function ProjectV2List() {
-  const newProjectUrl = Url.get(Url.pages.nativeProjects.new);
+  const newProjectUrl = Url.get(Url.pages.v2Projects.new);
   return (
     <FormSchema
       showHeader={true}

--- a/client/src/features/projectsV2/list/ProjectV2List.tsx
+++ b/client/src/features/projectsV2/list/ProjectV2List.tsx
@@ -35,7 +35,7 @@ interface ProjectV2ListProjectProps {
   project: Project;
 }
 function ProjectV2ListProject({ project }: ProjectV2ListProjectProps) {
-  const projectUrl = Url.get(Url.pages.projectsV2.show, { id: project.id });
+  const projectUrl = Url.get(Url.pages.nativeProjects.show, { id: project.id });
   return (
     <div
       data-cy="list-card"
@@ -99,7 +99,7 @@ function ProjectList() {
 }
 
 export default function ProjectV2List() {
-  const newProjectUrl = Url.get(Url.pages.projectsV2.new);
+  const newProjectUrl = Url.get(Url.pages.nativeProjects.new);
   return (
     <FormSchema
       showHeader={true}

--- a/client/src/features/projectsV2/new/ProjectV2New.tsx
+++ b/client/src/features/projectsV2/new/ProjectV2New.tsx
@@ -150,7 +150,7 @@ function ProjectV2BeingCreated({
       </div>
     );
   }
-  const projectList = Url.get(Url.pages.projectsV2.list);
+  const projectList = Url.get(Url.pages.nativeProjects.list);
   return (
     <>
       <div>Project created.</div>

--- a/client/src/features/projectsV2/new/ProjectV2New.tsx
+++ b/client/src/features/projectsV2/new/ProjectV2New.tsx
@@ -150,7 +150,7 @@ function ProjectV2BeingCreated({
       </div>
     );
   }
-  const projectList = Url.get(Url.pages.nativeProjects.list);
+  const projectList = Url.get(Url.pages.v2Projects.list);
   return (
     <>
       <div>Project created.</div>

--- a/client/src/features/projectsV2/show/ProjectV2Show.tsx
+++ b/client/src/features/projectsV2/show/ProjectV2Show.tsx
@@ -55,7 +55,7 @@ function ProjectV2Header({
   setSettingEdit,
   settingEdit,
 }: ProjectV2HeaderProps) {
-  const projectListUrl = Url.get(Url.pages.projectsV2.list);
+  const projectListUrl = Url.get(Url.pages.nativeProjects.list);
   return (
     <>
       <div>{project.slug}</div>
@@ -179,7 +179,9 @@ export default function ProjectV2Show() {
       return (
         <div>
           Project does not exist, or you are not authorized to access it.{" "}
-          <Link to={Url.get(Url.pages.projectsV2.list)}>Return to list</Link>
+          <Link to={Url.get(Url.pages.nativeProjects.list)}>
+            Return to list
+          </Link>
         </div>
       );
     }

--- a/client/src/features/projectsV2/show/ProjectV2Show.tsx
+++ b/client/src/features/projectsV2/show/ProjectV2Show.tsx
@@ -55,7 +55,7 @@ function ProjectV2Header({
   setSettingEdit,
   settingEdit,
 }: ProjectV2HeaderProps) {
-  const projectListUrl = Url.get(Url.pages.nativeProjects.list);
+  const projectListUrl = Url.get(Url.pages.v2Projects.list);
   return (
     <>
       <div>{project.slug}</div>
@@ -179,9 +179,7 @@ export default function ProjectV2Show() {
       return (
         <div>
           Project does not exist, or you are not authorized to access it.{" "}
-          <Link to={Url.get(Url.pages.nativeProjects.list)}>
-            Return to list
-          </Link>
+          <Link to={Url.get(Url.pages.v2Projects.list)}>Return to list</Link>
         </div>
       );
     }

--- a/client/src/utils/helpers/url/Url.js
+++ b/client/src/utils/helpers/url/Url.js
@@ -484,12 +484,12 @@ const Url = {
         ),
       },
     },
-    projectsV2: {
-      base: "/projectsV2",
-      new: "/projectsV2/new",
-      list: "/projectsV2",
-      show: new UrlRule((data) => `/projectsV2/${data.id}`, ["id"], null, [
-        "/projectsV2/id",
+    nativeProjects: {
+      base: "/native/projects",
+      new: "/native/projects/new",
+      list: "/native/projects",
+      show: new UrlRule((data) => `/native/projects/${data.id}`, ["id"], null, [
+        "/native/projects/id",
       ]),
     },
     sessions: {

--- a/client/src/utils/helpers/url/Url.js
+++ b/client/src/utils/helpers/url/Url.js
@@ -484,12 +484,12 @@ const Url = {
         ),
       },
     },
-    nativeProjects: {
-      base: "/native/projects",
-      new: "/native/projects/new",
-      list: "/native/projects",
-      show: new UrlRule((data) => `/native/projects/${data.id}`, ["id"], null, [
-        "/native/projects/id",
+    v2Projects: {
+      base: "/v2/projects",
+      new: "/v2/projects/new",
+      list: "/v2/projects",
+      show: new UrlRule((data) => `/v2/projects/${data.id}`, ["id"], null, [
+        "/v2/projects/id",
       ]),
     },
     sessions: {

--- a/tests/cypress/e2e/projectV2.spec.ts
+++ b/tests/cypress/e2e/projectV2.spec.ts
@@ -26,7 +26,7 @@ describe("Add new v2 project", () => {
     fixtures.config().versions().userTest().namespaces();
     fixtures.projects().landingUserProjects();
     fixtures.createProjectV2().readProjectV2();
-    cy.visit("projectsV2/new");
+    cy.visit("/native/projects/new");
   });
 
   it("create a new project", () => {
@@ -91,7 +91,7 @@ describe("Add new v2 project", () => {
 describe("Add new v2 project -- not logged in", () => {
   beforeEach(() => {
     fixtures.config().versions().userNone();
-    cy.visit("projectsV2/new");
+    cy.visit("/native/projects/new");
   });
 
   it("create a new project", () => {
@@ -103,7 +103,7 @@ describe("List v2 project", () => {
   beforeEach(() => {
     fixtures.config().versions().userTest().namespaces();
     fixtures.projects().landingUserProjects().listProjectV2();
-    cy.visit("projectsV2");
+    cy.visit("/native/projects");
   });
 
   it("list projects", () => {
@@ -130,7 +130,7 @@ describe("Edit v2 project", () => {
   beforeEach(() => {
     fixtures.config().versions().userTest().namespaces();
     fixtures.projects().landingUserProjects().listProjectV2();
-    cy.visit("projectsV2");
+    cy.visit("/native/projects");
   });
 
   it("changes project metadata", () => {

--- a/tests/cypress/e2e/projectV2.spec.ts
+++ b/tests/cypress/e2e/projectV2.spec.ts
@@ -26,7 +26,7 @@ describe("Add new v2 project", () => {
     fixtures.config().versions().userTest().namespaces();
     fixtures.projects().landingUserProjects();
     fixtures.createProjectV2().readProjectV2();
-    cy.visit("/native/projects/new");
+    cy.visit("/v2/projects/new");
   });
 
   it("create a new project", () => {
@@ -91,7 +91,7 @@ describe("Add new v2 project", () => {
 describe("Add new v2 project -- not logged in", () => {
   beforeEach(() => {
     fixtures.config().versions().userNone();
-    cy.visit("/native/projects/new");
+    cy.visit("/v2/projects/new");
   });
 
   it("create a new project", () => {
@@ -103,7 +103,7 @@ describe("List v2 project", () => {
   beforeEach(() => {
     fixtures.config().versions().userTest().namespaces();
     fixtures.projects().landingUserProjects().listProjectV2();
-    cy.visit("/native/projects");
+    cy.visit("/v2/projects");
   });
 
   it("list projects", () => {
@@ -130,7 +130,7 @@ describe("Edit v2 project", () => {
   beforeEach(() => {
     fixtures.config().versions().userTest().namespaces();
     fixtures.projects().landingUserProjects().listProjectV2();
-    cy.visit("/native/projects");
+    cy.visit("/v2/projects");
   });
 
   it("changes project metadata", () => {


### PR DESCRIPTION
Change the URL structure for renku-native projects from `projectsV2` to `native/projects` to allow introducing other native (v1) entities under the `native` path.

/deploy