### PR TITLE
Show project members in the project information page

### DIFF
--- a/client/src/features/ProjectPageV2/ProjectPageContent/ProjectInformation/ProjectInformation.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/ProjectInformation/ProjectInformation.tsx
@@ -25,7 +25,11 @@ import {
 import VisibilityIcon from "../../../../components/entities/VisibilityIcon.tsx";
 import projectPreviewImg from "../../../../styles/assets/projectImagePreview.svg";
 import { Url } from "../../../../utils/helpers/url";
-import type { Project } from "../../../projectsV2/api/projectV2.api.ts";
+import type {
+  Project,
+  ProjectMemberListResponse,
+  ProjectMemberResponse,
+} from "../../../projectsV2/api/projectV2.api.ts";
 import { useGetProjectsByProjectIdMembersQuery } from "../../../projectsV2/api/projectV2.enhanced-api.ts";
 import MembershipGuard from "../../utils/MembershipGuard.tsx";
 import styles from "./ProjectInformation.module.scss";
@@ -39,6 +43,70 @@ export function ProjectImageView() {
         alt="Project image preview"
       />
     </div>
+  );
+}
+
+function ProjectInformationMember({
+  member,
+}: {
+  member: ProjectMemberResponse;
+}) {
+  const classNames = ["fw-bold", "mb-1"];
+  if (member.last_name != null) {
+    return (
+      <div className={cx(classNames)}>
+        {member.first_name ?? ""} {member.last_name}
+      </div>
+    );
+  }
+  if (member.email != null) {
+    return <div className={cx(classNames)}>{member.email}</div>;
+  }
+  return <div className={cx(classNames)}>{member.id}</div>;
+}
+
+interface ProjectInformationMembersProps {
+  members: ProjectMemberListResponse | undefined;
+  membersUrl: string;
+}
+
+const MAX_MEMBERS_DISPLAYED = 5;
+
+function ProjectInformationMembers({
+  members,
+  membersUrl,
+}: ProjectInformationMembersProps) {
+  if (members == null) return null;
+  if (members.length == 0) {
+    return (
+      <MembershipGuard
+        disabled={null}
+        enabled={
+          <UnderlineArrowLink
+            tooltip="Add project members"
+            text="Add members"
+            to={membersUrl}
+          />
+        }
+        members={members}
+        minimumRole="editor"
+      />
+    );
+  }
+
+  return (
+    <>
+      {members.slice(0, MAX_MEMBERS_DISPLAYED).map((member, index) => (
+        <ProjectInformationMember key={index} member={member} />
+      ))}
+      {members.length > MAX_MEMBERS_DISPLAYED && (
+        <UnderlineArrowLink
+          tooltip="View all project members"
+          text="All members"
+          to={membersUrl}
+        />
+      )}
+    </>
   );
 }
 
