### PR TITLE
fix: use safe URL for repository icon

### DIFF
--- a/client/src/features/ProjectPageV2/ProjectPageContent/CodeRepositories/CodeRepositoryDisplay.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/CodeRepositories/CodeRepositoryDisplay.tsx
@@ -435,13 +435,9 @@ interface RepositoryIconProps {
 }
 
 function RepositoryIcon({ className, provider }: RepositoryIconProps) {
-  if (provider == null) {
-    return null;
-  }
-
   const iconUrl = useMemo(
     // eslint-disable-next-line spellcheck/spell-checker
-    () => safeNewUrl("/favicon.ico", provider),
+    () => (provider != null ? safeNewUrl("/favicon.ico", provider) : null),
     [provider]
   );
 

--- a/client/src/features/ProjectPageV2/ProjectPageContent/CodeRepositories/CodeRepositoryDisplay.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/CodeRepositories/CodeRepositoryDisplay.tsx
@@ -439,8 +439,16 @@ function RepositoryIcon({ className, provider }: RepositoryIconProps) {
     return null;
   }
 
-  // eslint-disable-next-line spellcheck/spell-checker
-  const iconUrl = new URL("/favicon.ico", provider);
+  const iconUrl = useMemo(
+    // eslint-disable-next-line spellcheck/spell-checker
+    () => safeNewUrl("/favicon.ico", provider),
+    [provider]
+  );
+
+  if (iconUrl == null) {
+    return null;
+  }
+
   return (
     <img
       className={className}

--- a/client/src/utils/helpers/safeNewUrl.utils.ts
+++ b/client/src/utils/helpers/safeNewUrl.utils.ts
@@ -17,12 +17,15 @@
  */
 
 /** Returns a new URL instance or null if `url` is not a valid URL string. */
-export function safeNewUrl(url: string | undefined | null): URL | null {
+export function safeNewUrl(
+  url: URL | string | undefined | null,
+  base?: URL | string | undefined
+): URL | null {
   if (url == null) {
     return null;
   }
   try {
-    return new URL(url);
+    return new URL(url, base);
   } catch (error) {
     if (error instanceof TypeError) {
       return null;


### PR DESCRIPTION
Fixes #3246.

Example: https://renku-ci-ui-3247.dev.renku.ch/v2/projects/flora.thiebaut/flora-test

/deploy renku=release-0.55.0