### PR TITLE
chore(tests): update headless tests command

### DIFF
--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -10,7 +10,7 @@
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.6.0",
         "@typescript-eslint/parser": "^5.6.0",
-        "cypress": "^13.2.0",
+        "cypress": "^13.7.1",
         "cypress-file-upload": "^5.0.8",
         "eslint": "^8.28.0",
         "eslint-config-prettier": "^8.8.0",
@@ -250,7 +250,8 @@
       "version": "18.17.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.18.tgz",
       "integrity": "sha512-/4QOuy3ZpV7Ya1GTRz5CYSz3DgkKpyUptXuQ5PPce7uuyJAOR7r9FhkmxJfvcNUXyklbC63a+YvB3jxy7s9ngw==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/@types/sinonjs__fake-timers": {
       "version": "8.1.1",
@@ -997,21 +998,20 @@
       }
     },
     "node_modules/cypress": {
-      "version": "13.2.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.2.0.tgz",
-      "integrity": "sha512-AvDQxBydE771GTq0TR4ZUBvv9m9ffXuB/ueEtpDF/6gOcvFR96amgwSJP16Yhqw6VhmwqspT5nAGzoxxB+D89g==",
+      "version": "13.7.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.7.1.tgz",
+      "integrity": "sha512-4u/rpFNxOFCoFX/Z5h+uwlkBO4mWzAjveURi3vqdSu56HPvVdyGTxGw4XKGWt399Y1JwIn9E1L9uMXQpc0o55w==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@cypress/request": "^3.0.0",
         "@cypress/xvfb": "^1.2.4",
-        "@types/node": "^18.17.5",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
         "blob-util": "^2.0.2",
         "bluebird": "^3.7.2",
-        "buffer": "^5.6.0",
+        "buffer": "^5.7.1",
         "cachedir": "^2.3.0",
         "chalk": "^4.1.0",
         "check-more-types": "^2.24.0",
@@ -1029,7 +1029,7 @@
         "figures": "^3.2.0",
         "fs-extra": "^9.1.0",
         "getos": "^3.2.1",
-        "is-ci": "^3.0.0",
+        "is-ci": "^3.0.1",
         "is-installed-globally": "~0.4.0",
         "lazy-ass": "^1.6.0",
         "listr2": "^3.8.3",
@@ -3898,7 +3898,8 @@
       "version": "18.17.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.18.tgz",
       "integrity": "sha512-/4QOuy3ZpV7Ya1GTRz5CYSz3DgkKpyUptXuQ5PPce7uuyJAOR7r9FhkmxJfvcNUXyklbC63a+YvB3jxy7s9ngw==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "@types/sinonjs__fake-timers": {
       "version": "8.1.1",
@@ -4417,20 +4418,19 @@
       }
     },
     "cypress": {
-      "version": "13.2.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.2.0.tgz",
-      "integrity": "sha512-AvDQxBydE771GTq0TR4ZUBvv9m9ffXuB/ueEtpDF/6gOcvFR96amgwSJP16Yhqw6VhmwqspT5nAGzoxxB+D89g==",
+      "version": "13.7.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.7.1.tgz",
+      "integrity": "sha512-4u/rpFNxOFCoFX/Z5h+uwlkBO4mWzAjveURi3vqdSu56HPvVdyGTxGw4XKGWt399Y1JwIn9E1L9uMXQpc0o55w==",
       "dev": true,
       "requires": {
         "@cypress/request": "^3.0.0",
         "@cypress/xvfb": "^1.2.4",
-        "@types/node": "^18.17.5",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
         "blob-util": "^2.0.2",
         "bluebird": "^3.7.2",
-        "buffer": "^5.6.0",
+        "buffer": "^5.7.1",
         "cachedir": "^2.3.0",
         "chalk": "^4.1.0",
         "check-more-types": "^2.24.0",
@@ -4448,7 +4448,7 @@
         "figures": "^3.2.0",
         "fs-extra": "^9.1.0",
         "getos": "^3.2.1",
-        "is-ci": "^3.0.0",
+        "is-ci": "^3.0.1",
         "is-installed-globally": "~0.4.0",
         "lazy-ass": "^1.6.0",
         "listr2": "^3.8.3",

--- a/tests/package.json
+++ b/tests/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "cypress": "cypress open --e2e --browser=chrome --config-file cypress.config.ts",
-    "cypress:headless": "cypress run --e2e --headless --config-file cypress.config.ts --spec '**/*'",
+    "cypress:headless": "cypress run --e2e --browser=chrome --headless --config-file cypress.config.ts --spec '**/*'",
     "e2e": "start-server-and-test start http://localhost:3000 cypress",
     "e2e:headless": "start-server-and-test start http://localhost:3000 cypress:headless",
     "lint": "eslint --max-warnings=0 cypress/",
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.6.0",
     "@typescript-eslint/parser": "^5.6.0",
-    "cypress": "^13.2.0",
+    "cypress": "^13.7.1",
     "cypress-file-upload": "^5.0.8",
     "eslint": "^8.28.0",
     "eslint-config-prettier": "^8.8.0",


### PR DESCRIPTION
Fixes the headless e2e tests when running on Apple Silicon (ensures headless chrome).