### PR TITLE
feat(client): add default URL to Renku 1.0 session entities

### DIFF
--- a/client/src/features/admin/AddSessionEnvironmentButton.tsx
+++ b/client/src/features/admin/AddSessionEnvironmentButton.tsx
@@ -31,7 +31,9 @@ import {
 
 import { Loader } from "../../components/Loader";
 import { RtkErrorAlert } from "../../components/errors/RtkErrorAlert";
-import SessionEnvironmentFormContent from "./SessionEnvironmentFormContent";
+import SessionEnvironmentFormContent, {
+  SessionEnvironmentForm,
+} from "./SessionEnvironmentFormContent";
 import { useAddSessionEnvironmentMutation } from "./adminSessions.api";
 
 export default function AddSessionEnvironmentButton() {
@@ -67,18 +69,20 @@ function AddSessionEnvironmentModal({
     formState: { errors },
     handleSubmit,
     reset,
-  } = useForm<AddSessionEnvironmentForm>({
+  } = useForm<SessionEnvironmentForm>({
     defaultValues: {
       container_image: "",
+      default_url: "",
       description: "",
       name: "",
     },
   });
   const onSubmit = useCallback(
-    (data: AddSessionEnvironmentForm) => {
+    (data: SessionEnvironmentForm) => {
       addSessionEnvironment({
         container_image: data.container_image,
         name: data.name,
+        default_url: data.default_url.trim() ? data.default_url : undefined,
         description: data.description.trim() ? data.description : undefined,
       });
     },
@@ -136,10 +140,4 @@ function AddSessionEnvironmentModal({
       </Form>
     </Modal>
   );
-}
-
-interface AddSessionEnvironmentForm {
-  container_image: string;
-  description: string;
-  name: string;
 }

--- a/client/src/features/admin/SessionEnvironmentFormContent.tsx
+++ b/client/src/features/admin/SessionEnvironmentFormContent.tsx
@@ -104,7 +104,7 @@ export default function SessionEnvironmentFormContent({
 
       <div>
         <Label className="form-label" for="addSessionEnvironmentDefaultUrl">
-          Container Image
+          Default URL
         </Label>
         <Controller
           control={control}

--- a/client/src/features/admin/SessionEnvironmentFormContent.tsx
+++ b/client/src/features/admin/SessionEnvironmentFormContent.tsx
@@ -113,7 +113,7 @@ export default function SessionEnvironmentFormContent({
             <Input
               className="form-control"
               id="addSessionEnvironmentDefaultUrl"
-              placeholder="Docker image"
+              placeholder="/lab"
               type="text"
               {...field}
             />

--- a/client/src/features/admin/SessionEnvironmentFormContent.tsx
+++ b/client/src/features/admin/SessionEnvironmentFormContent.tsx
@@ -22,6 +22,7 @@ import { Input, Label } from "reactstrap";
 
 export interface SessionEnvironmentForm {
   container_image: string;
+  default_url: string;
   description: string;
   name: string;
 }
@@ -77,7 +78,7 @@ export default function SessionEnvironmentFormContent({
         />
       </div>
 
-      <div>
+      <div className="mb-3">
         <Label className="form-label" for="addSessionEnvironmentContainerImage">
           Container Image
         </Label>
@@ -99,6 +100,25 @@ export default function SessionEnvironmentFormContent({
           rules={{ required: true }}
         />
         <div className="invalid-feedback">Please provide a container image</div>
+      </div>
+
+      <div>
+        <Label className="form-label" for="addSessionEnvironmentDefaultUrl">
+          Container Image
+        </Label>
+        <Controller
+          control={control}
+          name="default_url"
+          render={({ field }) => (
+            <Input
+              className="form-control"
+              id="addSessionEnvironmentDefaultUrl"
+              placeholder="Docker image"
+              type="text"
+              {...field}
+            />
+          )}
+        />
       </div>
     </>
   );

--- a/client/src/features/admin/SessionEnvironmentsSection.tsx
+++ b/client/src/features/admin/SessionEnvironmentsSection.tsx
@@ -120,24 +120,27 @@ function SessionEnvironmentDisplay({
           <CardText className="mb-0">
             {description ? description : <i>No description</i>}
           </CardText>
-          <CardText className="mb-0">
+          <CardText className="mb-0" tag="div">
             <CommandCopy command={container_image} />
           </CardText>
           <CardText className="mb-0">
+            {default_url ? (
+              <>
+                Default URL: <code>{default_url}</code>
+              </>
+            ) : (
+              <i>
+                No default URL {"("}will use <code>{"/lab"}</code>
+                {")"}
+              </i>
+            )}
+          </CardText>
+          <CardText>
             <TimeCaption
               datetime={creation_date}
               enableTooltip
               prefix="Created"
             />
-          </CardText>
-          <CardText>
-            {default_url ? (
-              <>
-                Default URL: <code>default_url</code>
-              </>
-            ) : (
-              <i>No default URL</i>
-            )}
           </CardText>
 
           <div className={cx("d-flex", "justify-content-end", "gap-2")}>

--- a/client/src/features/admin/SessionEnvironmentsSection.tsx
+++ b/client/src/features/admin/SessionEnvironmentsSection.tsx
@@ -107,7 +107,8 @@ interface SessionEnvironmentDisplayProps {
 function SessionEnvironmentDisplay({
   environment,
 }: SessionEnvironmentDisplayProps) {
-  const { container_image, creation_date, name, description } = environment;
+  const { container_image, creation_date, name, default_url, description } =
+    environment;
 
   return (
     <Col className={cx("col-12", "col-sm-6")}>
@@ -122,12 +123,21 @@ function SessionEnvironmentDisplay({
           <CardText className="mb-0">
             <CommandCopy command={container_image} />
           </CardText>
-          <CardText>
+          <CardText className="mb-0">
             <TimeCaption
               datetime={creation_date}
               enableTooltip
               prefix="Created"
             />
+          </CardText>
+          <CardText>
+            {default_url ? (
+              <>
+                Default URL: <code>default_url</code>
+              </>
+            ) : (
+              <i>No default URL</i>
+            )}
           </CardText>
 
           <div className={cx("d-flex", "justify-content-end", "gap-2")}>

--- a/client/src/features/admin/UpdateSessionEnvironmentButton.tsx
+++ b/client/src/features/admin/UpdateSessionEnvironmentButton.tsx
@@ -32,7 +32,9 @@ import {
 import { Loader } from "../../components/Loader";
 import { RtkErrorAlert } from "../../components/errors/RtkErrorAlert";
 import { SessionEnvironment } from "../sessionsV2/sessionsV2.types";
-import SessionEnvironmentFormContent from "./SessionEnvironmentFormContent";
+import SessionEnvironmentFormContent, {
+  SessionEnvironmentForm,
+} from "./SessionEnvironmentFormContent";
 import { useUpdateSessionEnvironmentMutation } from "./adminSessions.api";
 
 interface UpdateSessionEnvironmentButtonProps {
@@ -81,19 +83,21 @@ function UpdateSessionEnvironmentModal({
     formState: { errors, isDirty },
     handleSubmit,
     reset,
-  } = useForm<UpdateSessionEnvironmentForm>({
+  } = useForm<SessionEnvironmentForm>({
     defaultValues: {
       container_image: environment.container_image,
+      default_url: environment.default_url,
       description: environment.description,
       name: environment.name,
     },
   });
   const onSubmit = useCallback(
-    (data: UpdateSessionEnvironmentForm) => {
+    (data: SessionEnvironmentForm) => {
       updateSessionEnvironment({
         environmentId: environment.id,
         container_image: data.container_image,
         name: data.name,
+        default_url: data.default_url.trim() ? data.default_url : "",
         description: data.description.trim() ? data.description : "",
       });
     },
@@ -158,9 +162,4 @@ function UpdateSessionEnvironmentModal({
       </Form>
     </Modal>
   );
-}
-interface UpdateSessionEnvironmentForm {
-  container_image: string;
-  description: string;
-  name: string;
 }

--- a/client/src/features/admin/UpdateSessionEnvironmentButton.tsx
+++ b/client/src/features/admin/UpdateSessionEnvironmentButton.tsx
@@ -120,6 +120,7 @@ function UpdateSessionEnvironmentModal({
   useEffect(() => {
     reset({
       container_image: environment.container_image,
+      default_url: environment.default_url ?? "",
       description: environment.description ?? "",
       name: environment.name,
     });

--- a/client/src/features/admin/adminSessions.types.ts
+++ b/client/src/features/admin/adminSessions.types.ts
@@ -19,12 +19,14 @@
 export interface AddSessionEnvironmentParams {
   container_image: string;
   name: string;
+  default_url?: string;
   description?: string;
 }
 
 export interface UpdateSessionEnvironmentParams {
   environmentId: string;
   container_image?: string;
+  default_url?: string;
   description?: string;
   name?: string;
 }

--- a/client/src/features/sessionsV2/AddSessionLauncherButton.tsx
+++ b/client/src/features/sessionsV2/AddSessionLauncherButton.tsx
@@ -85,11 +85,12 @@ function AddSessionLauncherModal({
       environment_kind: "global_environment",
       environment_id: "",
       container_image: "",
+      default_url: "",
     },
   });
   const onSubmit = useCallback(
     (data: SessionLauncherForm) => {
-      const { description, name } = data;
+      const { default_url, description, name } = data;
       const environment: SessionLauncherEnvironment =
         data.environment_kind === "global_environment"
           ? {
@@ -104,6 +105,7 @@ function AddSessionLauncherModal({
         project_id: projectId ?? "",
         name,
         description: description.trim() ? description : undefined,
+        default_url: default_url.trim() ? default_url : undefined,
         ...environment,
       });
     },

--- a/client/src/features/sessionsV2/SessionLauncherFormContent.tsx
+++ b/client/src/features/sessionsV2/SessionLauncherFormContent.tsx
@@ -50,6 +50,7 @@ export interface SessionLauncherForm {
   environment_kind: EnvironmentKind;
   environment_id: string;
   container_image: string;
+  default_url: string;
 }
 
 interface SessionLauncherFormContentProps {
@@ -185,7 +186,7 @@ export default function SessionLauncherFormContent({
             name="environment_id"
             render={({ field }) => (
               <>
-                <Row className={cx("row-cols-2", "gy-4")}>
+                <Row className={cx("row-cols-2", "gy-4", "mb-3")}>
                   {environments.map((environment) => (
                     <SessionEnvironmentItem
                       key={environment.id}
@@ -213,7 +214,10 @@ export default function SessionLauncherFormContent({
       </div>
 
       <div
-        className={cx(watchEnvironmentKind !== "container_image" && "d-none")}
+        className={cx(
+          watchEnvironmentKind !== "container_image" && "d-none",
+          "mb-3"
+        )}
       >
         <Label className="form-label" for="addSessionLauncherContainerImage">
           Container Image
@@ -233,6 +237,25 @@ export default function SessionLauncherFormContent({
           rules={{ required: watchEnvironmentKind === "container_image" }}
         />
         <div className="invalid-feedback">Please provide a container image</div>
+      </div>
+
+      <div>
+        <Label className="form-label" for="addSessionLauncherDefaultUrl">
+          Default URL
+        </Label>
+        <Controller
+          control={control}
+          name="default_url"
+          render={({ field }) => (
+            <Input
+              className="form-control"
+              id="addSessionLauncherDefaultUrl"
+              placeholder="/lab"
+              type="text"
+              {...field}
+            />
+          )}
+        />
       </div>
     </>
   );

--- a/client/src/features/sessionsV2/SessionsV2.tsx
+++ b/client/src/features/sessionsV2/SessionsV2.tsx
@@ -110,7 +110,8 @@ interface SessionLauncherDisplayProps {
 }
 
 function SessionLauncherDisplay({ launcher }: SessionLauncherDisplayProps) {
-  const { creation_date, environment_kind, name, description } = launcher;
+  const { creation_date, environment_kind, name, default_url, description } =
+    launcher;
 
   const { data: environments, isLoading } =
     sessionsV2Api.endpoints.getSessionEnvironments.useQueryState(
@@ -158,9 +159,19 @@ function SessionLauncherDisplay({ launcher }: SessionLauncherDisplayProps) {
               Uses the <b>{environment.name}</b> session environment.
             </CardText>
           )}
-          <CardText className="mb-2" tag="div">
+          <CardText className="mb-0" tag="div">
             <p className="mb-0">Container image:</p>
             <CommandCopy command={container_image} noMargin />
+          </CardText>
+          <CardText className="mb-2">
+            Default URL:{" "}
+            <code>
+              {default_url
+                ? default_url
+                : environment && environment.default_url
+                ? environment.default_url
+                : "/lab"}
+            </code>
           </CardText>
           <CardText>
             <TimeCaption

--- a/client/src/features/sessionsV2/UpdateSessionLauncherModal.tsx
+++ b/client/src/features/sessionsV2/UpdateSessionLauncherModal.tsx
@@ -78,11 +78,12 @@ export default function UpdateSessionLauncherModal({
         launcher.environment_kind === "container_image"
           ? launcher.container_image
           : "",
+      default_url: launcher.default_url ?? "",
     },
   });
   const onSubmit = useCallback(
     (data: SessionLauncherForm) => {
-      const { description, name } = data;
+      const { default_url, description, name } = data;
       const environment: SessionLauncherEnvironment =
         data.environment_kind === "global_environment"
           ? {
@@ -97,6 +98,7 @@ export default function UpdateSessionLauncherModal({
         launcherId: launcher.id,
         name,
         description: description.trim() ? description : undefined,
+        default_url: default_url.trim() ? default_url : undefined,
         ...environment,
       });
     },
@@ -139,6 +141,7 @@ export default function UpdateSessionLauncherModal({
         launcher.environment_kind === "container_image"
           ? launcher.container_image
           : "",
+      default_url: launcher.default_url ?? "",
     });
   }, [launcher, reset]);
 

--- a/client/src/features/sessionsV2/sessionsV2.types.ts
+++ b/client/src/features/sessionsV2/sessionsV2.types.ts
@@ -21,6 +21,7 @@ export interface SessionEnvironment {
   creation_date: string;
   id: string;
   name: string;
+  default_url?: string;
   description?: string;
 }
 
@@ -31,6 +32,7 @@ export type SessionLauncher = {
   project_id: string;
   name: string;
   creation_date: string;
+  default_url?: string;
   description?: string;
   environment_kind: EnvironmentKind;
 } & SessionLauncherEnvironment;
@@ -54,6 +56,7 @@ export interface GetProjectSessionLaunchersParams {
 }
 
 export type AddSessionLauncherParams = {
+  default_url?: string;
   description?: string;
   name: string;
   project_id: string;
@@ -62,6 +65,7 @@ export type AddSessionLauncherParams = {
 
 export interface UpdateSessionLauncherParams {
   launcherId?: string;
+  default_url?: string;
   description?: string;
   name?: string;
   environment_kind?: EnvironmentKind;


### PR DESCRIPTION
See https://github.com/SwissDataScienceCenter/renku-data-services/issues/134.

/deploy #notest renku=build/new-sessions renku-data-services=leafty/134-default-url extra-values=initDb.image.repository=registry.dev.renku.ch/tasko.olevski/renku-images/init-db,initDb.image.tag=0.44.1-1.ebb0e80,keycloakx.initRealm.image.repository=registry.dev.renku.ch/tasko.olevski/renku-images/init-realm,keycloakx.initRealm.image.tag=0.44.1-1.ebb0e80.git.2200.h26267d0e