@@ -121,23 +189,7 @@ export default function ProjectInformation({ project }: { project: Project }) {
       </div>
       <div className={cx("border-bottom", "py-3", "text-start", "text-lg-end")}>
         <div>Members ({totalMembers})</div>
-        <MembershipGuard
-          disabled={
-            <UnderlineArrowLink
-              tooltip="View project members"
-              text="View members"
-              to={membersUrl}
-            />
-          }
-          enabled={
-            <UnderlineArrowLink
-              tooltip="Edit project members"
-              text="Edit members"
-              to={membersUrl}
-            />
-          }
-          members={members}
-        />
+        <ProjectInformationMembers members={members} membersUrl={membersUrl} />
       </div>
       <div className={cx("border-bottom", "py-3", "text-start", "text-lg-end")}>
         <div>Keywords ({totalKeywords})</div>

--- a/client/src/features/ProjectPageV2/ProjectPageContent/ProjectInformation/ProjectInformation.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/ProjectInformation/ProjectInformation.tsx
@@ -32,7 +32,7 @@ import type {
 } from "../../../projectsV2/api/projectV2.api.ts";
 import { useGetProjectsByProjectIdMembersQuery } from "../../../projectsV2/api/projectV2.enhanced-api.ts";
 import MembershipGuard from "../../utils/MembershipGuard.tsx";
-import { sortedMembers } from "../../utils/roleUtils.ts";
+import { toSortedMembers } from "../../utils/roleUtils.ts";
 import styles from "./ProjectInformation.module.scss";
 
 export function ProjectImageView() {
@@ -92,10 +92,10 @@ function ProjectInformationMembers({
       />
     );
   }
-  const membersSorted = sortedMembers(members);
+  const sortedMembers = toSortedMembers(members);
   return (
     <>
-      {membersSorted.slice(0, MAX_MEMBERS_DISPLAYED).map((member, index) => (
+      {sortedMembers.slice(0, MAX_MEMBERS_DISPLAYED).map((member, index) => (
         <ProjectInformationMember key={index} member={member} />
       ))}
       {members.length > MAX_MEMBERS_DISPLAYED && (

--- a/client/src/features/ProjectPageV2/ProjectPageContent/ProjectInformation/ProjectInformation.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/ProjectInformation/ProjectInformation.tsx
@@ -51,18 +51,16 @@ function ProjectInformationMember({
 }: {
   member: ProjectMemberResponse;
 }) {
-  const classNames = ["fw-bold", "mb-1"];
-  if (member.last_name != null) {
-    return (
-      <div className={cx(classNames)}>
-        {member.first_name ?? ""} {member.last_name}
-      </div>
-    );
-  }
-  if (member.email != null) {
-    return <div className={cx(classNames)}>{member.email}</div>;
-  }
-  return <div className={cx(classNames)}>{member.id}</div>;
+  const displayName =
+    member.first_name && member.last_name
+      ? `${member.first_name} ${member.last_name}`
+      : member.last_name
+      ? member.last_name
+      : member.email
+      ? member.email
+      : member.id;
+
+  return <div className={cx("fw-bold", "mb-1")}>{displayName}</div>;
 }
 
 interface ProjectInformationMembersProps {

--- a/client/src/features/ProjectPageV2/ProjectPageContent/ProjectInformation/ProjectInformation.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/ProjectInformation/ProjectInformation.tsx
@@ -32,6 +32,7 @@ import type {
 } from "../../../projectsV2/api/projectV2.api.ts";
 import { useGetProjectsByProjectIdMembersQuery } from "../../../projectsV2/api/projectV2.enhanced-api.ts";
 import MembershipGuard from "../../utils/MembershipGuard.tsx";
+import { sortedMembers } from "../../utils/roleUtils.ts";
 import styles from "./ProjectInformation.module.scss";
 
 export function ProjectImageView() {
@@ -91,10 +92,10 @@ function ProjectInformationMembers({
       />
     );
   }
-
+  const membersSorted = sortedMembers(members);
   return (
     <>
-      {members.slice(0, MAX_MEMBERS_DISPLAYED).map((member, index) => (
+      {membersSorted.slice(0, MAX_MEMBERS_DISPLAYED).map((member, index) => (
         <ProjectInformationMember key={index} member={member} />
       ))}
       {members.length > MAX_MEMBERS_DISPLAYED && (

--- a/client/src/features/ProjectPageV2/ProjectPageContent/Settings/ProjectSettingsMembers.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/Settings/ProjectSettingsMembers.tsx
@@ -39,7 +39,7 @@ import EditProjectMemberModal from "../../../projectsV2/fields/EditProjectMember
 import RemoveProjectMemberModal from "../../../projectsV2/fields/RemoveProjectMemberModal";
 
 import MembershipGuard from "../../utils/MembershipGuard.tsx";
-import { toNumericRole } from "../../utils/roleUtils.ts";
+import { sortedMembers } from "../../utils/roleUtils.ts";
 
 function OverviewBox({ children }: { children: ReactNode }) {
   return <div className={cx("bg-white", "rounded-3", "mt-3")}>{children}</div>;
@@ -150,15 +150,7 @@ function ProjectPageSettingsMembersTable({
   const [isEditMemberModalOpen, setIsEditMemberModalOpen] = useState(false);
   const [isRemoveMemberModalOpen, setIsRemoveMemberModalOpen] = useState(false);
   const [memberToEdit, setMemberToEdit] = useState<ProjectMemberResponse>();
-  const sortedMembers = [...members].sort((a, b) => {
-    if (a.role !== b.role) {
-      return toNumericRole(b.role) - toNumericRole(a.role);
-    }
-    if (a.email && b.email) {
-      return a.email.localeCompare(b.email);
-    }
-    return a.id < b.id ? -1 : 1;
-  });
+  const membersSorted = sortedMembers(members);
 
   const headerClasses = [
     "w-100",
@@ -198,7 +190,7 @@ function ProjectPageSettingsMembersTable({
           <span className={cx(headerClasses)}>Actions</span>
         </Col>
       </Row>
-      {sortedMembers.map((d, i) => {
+      {membersSorted.map((d, i) => {
         return (
           <ProjectPageSettingsMembersTableRow
             index={i}

--- a/client/src/features/ProjectPageV2/ProjectPageContent/Settings/ProjectSettingsMembers.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/Settings/ProjectSettingsMembers.tsx
@@ -39,7 +39,7 @@ import EditProjectMemberModal from "../../../projectsV2/fields/EditProjectMember
 import RemoveProjectMemberModal from "../../../projectsV2/fields/RemoveProjectMemberModal";
 
 import MembershipGuard from "../../utils/MembershipGuard.tsx";
-import { sortedMembers } from "../../utils/roleUtils.ts";
+import { toSortedMembers } from "../../utils/roleUtils.ts";
 
 function OverviewBox({ children }: { children: ReactNode }) {
   return <div className={cx("bg-white", "rounded-3", "mt-3")}>{children}</div>;
@@ -150,7 +150,7 @@ function ProjectPageSettingsMembersTable({
   const [isEditMemberModalOpen, setIsEditMemberModalOpen] = useState(false);
   const [isRemoveMemberModalOpen, setIsRemoveMemberModalOpen] = useState(false);
   const [memberToEdit, setMemberToEdit] = useState<ProjectMemberResponse>();
-  const membersSorted = sortedMembers(members);
+  const sortedMembers = toSortedMembers(members);
 
   const headerClasses = [
     "w-100",
@@ -190,7 +190,7 @@ function ProjectPageSettingsMembersTable({
           <span className={cx(headerClasses)}>Actions</span>
         </Col>
       </Row>
-      {membersSorted.map((d, i) => {
+      {sortedMembers.map((d, i) => {
         return (
           <ProjectPageSettingsMembersTableRow
             index={i}

--- a/client/src/features/ProjectPageV2/utils/roleUtils.ts
+++ b/client/src/features/ProjectPageV2/utils/roleUtils.ts
@@ -42,7 +42,10 @@ export function toNumericRole(role: string): number {
   return ROLE_MAP[r];
 }
 
-/** Return a sorted copy of the members */
+/** Return a sorted copy of the members
+ *
+ * Lexicographic sort by role (descending), email (ascending), user_id (ascending).
+ */
 export function sortedMembers(members: ProjectMemberListResponse) {
   return [...members].sort((a, b) => {
     if (a.role !== b.role) {

--- a/client/src/features/ProjectPageV2/utils/roleUtils.ts
+++ b/client/src/features/ProjectPageV2/utils/roleUtils.ts
@@ -16,7 +16,10 @@
  * limitations under the License.
  */
 
-import type { Role } from "../../projectsV2/api/projectV2.api";
+import type {
+  ProjectMemberListResponse,
+  Role,
+} from "../../projectsV2/api/projectV2.api";
 
 export type RoleOrNone = Role | "none";
 const ROLE_MAP: Record<RoleOrNone, number> = {
@@ -37,4 +40,17 @@ function stringToRoleOrNone(role: string): RoleOrNone {
 export function toNumericRole(role: string): number {
   const r = stringToRoleOrNone(role);
   return ROLE_MAP[r];
+}
+
+/** Return a sorted copy of the members */
+export function sortedMembers(members: ProjectMemberListResponse) {
+  return [...members].sort((a, b) => {
+    if (a.role !== b.role) {
+      return toNumericRole(b.role) - toNumericRole(a.role);
+    }
+    if (a.email && b.email) {
+      return a.email.localeCompare(b.email);
+    }
+    return a.id < b.id ? -1 : 1;
+  });
 }

--- a/client/src/features/ProjectPageV2/utils/roleUtils.ts
+++ b/client/src/features/ProjectPageV2/utils/roleUtils.ts
@@ -46,7 +46,7 @@ export function toNumericRole(role: string): number {
  *
  * Lexicographic sort by role (descending), email (ascending), user_id (ascending).
  */
-export function sortedMembers(members: ProjectMemberListResponse) {
+export function toSortedMembers(members: ProjectMemberListResponse) {
   return [...members].sort((a, b) => {
     if (a.role !== b.role) {
       return toNumericRole(b.role) - toNumericRole(a.role);

--- a/tests/cypress/e2e/projectV2.spec.ts
+++ b/tests/cypress/e2e/projectV2.spec.ts
@@ -166,31 +166,29 @@ describe("Navigate to project", () => {
   });
 
   it("shows project members", () => {
-    fixtures
-      .exactUser({
-        name: "getExactUserSuccess",
-        exactEmailQueryString: "foo%40bar.com",
-        response: [
-          {
-            id: "user-id",
-            email: "foo@bar.com",
-            first_name: "Foo",
-            last_name: "Bar",
-          },
-        ],
-      })
-      .exactUser({
-        name: "getExactUserFail",
-        exactEmailQueryString: "noone%40bar.com",
-        response: [],
-      })
-      .listProjectV2Members()
-      .readProjectV2();
-    cy.visit("/v2/projects/user1-uuid/test-2-v2-project/settings#members");
+    fixtures.listProjectV2Members().readProjectV2();
+    cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
     cy.wait("@readProjectV2");
-    cy.contains("Members of the project").should("be.visible");
     cy.contains("user1@email.com").should("be.visible");
     cy.contains("user3-uuid").should("be.visible");
+  });
+
+  it("shows at most 5 members", () => {
+    fixtures
+      .listProjectV2Members({
+        fixture: "projectV2/list-projectV2-members-many.json",
+      })
+      .readProjectV2();
+    cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
+    cy.wait("@readProjectV2");
+    cy.contains("User One").should("be.visible");
+    cy.contains("User Two").should("be.visible");
+    cy.contains("User Three").should("be.visible");
+    cy.contains("user4@email.com").should("be.visible");
+    cy.contains("user5-uuid").should("be.visible");
+    cy.contains("user6-uuid").should("not.exist");
+    cy.contains("All members").should("be.visible").click();
+    cy.contains("user6-uuid").should("be.visible");
   });
 });
 
@@ -496,7 +494,7 @@ describe("Editor cannot maintain members", () => {
   it("cannot change project members", () => {
     cy.contains("test 2 v2-project").should("be.visible");
     cy.wait("@listProjectV2Members");
-    cy.contains("View members").click();
+    cy.get("a[title='Settings']").click();
     cy.getDataCy("project-member-edit-1").should("be.disabled");
     cy.getDataCy("project-add-member").should("not.exist");
   });
@@ -530,7 +528,8 @@ describe("Viewer cannot edit project", () => {
     cy.wait("@getDataServicesUser");
     cy.getDataCy("project-settings-edit").should("not.exist");
     cy.getDataCy("project-description-edit").should("not.exist");
-    cy.contains("View members").should("be.visible");
+    cy.get("a[title='Settings']").click();
+    cy.getDataCy("project-member-edit-0").should("be.disabled");
   });
 
   it("cannot change project components", () => {

--- a/tests/cypress/e2e/projectV2.spec.ts
+++ b/tests/cypress/e2e/projectV2.spec.ts
@@ -173,7 +173,7 @@ describe("Navigate to project", () => {
     cy.contains("user3-uuid").should("be.visible");
   });
 
-  it("shows at most 5 members", () => {
+  it("shows at most 5 members, owners first", () => {
     fixtures
       .listProjectV2Members({
         fixture: "projectV2/list-projectV2-members-many.json",
@@ -185,10 +185,10 @@ describe("Navigate to project", () => {
     cy.contains("User Two").should("be.visible");
     cy.contains("User Three").should("be.visible");
     cy.contains("user4@email.com").should("be.visible");
-    cy.contains("user5-uuid").should("be.visible");
-    cy.contains("user6-uuid").should("not.exist");
-    cy.contains("All members").should("be.visible").click();
+    cy.contains("user5-uuid").should("not.exist");
     cy.contains("user6-uuid").should("be.visible");
+    cy.contains("All members").should("be.visible").click();
+    cy.contains("user5-uuid").should("be.visible");
   });
 });
 

--- a/tests/cypress/fixtures/projectV2/list-projectV2-members-many.json
+++ b/tests/cypress/fixtures/projectV2/list-projectV2-members-many.json
@@ -1,0 +1,35 @@
+[
+  {
+    "id": "user1-uuid",
+    "first_name": "User",
+    "last_name": "One",
+    "email": "user1@email.com",
+    "role": "owner"
+  },
+  {
+    "id": "user2-uuid",
+    "first_name": "User",
+    "last_name": "Two",
+    "email": "user2@email.com",
+    "role": "viewer"
+  },
+  {
+    "first_name": "User",
+    "last_name": "Three",
+    "id": "user3-uuid",
+    "role": "editor"
+  },
+  {
+    "id": "user4-uuid",
+    "email": "user4@email.com",
+    "role": "viewer"
+  },
+  {
+    "id": "user5-uuid",
+    "role": "viewer"
+  },
+  {
+    "id": "user6-uuid",
+    "role": "viewer"
+  }
+]

--- a/tests/cypress/fixtures/projectV2/list-projectV2-members-many.json
+++ b/tests/cypress/fixtures/projectV2/list-projectV2-members-many.json
@@ -30,6 +30,6 @@
   },
   {
     "id": "user6-uuid",
-    "role": "viewer"
+    "role": "owner"
   }
 ]


### PR DESCRIPTION
Show the names of the members in the project information page.

![image](https://github.com/SwissDataScienceCenter/renku-ui/assets/1196411/98c1049d-7c60-4caa-a26b-0a0d13597f41)

## Testing

Check the following:
- Project members are shown if you have access to the project
- At most 5 project members are shown
- No project members are shown if the user is not logged in


/deploy renku=release-0.52.x