### PR TITLE
[ShapeUp] feat: update start session with options

### DIFF
--- a/client/src/features/projectsV2/shared/WipBadge.tsx
+++ b/client/src/features/projectsV2/shared/WipBadge.tsx
@@ -21,9 +21,13 @@ import { Badge, UncontrolledTooltip } from "reactstrap";
 
 type WipBadeProps = {
   label?: string;
+  text?: string;
 };
 
-export default function WipBadge({ label = "Alpha" }: WipBadeProps) {
+export default function WipBadge({
+  label = "Alpha",
+  text = "Renku 2.0 is under active development and features may not work as expected.",
+}: WipBadeProps) {
   const ref = useRef<HTMLElement>(null);
 
   return (
@@ -31,10 +35,7 @@ export default function WipBadge({ label = "Alpha" }: WipBadeProps) {
       <Badge className="wip-badge" color="warning" innerRef={ref}>
         {label}
       </Badge>
-      <UncontrolledTooltip target={ref}>
-        Renku 2.0 is under active development and features may not work as
-        expected.
-      </UncontrolledTooltip>
+      <UncontrolledTooltip target={ref}>{text}</UncontrolledTooltip>
     </>
   );
 }

--- a/client/src/features/secrets/LazySecrets.tsx
+++ b/client/src/features/secrets/LazySecrets.tsx
@@ -18,7 +18,7 @@
 
 import { Suspense, lazy } from "react";
 
-import PageLoader from "./Secrets";
+import PageLoader from "../../components/PageLoader";
 
 const Secrets = lazy(() => import("./Secrets"));
 

--- a/client/src/features/secrets/SecretNew.tsx
+++ b/client/src/features/secrets/SecretNew.tsx
@@ -99,8 +99,8 @@ export default function SecretsNew() {
     <>
       <p>Here you can add a new secret to use in your sessions.</p>
       <p>
-        Names must be unique and can contain only letters, numbers, underscores
-        (_), and dashes (-). Values are limited to 5000 characters.
+        Names must be unique and can contain only letters, numbers, dots (.),
+        underscores (_), and dashes (-). Values are limited to 5000 characters.
       </p>
       <Form
         className="form-rk-green"
@@ -129,8 +129,10 @@ export default function SecretsNew() {
               validate: (value) =>
                 secrets.data?.map((s) => s.name).includes(value)
                   ? "This name is already used by another secret."
-                  : !/^[a-zA-Z0-9_-]+$/.test(value)
-                  ? "Only letters, numbers, underscores (_), and dashes (-)."
+                  : value && value.startsWith(".")
+                  ? "Name cannot start with a dot."
+                  : !/^[a-zA-Z0-9_.-]+$/.test(value)
+                  ? "Only letters, numbers, dots (.), underscores (_), and dashes (-)."
                   : undefined,
             }}
           />

--- a/client/src/features/secrets/Secrets.tsx
+++ b/client/src/features/secrets/Secrets.tsx
@@ -74,7 +74,7 @@ export default function Secrets() {
           <div className={cx("d-flex", "mb-2")}>
             <h2 className={cx("mb-0", "me-2")}>User Secrets</h2>
             <div className="my-auto">
-              <WipBadge />
+              <WipBadge text="This feature is under development and certain pieces may not work correctly." />
             </div>
           </div>
           <div>{pageInfo}</div>

--- a/client/src/features/session/components/StartNewSession.tsx
+++ b/client/src/features/session/components/StartNewSession.tsx
@@ -695,8 +695,8 @@ function StartSessionButton() {
     environmentVariables,
     lfsAutoFetch,
     pinnedDockerImage,
-    // secretsPath,
-    // secretsList,
+    secretsPath,
+    secretsList,
     sessionClass,
     storage,
   } = useAppSelector(({ startSessionOptions }) => startSessionOptions);
@@ -748,6 +748,11 @@ function StartSessionButton() {
     const imageValidated =
       dockerImageStatus === "not-available" ? undefined : pinnedDockerImage;
 
+    const userSecrets = secretsList.map((secret) => ({
+      id: secret.id,
+      path: secretsPath,
+    }));
+
     dispatch(setStarting(true));
     dispatch(
       setSteps([
@@ -768,6 +773,7 @@ function StartSessionButton() {
       lfsAutoFetch,
       namespace,
       project,
+      secrets: userSecrets,
       sessionClass,
       storage,
     });
@@ -783,6 +789,8 @@ function StartSessionButton() {
     namespace,
     pinnedDockerImage,
     project,
+    secretsList,
+    secretsPath,
     sessionClass,
     startSession,
     storage,

--- a/client/src/features/session/components/StartNewSession.tsx
+++ b/client/src/features/session/components/StartNewSession.tsx
@@ -71,6 +71,7 @@ import SessionCloudStorageOption from "./options/SessionCloudStorageOption";
 import SessionCommitOption from "./options/SessionCommitOption";
 import SessionDockerImage from "./options/SessionDockerImage";
 import SessionEnvironmentVariables from "./options/SessionEnvironmentVariables";
+import SessionUserSecrets from "./options/SessionUserSecrets";
 import { StartNotebookServerOptions } from "./options/StartNotebookServerOptions";
 
 export default function StartNewSession() {
@@ -663,6 +664,7 @@ function StartNewSessionOptions() {
       <SessionCommitOption />
       <StartNotebookServerOptions />
       <SessionCloudStorageOption />
+      <SessionUserSecrets />
       <SessionEnvironmentVariables />
     </>
   );

--- a/client/src/features/session/components/StartNewSession.tsx
+++ b/client/src/features/session/components/StartNewSession.tsx
@@ -748,10 +748,12 @@ function StartSessionButton() {
     const imageValidated =
       dockerImageStatus === "not-available" ? undefined : pinnedDockerImage;
 
-    const userSecrets = secretsList.map((secret) => ({
-      id: secret.id,
-      path: secretsPath,
-    }));
+    const userSecrets = secretsList.length
+      ? {
+          mount_path: secretsPath ? secretsPath : "/",
+          user_secrets_ids: secretsList.map((secret) => secret.id),
+        }
+      : undefined;
 
     dispatch(setStarting(true));
     dispatch(

--- a/client/src/features/session/components/StartNewSession.tsx
+++ b/client/src/features/session/components/StartNewSession.tsx
@@ -695,6 +695,8 @@ function StartSessionButton() {
     environmentVariables,
     lfsAutoFetch,
     pinnedDockerImage,
+    // secretsPath,
+    // secretsList,
     sessionClass,
     storage,
   } = useAppSelector(({ startSessionOptions }) => startSessionOptions);

--- a/client/src/features/session/components/options/AutostartSessionOptions.tsx
+++ b/client/src/features/session/components/options/AutostartSessionOptions.tsx
@@ -426,7 +426,6 @@ function useAutostartSessionOptions(): void {
       namespace,
       project,
       sessionClass: currentSessionClassId,
-      secrets: [],
       storage,
     });
   }, [

--- a/client/src/features/session/components/options/AutostartSessionOptions.tsx
+++ b/client/src/features/session/components/options/AutostartSessionOptions.tsx
@@ -426,6 +426,7 @@ function useAutostartSessionOptions(): void {
       namespace,
       project,
       sessionClass: currentSessionClassId,
+      secrets: [],
       storage,
     });
   }, [

--- a/client/src/features/session/components/options/SessionUserSecrets.tsx
+++ b/client/src/features/session/components/options/SessionUserSecrets.tsx
@@ -1,0 +1,54 @@
+/*!
+ * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+import cx from "classnames";
+import { Link } from "react-router-dom";
+
+import { Loader } from "../../../../components/Loader";
+import { User } from "../../../../model/renkuModels.types";
+import useLegacySelector from "../../../../utils/customHooks/useLegacySelector.hook";
+import { Url } from "../../../../utils/helpers/url";
+
+export default function SessionUserSecrets() {
+  const secretsUrl = Url.get(Url.pages.secrets);
+  const user = useLegacySelector<User>((state) => state.stateModel.user);
+
+  if (!user.fetched) return <Loader />;
+
+  const content = user.logged ? (
+    <>
+      <div className={cx("form-text", "my-1")}>
+        You can select secrets defined in the{" "}
+        <Link to={secretsUrl}> User Secrets page</Link> and mount them as files
+        in your session.
+        {/* <MountUserSecrets /> */}
+      </div>
+    </>
+  ) : (
+    <div className={cx("form-text", "my-1")}>
+      This feature is only available to logged users.
+    </div>
+  );
+
+  return (
+    <div className="field-group">
+      <div className="form-label">User Secrets</div>
+      {content}
+    </div>
+  );
+}

--- a/client/src/features/session/components/options/SessionUserSecrets.tsx
+++ b/client/src/features/session/components/options/SessionUserSecrets.tsx
@@ -122,6 +122,7 @@ function SessionUserSecretsSection() {
             "py-2",
             "w-100"
           )}
+          data-cy="session-secrets-toggle"
           color="none"
           onClick={toggleIsOpen}
         >

--- a/client/src/features/session/components/options/SessionUserSecrets.tsx
+++ b/client/src/features/session/components/options/SessionUserSecrets.tsx
@@ -126,21 +126,7 @@ function SessionUserSecretsSection() {
           color="none"
           onClick={toggleIsOpen}
         >
-          <span>
-            Secrets to mount:{" "}
-            {sessionOptions.secretsList.length > 0 ? (
-              <span className="fw-bold">
-                {[...sessionOptions.secretsList]
-                  .map((s) => s.name)
-                  .sort((a, b) => {
-                    return a.localeCompare(b); // localCompare is used to ignore case
-                  })
-                  .join(", ")}
-              </span>
-            ) : (
-              <span className="fw-bold">None</span>
-            )}
-          </span>
+          <MountedSecrets secretsList={sessionOptions.secretsList} />
           <div className="ms-auto">
             <ChevronFlippedIcon flipped={isOpen} />
           </div>
@@ -174,66 +160,81 @@ function SessionUserSecretsSection() {
             </div>
             <div>
               <Label className="form-label">Secrets</Label>
-              <div data-cy="session-secrets-checkbox-list">
-                {secrets.data &&
-                  [...secrets.data]
-                    .sort((a, b) => {
-                      return a.name.localeCompare(b.name);
-                    })
-                    .map((secret) => (
-                      <div
-                        className={cx("d-flex", "form-check", "form-switch")}
-                        key={secret.id}
-                      >
-                        <Input
-                          checked={sessionOptions.secretsList
-                            .map((s) => s.name)
-                            .includes(secret.name)}
-                          className={cx(
-                            "form-check-input",
-                            "me-2",
-                            "my-auto",
-                            "rounded-pill"
-                          )}
-                          data-cy="session-secrets-checkbox"
-                          name={`secrets-session-${secret.name}`}
-                          onChange={() => updateSecretsList(secret)}
-                          role="switch"
-                          type="checkbox"
-                        />
-                        <Label
-                          className={cx("form-check-label", "my-auto")}
-                          for={`secrets-session-${secret.name}`}
-                        >
-                          {secret.name}
-                        </Label>
-                      </div>
-                    ))}
-              </div>
-
-              {/* <div className="d-flex gap-2 flex-wrap">
-                {secrets.data?.map((secret) => (
-                  <Badge
-                    className="cursor-pointer rounded-pill fs-6 fw-normal text-primary border border-dark-subtle "
-                    color="none"
-                    key={secret.id}
-                  >
-                    {secret.name}
-                  </Badge>
-                  // <Button
-                  //   className="btn-outline-rk-green"
-                  //   key={secret.id}
-                  //   size="sm"
-                  //   onClick={() => {}}
-                  // >
-                  //   {secret.name}
-                  // </Button>
-                ))}
-              </div> */}
+              <SecretsCheckboxList
+                secrets={secrets.data}
+                selectedSecrets={sessionOptions.secretsList}
+                updateSecretsList={updateSecretsList}
+              />
             </div>
           </div>
         </CardBody>
       </Collapse>
     </Card>
   );
+}
+
+interface SecretsCheckboxListProps {
+  secrets?: SessionSecrets[];
+  selectedSecrets?: SessionSecrets[];
+  updateSecretsList: (secret: SessionSecrets) => void;
+}
+function SecretsCheckboxList({
+  secrets,
+  selectedSecrets,
+  updateSecretsList,
+}: SecretsCheckboxListProps) {
+  if (!secrets || !secrets.length) return null;
+  const sortedSecrets = [...secrets].sort((a, b) => {
+    return a.name.localeCompare(b.name);
+  });
+  const selectedSecretsNames =
+    selectedSecrets && selectedSecrets.length
+      ? selectedSecrets.map((s) => s.name)
+      : [];
+  return (
+    <div data-cy="session-secrets-checkbox-list">
+      {sortedSecrets.map((secret) => (
+        <div
+          className={cx("d-flex", "form-check", "form-switch")}
+          key={secret.id}
+        >
+          <Input
+            checked={selectedSecretsNames.includes(secret.name)}
+            className={cx(
+              "form-check-input",
+              "me-2",
+              "my-auto",
+              "rounded-pill"
+            )}
+            data-cy="session-secrets-checkbox"
+            name={`secrets-session-${secret.name}`}
+            onChange={() => updateSecretsList(secret)}
+            role="switch"
+            type="checkbox"
+          />
+          <Label
+            className={cx("form-check-label", "my-auto")}
+            for={`secrets-session-${secret.name}`}
+          >
+            {secret.name}
+          </Label>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+interface MountedSecretsProps {
+  secretsList: SessionSecrets[];
+}
+function MountedSecrets({ secretsList }: MountedSecretsProps) {
+  const content = !secretsList.length
+    ? "None"
+    : [...secretsList]
+        .map((s) => s.name)
+        .sort((a, b) => {
+          return a.localeCompare(b); // localCompare is used to ignore case
+        })
+        .join(", ");
+  return <span className="fw-bold">{content}</span>;
 }

--- a/client/src/features/session/components/options/SessionUserSecrets.tsx
+++ b/client/src/features/session/components/options/SessionUserSecrets.tsx
@@ -31,6 +31,7 @@ import { RtkOrNotebooksError } from "../../../../components/errors/RtkErrorAlert
 import { setSecretsList, setSecretsPath } from "../../startSessionOptionsSlice";
 import useAppDispatch from "../../../../utils/customHooks/useAppDispatch.hook";
 import useAppSelector from "../../../../utils/customHooks/useAppSelector.hook";
+import { SessionSecrets } from "../../startSessionOptions.types";
 
 export default function SessionUserSecrets() {
   const secretsUrl = Url.get(Url.pages.secrets);
@@ -81,10 +82,12 @@ function SessionUserSecretsSection() {
     [dispatch]
   );
   const updateSecretsList = useCallback(
-    (secret: string) => {
-      if (sessionOptions.secretsList.includes(secret)) {
+    (secret: SessionSecrets) => {
+      if (sessionOptions.secretsList.map((s) => s.name).includes(secret.name)) {
         dispatch(
-          setSecretsList(sessionOptions.secretsList.filter((s) => s !== secret))
+          setSecretsList(
+            sessionOptions.secretsList.filter((s) => s.name !== secret.name)
+          )
         );
       } else {
         dispatch(setSecretsList([...sessionOptions.secretsList, secret]));
@@ -124,7 +127,12 @@ function SessionUserSecretsSection() {
             Secrets to mount:{" "}
             {sessionOptions.secretsList.length > 0 ? (
               <span className="fw-bold">
-                {sessionOptions.secretsList.join(", ")}
+                {[...sessionOptions.secretsList]
+                  .map((s) => s.name)
+                  .sort((a, b) => {
+                    return a.localeCompare(b); // localCompare is used to ignore case
+                  })
+                  .join(", ")}
               </span>
             ) : (
               <span className="fw-bold">None</span>
@@ -159,54 +167,58 @@ function SessionUserSecretsSection() {
             <div>
               <Label className="form-label">Secrets</Label>
               <div>
-                {secrets.data?.map((secret) => (
-                  <div
-                    className={cx("form-check", "form-switch", "d-flex")}
-                    key={secret.id}
-                  >
-                    <Input
-                      checked={sessionOptions.secretsList.includes(secret.name)}
-                      className={cx(
-                        "form-check-input",
-                        "rounded-pill",
-                        "my-auto",
-                        "me-2"
-                      )}
-                      name={`secrets-session-${secret.name}`}
-                      onChange={() => updateSecretsList(secret.name)}
-                      role="switch"
-                      type="checkbox"
-                    />
-                    <Label
-                      className={cx("form-check-label", "my-auto")}
-                      for={`secrets-session-${secret.name}`}
-                    >
-                      {secret.name}
-                    </Label>
-                  </div>
-                ))}
+                {secrets.data &&
+                  [...secrets.data]
+                    .sort((a, b) => {
+                      return a.name.localeCompare(b.name);
+                    })
+                    .map((secret) => (
+                      <div
+                        className={cx("form-check", "form-switch", "d-flex")}
+                        key={secret.id}
+                      >
+                        <Input
+                          checked={sessionOptions.secretsList
+                            .map((s) => s.name)
+                            .includes(secret.name)}
+                          className={cx(
+                            "form-check-input",
+                            "rounded-pill",
+                            "my-auto",
+                            "me-2"
+                          )}
+                          name={`secrets-session-${secret.name}`}
+                          onChange={() => updateSecretsList(secret)}
+                          role="switch"
+                          type="checkbox"
+                        />
+                        <Label
+                          className={cx("form-check-label", "my-auto")}
+                          for={`secrets-session-${secret.name}`}
+                        >
+                          {secret.name}
+                        </Label>
+                      </div>
+                    ))}
               </div>
 
-              {/* <Label className="form-label" for="secrets-session-path">
-                Secrets
-              </Label>
-              <div className="d-flex gap-2">
+              {/* <div className="d-flex gap-2 flex-wrap">
                 {secrets.data?.map((secret) => (
-                  // <Badge
-                  //   className="cursor-pointer rounded-pill fs-6 fw-normal text-primary border border-dark-subtle "
-                  //   color="none"
-                  //   key={secret.id}
-                  // >
-                  //   {secret.name}
-                  // </Badge>
-                  <Button
-                    className="btn-outline-rk-green"
+                  <Badge
+                    className="cursor-pointer rounded-pill fs-6 fw-normal text-primary border border-dark-subtle "
+                    color="none"
                     key={secret.id}
-                    size="sm"
-                    onClick={() => {}}
                   >
                     {secret.name}
-                  </Button>
+                  </Badge>
+                  // <Button
+                  //   className="btn-outline-rk-green"
+                  //   key={secret.id}
+                  //   size="sm"
+                  //   onClick={() => {}}
+                  // >
+                  //   {secret.name}
+                  // </Button>
                 ))}
               </div> */}
             </div>

--- a/client/src/features/session/components/options/SessionUserSecrets.tsx
+++ b/client/src/features/session/components/options/SessionUserSecrets.tsx
@@ -55,7 +55,7 @@ export default function SessionUserSecrets() {
   );
 
   return (
-    <div className="field-group" data-cy="secrets-session">
+    <div className="field-group" data-cy="session-secrets">
       <div className="form-label">User Secrets</div>
       {content}
     </div>
@@ -105,23 +105,25 @@ function SessionUserSecretsSection() {
   if (secrets.isLoading) return <Loader />;
   if (secrets.isError)
     return <RtkOrNotebooksError dismissible={false} error={secrets.error} />;
-  if (secrets.data?.length === 0) return null;
+  if (secrets.data?.length === 0)
+    return (
+      <div className={cx("form-text", "my-1")}>No secrets defined yet.</div>
+    );
 
   return (
-    <Card className={cx("border", "border-dark-subtle")}>
-      <CardBody className={cx("px-0", "py-1")}>
+    <Card className={cx("border", "border-rk-border-input")}>
+      <CardBody className="p-0">
         <Button
           className={cx(
+            "bg-transparent",
+            "border-0",
             "d-flex",
-            "w-100",
             "px-3",
             "py-2",
-            "bg-transparent",
-            "border-0"
+            "w-100"
           )}
           color="none"
           onClick={toggleIsOpen}
-          size="sm"
         >
           <span>
             Secrets to mount:{" "}
@@ -145,28 +147,33 @@ function SessionUserSecretsSection() {
       </CardBody>
       <Collapse isOpen={isOpen}>
         <CardBody
-          className={cx("border-top", "border-dark-subtle", "small", "py-2")}
+          className={cx(
+            "border-rk-border-input",
+            "border-top",
+            "py-2",
+            "small"
+          )}
         >
           <div
             className="form-rk-green my-1"
-            data-cy="secrets-session-selection"
+            data-cy="session-secrets-selection"
           >
             <div className="mb-2">
               <Label className="form-label" for="secrets-session-path">
                 Mount path
               </Label>
               <Input
-                className="border-dark-subtle"
+                data-cy="session-secrets-mount-path"
                 id="secrets-session-path"
                 name="secrets-session-path"
+                onChange={(e) => changeSecretsPath(e.target.value)}
                 placeholder="/path/to/secrets"
                 value={sessionOptions.secretsPath}
-                onChange={(e) => changeSecretsPath(e.target.value)}
               />
             </div>
             <div>
               <Label className="form-label">Secrets</Label>
-              <div>
+              <div data-cy="session-secrets-checkbox-list">
                 {secrets.data &&
                   [...secrets.data]
                     .sort((a, b) => {
@@ -174,7 +181,7 @@ function SessionUserSecretsSection() {
                     })
                     .map((secret) => (
                       <div
-                        className={cx("form-check", "form-switch", "d-flex")}
+                        className={cx("d-flex", "form-check", "form-switch")}
                         key={secret.id}
                       >
                         <Input
@@ -183,10 +190,11 @@ function SessionUserSecretsSection() {
                             .includes(secret.name)}
                           className={cx(
                             "form-check-input",
-                            "rounded-pill",
+                            "me-2",
                             "my-auto",
-                            "me-2"
+                            "rounded-pill"
                           )}
+                          data-cy="session-secrets-checkbox"
                           name={`secrets-session-${secret.name}`}
                           onChange={() => updateSecretsList(secret)}
                           role="switch"

--- a/client/src/features/session/components/options/SessionUserSecrets.tsx
+++ b/client/src/features/session/components/options/SessionUserSecrets.tsx
@@ -64,7 +64,7 @@ export default function SessionUserSecrets() {
 
 function SessionUserSecretsSection() {
   // Handle the collapse
-  const [isOpen, setIsOpen] = useState(true);
+  const [isOpen, setIsOpen] = useState(false);
   const toggleIsOpen = useCallback(() => setIsOpen((isOpen) => !isOpen), []);
 
   // Fetch the secrets

--- a/client/src/features/session/sessions.api.ts
+++ b/client/src/features/session/sessions.api.ts
@@ -140,7 +140,7 @@ const sessionsApi = createApi({
           namespace,
           project,
           resource_class_id: sessionClass,
-          secrets,
+          ...(secrets ? { user_secrets: secrets } : {}),
           storage,
         };
         return {

--- a/client/src/features/session/sessions.api.ts
+++ b/client/src/features/session/sessions.api.ts
@@ -122,6 +122,7 @@ const sessionsApi = createApi({
         lfsAutoFetch,
         namespace,
         project,
+        secrets,
         sessionClass,
         storage,
       }) => {
@@ -139,6 +140,7 @@ const sessionsApi = createApi({
           namespace,
           project,
           resource_class_id: sessionClass,
+          secrets,
           storage,
         };
         return {

--- a/client/src/features/session/sessions.types.ts
+++ b/client/src/features/session/sessions.types.ts
@@ -100,7 +100,7 @@ export interface StartSessionParams {
   lfsAutoFetch: boolean;
   namespace: string;
   project: string;
-  secrets: SessionUserSecret[];
+  secrets?: SessionUserSecrets;
   sessionClass: number;
   storage: number;
 }
@@ -136,9 +136,9 @@ export interface CloudStorageDefinitionForSessionApi {
   target_path: string;
 }
 
-export interface SessionUserSecret {
-  id: string;
-  path: string;
+export interface SessionUserSecrets {
+  mount_path: string;
+  user_secrets_ids: string[];
 }
 
 export interface NotebooksErrorContent {

--- a/client/src/features/session/sessions.types.ts
+++ b/client/src/features/session/sessions.types.ts
@@ -100,6 +100,7 @@ export interface StartSessionParams {
   lfsAutoFetch: boolean;
   namespace: string;
   project: string;
+  secrets: SessionUserSecret[];
   sessionClass: number;
   storage: number;
 }
@@ -133,6 +134,11 @@ export interface CloudStorageDefinitionForSessionApi {
   readonly: boolean;
   source_path: string;
   target_path: string;
+}
+
+export interface SessionUserSecret {
+  id: string;
+  path: string;
 }
 
 export interface NotebooksErrorContent {

--- a/client/src/features/session/startSessionOptions.types.ts
+++ b/client/src/features/session/startSessionOptions.types.ts
@@ -28,6 +28,8 @@ export interface StartSessionOptions {
   environmentVariables: SessionEnvironmentVariable[];
   lfsAutoFetch: boolean;
   pinnedDockerImage: string;
+  secretsPath: string;
+  secretsList: string[];
   sessionClass: number;
   storage: number;
 }

--- a/client/src/features/session/startSessionOptions.types.ts
+++ b/client/src/features/session/startSessionOptions.types.ts
@@ -29,7 +29,7 @@ export interface StartSessionOptions {
   lfsAutoFetch: boolean;
   pinnedDockerImage: string;
   secretsPath: string;
-  secretsList: string[];
+  secretsList: SessionSecrets[];
   sessionClass: number;
   storage: number;
 }
@@ -62,4 +62,9 @@ export type DockerImageStatus =
 export interface SessionEnvironmentVariable {
   name: string;
   value: string;
+}
+
+export interface SessionSecrets {
+  name: string;
+  id: string;
 }

--- a/client/src/features/session/startSessionOptionsSlice.ts
+++ b/client/src/features/session/startSessionOptionsSlice.ts
@@ -37,6 +37,8 @@ const initialState: StartSessionOptions = {
   lfsAutoFetch: false,
   pinnedDockerImage: "",
   sessionClass: 0,
+  secretsPath: "",
+  secretsList: [],
   storage: MIN_SESSION_STORAGE_GB,
 };
 
@@ -110,6 +112,12 @@ export const startSessionOptionsSlice = createSlice({
     setSessionClass: (state, action: PayloadAction<number>) => {
       state.sessionClass = action.payload;
     },
+    setSecretsList: (state, action: PayloadAction<string[]>) => {
+      state.secretsList = action.payload;
+    },
+    setSecretsPath: (state, action: PayloadAction<string>) => {
+      state.secretsPath = action.payload;
+    },
     setStorage: (state, action: PayloadAction<number>) => {
       state.storage = action.payload;
     },
@@ -147,6 +155,8 @@ export const {
   setLfsAutoFetch,
   setPinnedDockerImage,
   setSessionClass,
+  setSecretsList,
+  setSecretsPath,
   setStorage,
   updateCloudStorageItem,
   updateEnvironmentVariable,

--- a/client/src/features/session/startSessionOptionsSlice.ts
+++ b/client/src/features/session/startSessionOptionsSlice.ts
@@ -23,6 +23,7 @@ import {
   DockerImageStatus,
   SessionCloudStorage,
   SessionEnvironmentVariable,
+  SessionSecrets,
   StartSessionOptions,
 } from "./startSessionOptions.types";
 
@@ -112,7 +113,7 @@ export const startSessionOptionsSlice = createSlice({
     setSessionClass: (state, action: PayloadAction<number>) => {
       state.sessionClass = action.payload;
     },
-    setSecretsList: (state, action: PayloadAction<string[]>) => {
+    setSecretsList: (state, action: PayloadAction<SessionSecrets[]>) => {
       state.secretsList = action.payload;
     },
     setSecretsPath: (state, action: PayloadAction<string>) => {

--- a/client/src/utils/helpers/url/Url.js
+++ b/client/src/utils/helpers/url/Url.js
@@ -493,6 +493,9 @@ const Url = {
     searchEntities: {
       base: "/search",
     },
+    secrets: {
+      base: "/secrets",
+    },
     groupV2: {
       base: "/v2/groups",
       new: "/v2/groups/new",

--- a/tests/cypress/e2e/newSession.spec.ts
+++ b/tests/cypress/e2e/newSession.spec.ts
@@ -194,6 +194,46 @@ describe("launch sessions", () => {
     cy.get("#cloud-storage-example-storage-active").should("be.checked");
   });
 
+  it("new session page - select secrets", () => {
+    // Check the output when no secrets are available
+    fixtures.listSecrets({ numberOfSecrets: 0 }).userTest();
+    cy.visit("/projects/e2e/local-test-project/sessions/new");
+    cy.get(".form-label").contains("User Secrets").should("be.visible");
+    cy.getDataCy("session-secrets")
+      .contains("No secrets defined yet.")
+      .should("be.visible");
+
+    // Select some secrets
+    fixtures.listSecrets({ numberOfSecrets: 5 });
+    cy.visit("/projects/e2e/local-test-project/sessions/new");
+    cy.getDataCy("session-secrets")
+      .contains("No secrets defined yet.")
+      .should("not.exist");
+    cy.getDataCy("session-secrets-toggle").contains("None").click();
+    cy.getDataCy("session-secrets-checkbox").should("have.length", 5);
+
+    cy.getDataCy("session-secrets-checkbox")
+      .first()
+      .should("not.be.checked")
+      .siblings()
+      .contains("secret_0");
+    cy.getDataCy("session-secrets-checkbox")
+      .first()
+      .click()
+      .should("be.checked");
+    cy.getDataCy("session-secrets-checkbox")
+      .last()
+      .should("not.be.checked")
+      .siblings()
+      .contains("secret_4");
+    cy.getDataCy("session-secrets-checkbox")
+      .last()
+      .click()
+      .should("be.checked");
+    cy.getDataCy("session-secrets-toggle").contains("None").should("not.exist");
+    cy.getDataCy("session-secrets-toggle").contains("secret_0, secret_4");
+  });
+
   it('new session page - show "email us" link', () => {
     fixtures.config({ fixture: "config-session-class-email-us.json" });
     fixtures.userTest();


### PR DESCRIPTION
This PR implements the second part of https://github.com/SwissDataScienceCenter/renku-ui/issues/3100 ,changing the "Start with options" page to include secrets.

re https://github.com/SwissDataScienceCenter/renku-ui/issues/3100

/deploy #notest renku=build/secrets-in-sessions renku-data-services=pitch/secret-storage secrets-storage=pitch/secret-storage extra-values=secretsStorage.encryptionKey=vMqdVXcSIwjwONvGiNE2vjzRjmi8NJ8Y9lTB8m3l/Xg=