### PR TITLE
feat: support pagination and refresh query automatically

### DIFF
--- a/client/src/features/searchV2/components/SearchV2Bar.tsx
+++ b/client/src/features/searchV2/components/SearchV2Bar.tsx
@@ -26,7 +26,7 @@ import useStartNewSearch from "../useStartSearch.hook";
 
 export default function SearchV2Bar() {
   const dispatch = useDispatch();
-  const { search } = useAppSelector((state) => state.searchV2);
+  const searchState = useAppSelector((state) => state.searchV2);
   const { startNewSearch } = useStartNewSearch();
 
   // focus search input when loading the component
@@ -47,7 +47,7 @@ export default function SearchV2Bar() {
 
   // basic autocomplete for searched values, without duplicates
   const previousSearchEntries = Array.from(
-    new Set(search.history.map((entry) => entry.query))
+    new Set(searchState.search.history.map((entry) => entry.query))
   ).map((value) => <option key={value} value={value} />);
 
   return (
@@ -64,7 +64,7 @@ export default function SearchV2Bar() {
         ref={inputRef}
         tabIndex={-1}
         type="text"
-        value={search.query}
+        value={searchState.search.query}
       />
       {previousSearchEntries.length > 0 && (
         <datalist id="previous-searches">{previousSearchEntries}</datalist>

--- a/client/src/features/searchV2/components/SearchV2DateFilter.tsx
+++ b/client/src/features/searchV2/components/SearchV2DateFilter.tsx
@@ -1,0 +1,85 @@
+import { DateFilter } from "../searchV2.types.ts";
+import { DateFilterTypes } from "../../../components/dateFilter/DateFilter.tsx";
+import { Input } from "../../../utils/ts-wrappers.jsx";
+import { ChangeEvent } from "react";
+import cx from "classnames";
+import { DateTime } from "luxon";
+import { SearchV2FilterContainer } from "./SearchV2Filters.tsx";
+import { AVAILABLE_DATE_FILTERS } from "../searchV2.utils.ts";
+
+interface SearchV2DateFilterProps {
+  name: string;
+  checked: DateFilter;
+  title: string;
+  toggleOption: (key: DateFilter) => void;
+}
+export function SearchV2DateFilter({
+  name,
+  title,
+  checked,
+  toggleOption,
+}: SearchV2DateFilterProps) {
+  const now = DateTime.utc();
+  const datesInput = checked.option === DateFilterTypes.custom && (
+    <>
+      <div>
+        <label className="px-2 author-label">From:</label>
+        <Input
+          type="date"
+          name="start"
+          max={now.toISODate()}
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+            toggleOption({ ...checked, from: e.target.value })
+          }
+          value={checked.from || ""}
+        />
+      </div>
+      <div>
+        <label className="px-2 author-label">To:</label>
+        <Input
+          type="date"
+          name="end"
+          max={now.toISODate()}
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+            toggleOption({ ...checked, to: e.target.value })
+          }
+          value={checked.to || ""}
+        />
+      </div>
+    </>
+  );
+
+  const filterKeys = Object.keys(AVAILABLE_DATE_FILTERS) as string[];
+  return (
+    <SearchV2FilterContainer name={name} title={title}>
+      {filterKeys.map((key) => {
+        const label = AVAILABLE_DATE_FILTERS[key].friendlyName;
+        const id = `search-filter-${name}-${key}`;
+        const isChecked = key === checked.option;
+
+        return (
+          <div
+            className={cx("form-rk-green", "d-flex", "align-items-center")}
+            key={id}
+          >
+            <input
+              checked={isChecked}
+              className="form-check-input"
+              data-cy={id}
+              id={id}
+              onChange={() => toggleOption({ option: key as DateFilterTypes })}
+              type="radio"
+            />
+            <label
+              className={cx("form-check-label", "ms-2", "mt-1")}
+              htmlFor={id}
+            >
+              {label}
+            </label>
+          </div>
+        );
+      })}
+      {datesInput}
+    </SearchV2FilterContainer>
+  );
+}

--- a/client/src/features/searchV2/components/SearchV2Filters.tsx
+++ b/client/src/features/searchV2/components/SearchV2Filters.tsx
@@ -20,7 +20,7 @@ import React, { useCallback } from "react";
 import { useDispatch } from "react-redux";
 import { Card, CardBody, Col, Row } from "reactstrap";
 
-import { setCreated, toggleFilter } from "../searchV2.slice";
+import { setCreated, setCreatedBy, toggleFilter } from "../searchV2.slice";
 import useAppSelector from "../../../utils/customHooks/useAppSelector.hook";
 import {
   DateFilter,
@@ -34,6 +34,7 @@ import {
 import useLegacySelector from "../../../utils/customHooks/useLegacySelector.hook";
 import { User } from "../../../model/renkuModels.types";
 import { SearchV2DateFilter } from "./SearchV2DateFilter.tsx";
+import { SearchV2UserFilter } from "./SearchV2UserFilter.tsx";
 
 export default function SearchV2Filters() {
   const dispatch = useDispatch();
@@ -87,6 +88,10 @@ export default function SearchV2Filters() {
           <h3>Filters</h3>
         </Col>
         <Col className={cx("d-flex", "flex-column", "gap-3")}>
+          <SearchV2UserFilter
+            createdBy={filters["createdBy"]}
+            removeUserFilter={() => dispatch(setCreatedBy(""))}
+          />
           {filtersList}
           <SearchV2DateFilter
             name="CreationDate"

--- a/client/src/features/searchV2/components/SearchV2Filters.tsx
+++ b/client/src/features/searchV2/components/SearchV2Filters.tsx
@@ -16,19 +16,24 @@
  * limitations under the License
  */
 import cx from "classnames";
-import { useCallback } from "react";
+import React, { useCallback } from "react";
 import { useDispatch } from "react-redux";
 import { Card, CardBody, Col, Row } from "reactstrap";
 
-import { toggleFilter } from "../searchV2.slice";
+import { setCreated, toggleFilter } from "../searchV2.slice";
 import useAppSelector from "../../../utils/customHooks/useAppSelector.hook";
-import { SearchV2FilterOptions, SearchV2State } from "../searchV2.types";
+import {
+  DateFilter,
+  SearchV2FilterOptions,
+  SearchV2State,
+} from "../searchV2.types";
 import {
   ANONYMOUS_USERS_EXCLUDE_FILTERS,
   AVAILABLE_FILTERS,
 } from "../searchV2.utils";
 import useLegacySelector from "../../../utils/customHooks/useLegacySelector.hook";
 import { User } from "../../../model/renkuModels.types";
+import { SearchV2DateFilter } from "./SearchV2DateFilter.tsx";
 
 export default function SearchV2Filters() {
   const dispatch = useDispatch();
@@ -39,16 +44,9 @@ export default function SearchV2Filters() {
   );
 
   const handleToggleFilter = useCallback(
-    (
-      filter: keyof SearchV2State["filters"],
-      value: SearchV2State["filters"][keyof SearchV2State["filters"]][number]
-    ) => {
-      dispatch(
-        toggleFilter({
-          filter,
-          value,
-        })
-      );
+    (filter: keyof SearchV2State["filters"], value: string | DateFilter) => {
+      if (filter === "created") dispatch(setCreated(value as DateFilter));
+      else dispatch(toggleFilter({ filter, value: value as string }));
     },
     [dispatch]
   );
@@ -66,17 +64,17 @@ export default function SearchV2Filters() {
         key={filterName}
         name={filterName}
         options={Object.entries(options).map(([key, value]) => ({
-          checked: !!(
+          checked: (
             filters[filterName as keyof SearchV2State["filters"]] as string[]
           ).includes(key),
           key,
           value,
         }))}
         title={filterName.charAt(0).toUpperCase() + filterName.slice(1)}
-        toggleOption={(value) => {
+        toggleOption={(value: string) => {
           handleToggleFilter(
             filterName as keyof SearchV2State["filters"],
-            value as SearchV2State["filters"][keyof SearchV2State["filters"]][number]
+            value
           );
         }}
       />
@@ -90,10 +88,14 @@ export default function SearchV2Filters() {
         </Col>
         <Col className={cx("d-flex", "flex-column", "gap-3")}>
           {filtersList}
-
-          <SearchV2FilterContainer name="creation-date" title="Creation date">
-            Not yet implemented
-          </SearchV2FilterContainer>
+          <SearchV2DateFilter
+            name="CreationDate"
+            title="Creation Date"
+            checked={filters["created"]}
+            toggleOption={(value: DateFilter) => {
+              handleToggleFilter("created", value);
+            }}
+          />
         </Col>
       </Row>
     </>
@@ -105,7 +107,7 @@ interface SearchV2FilterContainerProps {
   name: string;
   title: string;
 }
-function SearchV2FilterContainer({
+export function SearchV2FilterContainer({
   children,
   name,
   title,

--- a/client/src/features/searchV2/components/SearchV2Header.tsx
+++ b/client/src/features/searchV2/components/SearchV2Header.tsx
@@ -29,7 +29,13 @@ export default function SearchV2Header() {
   const { search, sorting } = useAppSelector((state) => state.searchV2);
   const dispatch = useDispatch();
   const searchResults = searchV2Api.endpoints.getSearchResults.useQueryState(
-    search.lastSearch != null ? search.lastSearch : skipToken
+    search.lastSearch != null
+      ? {
+          searchString: search.lastSearch,
+          page: search.page,
+          perPage: search.perPage,
+        }
+      : skipToken
   );
 
   const searchQuery = search.lastSearch;

--- a/client/src/features/searchV2/components/SearchV2Results.tsx
+++ b/client/src/features/searchV2/components/SearchV2Results.tsx
@@ -157,10 +157,11 @@ function SearchV2ResultUser({ user }: SearchV2ResultUserProps) {
   const url = Url.get(Url.pages.v2Users.show, { id: user.id });
   return (
     <SearchV2ResultsCard key={user.id} url={url} cardId={user.id}>
-      <h4 className="mb-0">{user.id}</h4>
-      <p className="form-text mb-0">
-        <TimeCaption datetime={user.creationDate} prefix="Created" />
-      </p>
+      <p className="form-text mb-0">{user.id}</p>
+      <h4 className="mb-0">
+        {user.firstName} {user.lastName}
+      </h4>
+      <p className="form-text mb-0">{user.email}</p>
     </SearchV2ResultsCard>
   );
 }

--- a/client/src/features/searchV2/components/SearchV2Results.tsx
+++ b/client/src/features/searchV2/components/SearchV2Results.tsx
@@ -19,6 +19,7 @@ import cx from "classnames";
 import { Link } from "react-router-dom";
 import { skipToken } from "@reduxjs/toolkit/query";
 import { Card, CardBody, Col, Row } from "reactstrap";
+import { useDispatch } from "react-redux";
 
 import searchV2Api from "../searchV2.api";
 import { Loader } from "../../../components/Loader";
@@ -27,15 +28,32 @@ import { Url } from "../../../utils/helpers/url/Url";
 import useAppSelector from "../../../utils/customHooks/useAppSelector.hook";
 import { simpleHash } from "../../../utils/helpers/HelperFunctions";
 import { ProjectSearchResult, UserSearchResult } from "../searchV2.types";
+import { Pagination } from "../../../components/Pagination";
+import { setPage } from "../searchV2.slice";
 
 export default function SearchV2Results() {
+  const searchState = useAppSelector((state) => state.searchV2);
+  const dispatch = useDispatch();
+
   return (
     <Row data-cy="search-results">
       <Col className="d-sm-none" xs={12}>
         <h3>Results</h3>
       </Col>
-      <Col>
+      <Col xs={12}>
         <SearchV2ResultsContent />
+      </Col>
+      <Col className="mt-4" xs={12}>
+        <Pagination
+          currentPage={searchState.search.page}
+          perPage={searchState.search.perPage}
+          totalItems={searchState.search.totalResults}
+          onPageChange={(page: number) => {
+            dispatch(setPage(page));
+          }}
+          showDescription={true}
+          className="rk-search-pagination"
+        />
       </Col>
     </Row>
   );
@@ -45,7 +63,13 @@ function SearchV2ResultsContent() {
   // get the search state
   const { search } = useAppSelector((state) => state.searchV2);
   const searchResults = searchV2Api.endpoints.getSearchResults.useQueryState(
-    search.lastSearch != null ? search.lastSearch : skipToken
+    search.lastSearch != null
+      ? {
+          searchString: search.lastSearch,
+          page: search.page,
+          perPage: search.perPage,
+        }
+      : skipToken
   );
 
   if (searchResults.isFetching) {

--- a/client/src/features/searchV2/components/SearchV2Results.tsx
+++ b/client/src/features/searchV2/components/SearchV2Results.tsx
@@ -18,7 +18,7 @@
 import cx from "classnames";
 import { Link } from "react-router-dom";
 import { skipToken } from "@reduxjs/toolkit/query";
-import { Card, CardBody, Col, Row } from "reactstrap";
+import { Button, Card, CardBody, Col, Row } from "reactstrap";
 import { useDispatch } from "react-redux";
 
 import searchV2Api from "../searchV2.api";
@@ -29,7 +29,7 @@ import useAppSelector from "../../../utils/customHooks/useAppSelector.hook";
 import { simpleHash } from "../../../utils/helpers/HelperFunctions";
 import { ProjectSearchResult, UserSearchResult } from "../searchV2.types";
 import { Pagination } from "../../../components/Pagination";
-import { setPage } from "../searchV2.slice";
+import { setCreatedBy, setPage } from "../searchV2.slice";
 
 export default function SearchV2Results() {
   const searchState = useAppSelector((state) => state.searchV2);
@@ -60,6 +60,7 @@ export default function SearchV2Results() {
 }
 
 function SearchV2ResultsContent() {
+  const dispatch = useDispatch();
   // get the search state
   const { search } = useAppSelector((state) => state.searchV2);
   const searchResults = searchV2Api.endpoints.getSearchResults.useQueryState(
@@ -93,7 +94,15 @@ function SearchV2ResultsContent() {
 
   const resultsOutput = searchResults.data.items.map((entity) => {
     if (entity.type === "Project") {
-      return <SearchV2ResultProject key={entity.id} project={entity} />;
+      return (
+        <SearchV2ResultProject
+          searchByUser={(userId) => {
+            dispatch(setCreatedBy(userId));
+          }}
+          key={entity.id}
+          project={entity}
+        />
+      );
     } else if (entity.type === "User") {
       return <SearchV2ResultUser key={entity.id} user={entity} />;
     }
@@ -108,39 +117,45 @@ function SearchV2ResultsContent() {
 interface SearchV2ResultsCardProps {
   cardId: string;
   children: React.ReactNode;
-  url: string;
+  url?: string;
 }
-function SearchV2ResultsCard({
-  cardId,
-  children,
-  url,
-}: SearchV2ResultsCardProps) {
+function SearchV2ResultsCard({ cardId, children }: SearchV2ResultsCardProps) {
   return (
     <Col key={cardId} xs={12} lg={6}>
-      <Link className="text-decoration-none" to={url}>
-        <div data-cy="search-card">
-          <Card className={cx("border", "rounded")}>
-            <CardBody>{children}</CardBody>
-          </Card>
-        </div>
-      </Link>
+      <div data-cy="search-card">
+        <Card className={cx("border", "rounded")}>
+          <CardBody>{children}</CardBody>
+        </Card>
+      </div>
     </Col>
   );
 }
 
 interface SearchV2ResultProjectProps {
   project: ProjectSearchResult;
+  searchByUser: (userId: string) => void;
 }
-function SearchV2ResultProject({ project }: SearchV2ResultProjectProps) {
+function SearchV2ResultProject({
+  project,
+  searchByUser,
+}: SearchV2ResultProjectProps) {
   const url = Url.get(Url.pages.v2Projects.show, { id: project.id });
   return (
-    <SearchV2ResultsCard key={project.id} url={url} cardId={project.id}>
-      <h4 className="mb-0">{project.name}</h4>
+    <SearchV2ResultsCard key={project.id} cardId={project.id}>
+      <Link to={url}>
+        <h4 className="mb-0">{project.name}</h4>
+      </Link>
       <p className={cx("form-text", "mb-0")}>
         {project.slug} - {project.visibility}
       </p>
       <p className={cx("form-text", "text-rk-green")}>
-        user-{project.createdBy.id}
+        <Button
+          className="pe-0 ps-1 pt-0 pb-0 mb-1"
+          color="link"
+          onClick={() => searchByUser(project.createdBy.id)}
+        >
+          user-{project.createdBy.id}
+        </Button>
       </p>
       <p>{project.description}</p>
       <p className="form-text mb-0">
@@ -154,9 +169,8 @@ interface SearchV2ResultUserProps {
   user: UserSearchResult;
 }
 function SearchV2ResultUser({ user }: SearchV2ResultUserProps) {
-  const url = Url.get(Url.pages.v2Users.show, { id: user.id });
   return (
-    <SearchV2ResultsCard key={user.id} url={url} cardId={user.id}>
+    <SearchV2ResultsCard key={user.id} cardId={user.id}>
       <p className="form-text mb-0">{user.id}</p>
       <h4 className="mb-0">
         {user.firstName} {user.lastName}

--- a/client/src/features/searchV2/components/SearchV2UserFilter.tsx
+++ b/client/src/features/searchV2/components/SearchV2UserFilter.tsx
@@ -1,0 +1,39 @@
+/*!
+ * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+import { Button } from "reactstrap";
+import { XLg } from "react-bootstrap-icons";
+import { SearchV2FilterContainer } from "./SearchV2Filters.tsx";
+
+interface SearchV2UserFilterProps {
+  createdBy: string;
+  removeUserFilter: () => void;
+}
+
+export function SearchV2UserFilter({
+  createdBy,
+  removeUserFilter,
+}: SearchV2UserFilterProps) {
+  if (!createdBy) return null;
+  return (
+    <SearchV2FilterContainer name="User" title="User">
+      <Button onClick={removeUserFilter} className="px-2 btn-outline-rk-green">
+        {createdBy} <XLg />
+      </Button>
+    </SearchV2FilterContainer>
+  );
+}

--- a/client/src/features/searchV2/searchV2.api.ts
+++ b/client/src/features/searchV2/searchV2.api.ts
@@ -17,7 +17,7 @@
  */
 
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
-import { SearchApiResponse } from "./searchV2.types";
+import { SearchApiParams, SearchApiResponse } from "./searchV2.types";
 
 const searchV2Api = createApi({
   reducerPath: "searchV2Api",
@@ -27,11 +27,15 @@ const searchV2Api = createApi({
   }),
   tagTypes: ["SearchV2"],
   endpoints: (builder) => ({
-    getSearchResults: builder.query<SearchApiResponse, string>({
-      query: (searchString) => {
+    getSearchResults: builder.query<SearchApiResponse, SearchApiParams>({
+      query: (params) => {
         return {
           method: "GET",
-          params: { q: searchString },
+          params: {
+            q: params.searchString,
+            page: params.page,
+            per_page: params.perPage,
+          },
           url: "",
         };
       },

--- a/client/src/features/searchV2/searchV2.api.ts
+++ b/client/src/features/searchV2/searchV2.api.ts
@@ -23,7 +23,7 @@ const searchV2Api = createApi({
   reducerPath: "searchV2Api",
   baseQuery: fetchBaseQuery({
     // eslint-disable-next-line spellcheck/spell-checker
-    baseUrl: "/apiv2/search", // ! Update to "/ui-server/api/search" after gateway updates
+    baseUrl: "/ui-server/api/search",
   }),
   tagTypes: ["SearchV2"],
   endpoints: (builder) => ({

--- a/client/src/features/searchV2/searchV2.slice.ts
+++ b/client/src/features/searchV2/searchV2.slice.ts
@@ -20,6 +20,7 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
 import {
   SearchV2State,
+  SearchV2Totals,
   SortingItem,
   ToggleFilterPayload,
 } from "./searchV2.types";
@@ -29,7 +30,12 @@ const initialState: SearchV2State = {
   search: {
     history: [],
     lastSearch: null,
+    outdated: false,
+    page: 1,
+    perPage: 10,
     query: "",
+    totalPages: 0,
+    totalResults: 0,
   },
   filters: {
     role: ["creator", "member", "none"],
@@ -43,10 +49,16 @@ export const searchV2Slice = createSlice({
   name: "searchV2",
   initialState,
   reducers: {
+    setPage: (state, action: PayloadAction<number>) => {
+      state.search.page = action.payload;
+      state.search.outdated = true;
+    },
     setQuery: (state, action: PayloadAction<string>) => {
       state.search.query = action.payload;
+      // ? Mind we don't mark the query as outdated here to prevent unnecessary re-fetching while typing
     },
     setSearch: (state, action: PayloadAction<string>) => {
+      state.search.outdated = false;
       state.search.lastSearch = action.payload;
       state.search.history = [
         ...state.search.history,
@@ -58,6 +70,11 @@ export const searchV2Slice = createSlice({
     },
     setSorting: (state, action: PayloadAction<SortingItem>) => {
       state.sorting = action.payload;
+      state.search.outdated = true;
+    },
+    setTotals: (state, action: PayloadAction<SearchV2Totals>) => {
+      state.search.totalResults = action.payload.results;
+      state.search.totalPages = action.payload.pages;
     },
     toggleFilter: (state, action: PayloadAction<ToggleFilterPayload>) => {
       const arrayToUpdate =
@@ -77,6 +94,7 @@ export const searchV2Slice = createSlice({
         ...state.filters,
         [action.payload.filter]: updatedArray,
       };
+      state.search.outdated = true;
     },
     reset: () => initialState,
   },
@@ -93,5 +111,12 @@ function toggleArrayItem(array: string[], item: string) {
   return array;
 }
 
-export const { reset, setQuery, setSearch, setSorting, toggleFilter } =
-  searchV2Slice.actions;
+export const {
+  setPage,
+  setQuery,
+  setSearch,
+  setSorting,
+  setTotals,
+  toggleFilter,
+  reset,
+} = searchV2Slice.actions;

--- a/client/src/features/searchV2/searchV2.slice.ts
+++ b/client/src/features/searchV2/searchV2.slice.ts
@@ -19,12 +19,14 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
 import {
+  DateFilter,
   SearchV2State,
   SearchV2Totals,
   SortingItem,
   ToggleFilterPayload,
 } from "./searchV2.types";
 import { AVAILABLE_SORTING } from "./searchV2.utils";
+import { DateFilterTypes } from "../../components/dateFilter/DateFilter";
 
 const initialState: SearchV2State = {
   search: {
@@ -41,6 +43,9 @@ const initialState: SearchV2State = {
     role: ["creator", "member", "none"],
     type: ["project"],
     visibility: ["public", "private"],
+    created: {
+      option: DateFilterTypes.all,
+    },
   },
   sorting: AVAILABLE_SORTING.scoreDesc,
 };
@@ -75,6 +80,10 @@ export const searchV2Slice = createSlice({
     setTotals: (state, action: PayloadAction<SearchV2Totals>) => {
       state.search.totalResults = action.payload.results;
       state.search.totalPages = action.payload.pages;
+    },
+    setCreated: (state, action: PayloadAction<DateFilter>) => {
+      state.filters.created = action.payload;
+      state.search.outdated = true;
     },
     toggleFilter: (state, action: PayloadAction<ToggleFilterPayload>) => {
       const arrayToUpdate =
@@ -116,6 +125,7 @@ export const {
   setQuery,
   setSearch,
   setSorting,
+  setCreated,
   setTotals,
   toggleFilter,
   reset,

--- a/client/src/features/searchV2/searchV2.slice.ts
+++ b/client/src/features/searchV2/searchV2.slice.ts
@@ -46,6 +46,7 @@ const initialState: SearchV2State = {
     created: {
       option: DateFilterTypes.all,
     },
+    createdBy: "",
   },
   sorting: AVAILABLE_SORTING.scoreDesc,
 };
@@ -56,6 +57,10 @@ export const searchV2Slice = createSlice({
   reducers: {
     setPage: (state, action: PayloadAction<number>) => {
       state.search.page = action.payload;
+      state.search.outdated = true;
+    },
+    setCreatedBy: (state, action: PayloadAction<string>) => {
+      state.filters.createdBy = action.payload;
       state.search.outdated = true;
     },
     setQuery: (state, action: PayloadAction<string>) => {
@@ -126,6 +131,7 @@ export const {
   setSearch,
   setSorting,
   setCreated,
+  setCreatedBy,
   setTotals,
   toggleFilter,
   reset,

--- a/client/src/features/searchV2/searchV2.types.ts
+++ b/client/src/features/searchV2/searchV2.types.ts
@@ -17,6 +17,7 @@
  */
 
 import { UserV2 } from "../userV2/userV2.types";
+import { DateFilterTypes } from "../../components/dateFilter/DateFilter.tsx";
 
 export type EntityType = "Project" | "User";
 
@@ -60,11 +61,17 @@ export interface UserSearchResult {
   type: "User";
 }
 
+export interface DateFilter {
+  option: DateFilterTypes;
+  from?: string;
+  to?: string;
+}
 export interface SearchV2State {
   filters: {
     role: ("creator" | "member" | "none")[];
     type: ("project" | "user")[];
     visibility: ("private" | "public")[];
+    created: DateFilter;
   };
   search: {
     history: {
@@ -89,7 +96,7 @@ export interface SearchV2Totals {
 
 export interface ToggleFilterPayload {
   filter: keyof SearchV2State["filters"];
-  value: SearchV2State["filters"][keyof SearchV2State["filters"]][number];
+  value: string;
 }
 
 export interface SearchV2FilterOptions {
@@ -105,4 +112,14 @@ export interface SortingItem {
 
 export interface SortingItems {
   [key: string]: SortingItem;
+}
+
+export interface DateFilterItem {
+  friendlyName: string;
+  getDateString:
+    | ((filter: string, from?: string, to?: string) => string)
+    | (() => string);
+}
+export interface DateFilterItems {
+  [key: string]: DateFilterItem;
 }

--- a/client/src/features/searchV2/searchV2.types.ts
+++ b/client/src/features/searchV2/searchV2.types.ts
@@ -56,9 +56,11 @@ export interface ProjectSearchResult {
 }
 
 export interface UserSearchResult {
-  creationDate: Date;
   id: string;
+  firstName: string;
+  lastName: string;
   type: "User";
+  email: string;
 }
 
 export interface DateFilter {

--- a/client/src/features/searchV2/searchV2.types.ts
+++ b/client/src/features/searchV2/searchV2.types.ts
@@ -20,6 +20,12 @@ import { UserV2 } from "../userV2/userV2.types";
 
 export type EntityType = "Project" | "User";
 
+export interface SearchApiParams {
+  searchString: string;
+  page: number;
+  perPage: number;
+}
+
 export interface SearchApiResponse {
   items: SearchResult[];
   pagingInfo: {
@@ -66,9 +72,19 @@ export interface SearchV2State {
       query: string;
     }[];
     lastSearch: string | null;
+    outdated: boolean;
+    page: number;
+    perPage: number;
     query: string;
+    totalPages: number;
+    totalResults: number;
   };
   sorting: SortingItem;
+}
+
+export interface SearchV2Totals {
+  pages: number;
+  results: number;
 }
 
 export interface ToggleFilterPayload {

--- a/client/src/features/searchV2/searchV2.types.ts
+++ b/client/src/features/searchV2/searchV2.types.ts
@@ -74,6 +74,7 @@ export interface SearchV2State {
     type: ("project" | "user")[];
     visibility: ("private" | "public")[];
     created: DateFilter;
+    createdBy: string;
   };
   search: {
     history: {

--- a/client/src/features/searchV2/searchV2.utils.test.ts
+++ b/client/src/features/searchV2/searchV2.utils.test.ts
@@ -32,7 +32,12 @@ describe("Test the searchV2.utils functions", () => {
       search: {
         history: [],
         lastSearch: "something else",
+        outdated: false,
+        page: 1,
+        perPage: 10,
         query: "test",
+        totalPages: 0,
+        totalResults: 0,
       },
       sorting: {
         friendlyName: "Best match",

--- a/client/src/features/searchV2/searchV2.utils.test.ts
+++ b/client/src/features/searchV2/searchV2.utils.test.ts
@@ -32,6 +32,7 @@ describe("Test the searchV2.utils functions", () => {
         created: {
           option: DateFilterTypes.all,
         },
+        createdBy: "",
       },
       search: {
         history: [],
@@ -60,6 +61,7 @@ describe("Test the searchV2.utils functions", () => {
       created: {
         option: DateFilterTypes.all,
       },
+      createdBy: "",
     };
     expect(buildSearchQuery(searchState)).toEqual(
       "sort:score-desc role:creator,member type:project visibility:private test"
@@ -81,6 +83,12 @@ describe("Test the searchV2.utils functions", () => {
     searchState.filters.created.option = DateFilterTypes.last90days;
     expect(buildSearchQuery(searchState)).toEqual(
       "visibility:private created>today-90d test sort:name-desc type:user role:none"
+    );
+
+    //Update createdBy filter
+    searchState.filters.createdBy = "abc";
+    expect(buildSearchQuery(searchState)).toEqual(
+      "visibility:private created>today-90d createdBy:abc test sort:name-desc type:user role:none"
     );
   });
 });

--- a/client/src/features/searchV2/searchV2.utils.test.ts
+++ b/client/src/features/searchV2/searchV2.utils.test.ts
@@ -20,6 +20,7 @@ import { describe, expect, it } from "vitest";
 
 import { buildSearchQuery } from "./searchV2.utils";
 import { SearchV2State } from "./searchV2.types";
+import { DateFilterTypes } from "../../components/dateFilter/DateFilter.tsx";
 
 describe("Test the searchV2.utils functions", () => {
   it("function buildSearchQuery ", () => {
@@ -28,6 +29,9 @@ describe("Test the searchV2.utils functions", () => {
         role: [],
         type: [],
         visibility: [],
+        created: {
+          option: DateFilterTypes.all,
+        },
       },
       search: {
         history: [],
@@ -53,6 +57,9 @@ describe("Test the searchV2.utils functions", () => {
       role: ["creator", "member"],
       type: ["project"],
       visibility: ["private"],
+      created: {
+        option: DateFilterTypes.all,
+      },
     };
     expect(buildSearchQuery(searchState)).toEqual(
       "sort:score-desc role:creator,member type:project visibility:private test"
@@ -68,6 +75,12 @@ describe("Test the searchV2.utils functions", () => {
     searchState.search.query = "test sort:name-desc type:user role:none";
     expect(buildSearchQuery(searchState)).toEqual(
       "visibility:private test sort:name-desc type:user role:none"
+    );
+
+    //Update date filter
+    searchState.filters.created.option = DateFilterTypes.last90days;
+    expect(buildSearchQuery(searchState)).toEqual(
+      "visibility:private created>today-90d test sort:name-desc type:user role:none"
     );
   });
 });

--- a/client/src/features/searchV2/searchV2.utils.ts
+++ b/client/src/features/searchV2/searchV2.utils.ts
@@ -115,7 +115,8 @@ export const buildSearchQuery = (searchState: SearchV2State): string => {
     searchQueryItems.push(`${sortPrefix}${searchState.sorting.sortingString}`);
 
   for (const filterName in searchState.filters) {
-    if (DATE_FILTERS.includes(filterName)) continue;
+    if (DATE_FILTERS.includes(filterName) || filterName === "createdBy")
+      continue;
     const filter = searchState.filters[
       filterName as keyof SearchV2State["filters"]
     ] as string[];
@@ -146,6 +147,11 @@ export const buildSearchQuery = (searchState: SearchV2State): string => {
       searchQueryItems.push(dateStringFilter);
     }
   });
+
+  // add createdBy filter
+  if (searchState.filters.createdBy)
+    searchQueryItems.push(`createdBy:${searchState.filters.createdBy}`);
+
   searchQueryItems.push(query);
 
   return searchQueryItems.join(" ");

--- a/client/src/features/searchV2/searchV2.utils.ts
+++ b/client/src/features/searchV2/searchV2.utils.ts
@@ -16,7 +16,13 @@
  * limitations under the License
  */
 
-import { SearchV2State, SortingItems } from "./searchV2.types";
+import { DateFilterTypes } from "../../components/dateFilter/DateFilter";
+import {
+  DateFilter,
+  DateFilterItems,
+  SearchV2State,
+  SortingItems,
+} from "./searchV2.types";
 
 export const AVAILABLE_FILTERS = {
   role: {
@@ -60,6 +66,41 @@ export const AVAILABLE_SORTING: SortingItems = {
   },
 };
 
+export const AVAILABLE_DATE_FILTERS: DateFilterItems = {
+  all: {
+    friendlyName: "All",
+    getDateString: () => "",
+  },
+  lastWeek: {
+    friendlyName: "Last Week",
+    getDateString: (filter: string) => `${filter}>today-7d`,
+  },
+  lastMonth: {
+    friendlyName: "Last Month",
+    getDateString: (filter: string) => `${filter}>today-31d`,
+  },
+  last90days: {
+    friendlyName: "Last 90 days",
+    getDateString: (filter: string) => `${filter}>today-90d`,
+  },
+  older: {
+    friendlyName: "Older",
+    getDateString: (filter: string) => `${filter}>today+90d`,
+  },
+  custom: {
+    friendlyName: "Custom",
+    getDateString: (filter: string, from?: string, to?: string) => {
+      const filters = [];
+      if (from) filters.push(`${filter}>${from}-1d`);
+
+      if (to) filters.push(`${filter}<${to}+1d`);
+      return filters.join(" ");
+    },
+  },
+};
+
+const DATE_FILTERS = ["created"];
+
 export const SORT_KEY = "sort";
 
 export const FILTER_ASSIGNMENT_CHAR = ":";
@@ -74,22 +115,37 @@ export const buildSearchQuery = (searchState: SearchV2State): string => {
     searchQueryItems.push(`${sortPrefix}${searchState.sorting.sortingString}`);
 
   for (const filterName in searchState.filters) {
-    const filter =
-      searchState.filters[filterName as keyof SearchV2State["filters"]];
+    if (DATE_FILTERS.includes(filterName)) continue;
+    const filter = searchState.filters[
+      filterName as keyof SearchV2State["filters"]
+    ] as string[];
     const filterPrefix = `${filterName}${FILTER_ASSIGNMENT_CHAR}`;
 
+    const totalAvailableFilters = Object.keys(
+      AVAILABLE_FILTERS[filterName as "role" | "visibility" | "type"]
+    ).length;
     // Exclude empty filters and filters where all members are selected
     if (
       filter.length > 0 &&
-      filter.length <
-        Object.keys(
-          AVAILABLE_FILTERS[filterName as keyof SearchV2State["filters"]]
-        ).length &&
+      filter.length < totalAvailableFilters &&
       !query.includes(filterPrefix)
     ) {
       searchQueryItems.push(`${filterPrefix}${filter.join(",")}`);
     }
   }
+
+  // add date filters
+  DATE_FILTERS.map((filter: string) => {
+    const dateFilter = searchState.filters[
+      filter as keyof SearchV2State["filters"]
+    ] as DateFilter;
+    if (dateFilter.option !== DateFilterTypes.all) {
+      const dateStringFilter = AVAILABLE_DATE_FILTERS[
+        dateFilter.option
+      ].getDateString("created", dateFilter.from, dateFilter.to);
+      searchQueryItems.push(dateStringFilter);
+    }
+  });
   searchQueryItems.push(query);
 
   return searchQueryItems.join(" ");

--- a/tests/cypress/e2e/searchV2.spec.ts
+++ b/tests/cypress/e2e/searchV2.spec.ts
@@ -43,12 +43,10 @@ describe("Search V2", () => {
 
     cy.getDataCy("search-filter-type-user").click();
     cy.getDataCy("search-filter-type-user").should("be.checked");
-    cy.getDataCy("search-input").type("{enter}");
     cy.getDataCy("search-card").should("have.length", 7);
 
     cy.getDataCy("search-filter-type-project").click();
     cy.getDataCy("search-filter-type-project").should("not.be.checked");
-    cy.getDataCy("search-button").click();
     cy.getDataCy("search-card").should("have.length", 2);
   });
 
@@ -59,7 +57,6 @@ describe("Search V2", () => {
     cy.getDataCy("search-header").contains("sort:score-desc");
 
     cy.getDataCy("search-sorting-select").select("Date: recently created");
-    cy.getDataCy("search-button").click();
     cy.getDataCy("search-header").contains("sort:date-desc");
   });
 });

--- a/tests/cypress/support/renkulab-fixtures/searchV2.ts
+++ b/tests/cypress/support/renkulab-fixtures/searchV2.ts
@@ -78,7 +78,7 @@ export function SearchV2<T extends FixturesConstructor>(Parent: T) {
         };
       }
 
-      cy.intercept("GET", "/apiv2/search?*", (req) => {
+      cy.intercept("GET", "/ui-server/api/search?*", (req) => {
         let body = null;
         const queryString = req.query["q"].toString();
         if (queryString.includes("type:")) {


### PR DESCRIPTION
This PR adds the following:

- Handles pagination (feel free to raise the default `perPage` value, currently at `10`, before merging).
- Automatically refresh the search result when changes on the UI require it (e.g. sorting, filtering, page number, ...)
- Search by Creation Date


/deploy renku=build/search-and-discovery-1.0 #notest renku-data-services=main renku-gateway=master
