### PR TITLE
feat: ad-hoc feature flag for Renku 1.0

### DIFF
--- a/client/src/components/navbar/NavBarItems.tsx
+++ b/client/src/components/navbar/NavBarItems.tsx
@@ -33,6 +33,7 @@ import { User } from "../../model/renkuModels.types";
 import NotificationsMenu from "../../notifications/NotificationsMenu";
 import { Docs, Links, RenkuPythonDocs } from "../../utils/constants/Docs";
 import type { AppParams } from "../../utils/context/appParams.types";
+import useAppSelector from "../../utils/customHooks/useAppSelector.hook";
 import useLegacySelector from "../../utils/customHooks/useLegacySelector.hook";
 import {
   getActiveProjectPathWithNamespace,
@@ -45,7 +46,6 @@ import { RenkuNavLink } from "../RenkuNavLink";
 import BootstrapGitLabIcon from "../icons/BootstrapGitLabIcon";
 
 import styles from "./NavBarItem.module.scss";
-import useLocalStorageFeatureFlags from "../../utils/feature-flags/useLocalStorageFeatureFlags";
 
 export function RenkuToolbarItemPlus() {
   const location = useLocation();
@@ -284,7 +284,7 @@ export function RenkuToolbarItemUser({ params }: RenkuToolbarItemUserProps) {
 
   const user = useLegacySelector<User>((state) => state.stateModel.user);
 
-  const [{ renku10Enabled }] = useLocalStorageFeatureFlags();
+  const { renku10Enabled } = useAppSelector(({ featureFlags }) => featureFlags);
 
   const gatewayURL = params.GATEWAY_URL;
   const uiserverURL = params.UISERVER_URL;

--- a/client/src/components/navbar/NavBarItems.tsx
+++ b/client/src/components/navbar/NavBarItems.tsx
@@ -45,6 +45,7 @@ import { RenkuNavLink } from "../RenkuNavLink";
 import BootstrapGitLabIcon from "../icons/BootstrapGitLabIcon";
 
 import styles from "./NavBarItem.module.scss";
+import useLocalStorageFeatureFlags from "../../utils/feature-flags/useLocalStorageFeatureFlags";
 
 export function RenkuToolbarItemPlus() {
   const location = useLocation();
@@ -283,6 +284,8 @@ export function RenkuToolbarItemUser({ params }: RenkuToolbarItemUserProps) {
 
   const user = useLegacySelector<User>((state) => state.stateModel.user);
 
+  const [{ renku10Enabled }] = useLocalStorageFeatureFlags();
+
   const gatewayURL = params.GATEWAY_URL;
   const uiserverURL = params.UISERVER_URL;
   const redirect_url = encodeURIComponent(params.BASE_URL);
@@ -323,6 +326,13 @@ export function RenkuToolbarItemUser({ params }: RenkuToolbarItemUserProps) {
           />
         </DropdownItem>
         <AdminDropdownItem />
+
+        {renku10Enabled && (
+          <Link to="/v2/projects" className="dropdown-item">
+            Renku 1.0
+          </Link>
+        )}
+
         <DropdownItem divider />
         <a
           id="logout-link"

--- a/client/src/features/rootV2/RootV2.tsx
+++ b/client/src/features/rootV2/RootV2.tsx
@@ -17,35 +17,40 @@
  */
 
 import cx from "classnames";
-import { Route, Routes } from "react-router-dom-v5-compat";
+import { useEffect, useState } from "react";
+import { Route, Routes, useNavigate } from "react-router-dom-v5-compat";
 
 import ContainerWrap from "../../components/container/ContainerWrap";
 import LazyNotFound from "../../not-found/LazyNotFound";
+import useAppDispatch from "../../utils/customHooks/useAppDispatch.hook";
+import useAppSelector from "../../utils/customHooks/useAppSelector.hook";
+import { setFlag } from "../../utils/feature-flags/featureFlags.slice";
 import LazyProjectV2List from "../projectsV2/LazyProjectV2List";
 import LazyProjectV2New from "../projectsV2/LazyProjectV2New";
 import LazyProjectV2Show from "../projectsV2/LazyProjectV2Show";
 import NavbarV2 from "./NavbarV2";
-import { useContext, useEffect } from "react";
-import { LocalStorageFeatureFlagsContext } from "../../utils/feature-flags/LocalStorageFeatureFlags.context";
-import useAppSelector from "../../utils/customHooks/useAppSelector.hook";
-import useAppDispatch from "../../utils/customHooks/useAppDispatch.hook";
-import { setFlag } from "../../utils/feature-flags/featureFlags.slice";
 
 export default function RootV2() {
+  const navigate = useNavigate();
+
   const { renku10Enabled } = useAppSelector(({ featureFlags }) => featureFlags);
   const dispatch = useAppDispatch();
 
-  // useEffect(() => {
-  //   if (!renku10Enabled) {
-  //     setFlag("renku10Enabled", true);
-  //   }
-  // }, [renku10Enabled, setFlag]);
+  const [isFirstRender, setIsFirstRender] = useState(true);
 
   useEffect(() => {
-    if (!renku10Enabled) {
+    if (isFirstRender && !renku10Enabled) {
       dispatch(setFlag({ flag: "renku10Enabled", value: true }));
+      return;
     }
-  }, [dispatch, renku10Enabled]);
+    if (!renku10Enabled) {
+      navigate("/");
+    }
+  }, [dispatch, isFirstRender, navigate, renku10Enabled]);
+
+  useEffect(() => {
+    setIsFirstRender(false);
+  }, []);
 
   return (
     <div className="w-100">

--- a/client/src/features/rootV2/RootV2.tsx
+++ b/client/src/features/rootV2/RootV2.tsx
@@ -25,8 +25,18 @@ import LazyProjectV2List from "../projectsV2/LazyProjectV2List";
 import LazyProjectV2New from "../projectsV2/LazyProjectV2New";
 import LazyProjectV2Show from "../projectsV2/LazyProjectV2Show";
 import NavbarV2 from "./NavbarV2";
+import useLocalStorageFeatureFlags from "../../utils/feature-flags/useLocalStorageFeatureFlags";
+import { useEffect } from "react";
 
 export default function RootV2() {
+  const [{ renku10Enabled }, { setFlag }] = useLocalStorageFeatureFlags();
+
+  useEffect(() => {
+    if (!renku10Enabled) {
+      setFlag("renku10Enabled", true);
+    }
+  }, [renku10Enabled, setFlag]);
+
   return (
     <div className="w-100">
       <NavbarV2 />

--- a/client/src/features/rootV2/RootV2.tsx
+++ b/client/src/features/rootV2/RootV2.tsx
@@ -25,17 +25,27 @@ import LazyProjectV2List from "../projectsV2/LazyProjectV2List";
 import LazyProjectV2New from "../projectsV2/LazyProjectV2New";
 import LazyProjectV2Show from "../projectsV2/LazyProjectV2Show";
 import NavbarV2 from "./NavbarV2";
-import useLocalStorageFeatureFlags from "../../utils/feature-flags/useLocalStorageFeatureFlags";
-import { useEffect } from "react";
+import { useContext, useEffect } from "react";
+import { LocalStorageFeatureFlagsContext } from "../../utils/feature-flags/LocalStorageFeatureFlags.context";
+import useAppSelector from "../../utils/customHooks/useAppSelector.hook";
+import useAppDispatch from "../../utils/customHooks/useAppDispatch.hook";
+import { setFlag } from "../../utils/feature-flags/featureFlags.slice";
 
 export default function RootV2() {
-  const [{ renku10Enabled }, { setFlag }] = useLocalStorageFeatureFlags();
+  const { renku10Enabled } = useAppSelector(({ featureFlags }) => featureFlags);
+  const dispatch = useAppDispatch();
+
+  // useEffect(() => {
+  //   if (!renku10Enabled) {
+  //     setFlag("renku10Enabled", true);
+  //   }
+  // }, [renku10Enabled, setFlag]);
 
   useEffect(() => {
     if (!renku10Enabled) {
-      setFlag("renku10Enabled", true);
+      dispatch(setFlag({ flag: "renku10Enabled", value: true }));
     }
-  }, [renku10Enabled, setFlag]);
+  }, [dispatch, renku10Enabled]);
 
   return (
     <div className="w-100">

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -23,6 +23,7 @@ import { UserCoordinator } from "./user";
 import { validatedAppParams } from "./utils/context/appParams.utils";
 import { Sentry } from "./utils/helpers/sentry";
 import { createCoreApiVersionedUrlConfig, Url } from "./utils/helpers/url";
+import useFeatureFlagSync from "./utils/feature-flags/useFeatureFlagSync.hook";
 
 const configFetch = fetch("/config.json");
 
@@ -101,6 +102,7 @@ configFetch.then((valuesRead) => {
         <Router>
           <AppErrorBoundary>
             <LoginHandler />
+            <FeatureFlagHandler />
             <VisibleApp
               client={client}
               coreApiVersionedUrlConfig={coreApiVersionedUrlConfig}
@@ -122,5 +124,10 @@ function LoginHandler() {
     LoginHelper.handleLoginParams(history);
   }, [history]);
 
+  return null;
+}
+
+function FeatureFlagHandler() {
+  useFeatureFlagSync();
   return null;
 }

--- a/client/src/utils/feature-flags/featureFlags.constants.ts
+++ b/client/src/utils/feature-flags/featureFlags.constants.ts
@@ -1,0 +1,25 @@
+/*!
+ * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+import { FeatureFlags } from "./featureFlags.types";
+
+export const FEATURE_FLAG_KEYS: (keyof FeatureFlags)[] = ["renku10Enabled"];
+
+export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
+  renku10Enabled: false,
+};

--- a/client/src/utils/feature-flags/featureFlags.types.ts
+++ b/client/src/utils/feature-flags/featureFlags.types.ts
@@ -1,0 +1,25 @@
+/*!
+ * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+type FeatureFlagsBase = {
+  [key: string]: boolean;
+};
+
+type FeatureFlagKey = "renku10Enabled";
+
+export type FeatureFlags = Pick<FeatureFlagsBase, FeatureFlagKey>;

--- a/client/src/utils/feature-flags/useFeatureFlagSync.hook.ts
+++ b/client/src/utils/feature-flags/useFeatureFlagSync.hook.ts
@@ -16,12 +16,32 @@
  * limitations under the License
  */
 
-import { FeatureFlags } from "./featureFlags.types";
+import { useEffect } from "react";
 
-export const FEATURE_FLAG_KEYS: (keyof FeatureFlags)[] = ["renku10Enabled"];
+import useAppDispatch from "../customHooks/useAppDispatch.hook";
+import { FEATURE_FLAG_LOCAL_STORAGE_KEY_PREFIX } from "./featureFlags.constants";
+import { reset } from "./featureFlags.slice";
 
-export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
-  renku10Enabled: false,
-};
+export default function useFeatureFlagSync() {
+  const dispatch = useAppDispatch();
 
-export const FEATURE_FLAG_LOCAL_STORAGE_KEY_PREFIX = "RENKU_FEATURE_FLAG__";
+  useEffect(() => {
+    function listener(event: StorageEvent) {
+      if (event.key == null) {
+        dispatch(reset());
+        return;
+      }
+      if (!event.key.startsWith(FEATURE_FLAG_LOCAL_STORAGE_KEY_PREFIX)) {
+        return;
+      }
+
+      dispatch(reset());
+    }
+
+    window.addEventListener("storage", listener);
+
+    return () => {
+      window.removeEventListener("storage", listener);
+    };
+  }, [dispatch]);
+}

--- a/client/src/utils/feature-flags/useLocalStorageFeatureFlags.ts
+++ b/client/src/utils/feature-flags/useLocalStorageFeatureFlags.ts
@@ -1,0 +1,72 @@
+/*!
+ * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+import { useCallback, useEffect, useState } from "react";
+
+import { FeatureFlags } from "./featureFlags.types";
+import {
+  DEFAULT_FEATURE_FLAGS,
+  FEATURE_FLAG_KEYS,
+} from "./featureFlags.constants";
+
+const localStorageKeyPrefix = "RENKU_FEATURE_FLAG__";
+
+export default function useLocalStorageFeatureFlags() {
+  const [featureFlags, setFeatureFlags] = useState<FeatureFlags>(
+    DEFAULT_FEATURE_FLAGS
+  );
+
+  const setFlag = useCallback((flag: keyof FeatureFlags, value: boolean) => {
+    const localStorageKey = `${localStorageKeyPrefix}${flag}`;
+    window.localStorage.setItem(localStorageKey, value ? "1" : "0");
+  }, []);
+
+  useEffect(() => {
+    function listener(event: StorageEvent) {
+      if (event.key == null) {
+        setFeatureFlags(DEFAULT_FEATURE_FLAGS);
+        return;
+      }
+      if (!event.key.startsWith(localStorageKeyPrefix)) {
+        return;
+      }
+
+      setFeatureFlags(readFlagsFromLocalStorage());
+    }
+
+    window.addEventListener("storage", listener);
+
+    return () => {
+      window.removeEventListener("storage", listener);
+    };
+  }, []);
+
+  return [featureFlags, { setFlag }] as const;
+}
+
+function readFlagsFromLocalStorage(): FeatureFlags {
+  const keyValuePairs = FEATURE_FLAG_KEYS.map((flag) => {
+    const localStorageKey = `${localStorageKeyPrefix}${flag}`;
+    const value = !!window.localStorage.getItem(localStorageKey);
+    return [flag, value] as [keyof FeatureFlags, boolean];
+  });
+  return keyValuePairs.reduce(
+    (featureFlags, [key, value]) => ({ ...featureFlags, [key]: value }),
+    { ...DEFAULT_FEATURE_FLAGS } as FeatureFlags
+  );
+}

--- a/client/src/utils/helpers/EnhancedState.ts
+++ b/client/src/utils/helpers/EnhancedState.ts
@@ -57,6 +57,7 @@ import userPreferencesApi from "../../features/user/userPreferences.api";
 import { versionsApi } from "../../features/versions/versions.api";
 import { workflowsApi } from "../../features/workflows/WorkflowsApi";
 import { workflowsSlice } from "../../features/workflows/WorkflowsSlice";
+import featureFlagsSlice from "../feature-flags/featureFlags.slice";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const createStore = <S = any, A extends Action = AnyAction>(
@@ -69,6 +70,7 @@ export const createStore = <S = any, A extends Action = AnyAction>(
     [dashboardMessageSlice.name]: dashboardMessageSlice.reducer,
     [datasetFormSlice.name]: datasetFormSlice.reducer,
     [displaySlice.name]: displaySlice.reducer,
+    [featureFlagsSlice.name]: featureFlagsSlice.reducer,
     [kgInactiveProjectsSlice.name]: kgInactiveProjectsSlice.reducer,
     [startSessionSlice.name]: startSessionSlice.reducer,
     [startSessionOptionsSlice.name]: startSessionOptionsSlice.reducer,


### PR DESCRIPTION
Add a "Renku 1.0" menu entry once the user visits any page within `/v2`.

![image](https://github.com/SwissDataScienceCenter/renku-ui/assets/951086/39781ddf-4515-4bfb-85da-a2a77ca0a799)

/deploy