### PR TITLE
chore(client): move verifyTitleCharacters() to optimize bundle size

### DIFF
--- a/client/src/project/new/ProjectNew.state.js
+++ b/client/src/project/new/ProjectNew.state.js
@@ -25,11 +25,8 @@
 
 import { projectKgApi } from "../../features/project/projectKg.api";
 import { newProjectSchema } from "../../model/RenkuModels";
-import {
-  sleep,
-  slugFromTitle,
-  verifyTitleCharacters,
-} from "../../utils/helpers/HelperFunctions";
+import { sleep, slugFromTitle } from "../../utils/helpers/HelperFunctions";
+import { verifyTitleCharacters } from "../../utils/helpers/verifyTitleCharacters.utils";
 import { CUSTOM_REPO_NAME } from "./ProjectNew.container";
 
 // ? reference https://docs.gitlab.com/ce/user/reserved_names.html#reserved-project-names

--- a/client/src/utils/Utils.test.jsx
+++ b/client/src/utils/Utils.test.jsx
@@ -41,8 +41,8 @@ import {
   refreshIfNecessary,
   slugFromTitle,
   splitAutosavedBranches,
-  verifyTitleCharacters,
 } from "./helpers/HelperFunctions";
+import { verifyTitleCharacters } from "./helpers/verifyTitleCharacters.utils";
 
 describe("Render React components and functions", () => {
   it("render RefreshButton", async () => {

--- a/client/src/utils/helpers/HelperFunctions.js
+++ b/client/src/utils/helpers/HelperFunctions.js
@@ -16,8 +16,6 @@
  * limitations under the License.
  */
 
-import XRegExp from "xregexp";
-
 const AUTOSAVED_PREFIX = "renku/autosave/";
 
 function convertUnicodeToAscii(string) {
@@ -112,11 +110,6 @@ function slugFromTitle(
 
   if (slug === separator) return "";
   return slug;
-}
-
-function verifyTitleCharacters(title) {
-  const regexPattern = XRegExp("^(\\pL|\\d|\\_|\\-|\\.|\\ )*$");
-  return regexPattern.test(title);
 }
 
 function getActiveProjectPathWithNamespace(currentPath) {
@@ -385,7 +378,6 @@ export {
   groupBy,
   gitLabUrlFromProfileUrl,
   isValidURL,
-  verifyTitleCharacters,
   convertUnicodeToAscii,
   refreshIfNecessary,
   sleep,

--- a/client/src/utils/helpers/verifyTitleCharacters.utils.ts
+++ b/client/src/utils/helpers/verifyTitleCharacters.utils.ts
@@ -1,0 +1,24 @@
+/*!
+ * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XRegExp from "xregexp";
+
+export function verifyTitleCharacters(title: string) {
+  const regexPattern = XRegExp("^(\\pL|\\d|\\_|\\-|\\.|\\ )*$");
+  return regexPattern.test(title);
+}


### PR DESCRIPTION
The `verifyTitleCharacters()` method is the only method which imports `xregexp`. Moving it to a separate file allows for bundle size optimization.

Before:
```
build/assets/index-zwCpWK0N.js                              1,960.44 kB │ gzip: 493.50 kB │ map: 6,098.69 kB
```

After:
```
build/assets/index-TyZG-yHr.js                              1,874.07 kB │ gzip: 456.83 kB │ map: 5,793.17 kB
```

/deploy
