### PR TITLE
chore(ci/cd): add an action to cleanup old deployments

### DIFF
--- a/.github/workflows/cleanup-old-deployments.js
+++ b/.github/workflows/cleanup-old-deployments.js
@@ -126,6 +126,6 @@ async function main({ core, github }) {
   }
 }
 
-module.exports = ({ core, github }) => {
-  main({ core, github });
+module.exports = async ({ core, github }) => {
+  await main({ core, github });
 };

--- a/.github/workflows/cleanup-old-deployments.js
+++ b/.github/workflows/cleanup-old-deployments.js
@@ -125,3 +125,7 @@ async function main({ core, github }) {
     }
   }
 }
+
+module.exports = ({ core, github }) => {
+  main({ core, github });
+};

--- a/.github/workflows/cleanup-old-deployments.yml
+++ b/.github/workflows/cleanup-old-deployments.yml
@@ -1,0 +1,17 @@
+name: Cleanup old deployments
+
+on:
+  workflow_dispatch:
+
+jobs:
+  cleanup-old-deployments:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const script = require('./.github/workflows/cleanup-old-deployments.js')
+            script({ core, github })

--- a/.github/workflows/cleanup-old-deployments.yml
+++ b/.github/workflows/cleanup-old-deployments.yml
@@ -14,4 +14,4 @@ jobs:
         with:
           script: |
             const script = require('./.github/workflows/cleanup-old-deployments.js')
-            script({ core, github })
+            await script({ core, github })

--- a/.github/workflows/cleanup-old-deployments.yml
+++ b/.github/workflows/cleanup-old-deployments.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  cleanup-old-deployments:
+  cleanup-old-deployments-from-github:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/playground.mjs
+++ b/.github/workflows/playground.mjs
@@ -1,0 +1,132 @@
+import { Octokit } from "octokit";
+
+const octokit = new Octokit({
+  auth: "REDACTED",
+});
+
+const {
+  data: { login },
+} = await octokit.rest.users.getAuthenticated();
+console.log(`Connected as ${login}`);
+
+async function getOldEnvironments() {
+  const now = new Date();
+  const SEVEN_DAYS = 7 * 24 * 60 * 60 * 1_000;
+
+  const {
+    data: { environments, total_count },
+  } = await octokit.request("GET /repos/{owner}/{repo}/environments", {
+    owner: "SwissDataScienceCenter",
+    repo: "renku-ui",
+    headers: {
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+
+  if (!environments) {
+    return [];
+  }
+
+  if (total_count && environments.length < total_count) {
+    console.log(
+      `Seeing only ${environments.length} environments out of ${total_count}`
+    );
+  }
+
+  const oldEnvironments = environments
+    .filter(({ updated_at }) => now - new Date(updated_at) > SEVEN_DAYS)
+    .sort((a, b) => new Date(a.updated_at) - new Date(b.updated_at));
+  return oldEnvironments;
+}
+
+async function getActiveDeployment(environment) {
+  const { data: deployments } = await octokit.request(
+    "GET /repos/{owner}/{repo}/deployments",
+    {
+      owner: "SwissDataScienceCenter",
+      repo: "renku-ui",
+      environment,
+      headers: {
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    }
+  );
+  const deploymentStatuses = await Promise.all(
+    deployments.map(async ({ id }) => {
+      const { data } = await octokit.request(
+        "GET /repos/{owner}/{repo}/deployments/{deployment_id}/statuses",
+        {
+          owner: "SwissDataScienceCenter",
+          repo: "renku-ui",
+          deployment_id: `${id}`,
+          headers: {
+            "X-GitHub-Api-Version": "2022-11-28",
+          },
+        }
+      );
+      const isSuccess = data.some(({ state }) => state === "success");
+      const isInactive = data.some(({ state }) => state === "inactive");
+      const environment_url = data.find(
+        ({ environment_url, state }) => !!environment_url && state === "success"
+      )?.environment_url;
+      return { id, isSuccess, isInactive, environment_url };
+    })
+  );
+  const activeDeploymentStatus = deploymentStatuses.find(
+    ({ isSuccess, isInactive }) => isSuccess && !isInactive
+  );
+  const activeDeployment = deployments.find(
+    ({ id }) => id === activeDeploymentStatus?.id
+  );
+  return [activeDeployment, activeDeploymentStatus?.environment_url];
+}
+
+async function decideIfEnvironmentShouldBeDeleted(
+  activeDeployment,
+  environment_url
+) {
+  if (!activeDeployment || !environment_url) {
+    return "delete";
+  }
+  try {
+    const { status } = await fetch(environment_url);
+    if (status >= 200 && status < 400) {
+      return "keep";
+    }
+    return "delete";
+  } catch {
+    return "error";
+  }
+}
+
+const oldEnvironments = await getOldEnvironments();
+
+for (let i = 0; i < oldEnvironments.length; ++i) {
+  const environment = oldEnvironments[i];
+
+  console.log(`Processing environment: ${environment.name}`);
+
+  const [activeDeployment, environment_url] = await getActiveDeployment(
+    environment.name
+  );
+  const decision = await decideIfEnvironmentShouldBeDeleted(
+    activeDeployment,
+    environment_url
+  );
+
+  console.log(`Decision: ${decision}`);
+
+  if (decision === "delete") {
+    await octokit.request(
+      "DELETE /repos/{owner}/{repo}/environments/{environment}",
+      {
+        owner: "SwissDataScienceCenter",
+        repo: "renku-ui",
+        environment: environment.name,
+        headers: {
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+      }
+    );
+  }
+}


### PR DESCRIPTION
Fixes #3068.

Add a manual action which cleans up old deployment environments from GitHub.

After cleanup, the PR will show that the git branch was previously deployed, but is not active:
![Screenshot 2024-03-15 at 15 37 49](https://github.com/SwissDataScienceCenter/renku-ui/assets/951086/fdba4fb4-d0eb-464c-8802-b2d7c6edac0d)

Removing old environments will de-clutter the "Deployments" section from the GitHub page:
![Screenshot 2024-03-15 at 15 39 34](https://github.com/SwissDataScienceCenter/renku-ui/assets/951086/a9b8b72d-74f0-49f5-99a7-27c34522bcd8)