### PR TITLE
feat(client): add support for entity tags on Renku 2.0 projects

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -133,6 +133,7 @@
           "dockerfile",
           "dockerignore",
           "enum",
+          "etag",
           "fetchable",
           "formgenerator",
           "fortran",

--- a/client/package.json
+++ b/client/package.json
@@ -21,7 +21,10 @@
     "storybook-start-server": "http-server storybook-static --port 6006 --silent",
     "storybook-wait-server": "wait-on http://127.0.0.1:6006",
     "storybook-test": "test-storybook",
-    "storybook-compile-and-test": "concurrently -k -s first -n 'BUILD,TEST' -c 'magenta,blue' 'npm run storybook-build && npm run storybook-start-server' 'npm run storybook-wait-server && npm run storybook-test'"
+    "storybook-compile-and-test": "concurrently -k -s first -n 'BUILD,TEST' -c 'magenta,blue' 'npm run storybook-build && npm run storybook-start-server' 'npm run storybook-wait-server && npm run storybook-test'",
+    "generate-api": "npm run generate-api:dataServicesUser && npm run generate-api:projectV2",
+    "generate-api:dataServicesUser": "rtk-query-codegen-openapi src/features/user/dataServicesUser.api/dataServicesUser.api-config.ts",
+    "generate-api:projectV2": "rtk-query-codegen-openapi src/features/projectsV2/api/projectV2.api-config.ts"
   },
   "type": "module",
   "dependencies": {

--- a/client/src/features/projectsV2/api/projectV2.api.ts
+++ b/client/src/features/projectsV2/api/projectV2.api.ts
@@ -28,6 +28,7 @@ const injectedRtkApi = api.injectEndpoints({
         url: `/projects/${queryArg.projectId}`,
         method: "PATCH",
         body: queryArg.projectPatch,
+        headers: { "If-Match": queryArg["If-Match"] },
       }),
     }),
     deleteProjectsByProjectId: build.mutation<
@@ -90,6 +91,8 @@ export type PatchProjectsByProjectIdApiResponse =
   /** status 200 The patched project */ Project;
 export type PatchProjectsByProjectIdApiArg = {
   projectId: string;
+  /** If-Match header, for avoiding mid-air collisions */
+  "If-Match": ETag;
   projectPatch: ProjectPatch;
 };
 export type DeleteProjectsByProjectIdApiResponse =
@@ -127,6 +130,7 @@ export type Repository = string;
 export type RepositoriesList = Repository[];
 export type Visibility = "private" | "public";
 export type Description = string;
+export type ETag = string;
 export type Project = {
   id: Ulid;
   name: Name;
@@ -136,6 +140,7 @@ export type Project = {
   repositories?: RepositoriesList;
   visibility: Visibility;
   description?: Description;
+  etag?: ETag;
 };
 export type ProjectsList = Project[];
 export type ErrorResponse = {

--- a/client/src/features/projectsV2/api/projectV2.api.ts
+++ b/client/src/features/projectsV2/api/projectV2.api.ts
@@ -92,7 +92,7 @@ export type PatchProjectsByProjectIdApiResponse =
 export type PatchProjectsByProjectIdApiArg = {
   projectId: string;
   /** If-Match header, for avoiding mid-air collisions */
-  "If-Match": ETag;
+  "If-Match"?: ETag;
   projectPatch: ProjectPatch;
 };
 export type DeleteProjectsByProjectIdApiResponse =

--- a/client/src/features/projectsV2/api/projectV2.api.ts
+++ b/client/src/features/projectsV2/api/projectV2.api.ts
@@ -130,7 +130,7 @@ export type Description = string;
 export type Project = {
   id: Ulid;
   name: Name;
-  slug: Slug;
+  slug?: Slug;
   creation_date: CreationDate;
   created_by: Member;
   repositories?: RepositoriesList;

--- a/client/src/features/projectsV2/api/projectV2.enhanced-api.ts
+++ b/client/src/features/projectsV2/api/projectV2.enhanced-api.ts
@@ -44,6 +44,9 @@ const injectedApi = api.injectEndpoints({
 const enhancedApi = injectedApi.enhanceEndpoints({
   addTagTypes: ["Project", "Members"],
   endpoints: {
+    postProjects: {
+      invalidatesTags: ["Project"],
+    },
     deleteProjectsByProjectId: {
       invalidatesTags: ["Project"],
     },

--- a/client/src/features/projectsV2/api/projectV2.openapi.json
+++ b/client/src/features/projectsV2/api/projectV2.openapi.json
@@ -169,6 +169,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/If-Match"
           }
         ],
         "requestBody": {
@@ -395,6 +398,9 @@
           },
           "description": {
             "$ref": "#/components/schemas/Description"
+          },
+          "etag": {
+            "$ref": "#/components/schemas/ETag"
           }
         },
         "required": ["id", "name", "created_by", "creation_date", "visibility"],
@@ -643,6 +649,11 @@
         "description": "User email",
         "example": "some-user@gmail.com"
       },
+      "ETag": {
+        "type": "string",
+        "description": "Entity Tag",
+        "example": "9EE498F9D565D0C41E511377425F32F3"
+      },
       "ErrorResponse": {
         "type": "object",
         "properties": {
@@ -679,6 +690,17 @@
               "$ref": "#/components/schemas/ErrorResponse"
             }
           }
+        }
+      }
+    },
+    "parameters": {
+      "If-Match": {
+        "in": "header",
+        "name": "If-Match",
+        "description": "If-Match header, for avoiding mid-air collisions",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/ETag"
         }
       }
     }

