### PR TITLE
fix(client): update footer links with Mastodon

### DIFF
--- a/client/src/landing/anonymousHomeNav.tsx
+++ b/client/src/landing/anonymousHomeNav.tsx
@@ -110,7 +110,7 @@ function BottomNav(props: AnonymousHomeConfig) {
                 url={Links.RENKU_BLOG}
               />
               <BottomNavExternalLink title="YouTube" url={Links.YOUTUBE} />
-              <BottomNavExternalLink title="Medium" url={Links.MEDIUM} />
+              <BottomNavExternalLink title="Mastodon" url={Links.MASTODON} />
             </BottomNavSection>
           </Col>
           <Col md={3}>

--- a/client/src/utils/constants/Docs.js
+++ b/client/src/utils/constants/Docs.js
@@ -38,6 +38,7 @@ const Links = {
   GITTER: "https://gitter.im/SwissDataScienceCenter/renku",
   GITHUB: "https://github.com/SwissDataScienceCenter/renku",
   HOMEPAGE: "https://datascience.ch",
+  MASTODON: "https://fosstodon.org/@renku",
   MEDIUM: "https://medium.com/the-renku-blog",
   YOUTUBE: "https://www.youtube.com/channel/UCMF2tBtWU1sKWvtPl_HpI4A",
   SDSC: "https://www.datascience.ch/",


### PR DESCRIPTION
Fixes #3059.

See also: https://github.com/SwissDataScienceCenter/renku-blog/pull/33.