### PR TITLE
chore(tests): update tsconfig.json

### DIFF
--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -3,6 +3,8 @@
   "compilerOptions": {
     "target": "es5",
     "types": ["cypress", "node", "cypress-file-upload"],
-    "lib": ["es2015", "dom"]
+    "lib": ["es2015", "dom"],
+    "skipLibCheck": true,
+    "noEmit": true
   }
 }


### PR DESCRIPTION
Update `tsconfig.json` in `tests/` to allow the use of `tsc` (the TypeScript compiler) without emitting `.js` files.

/deploy