### PR TITLE
feat(client): add an additional top bar for Renku 1.0

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -117,6 +117,7 @@
           "cloudstorage",
           "codegen",
           "codemirror",
+          "compat",
           "craco",
           "dagre",
           "dataset",

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -28,7 +28,6 @@ import { Helmet } from "react-helmet";
 import { Redirect, useLocation } from "react-router";
 import { Route, Switch } from "react-router-dom";
 import { ToastContainer } from "react-toastify";
-// eslint-disable-next-line spellcheck/spell-checker
 import { CompatRoute } from "react-router-dom-v5-compat";
 
 import { LoginHelper, LoginRedirect } from "./authentication";
@@ -199,9 +198,9 @@ function CentralContentContainer(props) {
               <LazyNotificationsPage />
             </ContainerWrap>
           </Route>
-          <Route path="/v2">
+          <CompatRoute path="/v2">
             <LazyRootV2 />
-          </Route>
+          </CompatRoute>
           <CompatRoute path="/style-guide">
             <ContainerWrap>
               <LazyStyleGuide />

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -198,9 +198,7 @@ function CentralContentContainer(props) {
             </ContainerWrap>
           </Route>
           <Route path="/v2">
-            {/* <ContainerWrap> */}
             <LazyRootV2 />
-            {/* </ContainerWrap> */}
           </Route>
           <Route path="/style-guide">
             <ContainerWrap>

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -39,6 +39,7 @@ import LazyDashboard from "./features/dashboard/LazyDashboard";
 import LazyInactiveKGProjectsPage from "./features/inactiveKgProjects/LazyInactiveKGProjectsPage";
 import LazySearchPage from "./features/kgSearch/LazySearchPage";
 import { Unavailable } from "./features/maintenance/Maintenance";
+import LazyRootV2 from "./features/rootV2/LazyRootV2";
 import LazyAnonymousSessionsList from "./features/session/components/LazyAnonymousSessionsList";
 import { useGetUserInfoQuery } from "./features/user/keycloakUser.api";
 import LazyHelp from "./help/LazyHelp";
@@ -51,9 +52,6 @@ import Cookie from "./privacy/Cookie";
 import LazyProjectView from "./project/LazyProjectView";
 import LazyProjectList from "./project/list/LazyProjectList";
 import LazyNewProject from "./project/new/LazyNewProject";
-import LazyProjectV2List from "./features/projectsV2/LazyProjectV2List";
-import LazyProjectV2New from "./features/projectsV2/LazyProjectV2New";
-import LazyProjectV2Show from "./features/projectsV2/LazyProjectV2Show";
 import LazyStyleGuide from "./styleguide/LazyStyleGuide";
 import AppContext from "./utils/context/appContext";
 import useLegacySelector from "./utils/customHooks/useLegacySelector.hook";
@@ -198,21 +196,11 @@ function CentralContentContainer(props) {
             <ContainerWrap>
               <LazyNotificationsPage />
             </ContainerWrap>
-          </Route>{" "}
-          <Route path={Url.get(Url.pages.v2Projects.new)}>
-            <ContainerWrap>
-              <LazyProjectV2New />
-            </ContainerWrap>
           </Route>
-          <Route path={`${Url.get(Url.pages.v2Projects.list)}/:id`}>
-            <ContainerWrap>
-              <LazyProjectV2Show />
-            </ContainerWrap>
-          </Route>
-          <Route path={Url.get(Url.pages.v2Projects.list)}>
-            <ContainerWrap>
-              <LazyProjectV2List />
-            </ContainerWrap>
+          <Route path="/v2">
+            {/* <ContainerWrap> */}
+            <LazyRootV2 />
+            {/* </ContainerWrap> */}
           </Route>
           <Route path="/style-guide">
             <ContainerWrap>

--- a/client/src/components/router/Router.tsx
+++ b/client/src/components/router/Router.tsx
@@ -18,7 +18,6 @@
 
 import { ReactNode } from "react";
 import { BrowserRouter } from "react-router-dom";
-// eslint-disable-next-line spellcheck/spell-checker
 import { CompatRouter } from "react-router-dom-v5-compat";
 
 interface RouterProps {

--- a/client/src/features/projectsV2/show/ProjectV2Show.tsx
+++ b/client/src/features/projectsV2/show/ProjectV2Show.tsx
@@ -17,7 +17,7 @@
  */
 import { useCallback, useState } from "react";
 import { ArrowLeft } from "react-bootstrap-icons";
-import { Link, useParams } from "react-router-dom";
+import { Link, useParams } from "react-router-dom-v5-compat";
 import {
   Dropdown,
   DropdownItem,
@@ -166,9 +166,9 @@ export function ProjectV2DescriptionAndRepositories({
 }
 
 export default function ProjectV2Show() {
-  const { id: projectId } = useParams<{ id: string }>();
+  const { id: projectId } = useParams<"id">();
   const { data, isLoading, error } = useGetProjectsByProjectIdQuery({
-    projectId,
+    projectId: projectId ?? "",
   });
 
   const [settingEdit, setSettingEdit] = useState<SettingEditOption>(null);

--- a/client/src/features/rootV2/LazyRootV2.tsx
+++ b/client/src/features/rootV2/LazyRootV2.tsx
@@ -15,15 +15,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License
  */
+
 import { Suspense, lazy } from "react";
+
 import PageLoader from "../../components/PageLoader";
 
-const ProjectV2Show = lazy(() => import("./show/ProjectV2Show"));
+const RootV2 = lazy(() => import("./RootV2"));
 
-export default function LazyProjectV2Show() {
+export default function LazyRootV2() {
   return (
     <Suspense fallback={<PageLoader />}>
-      <ProjectV2Show />
+      <RootV2 />
     </Suspense>
   );
 }

--- a/client/src/features/rootV2/NavbarV2.tsx
+++ b/client/src/features/rootV2/NavbarV2.tsx
@@ -1,0 +1,42 @@
+/*!
+ * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+import { Nav, NavItem, Navbar } from "reactstrap";
+import WipBadge from "../projectsV2/shared/WipBadge";
+import { RenkuNavLink } from "../../components/RenkuNavLink";
+import cx from "classnames";
+
+export default function NavbarV2() {
+  return (
+    <header className={cx("px-4", "bg-rk-blue")}>
+      <Navbar>
+        <div className={cx("text-white", "d-flex", "align-items-center")}>
+          <span className="me-1">Renku 1.0</span>
+          <WipBadge />
+        </div>
+        <Nav className="navbar-nav">
+          <NavItem>
+            <RenkuNavLink to="/v2/projects" title="Projects">
+              Projects
+            </RenkuNavLink>
+          </NavItem>
+        </Nav>
+      </Navbar>
+    </header>
+  );
+}

--- a/client/src/features/rootV2/NavbarV2.tsx
+++ b/client/src/features/rootV2/NavbarV2.tsx
@@ -16,24 +16,25 @@
  * limitations under the License
  */
 
-import { Nav, NavItem, Navbar } from "reactstrap";
-import WipBadge from "../projectsV2/shared/WipBadge";
-import { RenkuNavLink } from "../../components/RenkuNavLink";
 import cx from "classnames";
+import { Nav, NavItem, Navbar } from "reactstrap";
+
+import RenkuNavLinkV2 from "../../components/RenkuNavLinkV2";
+import WipBadge from "../projectsV2/shared/WipBadge";
 
 export default function NavbarV2() {
   return (
     <header className={cx("px-4", "bg-rk-blue")}>
-      <Navbar>
+      <Navbar className="px-2">
         <div className={cx("text-white", "d-flex", "align-items-center")}>
           <span className="me-1">Renku 1.0</span>
           <WipBadge />
         </div>
         <Nav className="navbar-nav">
           <NavItem>
-            <RenkuNavLink to="/v2/projects" title="Projects">
+            <RenkuNavLinkV2 end to="projects" title="Projects">
               Projects
-            </RenkuNavLink>
+            </RenkuNavLinkV2>
           </NavItem>
         </Nav>
       </Navbar>

--- a/client/src/features/rootV2/RootV2.tsx
+++ b/client/src/features/rootV2/RootV2.tsx
@@ -17,25 +17,33 @@
  */
 
 import { Route, Switch } from "react-router-dom";
+import cx from "classnames";
 
 import ContainerWrap from "../../components/container/ContainerWrap";
 import LazyProjectV2List from "../projectsV2/LazyProjectV2List";
 import LazyProjectV2New from "../projectsV2/LazyProjectV2New";
 import LazyProjectV2Show from "../projectsV2/LazyProjectV2Show";
+import LazyNotFound from "../../not-found/LazyNotFound";
+import NavbarV2 from "./NavbarV2";
 
 export default function RootV2() {
   return (
     <div className="w-100">
-      <div>Renku 1.0 Navbar</div>
+      <NavbarV2 />
 
-      <div className="d-flex flex-grow-1 h-100">
-        <ContainerWrap>
-          <Switch>
-            <Route path="/v2/projects">
+      <div className={cx("d-flex", "flex-grow-1", "h-100")}>
+        <Switch>
+          <Route path="/v2/projects">
+            <ContainerWrap>
               <ProjectsV2Routes />
-            </Route>
-          </Switch>
-        </ContainerWrap>
+            </ContainerWrap>
+          </Route>
+          <Route path="*">
+            <ContainerWrap fullSize>
+              <LazyNotFound />
+            </ContainerWrap>
+          </Route>
+        </Switch>
       </div>
     </div>
   );

--- a/client/src/features/rootV2/RootV2.tsx
+++ b/client/src/features/rootV2/RootV2.tsx
@@ -16,14 +16,14 @@
  * limitations under the License
  */
 
-import { Route, Switch } from "react-router-dom";
 import cx from "classnames";
+import { Route, Routes } from "react-router-dom-v5-compat";
 
 import ContainerWrap from "../../components/container/ContainerWrap";
+import LazyNotFound from "../../not-found/LazyNotFound";
 import LazyProjectV2List from "../projectsV2/LazyProjectV2List";
 import LazyProjectV2New from "../projectsV2/LazyProjectV2New";
 import LazyProjectV2Show from "../projectsV2/LazyProjectV2Show";
-import LazyNotFound from "../../not-found/LazyNotFound";
 import NavbarV2 from "./NavbarV2";
 
 export default function RootV2() {
@@ -32,18 +32,24 @@ export default function RootV2() {
       <NavbarV2 />
 
       <div className={cx("d-flex", "flex-grow-1", "h-100")}>
-        <Switch>
-          <Route path="/v2/projects">
-            <ContainerWrap>
-              <ProjectsV2Routes />
-            </ContainerWrap>
-          </Route>
-          <Route path="*">
-            <ContainerWrap fullSize>
-              <LazyNotFound />
-            </ContainerWrap>
-          </Route>
-        </Switch>
+        <Routes>
+          <Route
+            path="projects/*"
+            element={
+              <ContainerWrap>
+                <ProjectsV2Routes />
+              </ContainerWrap>
+            }
+          />
+          <Route
+            path="*"
+            element={
+              <ContainerWrap fullSize>
+                <LazyNotFound />
+              </ContainerWrap>
+            }
+          />
+        </Routes>
       </div>
     </div>
   );
@@ -51,16 +57,10 @@ export default function RootV2() {
 
 function ProjectsV2Routes() {
   return (
-    <Switch>
-      <Route path="/v2/projects/new">
-        <LazyProjectV2New />
-      </Route>
-      <Route path="/v2/projects/:id">
-        <LazyProjectV2Show />
-      </Route>
-      <Route path="/v2/projects">
-        <LazyProjectV2List />
-      </Route>
-    </Switch>
+    <Routes>
+      <Route path="/" element={<LazyProjectV2List />} />
+      <Route path="new" element={<LazyProjectV2New />} />
+      <Route path=":id" element={<LazyProjectV2Show />} />
+    </Routes>
   );
 }

--- a/client/src/features/rootV2/RootV2.tsx
+++ b/client/src/features/rootV2/RootV2.tsx
@@ -1,0 +1,58 @@
+/*!
+ * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+import { Route, Switch } from "react-router-dom";
+
+import ContainerWrap from "../../components/container/ContainerWrap";
+import LazyProjectV2List from "../projectsV2/LazyProjectV2List";
+import LazyProjectV2New from "../projectsV2/LazyProjectV2New";
+import LazyProjectV2Show from "../projectsV2/LazyProjectV2Show";
+
+export default function RootV2() {
+  return (
+    <div className="w-100">
+      <div>Renku 1.0 Navbar</div>
+
+      <div className="d-flex flex-grow-1 h-100">
+        <ContainerWrap>
+          <Switch>
+            <Route path="/v2/projects">
+              <ProjectsV2Routes />
+            </Route>
+          </Switch>
+        </ContainerWrap>
+      </div>
+    </div>
+  );
+}
+
+function ProjectsV2Routes() {
+  return (
+    <Switch>
+      <Route path="/v2/projects/new">
+        <LazyProjectV2New />
+      </Route>
+      <Route path="/v2/projects/:id">
+        <LazyProjectV2Show />
+      </Route>
+      <Route path="/v2/projects">
+        <LazyProjectV2List />
+      </Route>
+    </Switch>
+  );
+}

--- a/client/src/project/Project.present.jsx
+++ b/client/src/project/Project.present.jsx
@@ -28,7 +28,6 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import cx from "classnames";
 import { Component, Fragment, useEffect } from "react";
 import { Link, Route, Switch, useHistory, useParams } from "react-router-dom";
-// eslint-disable-next-line spellcheck/spell-checker
 import { CompatRoute } from "react-router-dom-v5-compat";
 import {
   Alert,


### PR DESCRIPTION
Adds an additional top bar when navigating paths under `/v2`.

![localhost_3000_v2](https://github.com/SwissDataScienceCenter/renku-ui/assets/951086/332b30e3-bd39-4829-84e0-ccc5621ed3a7)

/deploy renku=release-0.48.x