### PR TITLE
fix(client): update appearance of copy button in file view

### DIFF
--- a/client/src/file/File.present.jsx
+++ b/client/src/file/File.present.jsx
@@ -113,10 +113,7 @@ class FileCard extends React.Component {
                 <small> {formatBytes(this.props.fileSize)}</small>
               </div>
             ) : null}
-            <Clipboard
-              clipboardText={this.props.filePath}
-              className={cx("btn", "p-0", "border-0", "icon-link")}
-            />
+            <Clipboard clipboardText={this.props.filePath} />
           </div>
           <div
             className={cx(

--- a/client/src/file/File.present.jsx
+++ b/client/src/file/File.present.jsx
@@ -115,7 +115,7 @@ class FileCard extends React.Component {
             ) : null}
             <Clipboard
               clipboardText={this.props.filePath}
-              className="icon-link d-flex"
+              className={cx("btn", "p-0", "border-0", "icon-link")}
             />
           </div>
           <div

--- a/client/src/file/Lineage.present.jsx
+++ b/client/src/file/Lineage.present.jsx
@@ -347,7 +347,10 @@ class FileLineage extends Component {
               </div>
             ) : null}
             <span className="fileBarIconButton">
-              <Clipboard clipboardText={this.props.path} className="d-flex" />
+              <Clipboard
+                clipboardText={this.props.path}
+                className={cx("btn", "p-0", "border-0", "icon-link")}
+              />
             </span>
           </div>
 

--- a/client/src/file/Lineage.present.jsx
+++ b/client/src/file/Lineage.present.jsx
@@ -347,10 +347,7 @@ class FileLineage extends Component {
               </div>
             ) : null}
             <span className="fileBarIconButton">
-              <Clipboard
-                clipboardText={this.props.path}
-                className={cx("btn", "p-0", "border-0", "icon-link")}
-              />
+              <Clipboard clipboardText={this.props.path} />
             </span>
           </div>
 


### PR DESCRIPTION
Fix the appearance of the "copy path" buttons in the file view.

Before:
![Screenshot 2024-03-19 at 11 05 37](https://github.com/SwissDataScienceCenter/renku-ui/assets/951086/6557406a-7e69-4877-97f6-31fbd7ce7f6a)
![Screenshot 2024-03-19 at 11 05 34](https://github.com/SwissDataScienceCenter/renku-ui/assets/951086/67bcd8ef-cecf-4af4-a493-d6c2748a3462)

After:
![Screenshot 2024-03-19 at 11 00 10](https://github.com/SwissDataScienceCenter/renku-ui/assets/951086/314a6127-83a4-4487-b4cf-3eb6c80093bc)
![Screenshot 2024-03-19 at 11 00 06](https://github.com/SwissDataScienceCenter/renku-ui/assets/951086/05929fbc-7740-492e-827b-acbd9cea307c)

/deploy