### PR TITLE
[ShapeUp] feat: add new secret page

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -32,7 +32,7 @@ jobs:
       renku-notebooks: ${{ steps.deploy-comment.outputs.renku-notebooks}}
       renku-data-services: ${{ steps.deploy-comment.outputs.renku-data-services}}
       amalthea: ${{ steps.deploy-comment.outputs.amalthea}}
-      secrets_storage: "${{ needs.check-deploy.outputs.secrets-storage }}"
+      secrets-storage: "${{ needs.check-deploy.outputs.secrets-storage }}"
       test-enabled: ${{ steps.deploy-comment.outputs.test-enabled}}
       extra-values: ${{ steps.deploy-comment.outputs.extra-values}}
     steps:

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -32,7 +32,7 @@ jobs:
       renku-notebooks: ${{ steps.deploy-comment.outputs.renku-notebooks}}
       renku-data-services: ${{ steps.deploy-comment.outputs.renku-data-services}}
       amalthea: ${{ steps.deploy-comment.outputs.amalthea}}
-      secrets-storage: "${{ needs.check-deploy.outputs.secrets-storage }}"
+      secrets-storage: ${{ needs.check-deploy.outputs.secrets-storage }}
       test-enabled: ${{ steps.deploy-comment.outputs.test-enabled}}
       extra-values: ${{ steps.deploy-comment.outputs.extra-values}}
     steps:

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -32,7 +32,7 @@ jobs:
       renku-notebooks: ${{ steps.deploy-comment.outputs.renku-notebooks}}
       renku-data-services: ${{ steps.deploy-comment.outputs.renku-data-services}}
       amalthea: ${{ steps.deploy-comment.outputs.amalthea}}
-      secrets-storage: ${{ needs.check-deploy.outputs.secrets-storage }}
+      secrets-storage: ${{ steps.deploy-comment.outputs.secrets-storage }}
       test-enabled: ${{ steps.deploy-comment.outputs.test-enabled}}
       extra-values: ${{ steps.deploy-comment.outputs.extra-values}}
     steps:

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -32,11 +32,12 @@ jobs:
       renku-notebooks: ${{ steps.deploy-comment.outputs.renku-notebooks}}
       renku-data-services: ${{ steps.deploy-comment.outputs.renku-data-services}}
       amalthea: ${{ steps.deploy-comment.outputs.amalthea}}
+      secrets_storage: "${{ needs.check-deploy.outputs.secrets-storage }}"
       test-enabled: ${{ steps.deploy-comment.outputs.test-enabled}}
       extra-values: ${{ steps.deploy-comment.outputs.extra-values}}
     steps:
       - id: deploy-comment
-        uses: SwissDataScienceCenter/renku-actions/check-pr-description@v1.11.0
+        uses: SwissDataScienceCenter/renku-actions/check-pr-description@add-secrets-storage
         with:
           string: /deploy
           pr_ref: ${{ github.event.number }}
@@ -66,7 +67,7 @@ jobs:
           body: |
             You can access the deployment of this PR at https://renku-ci-ui-${{ github.event.number }}.dev.renku.ch
       - name: Build and deploy
-        uses: SwissDataScienceCenter/renku-actions/deploy-renku@v1.11.0
+        uses: SwissDataScienceCenter/renku-actions/deploy-renku@add-secrets-storage
         env:
           RANCHER_PROJECT_ID: ${{ secrets.CI_RANCHER_PROJECT }}
           DOCKER_PASSWORD: ${{ secrets.RENKU_DOCKER_PASSWORD }}
@@ -89,6 +90,7 @@ jobs:
           renku_graph: "${{ needs.check-deploy.outputs.renku-graph }}"
           renku_notebooks: "${{ needs.check-deploy.outputs.renku-notebooks }}"
           renku_data_services: "${{ needs.check-deploy.outputs.renku-data-services }}"
+          secrets_storage: "${{ needs.check-deploy.outputs.secrets-storage }}"
           amalthea: "${{ needs.check-deploy.outputs.amalthea }}"
           extra_values: "${{ needs.check-deploy.outputs.extra-values }}"
 

--- a/client/src/features/secrets/SecretDelete.tsx
+++ b/client/src/features/secrets/SecretDelete.tsx
@@ -20,6 +20,7 @@ import cx from "classnames";
 import { useCallback, useEffect, useState } from "react";
 import { TrashFill, XLg } from "react-bootstrap-icons";
 import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from "reactstrap";
+
 import { useDeleteSecretMutation } from "./secrets.api";
 import { RtkOrNotebooksError } from "../../components/errors/RtkErrorAlert";
 

