### PR TITLE
feat: move Renku 2.0 from "alpha" to "beta"

### DIFF
--- a/client/src/features/dashboardV2/DashboardV2.tsx
+++ b/client/src/features/dashboardV2/DashboardV2.tsx
@@ -126,7 +126,7 @@ function DashboardWelcome() {
       <Row className="mb-3">
         <Col>
           <h2>
-            <b>Welcome to the Renku 2.0 alpha preview!</b>
+            <b>Welcome to the Renku 2.0!</b>
           </h2>
         </Col>
       </Row>
@@ -156,12 +156,10 @@ function DashboardWelcome() {
       <Row>
         <Col>
           <WarnAlert timeout={0} dismissible={false}>
-            <h4>
-              Do not do any important work in the Renku 2.0 alpha preview!
-            </h4>
+            <h4>Do not do any important work in the Renku 2.0 beta preview!</h4>
             <p>
-              The alpha is for testing only. We do not guarantee saving and
-              persisting work in the alpha.
+              The beta is for testing only. We do not guarantee saving and
+              persisting work in the beta.
             </p>
             <div>
               You can go back to Renku 1.0 at any time.{" "}

--- a/client/src/features/dashboardV2/DashboardV2.tsx
+++ b/client/src/features/dashboardV2/DashboardV2.tsx
@@ -125,9 +125,7 @@ function DashboardWelcome() {
     <>
       <Row className="mb-3">
         <Col>
-          <h2>
-            <b>Welcome to the Renku 2.0!</b>
-          </h2>
+          <h2 className="fw-bold">Welcome to the Renku 2.0 beta preview!</h2>
         </Col>
       </Row>
       <Row className="mb-3">
@@ -135,15 +133,14 @@ function DashboardWelcome() {
           <p>
             <b>Learn more about Renku 2.0</b> on our{" "}
             <ExternalLink
-              className="me-2"
               url="https://blog.renkulab.io/renku-2/"
               iconAfter={true}
               role="text"
               title="blog"
-            />
+            />{" "}
             and see what&rsquo;s ahead on our{" "}
             <ExternalLink
-              url="https://github.com/SwissDataScienceCenter/renku-design-docs/blob/main/roadmap.md"
+              url="https://renku.notion.site/Roadmap-b1342b798b0141399dc39cb12afc60c9"
               iconAfter={true}
               role="text"
               title="roadmap"

--- a/client/src/features/projectsV2/shared/WipBadge.tsx
+++ b/client/src/features/projectsV2/shared/WipBadge.tsx
@@ -21,8 +21,8 @@ import cx from "classnames";
 import { Badge, UncontrolledTooltip } from "reactstrap";
 
 interface WipBadeProps {
-  children?: ReactNode; //label
-  tooltip?: ReactNode; //text
+  children?: ReactNode;
+  tooltip?: ReactNode;
 }
 
 export default function WipBadge({

--- a/client/src/features/projectsV2/shared/WipBadge.tsx
+++ b/client/src/features/projectsV2/shared/WipBadge.tsx
@@ -16,30 +16,31 @@
  * limitations under the License
  */
 
-import { useRef } from "react";
+import { ReactNode, useRef } from "react";
+import cx from "classnames";
 import { Badge, UncontrolledTooltip } from "reactstrap";
 
-type WipBadeProps = {
-  label?: string;
-  text?: string;
-};
+interface WipBadeProps {
+  children?: ReactNode; //label
+  tooltip?: ReactNode; //text
+}
 
 export default function WipBadge({
-  label = "Alpha",
-  text = "Renku 2.0 is under active development and features may not work as expected.",
+  children = "Beta",
+  tooltip = "Renku 2.0 is under active development and features may not work as expected.",
 }: WipBadeProps) {
-  const ref = useRef<HTMLElement>(null);
+  const ref = useRef<HTMLDivElement>(null);
 
   return (
     <>
       <Badge
-        className="wip-badge text-primary"
+        className={cx("wip-badge", "text-primary")}
         color="rk-yellow"
         innerRef={ref}
       >
-        {label}
+        {children}
       </Badge>
-      <UncontrolledTooltip target={ref}>{text}</UncontrolledTooltip>
+      <UncontrolledTooltip target={ref}>{tooltip}</UncontrolledTooltip>
     </>
   );
 }

--- a/client/src/features/rootV2/NavbarV2.tsx
+++ b/client/src/features/rootV2/NavbarV2.tsx
@@ -203,12 +203,12 @@ export default function NavbarV2() {
           >
             <img
               src={RENKU_ALPHA_LOGO}
-              alt="Renku v2 (alpha)"
+              alt="Renku 2.0 (beta)"
               className="pe-2"
               height="50"
             />
           </RenkuNavLinkV2>
-          <WipBadge label="2.0 Alpha" />
+          <WipBadge>2.0 Beta</WipBadge>
           <BackToV1Button outline={true} />
         </div>
         <NavbarToggler onClick={onToggle} className="border-0">

--- a/client/src/features/secrets/Secrets.tsx
+++ b/client/src/features/secrets/Secrets.tsx
@@ -74,7 +74,7 @@ export default function Secrets() {
           <div className={cx("d-flex", "mb-2")}>
             <h2 className={cx("mb-0", "me-2")}>User Secrets</h2>
             <div className="my-auto">
-              <WipBadge text="This feature is under development and certain pieces may not work correctly." />
+              <WipBadge tooltip="This feature is under development and certain pieces may not work correctly." />
             </div>
           </div>
           <div>{pageInfo}</div>


### PR DESCRIPTION
Details:
* Change "Alpha" badge to "Beta" badge
* Update the roadmap link on the Renku 2.0 dashboard

/deploy renku=release-0.55.0