### PR TITLE
chore: update the "who we are" section

### DIFF
--- a/client/src/landing/WhoWeAre/WhoWeAre.tsx
+++ b/client/src/landing/WhoWeAre/WhoWeAre.tsx
@@ -89,18 +89,21 @@ export default function WhoWeAre() {
               </div>
             </div>
             <div className={styles.whoWeAreLogos}>
-              <ExternalLink url={Links.SDSC} className="" role="link">
-                <img src={logo_SDSC} alt="SDSC" height="54" />
-              </ExternalLink>
+              <div>
+                <ExternalLink url={Links.SDSC} className="" role="link">
+                  <img src={logo_SDSC} alt="SDSC" height="54" />
+                </ExternalLink>
+                <div>Swiss Data Science Center</div>
+              </div>
               <div>
                 <ExternalLink url={Links.ETHZ} className="" role="link">
                   <img className="mb-2" src={logo_ETH} alt="ETH" height="25" />
                 </ExternalLink>
                 <div>
-                  Turnerstrasse 1,
+                  Wasserwerkstrasse 10,
                   <br />
                   8092 Zürich <br />
-                  +41 44 632 80 74
+                  +41 44 632 26 89
                 </div>
               </div>
               <div>


### PR DESCRIPTION
Fixes #3241.

![image](https://github.com/user-attachments/assets/2e64d662-a931-46bd-9f90-49395e9c97a4)

/deploy renku=release-0.55.0