### PR TITLE
feat: project page overview V2 (sessions and code repositories)

### DIFF
--- a/client/src/styles/bootstrap/_custom_bootstrap_variables2.0.scss
+++ b/client/src/styles/bootstrap/_custom_bootstrap_variables2.0.scss
@@ -31,7 +31,6 @@ $rk-bg-info: #dbeafe;
 $rk-success-50: #f7fee7;
 $rk-danger-50: #fef2f2;
 $rk-warning-50: #fefce8;
-
 $rk-success-100: #ecfccb;
 $rk-danger-100: #fee2e2;
 $rk-warning-100: #fef9c3;

--- a/tests/cypress/e2e/dashboard.spec.ts
+++ b/tests/cypress/e2e/dashboard.spec.ts
@@ -279,7 +279,7 @@ describe("dashboard message", () => {
 
     cy.getDataCy("dashboard-message")
       .find(".alert-icon")
-      .find('img[alt="info icon"]')
+      .find(".text-info")
       .should("be.visible");
 
     cy.getDataCy("dashboard-message")
@@ -312,7 +312,7 @@ describe("dashboard message", () => {
 
     cy.getDataCy("dashboard-message")
       .find(".alert-icon")
-      .find('img[alt="success icon"]')
+      .find(".text-success")
       .should("be.visible");
 
     cy.getDataCy("dashboard-message")


### PR DESCRIPTION
 PR to add project overview content. It includes:

Display session and code repositories.
Display session launcher info in side panel.
Add new session (custom image/existing environment).
Link existing code repository (Renku repo only).
Delete session launcher.
Remove code repository.
Edit session launcher.

Not included to handle cases where a user has no rights on the project.

![project overview](https://github.com/SwissDataScienceCenter/renku-ui/assets/43388408/568b6279-5b94-4314-9f94-024bd8a6076c)


/deploy renku=release-0.52.x