### PR TITLE
feat(client): use namespace/slug to identify projects (#3096)

### DIFF
--- a/client/src/features/projectsV2/api/projectV2.api.ts
+++ b/client/src/features/projectsV2/api/projectV2.api.ts
@@ -40,6 +40,14 @@ const injectedRtkApi = api.injectEndpoints({
         method: "DELETE",
       }),
     }),
+    getProjectsByNamespaceAndSlug: build.query<
+      GetProjectsByNamespaceAndSlugApiResponse,
+      GetProjectsByNamespaceAndSlugApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/projects/${queryArg["namespace"]}/${queryArg.slug}`,
+      }),
+    }),
     getProjectsByProjectIdMembers: build.query<
       GetProjectsByProjectIdMembersApiResponse,
       GetProjectsByProjectIdMembersApiArg
@@ -99,6 +107,12 @@ export type DeleteProjectsByProjectIdApiResponse =
   /** status 204 The project was removed or did not exist in the first place */ void;
 export type DeleteProjectsByProjectIdApiArg = {
   projectId: string;
+};
+export type GetProjectsByNamespaceAndSlugApiResponse =
+  /** status 200 The project */ Project;
+export type GetProjectsByNamespaceAndSlugApiArg = {
+  namespace: string;
+  slug: string;
 };
 export type GetProjectsByProjectIdMembersApiResponse =
   /** status 200 The project's members */ ProjectMemberListResponse;
@@ -185,6 +199,7 @@ export const {
   useGetProjectsByProjectIdQuery,
   usePatchProjectsByProjectIdMutation,
   useDeleteProjectsByProjectIdMutation,
+  useGetProjectsByNamespaceAndSlugQuery,
   useGetProjectsByProjectIdMembersQuery,
   usePatchProjectsByProjectIdMembersMutation,
   useDeleteProjectsByProjectIdMembersAndMemberIdMutation,

--- a/client/src/features/projectsV2/api/projectV2.enhanced-api.ts
+++ b/client/src/features/projectsV2/api/projectV2.enhanced-api.ts
@@ -153,6 +153,9 @@ const enhancedApi = injectedApi.enhanceEndpoints({
     getProjectsPaged: {
       providesTags: ["Project"],
     },
+    getProjectsByNamespaceAndSlug: {
+      providesTags: ["Project"],
+    },
     getProjectsByProjectId: {
       providesTags: ["Project"],
     },
@@ -185,6 +188,7 @@ export const {
   // project hooks
   useGetProjectsPagedQuery: useGetProjectsQuery,
   usePostProjectsMutation,
+  useGetProjectsByNamespaceAndSlugQuery,
   useGetProjectsByProjectIdQuery,
   usePatchProjectsByProjectIdMutation,
   useDeleteProjectsByProjectIdMutation,

--- a/client/src/features/projectsV2/api/projectV2.openapi.json
+++ b/client/src/features/projectsV2/api/projectV2.openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Renku Project Management Service",
     "description": "Service that allows creating, updating, deleting, and managing Renku native projects.\nAll errors have the same format as the schema called ErrorResponse.\n",
-    "version": "0.5.0"
+    "version": "0.6.0"
   },
   "servers": [
     {
@@ -226,6 +226,55 @@
         "responses": {
           "204": {
             "description": "The project was removed or did not exist in the first place"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          }
+        },
+        "tags": ["projects"]
+      }
+    },
+    "/projects/{namespace}/{slug}": {
+      "get": {
+        "summary": "Get a project by namespace and project slug",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "namespace",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "slug",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The project",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Project"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The project does not exist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           },
           "default": {
             "$ref": "#/components/responses/Error"
@@ -499,21 +548,21 @@
         "example": "My Renku Project :)"
       },
       "Slug": {
-        "description": "A command-line friendly name for a project or namespace",
+        "description": "A command-line/url friendly name for a namespace",
         "type": "string",
         "minLength": 1,
         "maxLength": 99,
         "pattern": "^(?!.*\\.git$|.*\\.atom$|.*[\\-._][\\-._].*)[a-zA-Z0-9][a-zA-Z0-9\\-_.]*$",
-        "example": "my-renku-project"
+        "example": "a-slug-example"
       },
       "CreationDate": {
-        "description": "The date and time the project was created (time is always in UTC)",
+        "description": "The date and time the resource was created (in UTC and ISO-8601 format)",
         "type": "string",
         "format": "date-time",
         "example": "2023-11-01T17:32:28Z"
       },
       "Description": {
-        "description": "A description for project",
+        "description": "A description for the resource",
         "type": "string",
         "maxLength": 500
       },

--- a/client/src/features/projectsV2/list/ProjectV2List.tsx
+++ b/client/src/features/projectsV2/list/ProjectV2List.tsx
@@ -35,7 +35,10 @@ interface ProjectV2ListProjectProps {
   project: Project;
 }
 function ProjectV2ListProject({ project }: ProjectV2ListProjectProps) {
-  const projectUrl = Url.get(Url.pages.v2Projects.show, { id: project.id });
+  const projectUrl = Url.get(Url.pages.projectV2.show, {
+    namespace: project.namespace,
+    slug: project.slug,
+  });
   return (
     <div
       data-cy="list-card"
@@ -100,7 +103,7 @@ function ProjectList() {
 }
 
 export default function ProjectV2List() {
-  const newProjectUrl = Url.get(Url.pages.v2Projects.new);
+  const newProjectUrl = Url.get(Url.pages.projectV2.new);
   return (
     <FormSchema
       showHeader={true}

--- a/client/src/features/projectsV2/new/ProjectV2New.tsx
+++ b/client/src/features/projectsV2/new/ProjectV2New.tsx
@@ -154,7 +154,7 @@ function ProjectV2BeingCreated({
       </div>
     );
   }
-  const projectList = Url.get(Url.pages.v2Projects.list);
+  const projectList = Url.get(Url.pages.projectV2.list);
   return (
     <>
       <div>Project created.</div>

--- a/client/src/features/projectsV2/show/groupEditForms.tsx
+++ b/client/src/features/projectsV2/show/groupEditForms.tsx
@@ -20,7 +20,7 @@ import cx from "classnames";
 import { useCallback, useEffect, useState } from "react";
 import { CheckLg, XLg } from "react-bootstrap-icons";
 import { useForm } from "react-hook-form";
-import { Redirect } from "react-router-dom";
+import { Navigate } from "react-router-dom-v5-compat";
 
 import {
   Button,
@@ -33,6 +33,7 @@ import {
 } from "reactstrap";
 
 import { Loader } from "../../../components/Loader";
+import { Url } from "../../../utils/helpers/url";
 
 import {
   useDeleteGroupsByGroupSlugMutation,
@@ -195,7 +196,12 @@ export function GroupMetadataForm({
   }, []);
 
   if (data != null && data.slug !== group.slug)
-    return <Redirect to={`${data.slug}`} />;
+    return (
+      <Navigate
+        to={Url.get(Url.pages.groupV2.show, { slug: data.slug })}
+        replace
+      />
+    );
 
   return (
     <div>

--- a/client/src/features/rootV2/NavbarV2.tsx
+++ b/client/src/features/rootV2/NavbarV2.tsx
@@ -25,7 +25,7 @@ import WipBadge from "../projectsV2/shared/WipBadge";
 
 export default function NavbarV2() {
   const matchesShowSessionPage = useMatch(
-    "/v2/projects/:id/sessions/show/:session"
+    "/v2/projects/:namespace/:slug/sessions/show/:session"
   );
 
   if (matchesShowSessionPage) {

--- a/client/src/features/rootV2/RootV2.tsx
+++ b/client/src/features/rootV2/RootV2.tsx
@@ -133,6 +133,14 @@ function ProjectsV2Routes() {
         }
       />
       <Route
+        path=":namespace/:slug"
+        element={
+          <ContainerWrap>
+            <LazyProjectV2Show />
+          </ContainerWrap>
+        }
+      />
+      <Route
         path=":id"
         element={
           <ContainerWrap>

--- a/client/src/features/rootV2/RootV2.tsx
+++ b/client/src/features/rootV2/RootV2.tsx
@@ -148,7 +148,10 @@ function ProjectsV2Routes() {
           </ContainerWrap>
         }
       />
-      <Route path=":id/sessions/*" element={<ProjectSessionsRoutes />} />
+      <Route
+        path=":namespace/:slug/sessions/*"
+        element={<ProjectSessionsRoutes />}
+      />
     </Routes>
   );
 }

--- a/client/src/features/searchV2/components/SearchV2Results.tsx
+++ b/client/src/features/searchV2/components/SearchV2Results.tsx
@@ -141,7 +141,7 @@ function SearchV2ResultProject({
   project,
   searchByUser,
 }: SearchV2ResultProjectProps) {
-  const url = Url.get(Url.pages.v2Projects.show, { id: project.id });
+  const url = Url.get(Url.pages.projectV2.showId, { id: project.id });
   return (
     <SearchV2ResultsCard
       key={`project-${project.id}`}

--- a/client/src/features/sessionsV2/AddSessionLauncherButton.tsx
+++ b/client/src/features/sessionsV2/AddSessionLauncherButton.tsx
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+import { skipToken } from "@reduxjs/toolkit/query";
 import cx from "classnames";
 import { useCallback, useEffect, useState } from "react";
 import { PlusLg, XLg } from "react-bootstrap-icons";
@@ -32,6 +33,7 @@ import {
 
 import { Loader } from "../../components/Loader";
 import { RtkErrorAlert } from "../../components/errors/RtkErrorAlert";
+import { useGetProjectsByNamespaceAndSlugQuery } from "../projectsV2/api/projectV2.enhanced-api";
 import SessionLauncherFormContent, {
   SessionLauncherForm,
 } from "./SessionLauncherFormContent";
@@ -64,7 +66,11 @@ function AddSessionLauncherModal({
   isOpen,
   toggle,
 }: AddSessionLauncherModalProps) {
-  const { id: projectId } = useParams<"id">();
+  const { namespace, slug } = useParams<{ namespace: string; slug: string }>();
+  const { data: project } = useGetProjectsByNamespaceAndSlugQuery(
+    namespace && slug ? { namespace, slug } : skipToken
+  );
+  const projectId = project?.id;
 
   const { data: environments } =
     sessionsV2Api.endpoints.getSessionEnvironments.useQueryState();

--- a/client/src/features/sessionsV2/PauseOrDeleteSessionModal.tsx
+++ b/client/src/features/sessionsV2/PauseOrDeleteSessionModal.tsx
@@ -100,12 +100,14 @@ function AnonymousDeleteSessionModal({
   sessionName,
   toggleModal,
 }: AnonymousDeleteSessionModalProps) {
-  const { id: projectId_ } = useParams<"id">();
-  const projectId = projectId_ ?? "";
+  const { namespace, slug } = useParams<{ namespace: string; slug: string }>();
 
   const navigate = useNavigate();
 
-  const backUrl = generatePath("../../:projectId", { projectId });
+  const backUrl = generatePath("../../:namespace/:slug", {
+    namespace: namespace ?? "",
+    slug: slug ?? "",
+  });
 
   const [stopSession, { isSuccess, error }] = useStopSessionMutation();
 
@@ -218,12 +220,14 @@ function PauseSessionModalBody({
   toggleAction,
   toggleModal,
 }: ModalBodyProps) {
-  const { id: projectId_ } = useParams<"id">();
-  const projectId = projectId_ ?? "";
+  const { namespace, slug } = useParams<{ namespace: string; slug: string }>();
 
   const navigate = useNavigate();
 
-  const backUrl = generatePath("../../:projectId", { projectId });
+  const backUrl = generatePath("../../:namespace/:slug", {
+    namespace: namespace ?? "",
+    slug: slug ?? "",
+  });
 
   const [patchSession, { isSuccess, error }] = usePatchSessionMutation();
 
@@ -335,12 +339,14 @@ function DeleteSessionModalBody({
   toggleAction,
   toggleModal,
 }: ModalBodyProps) {
-  const { id: projectId_ } = useParams<"id">();
-  const projectId = projectId_ ?? "";
+  const { namespace, slug } = useParams<{ namespace: string; slug: string }>();
 
   const navigate = useNavigate();
 
-  const backUrl = generatePath("../../:projectId", { projectId });
+  const backUrl = generatePath("../../:namespace/:slug", {
+    namespace: namespace ?? "",
+    slug: slug ?? "",
+  });
 
   const [stopSession, { isSuccess, error }] = useStopSessionMutation();
 

--- a/client/src/features/sessionsV2/SessionStartPage.tsx
+++ b/client/src/features/sessionsV2/SessionStartPage.tsx
@@ -37,8 +37,8 @@ import useAppDispatch from "../../utils/customHooks/useAppDispatch.hook";
 import useAppSelector from "../../utils/customHooks/useAppSelector.hook";
 import { useGetResourcePoolsQuery } from "../dataServices/dataServices.api";
 import { useGetAllRepositoryCommitsQuery } from "../project/projectGitLab.api";
+import { useGetProjectsByNamespaceAndSlugQuery } from "../projectsV2/api/projectV2.enhanced-api";
 import type { Project } from "../projectsV2/api/projectV2.api";
-import { useGetProjectsByProjectIdQuery } from "../projectsV2/api/projectV2.enhanced-api";
 import {
   useGetDockerImageQuery,
   useStartRenku2SessionMutation,
@@ -55,15 +55,18 @@ import startSessionOptionsV2Slice from "./startSessionOptionsV2.slice";
 import { SessionRepository } from "./startSessionOptionsV2.types";
 
 export default function SessionStartPage() {
-  const { id: projectId, launcherId } = useParams<"id" | "launcherId">();
-
+  const { launcherId, namespace, slug } = useParams<
+    "launcherId" | "namespace" | "slug"
+  >();
   const {
     data: project,
     isLoading: isLoadingProject,
     error: projectError,
-  } = useGetProjectsByProjectIdQuery({
-    projectId: projectId ?? "",
-  });
+  } = useGetProjectsByNamespaceAndSlugQuery(
+    namespace && slug ? { namespace, slug } : skipToken
+  );
+  const projectId = project?.id ?? "";
+
   const {
     data: launchers,
     isLoading: isLoadingLaunchers,

--- a/client/src/features/sessionsV2/SessionsV2.tsx
+++ b/client/src/features/sessionsV2/SessionsV2.tsx
@@ -47,6 +47,7 @@ import {
 } from "../../notebooks/components/SessionListStatus";
 import { NotebookAnnotations } from "../../notebooks/components/session.types";
 import useAppSelector from "../../utils/customHooks/useAppSelector.hook";
+import { useGetProjectsByNamespaceAndSlugQuery } from "../projectsV2/api/projectV2.enhanced-api";
 import type { Project } from "../projectsV2/api/projectV2.api";
 import sessionsApi, { useGetSessionsQuery } from "../session/sessions.api";
 import { Session } from "../session/sessions.types";
@@ -92,8 +93,12 @@ export default function SessionsV2({ project }: SessionsV2Props) {
 }
 
 function SessionLaunchersListDisplay() {
-  const { id: projectId } = useParams<"id">();
+  const { namespace, slug } = useParams<{ namespace: string; slug: string }>();
+  const { data: project } = useGetProjectsByNamespaceAndSlugQuery(
+    namespace && slug ? { namespace, slug } : skipToken
+  );
 
+  const projectId = project?.id;
   const {
     data: launchers,
     error: launchersError,
@@ -150,7 +155,9 @@ function SessionLaunchersListDisplay() {
           <SessionLauncherDisplay
             key={launcher.id}
             launcher={launcher}
+            namespace={namespace ?? ""}
             projectId={projectId ?? ""}
+            slug={slug ?? ""}
           />
         ))}
         {Object.entries(orphanSessions).map(([key, session]) => (
@@ -163,12 +170,16 @@ function SessionLaunchersListDisplay() {
 
 interface SessionLauncherDisplayProps {
   launcher: SessionLauncher;
+  namespace: string;
   projectId: string;
+  slug: string;
 }
 
 function SessionLauncherDisplay({
   launcher,
+  namespace,
   projectId,
+  slug,
 }: SessionLauncherDisplayProps) {
   const { creation_date, environment_kind, name, default_url, description } =
     launcher;
@@ -272,7 +283,8 @@ function SessionLauncherDisplay({
             <div className="mt-auto">
               <StartSessionButton
                 launcherId={launcher.id}
-                projectId={projectId}
+                namespace={namespace}
+                slug={slug}
               />
             </div>
           )}

--- a/client/src/features/sessionsV2/ShowSessionPage.tsx
+++ b/client/src/features/sessionsV2/ShowSessionPage.tsx
@@ -47,15 +47,19 @@ import styles from "../session/components/ShowSession.module.scss";
 const logo = "/static/public/img/logo.svg";
 
 export default function ShowSessionPage() {
-  const { id: projectId_, session: sessionName_ } = useParams<
-    "id" | "session"
-  >();
-  const projectId = projectId_ ?? "";
+  const {
+    namespace,
+    slug,
+    session: sessionName_,
+  } = useParams<"namespace" | "slug" | "session">();
   const sessionName = sessionName_ ?? "";
 
   const navigate = useNavigate();
 
-  const backUrl = generatePath("../../:projectId", { projectId });
+  const backUrl = generatePath("../../:namespace/:slug", {
+    namespace: namespace ?? "",
+    slug: slug ?? "",
+  });
 
   const { data: sessions, isLoading } = useGetSessionsQuery();
   const thisSession = useMemo(() => {

--- a/client/src/features/sessionsV2/StartSessionButton.tsx
+++ b/client/src/features/sessionsV2/StartSessionButton.tsx
@@ -21,19 +21,22 @@ import { PlayFill } from "react-bootstrap-icons";
 import { Link, generatePath } from "react-router-dom-v5-compat";
 
 interface StartSessionButtonProps {
-  projectId: string;
+  namespace: string;
+  slug: string;
   launcherId: string;
 }
 
 export default function StartSessionButton({
-  projectId,
   launcherId,
+  namespace,
+  slug,
 }: StartSessionButtonProps) {
   const startUrl = generatePath(
-    "/v2/projects/:projectId/sessions/:launcherId/start",
+    "/v2/projects/:namespace/:slug/sessions/:launcherId/start",
     {
-      projectId,
       launcherId,
+      namespace,
+      slug,
     }
   );
 

--- a/client/src/landing/NavBar.jsx
+++ b/client/src/landing/NavBar.jsx
@@ -63,7 +63,7 @@ function RenkuNavBarInner(props) {
   return (
     <Switch key="mainNav">
       <Route path={sessionShowUrl} />
-      <Route path="/v2/projects/:id/sessions/show/:server" />
+      <Route path="/v2/projects/:namespace/:slug/sessions/show/:server" />
       <Route>
         {user.logged ? (
           <LoggedInNavBar

--- a/client/src/landing/NavBar.jsx
+++ b/client/src/landing/NavBar.jsx
@@ -190,7 +190,7 @@ function FooterNavbarInner({ location, params }) {
   return (
     <Switch key="footerNav">
       <Route path={sessionShowUrl} />
-      <Route path="/v2/projects/:id/sessions/show/:server" />
+      <Route path="/v2/projects/:namespace/:slug/sessions/show/:server" />
       <Route>{footer}</Route>
     </Switch>
   );

--- a/client/src/utils/helpers/url/Url.js
+++ b/client/src/utils/helpers/url/Url.js
@@ -501,11 +501,17 @@ const Url = {
         "/v2/groups/slug",
       ]),
     },
-    v2Projects: {
+    projectV2: {
       base: "/v2/projects",
       new: "/v2/projects/new",
       list: "/v2/projects",
-      show: new UrlRule((data) => `/v2/projects/${data.id}`, ["id"], null, [
+      show: new UrlRule(
+        (data) => `/v2/projects/${data.namespace}/${data.slug}`,
+        ["namespace", "slug"],
+        null,
+        ["/v2/projects/namespace/slug"]
+      ),
+      showId: new UrlRule((data) => `/v2/projects/${data.id}`, ["id"], null, [
         "/v2/projects/id",
       ]),
     },

--- a/tests/cypress/e2e/projectV2.spec.ts
+++ b/tests/cypress/e2e/projectV2.spec.ts
@@ -162,6 +162,26 @@ describe("List v2 project", () => {
   });
 });
 
+describe("Navigate to project", () => {
+  beforeEach(() => {
+    fixtures.config().versions().userTest().namespaces();
+    fixtures.projects().landingUserProjects().readProjectV2();
+  });
+
+  it("shows projects by namespace/slug", () => {
+    cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
+    cy.contains("test 2 v2-project").should("be.visible");
+  });
+
+  it("shows projects by project id", () => {
+    fixtures.readProjectV2ById();
+    cy.visit("/v2/projects/THEPROJECTULID26CHARACTERS");
+    cy.wait("@readProjectV2ById");
+    cy.contains("test 2 v2-project").should("be.visible");
+    cy.location("pathname").should("contain", "/user1-uuid/test-2-v2-project");
+  });
+});
+
 describe("Edit v2 project", () => {
   beforeEach(() => {
     fixtures.config().versions().userTest().namespaces();

--- a/tests/cypress/fixtures/projectV2/list-projectV2.json
+++ b/tests/cypress/fixtures/projectV2/list-projectV2.json
@@ -3,7 +3,7 @@
     "id": "THEPROJECTULID26CHARACTERS",
     "name": "test 2 v2-project",
     "slug": "test-2-v2-project",
-    "namespace": "namespace1",
+    "namespace": "user1-uuid",
     "creation_date": "2023-11-15T09:55:59Z",
     "created_by": "user1-uuid",
     "repositories": [

--- a/tests/cypress/support/renkulab-fixtures/projectV2.ts
+++ b/tests/cypress/support/renkulab-fixtures/projectV2.ts
@@ -27,12 +27,12 @@ interface ListManyProjectArgs extends NameOnlyFixture {
   numberOfProjects?: number;
 }
 
-interface ListProjectV2MembersFixture extends ProjectV2Args {
+interface ListProjectV2MembersFixture extends ProjectV2IdArgs {
   removeMemberId?: string;
   addMember?: { id: string; email: string; role: string };
 }
 
-interface ProjectV2Args extends SimpleFixture {
+interface ProjectV2IdArgs extends SimpleFixture {
   projectId?: string;
 }
 
@@ -40,8 +40,13 @@ interface ProjectV2DeleteFixture extends NameOnlyFixture {
   projectId?: string;
 }
 
-interface ProjectV2DeleteMemberFixture extends ProjectV2Args {
+interface ProjectV2DeleteMemberFixture extends ProjectV2IdArgs {
   memberId?: string;
+}
+
+interface ProjectV2NameArgs extends SimpleFixture {
+  namespace?: string;
+  projectSlug?: string;
 }
 
 export function generateProjects(numberOfProjects: number, start: number) {
@@ -179,16 +184,17 @@ export function ProjectV2<T extends FixturesConstructor>(Parent: T) {
       return this;
     }
 
-    postDeleteReadProjectV2(args?: ProjectV2DeleteFixture) {
+    postDeleteReadProjectV2(args?: ProjectV2NameArgs) {
       const {
         name = "postDeleteReadProjectV2",
-        projectId = "THEPROJECTULID26CHARACTERS",
+        namespace = "user1-uuid",
+        projectSlug = "test-2-v2-project",
       } = args ?? {};
       const response = {
         body: {
           error: {
             code: 1404,
-            message: `Project with id ${projectId} does not exist.`,
+            message: `Project  ${namespace}/${projectSlug} does not exist.`,
           },
         },
         delay: 2000,
@@ -196,16 +202,32 @@ export function ProjectV2<T extends FixturesConstructor>(Parent: T) {
       };
       cy.intercept(
         "GET",
-        `/ui-server/api/data/projects/${projectId}`,
+        `/ui-server/api/data/projects/${namespace}/${projectSlug}`,
         response
       ).as(name);
       return this;
     }
 
-    readProjectV2(args?: ProjectV2Args) {
+    readProjectV2(args?: ProjectV2NameArgs) {
       const {
         fixture = "projectV2/read-projectV2.json",
         name = "readProjectV2",
+        namespace = "user1-uuid",
+        projectSlug = "test-2-v2-project",
+      } = args ?? {};
+      const response = { fixture };
+      cy.intercept(
+        "GET",
+        `/ui-server/api/data/projects/${namespace}/${projectSlug}`,
+        response
+      ).as(name);
+      return this;
+    }
+
+    readProjectV2ById(args?: ProjectV2IdArgs) {
+      const {
+        fixture = "projectV2/read-projectV2.json",
+        name = "readProjectV2ById",
         projectId = "THEPROJECTULID26CHARACTERS",
       } = args ?? {};
       const response = { fixture };
@@ -217,7 +239,7 @@ export function ProjectV2<T extends FixturesConstructor>(Parent: T) {
       return this;
     }
 
-    updateProjectV2(args?: ProjectV2Args) {
+    updateProjectV2(args?: ProjectV2IdArgs) {
       const {
         fixture = "projectV2/update-projectV2-metadata.json",
         name = "updateProjectV2",


### PR DESCRIPTION
* Changes to use namespace/slug in the URL for the project page (instead of project Id)
* Minor changes like rename `v2Projects` to `projectV2` and use Navigate instead of Redirect

Fix #3096 

/deploy renku-data-services=main