--- a/client/src/features/secrets/SecretDelete.tsx
+++ b/client/src/features/secrets/SecretDelete.tsx
@@ -51,10 +51,11 @@ export default function SecretDelete({ secret }: SecretsDeleteProps) {
   return (
     <>
       <Button
-        className="ms-2"
+        className="text-nowrap"
         color="outline-danger"
         data-cy="secret-delete-button"
         onClick={toggleModal}
+        size="sm"
       >
         <TrashFill className={cx("bi", "me-1")} />
         Delete

--- a/client/src/features/secrets/SecretDelete.tsx
+++ b/client/src/features/secrets/SecretDelete.tsx
@@ -65,12 +65,13 @@ export default function SecretDelete({ secretId }: SecretsDeleteProps) {
           </p>
         </ModalBody>
         <ModalFooter>
-          <Button onClick={toggleModal}>
+          <Button data-cy="secrets-delete-cancel-button" onClick={toggleModal}>
             <XLg className={cx("bi", "me-1")} />
             Cancel
           </Button>
           <Button
             color="outline-danger"
+            data-cy="secrets-delete-delete-button"
             disabled={result.isLoading}
             onClick={deleteSecret}
           >

--- a/client/src/features/secrets/SecretDelete.tsx
+++ b/client/src/features/secrets/SecretDelete.tsx
@@ -27,17 +27,19 @@ interface SecretsDeleteProps {
   secretId: string;
 }
 export default function SecretDelete({ secretId }: SecretsDeleteProps) {
+  // Set up the modal
   const [showModal, setShowModal] = useState(false);
-
   const toggleModal = useCallback(() => {
     setShowModal((showModal) => !showModal);
   }, []);
 
+  // Handle posting data
   const [deleteSecretMutation, result] = useDeleteSecretMutation();
   const deleteSecret = useCallback(() => {
     deleteSecretMutation(secretId);
   }, [deleteSecretMutation, secretId]);
 
+  // Automatically close the modal when the secret is modified
   useEffect(() => {
     if (result.isSuccess) {
       toggleModal();

--- a/client/src/features/secrets/SecretDelete.tsx
+++ b/client/src/features/secrets/SecretDelete.tsx
@@ -23,11 +23,12 @@ import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from "reactstrap";
 
 import { useDeleteSecretMutation } from "./secrets.api";
 import { RtkOrNotebooksError } from "../../components/errors/RtkErrorAlert";
+import { SecretDetails } from "./secrets.types";
 
 interface SecretsDeleteProps {
-  secretId: string;
+  secret: SecretDetails;
 }
-export default function SecretDelete({ secretId }: SecretsDeleteProps) {
+export default function SecretDelete({ secret }: SecretsDeleteProps) {
   // Set up the modal
   const [showModal, setShowModal] = useState(false);
   const toggleModal = useCallback(() => {
@@ -37,8 +38,8 @@ export default function SecretDelete({ secretId }: SecretsDeleteProps) {
   // Handle posting data
   const [deleteSecretMutation, result] = useDeleteSecretMutation();
   const deleteSecret = useCallback(() => {
-    deleteSecretMutation(secretId);
-  }, [deleteSecretMutation, secretId]);
+    deleteSecretMutation(secret.id);
+  }, [deleteSecretMutation, secret.id]);
 
   // Automatically close the modal when the secret is modified
   useEffect(() => {
@@ -66,7 +67,7 @@ export default function SecretDelete({ secretId }: SecretsDeleteProps) {
           <p className="mb-0">
             Please confirm that you want to{" "}
             <span className="fw-bold">permanently</span> delete the secret{" "}
-            <code>{secretId}</code>.
+            <code>{secret.name}</code>.
           </p>
         </ModalBody>
         <ModalFooter>

--- a/client/src/features/secrets/SecretDelete.tsx
+++ b/client/src/features/secrets/SecretDelete.tsx
@@ -49,7 +49,12 @@ export default function SecretDelete({ secretId }: SecretsDeleteProps) {
 
   return (
     <>
-      <Button className="ms-2" color="outline-danger" onClick={toggleModal}>
+      <Button
+        className="ms-2"
+        color="outline-danger"
+        data-cy="secret-delete-button"
+        onClick={toggleModal}
+      >
         <TrashFill className={cx("bi", "me-1")} />
         Delete
       </Button>

--- a/client/src/features/secrets/SecretDelete.tsx
+++ b/client/src/features/secrets/SecretDelete.tsx
@@ -1,0 +1,81 @@
+/*!
+ * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+import cx from "classnames";
+import { useCallback, useEffect, useState } from "react";
+import { TrashFill, XLg } from "react-bootstrap-icons";
+import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from "reactstrap";
+import { useDeleteSecretMutation } from "./secrets.api";
+import { RtkOrNotebooksError } from "../../components/errors/RtkErrorAlert";
+
+interface SecretsDeleteProps {
+  secretId: string;
+}
+export default function SecretDelete({ secretId }: SecretsDeleteProps) {
+  const [showModal, setShowModal] = useState(false);
+
+  const toggleModal = useCallback(() => {
+    setShowModal((showModal) => !showModal);
+  }, []);
+
+  const [deleteSecretMutation, result] = useDeleteSecretMutation();
+  const deleteSecret = useCallback(() => {
+    deleteSecretMutation(secretId);
+  }, [deleteSecretMutation, secretId]);
+
+  useEffect(() => {
+    if (result.isSuccess) {
+      toggleModal();
+    }
+  }, [result.isSuccess, toggleModal]);
+
+  return (
+    <>
+      <Button className="ms-2" color="outline-danger" onClick={toggleModal}>
+        <TrashFill className={cx("bi", "me-1")} />
+        Delete
+      </Button>
+
+      <Modal isOpen={showModal} toggle={toggleModal}>
+        <ModalHeader toggle={toggleModal}>Are you sure?</ModalHeader>
+        <ModalBody>
+          {result.isError && <RtkOrNotebooksError error={result.error} />}
+          <p className="mb-0">
+            Please confirm that you want to{" "}
+            <span className="fw-bold">permanently</span> delete the secret{" "}
+            <code>{secretId}</code>.
+          </p>
+        </ModalBody>
+        <ModalFooter>
+          <Button onClick={toggleModal}>
+            <XLg className={cx("bi", "me-1")} />
+            Cancel
+          </Button>
+          <Button
+            color="outline-danger"
+            disabled={result.isLoading}
+            onClick={deleteSecret}
+          >
+            <TrashFill className={cx("bi", "me-1")} />
+            Delete secret
+          </Button>
+        </ModalFooter>
+      </Modal>
+    </>
+  );
+}

--- a/client/src/features/secrets/SecretEdit.tsx
+++ b/client/src/features/secrets/SecretEdit.tsx
@@ -90,7 +90,11 @@ export default function SecretEdit({ secretId }: SecretsEditProps) {
 
   return (
     <>
-      <Button className="btn-outline-rk-green" onClick={toggleModal}>
+      <Button
+        className="btn-outline-rk-green"
+        data-cy="secret-edit-button"
+        onClick={toggleModal}
+      >
         <PencilSquare className={cx("bi", "me-1")} />
         Edit
       </Button>

--- a/client/src/features/secrets/SecretEdit.tsx
+++ b/client/src/features/secrets/SecretEdit.tsx
@@ -41,6 +41,7 @@ import {
 import { useEditSecretMutation } from "./secrets.api";
 import { RtkOrNotebooksError } from "../../components/errors/RtkErrorAlert";
 import { EditSecretForm, SecretDetails } from "./secrets.types";
+import { BLUR_TEXT_STYLE, SECRETS_VALUE_LENGTH_LIMIT } from "./secrets.utils";
 
 interface SecretsEditProps {
   secret: SecretDetails;
@@ -91,9 +92,10 @@ export default function SecretEdit({ secret }: SecretsEditProps) {
   return (
     <>
       <Button
-        className="btn-outline-rk-green"
+        className={cx("btn-outline-rk-green", "text-nowrap")}
         data-cy="secret-edit-button"
         onClick={toggleModal}
+        size="sm"
       >
         <PencilSquare className={cx("bi", "me-1")} />
         Edit
@@ -104,6 +106,12 @@ export default function SecretEdit({ secret }: SecretsEditProps) {
           Edit Secret <code>{secret.name}</code>
         </ModalHeader>
         <ModalBody>
+          <p>
+            Here you can replace the value. The change will apply only to new
+            sessions. If you need to rename, please delete the secret and create
+            a new one.
+          </p>
+          <p>Values are limited to 5000 characters.</p>
           <Form
             className="form-rk-green"
             data-cy="secrets-edit-form"
@@ -127,13 +135,18 @@ export default function SecretEdit({ secret }: SecretsEditProps) {
                         errors.value && "is-invalid"
                       )}
                       id="edit-secret-value"
-                      placeholder="Value"
-                      type={showPlainText ? "text" : "password"}
+                      style={showPlainText ? {} : BLUR_TEXT_STYLE}
+                      // ! TODO: move style to a css file, and include `::selection` to prevent showing the text when highlighted
+                      type="textarea"
                       {...field}
                     />
                   )}
                   rules={{
                     required: "Please provide a value.",
+                    validate: (value) =>
+                      value.length > SECRETS_VALUE_LENGTH_LIMIT
+                        ? `Value cannot exceed ${SECRETS_VALUE_LENGTH_LIMIT} characters.`
+                        : undefined,
                   }}
                 />
                 <Button
@@ -173,7 +186,7 @@ export default function SecretEdit({ secret }: SecretsEditProps) {
             type="submit"
           >
             <PencilSquare className={cx("bi", "me-1")} />
-            Edit
+            Replace
           </Button>
           <Button
             className="btn-outline-rk-green"

--- a/client/src/features/secrets/SecretEdit.tsx
+++ b/client/src/features/secrets/SecretEdit.tsx
@@ -18,22 +18,30 @@
 
 import cx from "classnames";
 import { useCallback, useEffect, useState } from "react";
-import { PencilSquare, XLg } from "react-bootstrap-icons";
+import {
+  EyeFill,
+  EyeSlashFill,
+  PencilSquare,
+  XLg,
+} from "react-bootstrap-icons";
 import { Controller, useForm } from "react-hook-form";
 import {
   Button,
   Form,
   Input,
+  InputGroup,
   Label,
   Modal,
   ModalBody,
   ModalFooter,
   ModalHeader,
+  UncontrolledTooltip,
 } from "reactstrap";
 
 import { useEditSecretMutation } from "./secrets.api";
 import { RtkOrNotebooksError } from "../../components/errors/RtkErrorAlert";
 import { EditSecretForm } from "./secrets.types";
+
 interface SecretsEditProps {
   secretId: string;
 }
@@ -42,6 +50,12 @@ export default function SecretEdit({ secretId }: SecretsEditProps) {
   const [showModal, setShowModal] = useState(false);
   const toggleModal = useCallback(() => {
     setShowModal((showModal) => !showModal);
+  }, []);
+
+  // Hide/show the secret value
+  const [showPlainText, setShowPlainText] = useState(false);
+  const toggleShowPlainText = useCallback(() => {
+    setShowPlainText((showPlainText) => !showPlainText);
   }, []);
 
   // Set up the form
@@ -88,25 +102,49 @@ export default function SecretEdit({ secretId }: SecretsEditProps) {
         <ModalBody>
           <Form className="form-rk-green" onSubmit={handleSubmit(onSubmit)}>
             <div className="mb-3">
-              <Label className="form-label" for="editSecretValue">
+              <Label className="form-label" for="edit-secret-value">
                 Value
               </Label>
-              <Controller
-                control={control}
-                name="value"
-                render={({ field }) => (
-                  <Input
-                    className={cx("form-control", errors.value && "is-invalid")}
-                    id="editSecretValue"
-                    placeholder="Value"
-                    type="text"
-                    {...field}
-                  />
-                )}
-                rules={{
-                  required: "Please provide a value.",
-                }}
-              />
+              <InputGroup>
+                <Controller
+                  control={control}
+                  name="value"
+                  render={({ field }) => (
+                    <Input
+                      className={cx(
+                        "form-control",
+                        "rounded-0",
+                        "rounded-start",
+                        errors.value && "is-invalid"
+                      )}
+                      id="edit-secret-value"
+                      placeholder="Value"
+                      type={showPlainText ? "text" : "password"}
+                      {...field}
+                    />
+                  )}
+                  rules={{
+                    required: "Please provide a value.",
+                  }}
+                />
+                <Button
+                  className="rounded-end"
+                  id="secret-new-show-value"
+                  onClick={() => toggleShowPlainText()}
+                >
+                  {showPlainText ? (
+                    <EyeFill className="bi" />
+                  ) : (
+                    <EyeSlashFill className="bi" />
+                  )}
+                  <UncontrolledTooltip
+                    placement="top"
+                    target="secret-new-show-value"
+                  >
+                    Hide/show secret value
+                  </UncontrolledTooltip>
+                </Button>
+              </InputGroup>
               {errors.value && (
                 <div className="invalid-feedback">{errors.value.message}</div>
               )}

--- a/client/src/features/secrets/SecretEdit.tsx
+++ b/client/src/features/secrets/SecretEdit.tsx
@@ -129,7 +129,7 @@ export default function SecretEdit({ secret }: SecretsEditProps) {
                   name="value"
                   render={({ field }) => (
                     <Input
-                      autoComplete="new-password"
+                      autoComplete="off"
                       className={cx(
                         "form-control",
                         "rounded-0",

--- a/client/src/features/secrets/SecretEdit.tsx
+++ b/client/src/features/secrets/SecretEdit.tsx
@@ -1,0 +1,77 @@
+/*!
+ * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+import cx from "classnames";
+import { useCallback, useEffect, useState } from "react";
+import { PencilSquare, XLg } from "react-bootstrap-icons";
+import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from "reactstrap";
+import { useEditSecretMutation } from "./secrets.api";
+import { RtkOrNotebooksError } from "../../components/errors/RtkErrorAlert";
+
+interface SecretsEditProps {
+  secretId: string;
+}
+export default function SecretEdit({ secretId }: SecretsEditProps) {
+  const [showModal, setShowModal] = useState(false);
+
+  const toggleModal = useCallback(() => {
+    setShowModal((showModal) => !showModal);
+  }, []);
+
+  const [editSecretMutation, result] = useEditSecretMutation();
+  const editSecret = useCallback(() => {
+    editSecretMutation({ id: secretId, value: "TMP NEW VALUE" });
+  }, [editSecretMutation, secretId]);
+
+  useEffect(() => {
+    if (result.isSuccess) {
+      toggleModal();
+    }
+  }, [result.isSuccess, toggleModal]);
+
+  return (
+    <>
+      <Button className="btn-outline-rk-green" onClick={toggleModal}>
+        <PencilSquare className={cx("bi", "me-1")} />
+        Edit
+      </Button>
+
+      <Modal isOpen={showModal} toggle={toggleModal}>
+        <ModalHeader toggle={toggleModal}>
+          Edit Secret <code>{secretId}</code>
+        </ModalHeader>
+        <ModalBody>
+          {result.isError && <RtkOrNotebooksError error={result.error} />}
+          <p>
+            <i>Work in progress</i>
+          </p>
+        </ModalBody>
+        <ModalFooter>
+          <Button disabled={result.isLoading} onClick={editSecret}>
+            <PencilSquare className={cx("bi", "me-1")} />
+            Edit
+          </Button>
+          <Button className="btn-outline-rk-green" onClick={toggleModal}>
+            <XLg className={cx("bi", "me-1")} />
+            Cancel
+          </Button>
+        </ModalFooter>
+      </Modal>
+    </>
+  );
+}

--- a/client/src/features/secrets/SecretEdit.tsx
+++ b/client/src/features/secrets/SecretEdit.tsx
@@ -41,7 +41,9 @@ import {
 import { useEditSecretMutation } from "./secrets.api";
 import { RtkOrNotebooksError } from "../../components/errors/RtkErrorAlert";
 import { EditSecretForm, SecretDetails } from "./secrets.types";
-import { BLUR_TEXT_STYLE, SECRETS_VALUE_LENGTH_LIMIT } from "./secrets.utils";
+import { SECRETS_VALUE_LENGTH_LIMIT } from "./secrets.utils";
+
+import styles from "./secrets.module.scss";
 
 interface SecretsEditProps {
   secret: SecretDetails;
@@ -132,11 +134,10 @@ export default function SecretEdit({ secret }: SecretsEditProps) {
                         "form-control",
                         "rounded-0",
                         "rounded-start",
+                        !showPlainText && styles.blurredText,
                         errors.value && "is-invalid"
                       )}
                       id="edit-secret-value"
-                      style={showPlainText ? {} : BLUR_TEXT_STYLE}
-                      // ! TODO: move style to a css file, and include `::selection` to prevent showing the text when highlighted
                       type="textarea"
                       {...field}
                     />

--- a/client/src/features/secrets/SecretEdit.tsx
+++ b/client/src/features/secrets/SecretEdit.tsx
@@ -119,6 +119,7 @@ export default function SecretEdit({ secret }: SecretsEditProps) {
                   name="value"
                   render={({ field }) => (
                     <Input
+                      autoComplete="new-password"
                       className={cx(
                         "form-control",
                         "rounded-0",

--- a/client/src/features/secrets/SecretEdit.tsx
+++ b/client/src/features/secrets/SecretEdit.tsx
@@ -40,12 +40,12 @@ import {
 
 import { useEditSecretMutation } from "./secrets.api";
 import { RtkOrNotebooksError } from "../../components/errors/RtkErrorAlert";
-import { EditSecretForm } from "./secrets.types";
+import { EditSecretForm, SecretDetails } from "./secrets.types";
 
 interface SecretsEditProps {
-  secretId: string;
+  secret: SecretDetails;
 }
-export default function SecretEdit({ secretId }: SecretsEditProps) {
+export default function SecretEdit({ secret }: SecretsEditProps) {
   // Set up the modal
   const [showModal, setShowModal] = useState(false);
   const toggleModal = useCallback(() => {
@@ -75,9 +75,9 @@ export default function SecretEdit({ secretId }: SecretsEditProps) {
   const [editSecretMutation, result] = useEditSecretMutation();
   const onSubmit = useCallback(
     (newSecret: EditSecretForm) => {
-      editSecretMutation({ id: secretId, ...newSecret });
+      editSecretMutation({ id: secret.id, ...newSecret });
     },
-    [editSecretMutation, secretId]
+    [editSecretMutation, secret.id]
   );
 
   // Automatically close the modal when the secret is modified
@@ -101,7 +101,7 @@ export default function SecretEdit({ secretId }: SecretsEditProps) {
 
       <Modal isOpen={showModal} toggle={toggleModal}>
         <ModalHeader toggle={toggleModal}>
-          Edit Secret <code>{secretId}</code>
+          Edit Secret <code>{secret.name}</code>
         </ModalHeader>
         <ModalBody>
           <Form

--- a/client/src/features/secrets/SecretEdit.tsx
+++ b/client/src/features/secrets/SecretEdit.tsx
@@ -100,7 +100,11 @@ export default function SecretEdit({ secretId }: SecretsEditProps) {
           Edit Secret <code>{secretId}</code>
         </ModalHeader>
         <ModalBody>
-          <Form className="form-rk-green" onSubmit={handleSubmit(onSubmit)}>
+          <Form
+            className="form-rk-green"
+            data-cy="secrets-edit-form"
+            onSubmit={handleSubmit(onSubmit)}
+          >
             <div className="mb-3">
               <Label className="form-label" for="edit-secret-value">
                 Value
@@ -158,6 +162,7 @@ export default function SecretEdit({ secretId }: SecretsEditProps) {
             </div>
           )}
           <Button
+            data-cy="secrets-edit-edit-button"
             disabled={result.isLoading}
             onClick={handleSubmit(onSubmit)}
             type="submit"
@@ -165,7 +170,11 @@ export default function SecretEdit({ secretId }: SecretsEditProps) {
             <PencilSquare className={cx("bi", "me-1")} />
             Edit
           </Button>
-          <Button className="btn-outline-rk-green" onClick={toggleModal}>
+          <Button
+            className="btn-outline-rk-green"
+            data-cy="secrets-edit-cancel-button"
+            onClick={toggleModal}
+          >
             <XLg className={cx("bi", "me-1")} />
             Cancel
           </Button>

--- a/client/src/features/secrets/SecretEdit.tsx
+++ b/client/src/features/secrets/SecretEdit.tsx
@@ -100,12 +100,12 @@ export default function SecretEdit({ secret }: SecretsEditProps) {
         size="sm"
       >
         <PencilSquare className={cx("bi", "me-1")} />
-        Edit
+        Replace
       </Button>
 
       <Modal isOpen={showModal} toggle={toggleModal}>
         <ModalHeader toggle={toggleModal}>
-          Edit Secret <code>{secret.name}</code>
+          Replace Secret <code>{secret.name}</code>
         </ModalHeader>
         <ModalBody>
           <p>
@@ -181,6 +181,14 @@ export default function SecretEdit({ secret }: SecretsEditProps) {
             </div>
           )}
           <Button
+            className="btn-outline-rk-green"
+            data-cy="secrets-edit-cancel-button"
+            onClick={toggleModal}
+          >
+            <XLg className={cx("bi", "me-1")} />
+            Cancel
+          </Button>
+          <Button
             data-cy="secrets-edit-edit-button"
             disabled={result.isLoading}
             onClick={handleSubmit(onSubmit)}
@@ -188,14 +196,6 @@ export default function SecretEdit({ secret }: SecretsEditProps) {
           >
             <PencilSquare className={cx("bi", "me-1")} />
             Replace
-          </Button>
-          <Button
-            className="btn-outline-rk-green"
-            data-cy="secrets-edit-cancel-button"
-            onClick={toggleModal}
-          >
-            <XLg className={cx("bi", "me-1")} />
-            Cancel
           </Button>
         </ModalFooter>
       </Modal>

--- a/client/src/features/secrets/SecretEdit.tsx
+++ b/client/src/features/secrets/SecretEdit.tsx
@@ -152,10 +152,10 @@ export default function SecretEdit({ secretId }: SecretsEditProps) {
                     Hide/show secret value
                   </UncontrolledTooltip>
                 </Button>
+                {errors.value && (
+                  <div className="invalid-feedback">{errors.value.message}</div>
+                )}
               </InputGroup>
-              {errors.value && (
-                <div className="invalid-feedback">{errors.value.message}</div>
-              )}
             </div>
           </Form>
         </ModalBody>

--- a/client/src/features/secrets/SecretNew.tsx
+++ b/client/src/features/secrets/SecretNew.tsx
@@ -116,7 +116,7 @@ export default function SecretsNew() {
             name="name"
             render={({ field }) => (
               <Input
-                autoComplete="new-password"
+                autoComplete="off"
                 className={cx("form-control", errors.name && "is-invalid")}
                 id="new-secret-name"
                 placeholder="Unique name"
@@ -149,7 +149,7 @@ export default function SecretsNew() {
               name="value"
               render={({ field }) => (
                 <Input
-                  autoComplete="new-password"
+                  autoComplete="off"
                   className={cx(
                     "form-control",
                     "rounded-0",

--- a/client/src/features/secrets/SecretNew.tsx
+++ b/client/src/features/secrets/SecretNew.tsx
@@ -179,16 +179,6 @@ export default function SecretsNew() {
 
   return (
     <>
-      <div className="mb-2">
-        <Button
-          id="new-secret-button"
-          className="btn-outline-rk-green"
-          onClick={toggleModal}
-        >
-          <PlusLg className={cx("bi", "me-1")} />
-          Add New Secret
-        </Button>
-      </div>
       <Modal isOpen={showModal} toggle={toggleModal}>
         <ModalHeader toggle={toggleModal}>Add New Secret</ModalHeader>
         <ModalBody>{modalBody}</ModalBody>
@@ -217,6 +207,16 @@ export default function SecretsNew() {
           </Button>
         </ModalFooter>
       </Modal>
+      <div className="mb-3">
+        <Button
+          id="new-secret-button"
+          className="btn-outline-rk-green"
+          onClick={toggleModal}
+        >
+          <PlusLg className={cx("bi", "me-1")} />
+          Add New Secret
+        </Button>
+      </div>
     </>
   );
 }

--- a/client/src/features/secrets/SecretNew.tsx
+++ b/client/src/features/secrets/SecretNew.tsx
@@ -1,0 +1,77 @@
+/*!
+ * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+import cx from "classnames";
+import { useCallback, useEffect, useState } from "react";
+import { PlusLg, XLg } from "react-bootstrap-icons";
+import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from "reactstrap";
+import { useAddSecretMutation } from "./secrets.api";
+import { RtkOrNotebooksError } from "../../components/errors/RtkErrorAlert";
+
+export default function SecretsList() {
+  const [showModal, setShowModal] = useState(false);
+
+  const toggleModal = useCallback(() => {
+    setShowModal((showModal) => !showModal);
+  }, []);
+
+  const [addSecretMutation, result] = useAddSecretMutation();
+  const addSecret = useCallback(() => {
+    addSecretMutation({ name: "TMP NEW SECRET", value: "TMP NEW VALUE" });
+  }, [addSecretMutation]);
+
+  useEffect(() => {
+    if (result.isSuccess) {
+      toggleModal();
+    }
+  }, [result.isSuccess, toggleModal]);
+
+  return (
+    <>
+      <div className="mb-2">
+        <Button
+          id="new-secret-button"
+          className="btn-outline-rk-green"
+          onClick={toggleModal}
+        >
+          <PlusLg className={cx("bi", "me-1")} />
+          Add New Secret
+        </Button>
+      </div>
+      <Modal isOpen={showModal} toggle={toggleModal}>
+        <ModalHeader toggle={toggleModal}>Add New Secret</ModalHeader>
+        <ModalBody>
+          {result.isError && <RtkOrNotebooksError error={result.error} />}
+          <p>
+            <i>Work in progress</i>
+          </p>
+        </ModalBody>
+        <ModalFooter>
+          <Button disabled={result.isLoading} onClick={addSecret}>
+            <PlusLg className={cx("bi", "me-1")} />
+            Add
+          </Button>
+          <Button className="btn-outline-rk-green" onClick={toggleModal}>
+            <XLg className={cx("bi", "me-1")} />
+            Cancel
+          </Button>
+        </ModalFooter>
+      </Modal>
+    </>
+  );
+}

--- a/client/src/features/secrets/SecretNew.tsx
+++ b/client/src/features/secrets/SecretNew.tsx
@@ -18,17 +18,19 @@
 
 import cx from "classnames";
 import { useCallback, useEffect, useState } from "react";
-import { PlusLg, XLg } from "react-bootstrap-icons";
+import { EyeFill, EyeSlashFill, PlusLg, XLg } from "react-bootstrap-icons";
 import { Controller, useForm } from "react-hook-form";
 import {
   Button,
   Form,
   Input,
+  InputGroup,
   Label,
   Modal,
   ModalBody,
   ModalFooter,
   ModalHeader,
+  UncontrolledTooltip,
 } from "reactstrap";
 
 import secretsApi, { useAddSecretMutation } from "./secrets.api";
@@ -41,6 +43,12 @@ export default function SecretsNew() {
   const [showModal, setShowModal] = useState(false);
   const toggleModal = useCallback(() => {
     setShowModal((showModal) => !showModal);
+  }, []);
+
+  // Hide/show the secret value
+  const [showPlainText, setShowPlainText] = useState(false);
+  const toggleShowPlainText = useCallback(() => {
+    setShowPlainText((showPlainText) => !showPlainText);
   }, []);
 
   // Set up the form
@@ -87,7 +95,7 @@ export default function SecretsNew() {
   ) : (
     <Form className="form-rk-green" onSubmit={handleSubmit(onSubmit)}>
       <div className="mb-3">
-        <Label className="form-label" for="newSecretName">
+        <Label className="form-label" for="new-secret-name">
           Name
         </Label>
         <Controller
@@ -96,7 +104,7 @@ export default function SecretsNew() {
           render={({ field }) => (
             <Input
               className={cx("form-control", errors.name && "is-invalid")}
-              id="newSecretName"
+              id="new-secret-name"
               placeholder="Unique name"
               type="text"
               {...field}
@@ -105,8 +113,11 @@ export default function SecretsNew() {
           rules={{
             required: "Please provide a name.",
             validate: (value) =>
-              !secrets.data?.includes(value) ||
-              "This secret name already exists.",
+              secrets.data?.map((s) => s.name).includes(value)
+                ? "This name is already used by another secret."
+                : !/^[a-zA-Z0-9_-]+$/.test(value)
+                ? "Only letters, numbers, underscores (_), and dashes (-)."
+                : undefined,
           }}
         />
         {errors.name && (
@@ -115,25 +126,46 @@ export default function SecretsNew() {
       </div>
 
       <div className="mb-3">
-        <Label className="form-label" for="newSecretValue">
+        <Label className="form-label" for="new-secret-value">
           Value
         </Label>
-        <Controller
-          control={control}
-          name="value"
-          render={({ field }) => (
-            <Input
-              className={cx("form-control", errors.value && "is-invalid")}
-              id="newSecretValue"
-              placeholder="Value"
-              type="text"
-              {...field}
-            />
-          )}
-          rules={{
-            required: "Please provide a value.",
-          }}
-        />
+        <InputGroup>
+          <Controller
+            control={control}
+            name="value"
+            render={({ field }) => (
+              <Input
+                className={cx(
+                  "form-control",
+                  "rounded-0",
+                  "rounded-start",
+                  errors.value && "is-invalid"
+                )}
+                id="new-secret-value"
+                placeholder="Value"
+                type={showPlainText ? "text" : "password"}
+                {...field}
+              />
+            )}
+            rules={{
+              required: "Please provide a value.",
+            }}
+          />
+          <Button
+            className="rounded-end"
+            id="secret-new-show-value"
+            onClick={() => toggleShowPlainText()}
+          >
+            {showPlainText ? (
+              <EyeFill className="bi" />
+            ) : (
+              <EyeSlashFill className="bi" />
+            )}
+            <UncontrolledTooltip placement="top" target="secret-new-show-value">
+              Hide/show secret value
+            </UncontrolledTooltip>
+          </Button>
+        </InputGroup>
         {errors.value && (
           <div className="invalid-feedback">{errors.value.message}</div>
         )}

--- a/client/src/features/secrets/SecretNew.tsx
+++ b/client/src/features/secrets/SecretNew.tsx
@@ -208,6 +208,14 @@ export default function SecretsNew() {
             </div>
           )}
           <Button
+            className="btn-outline-rk-green"
+            data-cy="secrets-new-cancel-button"
+            onClick={toggleModal}
+          >
+            <XLg className={cx("bi", "me-1")} />
+            Cancel
+          </Button>
+          <Button
             data-cy="secrets-new-add-button"
             disabled={result.isLoading}
             onClick={handleSubmit(onSubmit)}
@@ -215,14 +223,6 @@ export default function SecretsNew() {
           >
             <PlusLg className={cx("bi", "me-1")} />
             Add
-          </Button>
-          <Button
-            className="btn-outline-rk-green"
-            data-cy="secrets-new-cancel-button"
-            onClick={toggleModal}
-          >
-            <XLg className={cx("bi", "me-1")} />
-            Cancel
           </Button>
         </ModalFooter>
       </Modal>

--- a/client/src/features/secrets/SecretNew.tsx
+++ b/client/src/features/secrets/SecretNew.tsx
@@ -37,6 +37,7 @@ import secretsApi, { useAddSecretMutation } from "./secrets.api";
 import { RtkOrNotebooksError } from "../../components/errors/RtkErrorAlert";
 import { Loader } from "../../components/Loader";
 import { AddSecretForm } from "./secrets.types";
+import { BLUR_TEXT_STYLE, SECRETS_VALUE_LENGTH_LIMIT } from "./secrets.utils";
 
 export default function SecretsNew() {
   // Set up the modal
@@ -93,90 +94,104 @@ export default function SecretsNew() {
   const modalBody = secrets.isLoading ? (
     <Loader />
   ) : (
-    <Form
-      className="form-rk-green"
-      data-cy="secrets-new-form"
-      onSubmit={handleSubmit(onSubmit)}
-    >
-      <div className="mb-3">
-        <Label className="form-label" for="new-secret-name">
-          Name
-        </Label>
-        <Controller
-          control={control}
-          name="name"
-          render={({ field }) => (
-            <Input
-              autoComplete="new-password"
-              className={cx("form-control", errors.name && "is-invalid")}
-              id="new-secret-name"
-              placeholder="Unique name"
-              type="text"
-              {...field}
-            />
-          )}
-          rules={{
-            required: "Please provide a name.",
-            validate: (value) =>
-              secrets.data?.map((s) => s.name).includes(value)
-                ? "This name is already used by another secret."
-                : !/^[a-zA-Z0-9_-]+$/.test(value)
-                ? "Only letters, numbers, underscores (_), and dashes (-)."
-                : undefined,
-          }}
-        />
-        {errors.name && (
-          <div className="invalid-feedback">{errors.name.message}</div>
-        )}
-      </div>
-
-      <div className="mb-3">
-        <Label className="form-label" for="new-secret-value">
-          Value
-        </Label>
-        <InputGroup>
+    <>
+      <p>Here you can add a new secret to use in your sessions.</p>
+      <p>
+        Names must be unique and can contain only letters, numbers, underscores
+        (_), and dashes (-). Values are limited to 5000 characters.
+      </p>
+      <Form
+        className="form-rk-green"
+        data-cy="secrets-new-form"
+        onSubmit={handleSubmit(onSubmit)}
+      >
+        <div className="mb-3">
+          <Label className="form-label" for="new-secret-name">
+            Name
+          </Label>
           <Controller
             control={control}
-            name="value"
+            name="name"
             render={({ field }) => (
               <Input
                 autoComplete="new-password"
-                className={cx(
-                  "form-control",
-                  "rounded-0",
-                  "rounded-start",
-                  errors.value && "is-invalid"
-                )}
-                id="new-secret-value"
-                placeholder="Value"
-                type={showPlainText ? "text" : "password"}
+                className={cx("form-control", errors.name && "is-invalid")}
+                id="new-secret-name"
+                placeholder="Unique name"
+                type="text"
                 {...field}
               />
             )}
             rules={{
-              required: "Please provide a value.",
+              required: "Please provide a name.",
+              validate: (value) =>
+                secrets.data?.map((s) => s.name).includes(value)
+                  ? "This name is already used by another secret."
+                  : !/^[a-zA-Z0-9_-]+$/.test(value)
+                  ? "Only letters, numbers, underscores (_), and dashes (-)."
+                  : undefined,
             }}
           />
-          <Button
-            className="rounded-end"
-            id="secret-new-show-value"
-            onClick={() => toggleShowPlainText()}
-          >
-            {showPlainText ? (
-              <EyeFill className="bi" />
-            ) : (
-              <EyeSlashFill className="bi" />
-            )}
-            <UncontrolledTooltip placement="top" target="secret-new-show-value">
-              Hide/show secret value
-            </UncontrolledTooltip>
-          </Button>
-          {errors.value && (
-            <div className="invalid-feedback">{errors.value.message}</div>
+          {errors.name && (
+            <div className="invalid-feedback">{errors.name.message}</div>
           )}
-        </InputGroup>
-      </div>
-    </Form>
+        </div>
+
+        <div className="mb-3">
+          <Label className="form-label" for="new-secret-value">
+            Value
+          </Label>
+          <InputGroup>
+            <Controller
+              control={control}
+              name="value"
+              render={({ field }) => (
+                <Input
+                  autoComplete="new-password"
+                  className={cx(
+                    "form-control",
+                    "rounded-0",
+                    "rounded-start",
+                    errors.value && "is-invalid"
+                  )}
+                  id="new-secret-value"
+                  style={showPlainText ? {} : BLUR_TEXT_STYLE}
+                  type="textarea"
+                  {...field}
+                />
+              )}
+              rules={{
+                required: "Please provide a value.",
+                validate: (value) =>
+                  value.length > SECRETS_VALUE_LENGTH_LIMIT
+                    ? `Value cannot exceed ${SECRETS_VALUE_LENGTH_LIMIT} characters.`
+                    : undefined,
+              }}
+            />
+            <Button
+              className="rounded-end"
+              id="secret-new-show-value"
+              onClick={() => toggleShowPlainText()}
+            >
+              {showPlainText ? (
+                <EyeFill className="bi" />
+              ) : (
+                <EyeSlashFill className="bi" />
+              )}
+              <UncontrolledTooltip
+                placement="top"
+                target="secret-new-show-value"
+              >
+                Hide/show secret value
+              </UncontrolledTooltip>
+            </Button>
+            {errors.value && (
+              <div className="invalid-feedback">{errors.value.message}</div>
+            )}
+          </InputGroup>
+        </div>
+      </Form>
+    </>
   );
 
   return (

--- a/client/src/features/secrets/SecretNew.tsx
+++ b/client/src/features/secrets/SecretNew.tsx
@@ -37,7 +37,9 @@ import secretsApi, { useAddSecretMutation } from "./secrets.api";
 import { RtkOrNotebooksError } from "../../components/errors/RtkErrorAlert";
 import { Loader } from "../../components/Loader";
 import { AddSecretForm } from "./secrets.types";
-import { BLUR_TEXT_STYLE, SECRETS_VALUE_LENGTH_LIMIT } from "./secrets.utils";
+import { SECRETS_VALUE_LENGTH_LIMIT } from "./secrets.utils";
+
+import styles from "./secrets.module.scss";
 
 export default function SecretsNew() {
   // Set up the modal
@@ -152,10 +154,10 @@ export default function SecretsNew() {
                     "form-control",
                     "rounded-0",
                     "rounded-start",
+                    !showPlainText && styles.blurredText,
                     errors.value && "is-invalid"
                   )}
                   id="new-secret-value"
-                  style={showPlainText ? {} : BLUR_TEXT_STYLE}
                   type="textarea"
                   {...field}
                 />

--- a/client/src/features/secrets/SecretNew.tsx
+++ b/client/src/features/secrets/SecretNew.tsx
@@ -93,7 +93,11 @@ export default function SecretsNew() {
   const modalBody = secrets.isLoading ? (
     <Loader />
   ) : (
-    <Form className="form-rk-green" onSubmit={handleSubmit(onSubmit)}>
+    <Form
+      className="form-rk-green"
+      data-cy="secrets-new-form"
+      onSubmit={handleSubmit(onSubmit)}
+    >
       <div className="mb-3">
         <Label className="form-label" for="new-secret-name">
           Name
@@ -195,6 +199,7 @@ export default function SecretsNew() {
             </div>
           )}
           <Button
+            data-cy="secrets-new-add-button"
             disabled={result.isLoading}
             onClick={handleSubmit(onSubmit)}
             type="submit"
@@ -202,7 +207,11 @@ export default function SecretsNew() {
             <PlusLg className={cx("bi", "me-1")} />
             Add
           </Button>
-          <Button className="btn-outline-rk-green" onClick={toggleModal}>
+          <Button
+            className="btn-outline-rk-green"
+            data-cy="secrets-new-cancel-button"
+            onClick={toggleModal}
+          >
             <XLg className={cx("bi", "me-1")} />
             Cancel
           </Button>

--- a/client/src/features/secrets/SecretNew.tsx
+++ b/client/src/features/secrets/SecretNew.tsx
@@ -169,10 +169,10 @@ export default function SecretsNew() {
               Hide/show secret value
             </UncontrolledTooltip>
           </Button>
+          {errors.value && (
+            <div className="invalid-feedback">{errors.value.message}</div>
+          )}
         </InputGroup>
-        {errors.value && (
-          <div className="invalid-feedback">{errors.value.message}</div>
-        )}
       </div>
     </Form>
   );

--- a/client/src/features/secrets/SecretNew.tsx
+++ b/client/src/features/secrets/SecretNew.tsx
@@ -107,6 +107,7 @@ export default function SecretsNew() {
           name="name"
           render={({ field }) => (
             <Input
+              autoComplete="new-password"
               className={cx("form-control", errors.name && "is-invalid")}
               id="new-secret-name"
               placeholder="Unique name"
@@ -139,6 +140,7 @@ export default function SecretsNew() {
             name="value"
             render={({ field }) => (
               <Input
+                autoComplete="new-password"
                 className={cx(
                   "form-control",
                   "rounded-0",

--- a/client/src/features/secrets/Secrets.tsx
+++ b/client/src/features/secrets/Secrets.tsx
@@ -18,18 +18,30 @@
 
 import { Col, Row } from "reactstrap";
 
+import SecretsList from "./SecretsList";
+import SecretNew from "./SecretNew";
+
 export default function Secrets() {
   return (
     <>
       <Row>
         <Col>
-          <h2>Secrets</h2>
+          <h2>User Secrets</h2>
+          <p>
+            Here you can add, edit and remove user secrets that you can mount
+            into your sessions (missing DOC REF).
+          </p>
         </Col>
       </Row>
       <Row>
-        <p>
-          <i>Work in progress...</i>
-        </p>
+        <Col>
+          <SecretNew />
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          <SecretsList />
+        </Col>
       </Row>
     </>
   );

--- a/client/src/features/secrets/Secrets.tsx
+++ b/client/src/features/secrets/Secrets.tsx
@@ -22,7 +22,7 @@ import { Col, Row } from "reactstrap";
 import SecretsList from "./SecretsList";
 import SecretNew from "./SecretNew";
 import { ExternalLink } from "../../components/ExternalLinks";
-import { DOCS_SECRETS_URL } from "./secrets.utils";
+import { SECRETS_DOCS_URL } from "./secrets.utils";
 import WipBadge from "../projectsV2/shared/WipBadge";
 import useLegacySelector from "../../utils/customHooks/useLegacySelector.hook";
 import { User } from "../../model/renkuModels.types";
@@ -36,22 +36,25 @@ export default function Secrets() {
 
   const pageInfo = user.logged ? (
     <>
+      <p>Here you can store secrets to use in your sessions.</p>
+
       <p>
-        Here you can add, edit and remove secrets that you can mount into your
-        sessions. Please refer to the{" "}
+        To use secrets in a session, start a session via “Start with Options” in
+        the Session start drop down menu. Then scroll down to the User Secrets
+        section and select the secrets you would like to include in the session.
+        The secrets you select will be mounted in the session as files in a
+        directory of your choice as <code>secret-name.txt</code>.
+      </p>
+      <p>
+        For more information, please refer to{" "}
         <ExternalLink
           role="text"
           iconSup={true}
           iconAfter={true}
-          title="documentation page Secrets in RenkuLab"
-          url={DOCS_SECRETS_URL}
+          title="our documentation"
+          url={SECRETS_DOCS_URL}
         />
         .
-      </p>
-      <p>
-        Mind that you will need to click on the &quot;Start with options&quot;
-        menu entry on the Start Sessions dropdown button and manually select the
-        secrets you want to mount.
       </p>
     </>
   ) : (

--- a/client/src/features/secrets/Secrets.tsx
+++ b/client/src/features/secrets/Secrets.tsx
@@ -27,7 +27,7 @@ import WipBadge from "../projectsV2/shared/WipBadge";
 
 export default function Secrets() {
   return (
-    <>
+    <div data-cy="secrets-page">
       <Row>
         <Col>
           <div className={cx("d-flex", "mb-2")}>
@@ -66,6 +66,6 @@ export default function Secrets() {
           <SecretsList />
         </Col>
       </Row>
-    </>
+    </div>
   );
 }

--- a/client/src/features/secrets/Secrets.tsx
+++ b/client/src/features/secrets/Secrets.tsx
@@ -16,20 +16,43 @@
  * limitations under the License
  */
 
+import cx from "classnames";
 import { Col, Row } from "reactstrap";
 
 import SecretsList from "./SecretsList";
 import SecretNew from "./SecretNew";
+import { ExternalLink } from "../../components/ExternalLinks";
+import { DOCS_SECRETS_URL } from "./secrets.utils";
+import WipBadge from "../projectsV2/shared/WipBadge";
 
 export default function Secrets() {
   return (
     <>
       <Row>
         <Col>
-          <h2>User Secrets</h2>
+          <div className={cx("d-flex", "mb-2")}>
+            <h2 className={cx("mb-0", "me-2")}>User Secrets</h2>
+            <div className="my-auto">
+              <WipBadge />
+            </div>
+          </div>
+
           <p>
-            Here you can add, edit and remove user secrets that you can mount
-            into your sessions (missing DOC REF).
+            Here you can add, edit and remove secrets that you can mount into
+            your sessions. Please refer to the{" "}
+            <ExternalLink
+              role="text"
+              iconSup={true}
+              iconAfter={true}
+              title="documentation page Secrets in RenkuLab"
+              url={DOCS_SECRETS_URL}
+            />
+            .
+          </p>
+          <p>
+            Mind that you will need to click on the &quot;Start with
+            options&quot; menu entry on the Start Sessions dropdown button and
+            manually select the secrets you want to mount.
           </p>
         </Col>
       </Row>

--- a/client/src/features/secrets/Secrets.tsx
+++ b/client/src/features/secrets/Secrets.tsx
@@ -24,8 +24,46 @@ import SecretNew from "./SecretNew";
 import { ExternalLink } from "../../components/ExternalLinks";
 import { DOCS_SECRETS_URL } from "./secrets.utils";
 import WipBadge from "../projectsV2/shared/WipBadge";
+import useLegacySelector from "../../utils/customHooks/useLegacySelector.hook";
+import { User } from "../../model/renkuModels.types";
+import { Loader } from "../../components/Loader";
+import LoginAlert from "../../components/loginAlert/LoginAlert";
 
 export default function Secrets() {
+  const user = useLegacySelector<User>((state) => state.stateModel.user);
+
+  if (!user.fetched) return <Loader />;
+
+  const pageInfo = user.logged ? (
+    <>
+      <p>
+        Here you can add, edit and remove secrets that you can mount into your
+        sessions. Please refer to the{" "}
+        <ExternalLink
+          role="text"
+          iconSup={true}
+          iconAfter={true}
+          title="documentation page Secrets in RenkuLab"
+          url={DOCS_SECRETS_URL}
+        />
+        .
+      </p>
+      <p>
+        Mind that you will need to click on the &quot;Start with options&quot;
+        menu entry on the Start Sessions dropdown button and manually select the
+        secrets you want to mount.
+      </p>
+    </>
+  ) : (
+    <>
+      <LoginAlert
+        logged={user.logged}
+        textIntro="Only authenticated users can create and manage Secrets."
+        textPost="to access this page."
+      />
+    </>
+  );
+
   return (
     <div data-cy="secrets-page">
       <Row>
@@ -36,36 +74,23 @@ export default function Secrets() {
               <WipBadge />
             </div>
           </div>
-
-          <p>
-            Here you can add, edit and remove secrets that you can mount into
-            your sessions. Please refer to the{" "}
-            <ExternalLink
-              role="text"
-              iconSup={true}
-              iconAfter={true}
-              title="documentation page Secrets in RenkuLab"
-              url={DOCS_SECRETS_URL}
-            />
-            .
-          </p>
-          <p>
-            Mind that you will need to click on the &quot;Start with
-            options&quot; menu entry on the Start Sessions dropdown button and
-            manually select the secrets you want to mount.
-          </p>
+          <div>{pageInfo}</div>
         </Col>
       </Row>
-      <Row>
-        <Col>
-          <SecretNew />
-        </Col>
-      </Row>
-      <Row>
-        <Col>
-          <SecretsList />
-        </Col>
-      </Row>
+      {user.logged && (
+        <>
+          <Row>
+            <Col>
+              <SecretNew />
+            </Col>
+          </Row>
+          <Row>
+            <Col>
+              <SecretsList />
+            </Col>
+          </Row>
+        </>
+      )}
     </div>
   );
 }

--- a/client/src/features/secrets/SecretsList.tsx
+++ b/client/src/features/secrets/SecretsList.tsx
@@ -1,0 +1,51 @@
+/*!
+ * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+import cx from "classnames";
+import { Col, Container, Row } from "reactstrap";
+
+import { Loader } from "../../components/Loader";
+import { useGetSecretsQuery } from "./secrets.api";
+import { RtkOrNotebooksError } from "../../components/errors/RtkErrorAlert";
+import SecretsListItem from "./SecretsListItem";
+
+export default function SecretsList() {
+  const secrets = useGetSecretsQuery();
+
+  if (secrets.isLoading) return <Loader />;
+
+  if (secrets.isError)
+    return <RtkOrNotebooksError dismissible={false} error={secrets.error} />;
+
+  if (secrets.data?.length === 0) return <p>No secrets found</p>;
+
+  const secretsList = secrets.data?.map((secret) => {
+    return (
+      <Col key={secret}>
+        <SecretsListItem secretName={secret} />
+      </Col>
+    );
+  });
+  return (
+    <Container className={cx("p-0", "mt-2")} fluid data-cy="cloud-storage-rows">
+      <Row className={cx("gy-2", "row-cols-1", "row-cols-lg-2")}>
+        {secretsList}
+      </Row>
+    </Container>
+  );
+}

--- a/client/src/features/secrets/SecretsList.tsx
+++ b/client/src/features/secrets/SecretsList.tsx
@@ -32,7 +32,7 @@ export default function SecretsList() {
   if (secrets.isError)
     return <RtkOrNotebooksError dismissible={false} error={secrets.error} />;
 
-  if (secrets.data?.length === 0) return <p>No secrets found</p>;
+  if (secrets.data?.length === 0) return null;
 
   const secretsList = secrets.data?.map((secret) => {
     return (

--- a/client/src/features/secrets/SecretsList.tsx
+++ b/client/src/features/secrets/SecretsList.tsx
@@ -36,8 +36,8 @@ export default function SecretsList() {
 
   const secretsList = secrets.data?.map((secret) => {
     return (
-      <Col key={secret}>
-        <SecretsListItem secretName={secret} />
+      <Col key={secret.id}>
+        <SecretsListItem secret={secret} />
       </Col>
     );
   });

--- a/client/src/features/secrets/SecretsList.tsx
+++ b/client/src/features/secrets/SecretsList.tsx
@@ -42,7 +42,7 @@ export default function SecretsList() {
     );
   });
   return (
-    <Container className={cx("p-0", "mt-2")} fluid data-cy="cloud-storage-rows">
+    <Container className={cx("p-0", "mt-2")} data-cy="secrets-list" fluid>
       <Row className={cx("gy-2", "row-cols-1", "row-cols-lg-2")}>
         {secretsList}
       </Row>

--- a/client/src/features/secrets/SecretsList.tsx
+++ b/client/src/features/secrets/SecretsList.tsx
@@ -43,7 +43,7 @@ export default function SecretsList() {
   });
   return (
     <Container className={cx("p-0", "mt-2")} data-cy="secrets-list" fluid>
-      <Row className={cx("gy-2", "row-cols-1", "row-cols-lg-2")}>
+      <Row className={cx("g-2", "row-cols-1", "row-cols-xl-2")}>
         {secretsList}
       </Row>
     </Container>

--- a/client/src/features/secrets/SecretsListItem.tsx
+++ b/client/src/features/secrets/SecretsListItem.tsx
@@ -45,8 +45,8 @@ export default function SecretsListItem({ secret }: SecretsListItemProps) {
           )}
         >
           <span className="fw-bold">{secret.name}</span>
-          <span className="text-rk-text-light my-auto small">
-            Edited {+new Date(secret.modification_date) - +new Date() < 5_000}
+          <span className={cx("text-rk-text-light", "my-auto small")}>
+            Edited{" "}
             <TimeCaption
               datetime={secret.modification_date}
               enableTooltip

--- a/client/src/features/secrets/SecretsListItem.tsx
+++ b/client/src/features/secrets/SecretsListItem.tsx
@@ -20,18 +20,16 @@ import cx from "classnames";
 import { useCallback, useState } from "react";
 import { Card, CardBody, Collapse } from "reactstrap";
 
-import { Loader } from "../../components/Loader";
-import { useGetSecretDetailsQuery } from "./secrets.api";
 import ChevronFlippedIcon from "../../components/icons/ChevronFlippedIcon";
-import { RtkOrNotebooksError } from "../../components/errors/RtkErrorAlert";
 import { TimeCaption } from "../../components/TimeCaption";
 import SecretEdit from "./SecretEdit";
 import SecretDelete from "./SecretDelete";
+import { SecretDetails } from "./secrets.types";
 
 interface SecretsListItemProps {
-  secretName: string;
+  secret: SecretDetails;
 }
-export default function SecretsListItem({ secretName }: SecretsListItemProps) {
+export default function SecretsListItem({ secret }: SecretsListItemProps) {
   const [showDetails, setShowDetails] = useState(false);
   const toggleDetails = useCallback(() => {
     setShowDetails((showDetails) => !showDetails);
@@ -44,56 +42,38 @@ export default function SecretsListItem({ secretName }: SecretsListItemProps) {
           className={cx("d-flex", "w-100", "p-3", "bg-transparent", "border-0")}
           onClick={toggleDetails}
         >
-          <div>{secretName}</div>
+          <div>{secret.name}</div>
           <div className="ms-auto">
             <ChevronFlippedIcon flipped={showDetails} />
           </div>
         </button>
       </CardBody>
       <Collapse isOpen={showDetails} mountOnEnter>
-        <SecretListItemDetails secretName={secretName} />
+        <CardBody className={cx("border-top", "pb-0")}>
+          <div>
+            <div className="mb-2">
+              <p className={cx("mb-0", "text-rk-text-light")}>ID</p>
+              <p className="mb-0">{secret.id ? secret.id : "N/A"}</p>
+            </div>
+            <div className="mb-2">
+              <p className={cx("mb-0", "text-rk-text-light")}>Last modified</p>
+              <p className="mb-0">
+                <TimeCaption
+                  datetime={secret.modification_date}
+                  enableTooltip
+                  noCaption
+                  prefix=""
+                />
+              </p>
+            </div>
+          </div>
+        </CardBody>
+
+        <CardBody className={cx("d-flex", "justify-content-end", "pt-0")}>
+          <SecretEdit secretId={secret.id} />
+          <SecretDelete secretId={secret.id} />
+        </CardBody>
       </Collapse>
     </Card>
-  );
-}
-
-function SecretListItemDetails({ secretName }: SecretsListItemProps) {
-  const secretDetails = useGetSecretDetailsQuery(secretName);
-
-  if (secretDetails.isLoading) return <Loader />;
-
-  const detailSection = secretDetails.isError ? (
-    <RtkOrNotebooksError dismissible={false} error={secretDetails.error} />
-  ) : (
-    <div>
-      <div className="mb-2">
-        <p className={cx("mb-0", "text-rk-text-light")}>ID</p>
-        <p className="mb-0">
-          {secretDetails.data?.id ? secretDetails.data.id : "N/A"}
-        </p>
-      </div>
-      <div className="mb-2">
-        <p className={cx("mb-0", "text-rk-text-light")}>Last modified</p>
-        <p className="mb-0">
-          <TimeCaption
-            datetime={secretDetails.data?.modification_date}
-            enableTooltip
-            noCaption
-            prefix=""
-          />
-        </p>
-      </div>
-    </div>
-  );
-
-  return (
-    <>
-      <CardBody className={cx("border-top", "pb-0")}>{detailSection}</CardBody>
-
-      <CardBody className={cx("d-flex", "justify-content-end", "pt-0")}>
-        <SecretEdit secretId={secretName} />
-        <SecretDelete secretId={secretName} />
-      </CardBody>
-    </>
   );
 }

--- a/client/src/features/secrets/SecretsListItem.tsx
+++ b/client/src/features/secrets/SecretsListItem.tsx
@@ -17,10 +17,8 @@
  */
 
 import cx from "classnames";
-import { useCallback, useState } from "react";
-import { Card, CardBody, Collapse } from "reactstrap";
+import { Card, CardBody } from "reactstrap";
 
-import ChevronFlippedIcon from "../../components/icons/ChevronFlippedIcon";
 import { TimeCaption } from "../../components/TimeCaption";
 import SecretEdit from "./SecretEdit";
 import SecretDelete from "./SecretDelete";
@@ -30,50 +28,38 @@ interface SecretsListItemProps {
   secret: SecretDetails;
 }
 export default function SecretsListItem({ secret }: SecretsListItemProps) {
-  const [showDetails, setShowDetails] = useState(false);
-  const toggleDetails = useCallback(() => {
-    setShowDetails((showDetails) => !showDetails);
-  }, []);
-
   return (
-    <Card className="border" data-cy="secrets-list-item">
-      <CardBody className="p-0">
-        <button
-          className={cx("d-flex", "w-100", "p-3", "bg-transparent", "border-0")}
-          onClick={toggleDetails}
+    <Card
+      className="border"
+      data-cy="secrets-list-item"
+      key={secret.id + secret.modification_date} // force re-render on updates
+    >
+      <CardBody>
+        <div
+          className={cx(
+            "d-flex",
+            "gap-3",
+            "flex-wrap",
+            "align-items-center",
+            "w-100"
+          )}
         >
-          <div>{secret.name}</div>
-          <div className="ms-auto">
-            <ChevronFlippedIcon flipped={showDetails} />
+          <span className="fw-bold">{secret.name}</span>
+          <span className="text-rk-text-light my-auto small">
+            Edited {+new Date(secret.modification_date) - +new Date() < 5_000}
+            <TimeCaption
+              datetime={secret.modification_date}
+              enableTooltip
+              noCaption
+              prefix=""
+            />
+          </span>
+          <div className={cx("ms-auto", "d-flex", "gap-2")}>
+            <SecretEdit secret={secret} />
+            <SecretDelete secret={secret} />
           </div>
-        </button>
+        </div>
       </CardBody>
-      <Collapse isOpen={showDetails} mountOnEnter>
-        <CardBody className={cx("border-top", "pb-0")}>
-          <div>
-            <div className="mb-2">
-              <p className={cx("mb-0", "text-rk-text-light")}>ID</p>
-              <p className="mb-0">{secret.id ? secret.id : "N/A"}</p>
-            </div>
-            <div className="mb-2">
-              <p className={cx("mb-0", "text-rk-text-light")}>Last modified</p>
-              <p className="mb-0">
-                <TimeCaption
-                  datetime={secret.modification_date}
-                  enableTooltip
-                  noCaption
-                  prefix=""
-                />
-              </p>
-            </div>
-          </div>
-        </CardBody>
-
-        <CardBody className={cx("d-flex", "justify-content-end", "pt-0")}>
-          <SecretEdit secret={secret} />
-          <SecretDelete secret={secret} />
-        </CardBody>
-      </Collapse>
     </Card>
   );
 }

--- a/client/src/features/secrets/SecretsListItem.tsx
+++ b/client/src/features/secrets/SecretsListItem.tsx
@@ -70,8 +70,8 @@ export default function SecretsListItem({ secret }: SecretsListItemProps) {
         </CardBody>
 
         <CardBody className={cx("d-flex", "justify-content-end", "pt-0")}>
-          <SecretEdit secretId={secret.id} />
-          <SecretDelete secretId={secret.id} />
+          <SecretEdit secret={secret} />
+          <SecretDelete secret={secret} />
         </CardBody>
       </Collapse>
     </Card>

--- a/client/src/features/secrets/SecretsListItem.tsx
+++ b/client/src/features/secrets/SecretsListItem.tsx
@@ -1,0 +1,102 @@
+/*!
+ * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+import cx from "classnames";
+import { useCallback, useState } from "react";
+import { Card, CardBody, Collapse } from "reactstrap";
+
+import { Loader } from "../../components/Loader";
+import { useGetSecretDetailsQuery } from "./secrets.api";
+import ChevronFlippedIcon from "../../components/icons/ChevronFlippedIcon";
+import { RtkOrNotebooksError } from "../../components/errors/RtkErrorAlert";
+import { TimeCaption } from "../../components/TimeCaption";
+import SecretEdit from "./SecretEdit";
+import SecretDelete from "./SecretDelete";
+
+const NOT_AVAILABLE = "N/A";
+
+interface SecretsListItemProps {
+  secretName: string;
+}
+export default function SecretsListItem({ secretName }: SecretsListItemProps) {
+  const [showDetails, setShowDetails] = useState(false);
+
+  const toggleDetails = useCallback(() => {
+    setShowDetails((showDetails) => !showDetails);
+  }, []);
+
+  return (
+    <Card className="border">
+      <CardBody className="p-0">
+        <button
+          className={cx("d-flex", "w-100", "p-3", "bg-transparent", "border-0")}
+          onClick={toggleDetails}
+        >
+          <div>{secretName}</div>
+          <div className="ms-auto">
+            <ChevronFlippedIcon flipped={showDetails} />
+          </div>
+        </button>
+      </CardBody>
+      <Collapse isOpen={showDetails} mountOnEnter>
+        <SecretListItemDetails secretName={secretName} />
+      </Collapse>
+    </Card>
+  );
+}
+
+function SecretListItemDetails({ secretName }: SecretsListItemProps) {
+  const secretDetails = useGetSecretDetailsQuery(secretName);
+
+  if (secretDetails.isLoading) return <Loader />;
+
+  const detailSection = secretDetails.isError ? (
+    <RtkOrNotebooksError dismissible={false} error={secretDetails.error} />
+  ) : (
+    <div>
+      <div className="mb-2">
+        <p className={cx("mb-0", "text-rk-text-light")}>ID</p>
+        <p className="mb-0">
+          {secretDetails.data?.id ? secretDetails.data.id : NOT_AVAILABLE}
+        </p>
+      </div>
+      <div className="mb-2">
+        <p className={cx("mb-0", "text-rk-text-light")}>Last modified</p>
+        <p className="mb-0">
+          <TimeCaption
+            datetime={secretDetails.data?.modification_date}
+            enableTooltip
+            noCaption
+            prefix=""
+          />
+        </p>
+      </div>
+    </div>
+  );
+
+  return (
+    <>
+      <CardBody className={cx("border-top", "pb-0")}>{detailSection}</CardBody>
+
+      <CardBody className={cx("d-flex", "justify-content-end", "pt-0")}>
+        <SecretEdit secretId={secretName} />
+        <SecretDelete secretId={secretName} />
+      </CardBody>
+    </>
+  );
+}

--- a/client/src/features/secrets/SecretsListItem.tsx
+++ b/client/src/features/secrets/SecretsListItem.tsx
@@ -28,14 +28,11 @@ import { TimeCaption } from "../../components/TimeCaption";
 import SecretEdit from "./SecretEdit";
 import SecretDelete from "./SecretDelete";
 
-const NOT_AVAILABLE = "N/A";
-
 interface SecretsListItemProps {
   secretName: string;
 }
 export default function SecretsListItem({ secretName }: SecretsListItemProps) {
   const [showDetails, setShowDetails] = useState(false);
-
   const toggleDetails = useCallback(() => {
     setShowDetails((showDetails) => !showDetails);
   }, []);
@@ -72,7 +69,7 @@ function SecretListItemDetails({ secretName }: SecretsListItemProps) {
       <div className="mb-2">
         <p className={cx("mb-0", "text-rk-text-light")}>ID</p>
         <p className="mb-0">
-          {secretDetails.data?.id ? secretDetails.data.id : NOT_AVAILABLE}
+          {secretDetails.data?.id ? secretDetails.data.id : "N/A"}
         </p>
       </div>
       <div className="mb-2">

--- a/client/src/features/secrets/SecretsListItem.tsx
+++ b/client/src/features/secrets/SecretsListItem.tsx
@@ -36,7 +36,7 @@ export default function SecretsListItem({ secret }: SecretsListItemProps) {
   }, []);
 
   return (
-    <Card className="border">
+    <Card className="border" data-cy="secrets-list-item">
       <CardBody className="p-0">
         <button
           className={cx("d-flex", "w-100", "p-3", "bg-transparent", "border-0")}

--- a/client/src/features/secrets/secrets.api.ts
+++ b/client/src/features/secrets/secrets.api.ts
@@ -31,44 +31,24 @@ const secretsApi = createApi({
   }),
   tagTypes: ["Secrets", "Secret"],
   endpoints: (builder) => ({
-    getSecrets: builder.query<string[], void>({
+    getSecrets: builder.query<SecretDetails[], void>({
       query: () => {
         return {
           url: "",
-          // ! TMP API - until APIs are deployed and responding
-          validateStatus: (response) => {
-            return response.status < 400 || response.status === 404;
-          },
         };
       },
       providesTags: ["Secrets"],
-      // ! TMP API - until APIs are deployed and responding
-      transformResponse: () => {
-        return ["Secret1", "Secret2"];
-      },
     }),
     getSecretDetails: builder.query<SecretDetails, string>({
       query: (secretId) => {
         return {
           url: secretId,
-          // ! TMP API - until APIs are deployed and responding
-          validateStatus: (response) => {
-            return response.status < 400 || response.status === 404;
-          },
         };
       },
       providesTags: (result, _error, secretId) =>
         result && result.id === secretId
           ? [{ type: "Secret", id: secretId }]
           : [],
-      // ! TMP API - until APIs are deployed and responding
-      transformResponse: (_arg1, _arg2, arg3) => {
-        return {
-          id: "1234-1234-5678-abcd",
-          name: arg3,
-          modification_date: new Date(),
-        };
-      },
     }),
     addSecret: builder.mutation<SecretDetails, AddSecretParams>({
       query: (secret) => {
@@ -76,10 +56,6 @@ const secretsApi = createApi({
           url: "",
           method: "POST",
           body: secret,
-          // ! TMP API - until APIs are deployed and responding
-          validateStatus: (response) => {
-            return response.status < 400 || response.status === 404;
-          },
         };
       },
       invalidatesTags: ["Secrets"],
@@ -90,13 +66,10 @@ const secretsApi = createApi({
           url: secret.id,
           method: "PATCH",
           body: { value: secret.value },
-          // ! TMP API - until APIs are deployed and responding
-          validateStatus: (response) => {
-            return response.status < 400 || response.status === 404;
-          },
         };
       },
       invalidatesTags: (_result, _error, params) => [
+        "Secrets",
         { type: "Secret", id: params.id },
       ],
     }),
@@ -105,10 +78,6 @@ const secretsApi = createApi({
         return {
           url: secretId,
           method: "DELETE",
-          // ! TMP API - until APIs are deployed and responding
-          validateStatus: (response) => {
-            return response.status < 400 || response.status === 404;
-          },
         };
       },
       invalidatesTags: (_result, _error, param) => [

--- a/client/src/features/secrets/secrets.api.ts
+++ b/client/src/features/secrets/secrets.api.ts
@@ -1,0 +1,94 @@
+/*!
+ * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+
+import {
+  AddSecretParams,
+  EditSecretParams,
+  SecretDetails,
+} from "./secrets.types";
+
+const secretsApi = createApi({
+  reducerPath: "secrets",
+  baseQuery: fetchBaseQuery({
+    baseUrl: "/ui-server/api/data/user/secrets",
+  }),
+  tagTypes: ["Secrets", "Secret"],
+  endpoints: (builder) => ({
+    getSecrets: builder.query<string[], void>({
+      query: () => {
+        return {
+          url: "",
+        };
+      },
+      providesTags: ["Secrets"],
+      // ! Double check we don't need this anymore
+      // // validateStatus: (response, body) => { return response.status < 400 && !body.error?.code; },
+    }),
+    getSecretDetails: builder.query<SecretDetails, string>({
+      query: (secretId) => {
+        return {
+          url: secretId,
+        };
+      },
+      providesTags: (result, _error, secretId) =>
+        result && result.id === secretId
+          ? [{ type: "Secret" as const, id: secretId }]
+          : [],
+    }),
+    addSecret: builder.mutation<SecretDetails, AddSecretParams>({
+      query: (secret) => {
+        return {
+          url: "",
+          method: "POST",
+          body: secret,
+        };
+      },
+      invalidatesTags: ["Secrets"],
+    }),
+    editSecret: builder.mutation<SecretDetails, EditSecretParams>({
+      query: (secret) => {
+        return {
+          url: secret.id,
+          method: "PATCH",
+          body: { value: secret.value },
+        };
+      },
+      // ? We don't need to invalidate the secrets since we never get the values anyway
+    }),
+    deleteSecret: builder.mutation<void, string>({
+      query: (secretId) => {
+        return {
+          url: secretId,
+          method: "DELETE",
+        };
+      },
+      invalidatesTags: ["Secrets"],
+    }),
+  }),
+});
+
+export default secretsApi;
+export const {
+  useGetSecretsQuery,
+  useGetSecretDetailsQuery,
+  useAddSecretMutation,
+  useEditSecretMutation,
+  useDeleteSecretMutation,
+} = secretsApi;

--- a/client/src/features/secrets/secrets.api.ts
+++ b/client/src/features/secrets/secrets.api.ts
@@ -35,22 +35,40 @@ const secretsApi = createApi({
       query: () => {
         return {
           url: "",
+          // ! TMP API - until APIs are deployed and responding
+          validateStatus: (response) => {
+            return response.status < 400 || response.status === 404;
+          },
         };
       },
       providesTags: ["Secrets"],
-      // ! Double check we don't need this anymore
-      // // validateStatus: (response, body) => { return response.status < 400 && !body.error?.code; },
+      // ! TMP API - until APIs are deployed and responding
+      transformResponse: () => {
+        return ["Secret1", "Secret2"];
+      },
     }),
     getSecretDetails: builder.query<SecretDetails, string>({
       query: (secretId) => {
         return {
           url: secretId,
+          // ! TMP API - until APIs are deployed and responding
+          validateStatus: (response) => {
+            return response.status < 400 || response.status === 404;
+          },
         };
       },
       providesTags: (result, _error, secretId) =>
         result && result.id === secretId
-          ? [{ type: "Secret" as const, id: secretId }]
+          ? [{ type: "Secret", id: secretId }]
           : [],
+      // ! TMP API - until APIs are deployed and responding
+      transformResponse: (_arg1, _arg2, arg3) => {
+        return {
+          id: "1234-1234-5678-abcd",
+          name: arg3,
+          modification_date: new Date(),
+        };
+      },
     }),
     addSecret: builder.mutation<SecretDetails, AddSecretParams>({
       query: (secret) => {
@@ -58,6 +76,10 @@ const secretsApi = createApi({
           url: "",
           method: "POST",
           body: secret,
+          // ! TMP API - until APIs are deployed and responding
+          validateStatus: (response) => {
+            return response.status < 400 || response.status === 404;
+          },
         };
       },
       invalidatesTags: ["Secrets"],
@@ -68,18 +90,31 @@ const secretsApi = createApi({
           url: secret.id,
           method: "PATCH",
           body: { value: secret.value },
+          // ! TMP API - until APIs are deployed and responding
+          validateStatus: (response) => {
+            return response.status < 400 || response.status === 404;
+          },
         };
       },
-      // ? We don't need to invalidate the secrets since we never get the values anyway
+      invalidatesTags: (_result, _error, params) => [
+        { type: "Secret", id: params.id },
+      ],
     }),
     deleteSecret: builder.mutation<void, string>({
       query: (secretId) => {
         return {
           url: secretId,
           method: "DELETE",
+          // ! TMP API - until APIs are deployed and responding
+          validateStatus: (response) => {
+            return response.status < 400 || response.status === 404;
+          },
         };
       },
-      invalidatesTags: ["Secrets"],
+      invalidatesTags: (_result, _error, param) => [
+        "Secrets",
+        { type: "Secret", id: param },
+      ],
     }),
   }),
 });

--- a/client/src/features/secrets/secrets.module.scss
+++ b/client/src/features/secrets/secrets.module.scss
@@ -1,0 +1,6 @@
+.blurredText,
+.blurredText:focus,
+.blurredText::selection {
+  color: transparent;
+  text-shadow: 0 0 8px rgba(0, 0, 0, 0.5);
+}

--- a/client/src/features/secrets/secrets.types.ts
+++ b/client/src/features/secrets/secrets.types.ts
@@ -1,0 +1,33 @@
+/*!
+ * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface SecretDetails {
+  id: string;
+  modification_date: Date;
+  name: string;
+}
+
+export interface AddSecretParams {
+  name: string;
+  value: string;
+}
+
+export interface EditSecretParams {
+  id: string;
+  value: string;
+}

--- a/client/src/features/secrets/secrets.utils.tsx
+++ b/client/src/features/secrets/secrets.utils.tsx
@@ -18,4 +18,11 @@
 
 import { Docs } from "../../utils/constants/Docs";
 
-export const DOCS_SECRETS_URL = Docs.rtdTopicGuide("secrets/secrets.html");
+export const SECRETS_DOCS_URL = Docs.rtdTopicGuide("secrets/secrets.html");
+
+export const SECRETS_VALUE_LENGTH_LIMIT = 5_000;
+
+export const BLUR_TEXT_STYLE = {
+  color: "transparent",
+  textShadow: "0 0 8px rgba(0,0,0,0.5)",
+};

--- a/client/src/features/secrets/secrets.utils.tsx
+++ b/client/src/features/secrets/secrets.utils.tsx
@@ -16,24 +16,6 @@
  * limitations under the License.
  */
 
-export interface SecretDetails {
-  id: string;
-  modification_date: Date;
-  name: string;
-}
+import { Docs } from "../../utils/constants/Docs";
 
-export interface AddSecretParams {
-  name: string;
-  value: string;
-}
-
-export interface EditSecretParams {
-  id: string;
-  value: string;
-}
-
-export type AddSecretForm = AddSecretParams;
-
-export interface EditSecretForm {
-  value: string;
-}
+export const DOCS_SECRETS_URL = Docs.rtdTopicGuide("secrets/secrets.html");

--- a/client/src/features/secrets/secrets.utils.tsx
+++ b/client/src/features/secrets/secrets.utils.tsx
@@ -21,8 +21,3 @@ import { Docs } from "../../utils/constants/Docs";
 export const SECRETS_DOCS_URL = Docs.rtdTopicGuide("secrets/secrets.html");
 
 export const SECRETS_VALUE_LENGTH_LIMIT = 5_000;
-
-export const BLUR_TEXT_STYLE = {
-  color: "transparent",
-  textShadow: "0 0 8px rgba(0,0,0,0.5)",
-};

--- a/client/src/utils/helpers/EnhancedState.ts
+++ b/client/src/utils/helpers/EnhancedState.ts
@@ -49,6 +49,7 @@ import { projectV2NewSlice } from "../../features/projectsV2/new/projectV2New.sl
 import { recentUserActivityApi } from "../../features/recentUserActivity/RecentUserActivityApi";
 import searchV2Api from "../../features/searchV2/searchV2.api";
 import { searchV2Slice } from "../../features/searchV2/searchV2.slice";
+import secretsApi from "../../features/secrets/secrets.api";
 import sessionsApi from "../../features/session/sessions.api";
 import sessionSidecarApi from "../../features/session/sidecar.api";
 import startSessionSlice from "../../features/session/startSession.slice";
@@ -103,6 +104,7 @@ export const createStore = <S = any, A extends Action = AnyAction>(
     [projectV2Api.reducerPath]: projectV2Api.reducer,
     [recentUserActivityApi.reducerPath]: recentUserActivityApi.reducer,
     [searchV2Api.reducerPath]: searchV2Api.reducer,
+    [secretsApi.reducerPath]: secretsApi.reducer,
     [sessionsApi.reducerPath]: sessionsApi.reducer,
     [sessionSidecarApi.reducerPath]: sessionSidecarApi.reducer,
     [sessionsV2Api.reducerPath]: sessionsV2Api.reducer,
@@ -138,6 +140,7 @@ export const createStore = <S = any, A extends Action = AnyAction>(
         .concat(projectV2Api.middleware)
         .concat(recentUserActivityApi.middleware)
         .concat(searchV2Api.middleware)
+        .concat(secretsApi.middleware)
         .concat(sessionsApi.middleware)
         .concat(sessionSidecarApi.middleware)
         .concat(sessionSidecarApi.middleware)

--- a/tests/cypress/e2e/secrets.spec.ts
+++ b/tests/cypress/e2e/secrets.spec.ts
@@ -49,15 +49,7 @@ describe("Secrets", () => {
     cy.get("#new-secret-button").should("be.visible");
     cy.getDataCy("secrets-list").should("exist");
     cy.getDataCy("secrets-list-item").should("have.length", 5);
-    cy.getDataCy("secrets-list")
-      .find('[data-cy="secrets-list-item"] button')
-      .first()
-      .contains("secret_0")
-      .click();
-    cy.getDataCy("secrets-list")
-      .find('[data-cy="secrets-list-item"]')
-      .first()
-      .contains("id_0");
+    cy.getDataCy("secrets-list").first().contains("secret_0").click();
 
     cy.get("#new-secret-button").should("be.visible").click();
     cy.getDataCy("secrets-new-add-button").should("be.visible").click();
@@ -91,11 +83,7 @@ describe("Secrets", () => {
     fixtures.userTest().listSecrets({ numberOfSecrets: 2 }).editSecret();
     cy.visit("/secrets");
 
-    cy.getDataCy("secrets-list")
-      .find('[data-cy="secrets-list-item"] button')
-      .first()
-      .contains("secret_0")
-      .click();
+    cy.getDataCy("secrets-list").first().contains("secret_0").click();
     cy.getDataCy("secrets-list")
       .find('[data-cy="secret-edit-button"]')
       .first()
@@ -111,11 +99,7 @@ describe("Secrets", () => {
     fixtures.userTest().listSecrets({ numberOfSecrets: 2 }).deleteSecret();
     cy.visit("/secrets");
 
-    cy.getDataCy("secrets-list")
-      .find('[data-cy="secrets-list-item"] button')
-      .first()
-      .contains("secret_0")
-      .click();
+    cy.getDataCy("secrets-list").first().contains("secret_0").click();
     cy.getDataCy("secrets-list")
       .find('[data-cy="secret-delete-button"]')
       .first()

--- a/tests/cypress/e2e/secrets.spec.ts
+++ b/tests/cypress/e2e/secrets.spec.ts
@@ -1,0 +1,116 @@
+/*!
+ * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fixtures from "../support/renkulab-fixtures";
+
+describe("Secrets", () => {
+  beforeEach(() => {
+    fixtures.config().versions().userTest();
+  });
+
+  it("Load and empty secrets page", () => {
+    fixtures.listSecrets();
+    cy.visit("/secrets");
+
+    cy.get("#new-secret-button").should("be.visible");
+    cy.getDataCy("secrets-list").should("not.exist");
+  });
+
+  it("Load page with secrets", () => {
+    fixtures.listSecrets({ numberOfSecrets: 5 });
+    cy.visit("/secrets");
+
+    cy.get("#new-secret-button").should("be.visible");
+    cy.getDataCy("secrets-list").should("exist");
+    cy.getDataCy("secrets-list-item").should("have.length", 5);
+    cy.getDataCy("secrets-list")
+      .find('[data-cy="secrets-list-item"] button')
+      .first()
+      .contains("secret_0")
+      .click();
+    cy.getDataCy("secrets-list")
+      .find('[data-cy="secrets-list-item"]')
+      .first()
+      .contains("id_0");
+  });
+
+  it("Edit secret", () => {
+    fixtures.listSecrets({ numberOfSecrets: 2 }).editSecret();
+    cy.visit("/secrets");
+
+    cy.getDataCy("secrets-list")
+      .find('[data-cy="secrets-list-item"] button')
+      .first()
+      .contains("secret_0")
+      .click();
+    cy.getDataCy("secrets-list")
+      .find('[data-cy="secret-edit-button"]')
+      .first()
+      .click();
+
+    cy.getDataCy("secrets-edit-form").should("be.visible");
+    cy.get("#edit-secret-value").type("new_value");
+    cy.getDataCy("secrets-edit-edit-button").should("be.enabled").click();
+    cy.getDataCy("secrets-edit-form").should("not.be.visible");
+  });
+
+  it("Delete secret", () => {
+    fixtures.listSecrets({ numberOfSecrets: 2 }).deleteSecret();
+    cy.visit("/secrets");
+
+    cy.getDataCy("secrets-list")
+      .find('[data-cy="secrets-list-item"] button')
+      .first()
+      .contains("secret_0")
+      .click();
+    cy.getDataCy("secrets-list")
+      .find('[data-cy="secret-delete-button"]')
+      .first()
+      .click();
+
+    cy.getDataCy("secrets-delete-delete-button").should("be.enabled").click();
+    cy.getDataCy("secrets-delete-delete-button").should("not.be.visible");
+  });
+
+  // ! TODO: finish test and inspect delay issue
+  // it("Create secret", () => {
+  //   fixtures.listSecrets();
+  //   cy.visit("/secrets");
+  //   cy.wait("@listSecrets");
+
+  //   // eslint-disable-next-line cypress/no-unnecessary-waiting
+  //   cy.wait(500); // ! something's off with showing the modal
+  //   cy.get("#new-secret-button").should("be.visible").click();
+  //   // cy.get("#new-secret-button").should("be.visible").click();
+
+  //   // cy.getDataCy("secrets-list")
+  //   //   .find('[data-cy="secrets-list-item"] button')
+  //   //   .first()
+  //   //   .contains("secret_0")
+  //   //   .click();
+  //   // cy.getDataCy("secrets-list")
+  //   //   .find('[data-cy="secret-edit-button"]')
+  //   //   .first()
+  //   //   .click();
+
+  //   // cy.getDataCy("secrets-edit-form").should("be.visible");
+  //   // cy.get("#edit-secret-value").type("new_value");
+  //   // cy.getDataCy("secrets-edit-edit-button").should("be.enabled").click();
+  //   // cy.getDataCy("secrets-edit-form").should("not.be.visible");
+  // });
+});

--- a/tests/cypress/support/renkulab-fixtures/index.ts
+++ b/tests/cypress/support/renkulab-fixtures/index.ts
@@ -32,6 +32,7 @@ import { NewSession } from "./newSession";
 import { Projects } from "./projects";
 import { ProjectV2 } from "./projectV2";
 import { SearchV2 } from "./searchV2";
+import { Secrets } from "./secrets";
 import { Sessions } from "./sessions";
 import { Terms } from "./terms";
 import { User } from "./user";
@@ -51,10 +52,14 @@ const V1Fixtures = NewProject(
                 Projects(
                   ProjectV2(
                     SearchV2(
-                      Terms(
-                        User(
-                          UserPreferences(
-                            Versions(Workflows(KgSearch(Global(BaseFixtures))))
+                      Secrets(
+                        Terms(
+                          User(
+                            UserPreferences(
+                              Versions(
+                                Workflows(KgSearch(Global(BaseFixtures)))
+                              )
+                            )
                           )
                         )
                       )

--- a/tests/cypress/support/renkulab-fixtures/secrets.ts
+++ b/tests/cypress/support/renkulab-fixtures/secrets.ts
@@ -48,6 +48,21 @@ export function Secrets<T extends FixturesConstructor>(Parent: T) {
       return this;
     }
 
+    newSecret(args?: NameOnlyFixture) {
+      const { name = "fake_id" } = args ?? {};
+      const response = {
+        body: {
+          id: "fake_id",
+          modification_date: new Date(),
+          name: "fake_secret",
+        },
+      };
+      cy.intercept("POST", "/ui-server/api/data/user/secrets", response).as(
+        name
+      );
+      return this;
+    }
+
     editSecret(args?: NameOnlyFixture) {
       const { name = "editSecret" } = args ?? {};
       const response = {

--- a/tests/cypress/support/renkulab-fixtures/secrets.ts
+++ b/tests/cypress/support/renkulab-fixtures/secrets.ts
@@ -1,0 +1,77 @@
+/*!
+ * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FixturesConstructor } from "./fixtures";
+import { NameOnlyFixture } from "./fixtures.types";
+
+interface ListSecretsArgs extends NameOnlyFixture {
+  numberOfSecrets?: number;
+}
+
+function generateFakeSecrets(num: number) {
+  const secrets = [];
+  for (let i = 0; i < num; ++i) {
+    secrets.push({
+      id: `id_${i}`,
+      modification_date: new Date(),
+      name: `secret_${i}`,
+    });
+  }
+  return secrets;
+}
+
+export function Secrets<T extends FixturesConstructor>(Parent: T) {
+  return class SecretsFixtures extends Parent {
+    listSecrets(args?: ListSecretsArgs) {
+      const { name = "listSecrets", numberOfSecrets = 0 } = args ?? {};
+      const response = {
+        body: generateFakeSecrets(numberOfSecrets),
+      };
+      cy.intercept("GET", "/ui-server/api/data/user/secrets", response).as(
+        name
+      );
+      return this;
+    }
+
+    editSecret(args?: NameOnlyFixture) {
+      const { name = "editSecret" } = args ?? {};
+      const response = {
+        body: {
+          id: "fake_id",
+          modification_date: new Date(),
+          name: "fake_secret",
+        },
+      };
+      cy.intercept("PATCH", "/ui-server/api/data/user/secrets/*", response).as(
+        name
+      );
+      return this;
+    }
+
+    deleteSecret(args?: NameOnlyFixture) {
+      const { name = "deleteSecret" } = args ?? {};
+      const response = {
+        body: {},
+      };
+      cy.intercept("DELETE", "/ui-server/api/data/user/secrets/*", response).as(
+        name
+      );
+      return this;
+    }
+  };
+}


### PR DESCRIPTION
This PR implements the first part of #3100 , adding a new page to list and manage user secrets.

![image](https://github.com/SwissDataScienceCenter/renku-ui/assets/43481553/9c7cff94-6f5b-41c9-bfff-8dddf17c79a6)

The new page is accessible from the User dropdown menu on the top right.

![image](https://github.com/SwissDataScienceCenter/renku-ui/assets/43481553/d8003594-9cac-4a72-b44a-ccc73fbce53b)

re #3100

/deploy #notest renku=build/secrets-in-sessions renku-data-services=pitch/secret-storage secrets-storage=pitch/secret-storage extra-values=secretsStorage.encryptionKey=vMqdVXcSIwjwONvGiNE2vjzRjmi8NJ8Y9lTB8m3l/Xg=