--- a/client/src/features/projectsV2/api/projectV2.openapi.json
+++ b/client/src/features/projectsV2/api/projectV2.openapi.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.1.0",
+  "openapi": "3.0.2",
   "info": {
     "title": "Renku Project Management Service",
     "description": "Service that allows creating, updating, deleting, and managing Renku native projects.\nAll errors have the same format as the schema called ErrorResponse.\n",
@@ -397,14 +397,7 @@
             "$ref": "#/components/schemas/Description"
           }
         },
-        "required": [
-          "id",
-          "name",
-          "slug",
-          "created_by",
-          "creation_date",
-          "visibility"
-        ],
+        "required": ["id", "name", "created_by", "creation_date", "visibility"],
         "example": {
           "id": "01AN4Z79ZS5XN0F25N3DB94T4R",
           "name": "Renku R Project",

--- a/client/src/features/projectsV2/api/projectV2.openapi.json
+++ b/client/src/features/projectsV2/api/projectV2.openapi.json
@@ -698,7 +698,7 @@
         "in": "header",
         "name": "If-Match",
         "description": "If-Match header, for avoiding mid-air collisions",
-        "required": true,
+        "required": false,
         "schema": {
           "$ref": "#/components/schemas/ETag"
         }

--- a/client/src/features/projectsV2/show/ProjectV2EditForm.tsx
+++ b/client/src/features/projectsV2/show/ProjectV2EditForm.tsx
@@ -105,7 +105,7 @@ function ProjectDeleteConfirmation({
         <Button
           className="ms-2"
           color="danger"
-          disabled={typedName !== project.slug.trim()}
+          disabled={typedName !== project.slug?.trim()}
           onClick={onDelete}
         >
           {result.isLoading ? (

--- a/client/src/features/projectsV2/show/ProjectV2EditForm.tsx
+++ b/client/src/features/projectsV2/show/ProjectV2EditForm.tsx
@@ -172,7 +172,11 @@ export function ProjectV2MetadataForm({
 
   const onSubmit = useCallback(
     (data: ProjectV2Metadata) => {
-      updateProject({ projectId: project.id, projectPatch: data })
+      updateProject({
+        "If-Match": project.etag ?? "",
+        projectId: project.id,
+        projectPatch: data,
+      })
         .unwrap()
         .then(() => setSettingEdit(null));
     },
@@ -350,7 +354,11 @@ export function ProjectV2RepositoryForm({
   const onSubmit = useCallback(
     (data: ProjectV2Repositories) => {
       const repositories = data.repositories.map((r) => r.url);
-      updateProject({ projectId: project.id, projectPatch: { repositories } })
+      updateProject({
+        "If-Match": project.etag ?? "",
+        projectId: project.id,
+        projectPatch: { repositories },
+      })
         .unwrap()
         .then(() => setSettingEdit(null));
     },

--- a/client/src/features/projectsV2/show/ProjectV2EditForm.tsx
+++ b/client/src/features/projectsV2/show/ProjectV2EditForm.tsx
@@ -49,6 +49,7 @@ import ProjectRepositoryFormField from "../fields/ProjectRepositoryFormField";
 import ProjectVisibilityFormField from "../fields/ProjectVisibilityFormField";
 
 import { SettingEditOption } from "./projectV2Show.types";
+import { RtkErrorAlert } from "../../../components/errors/RtkErrorAlert";
 
 type ProjectV2Metadata = Omit<ProjectPatch, "repositories">;
 
@@ -162,7 +163,7 @@ export function ProjectV2MetadataForm({
     },
   });
 
-  const [updateProject, { isLoading, isError }] =
+  const [updateProject, { isLoading, error }] =
     usePatchProjectsByProjectIdMutation();
 
   const isUpdating = isLoading;
@@ -200,6 +201,9 @@ export function ProjectV2MetadataForm({
         project={project}
         toggle={toggle}
       />
+
+      {error && <RtkErrorAlert error={error} />}
+
       <Form
         className="form-rk-green"
         noValidate
@@ -217,7 +221,6 @@ export function ProjectV2MetadataForm({
           errors={errors}
         />
         <ProjectEditSubmitGroup isUpdating={isUpdating} onCancel={onCancel} />
-        {isError && <div>There was an error</div>}
       </Form>
     </div>
   );

--- a/client/src/features/projectsV2/show/ProjectV2EditForm.tsx
+++ b/client/src/features/projectsV2/show/ProjectV2EditForm.tsx
@@ -174,7 +174,7 @@ export function ProjectV2MetadataForm({
   const onSubmit = useCallback(
     (data: ProjectV2Metadata) => {
       updateProject({
-        "If-Match": project.etag ?? "",
+        "If-Match": project.etag ? project.etag : undefined,
         projectId: project.id,
         projectPatch: data,
       })
@@ -358,7 +358,7 @@ export function ProjectV2RepositoryForm({
     (data: ProjectV2Repositories) => {
       const repositories = data.repositories.map((r) => r.url);
       updateProject({
-        "If-Match": project.etag ?? "",
+        "If-Match": project.etag ? project.etag : undefined,
         projectId: project.id,
         projectPatch: { repositories },
       })


### PR DESCRIPTION
Adds support for entity tags on Renku 2.0 projects.

* Send `If-Match` header with `ETag` value if such a value exists.

With this update, the UI supports the Renku 2.0 projects API both with ETags and without ETags.

/deploy renku=release-0.50.x