### PR TITLE
fix: unify texts when deleting a session Renku 2.0

### DIFF
--- a/client/src/features/session/components/SessionHibernated.tsx
+++ b/client/src/features/session/components/SessionHibernated.tsx
@@ -130,7 +130,7 @@ function addErrorNotification({
       : "Unknown error";
   notifications.addError(
     NOTIFICATION_TOPICS.SESSION_START,
-    "Unable to stop the current session",
+    "Unable to resume the current session",
     undefined,
     undefined,
     undefined,

--- a/client/src/features/sessionsV2/PauseOrDeleteSessionModal.tsx
+++ b/client/src/features/sessionsV2/PauseOrDeleteSessionModal.tsx
@@ -445,7 +445,7 @@ function addErrorNotification({
       : "Unknown error";
   notifications.addError(
     NOTIFICATION_TOPICS.SESSION_START,
-    "Unable to stop the current session",
+    "Unable to delete the current session",
     undefined,
     undefined,
     undefined,

--- a/client/src/features/sessionsV2/components/SessionStatus/SessionStatus.tsx
+++ b/client/src/features/sessionsV2/components/SessionStatus/SessionStatus.tsx
@@ -91,7 +91,7 @@ export function SessionStatusV2Label({ session }: ActiveSessionV2Props) {
           className={cx("me-1", "text-warning-emphasis")}
           inline
         />
-        <span className="text-warning-emphasis">Stopping Session</span>
+        <span className="text-warning-emphasis">Deleting Session</span>
       </SessionBadge>
     ) : state === "hibernated" ? (
       <SessionBadge className={cx("border-dark-subtle", "bg-light")}>
@@ -172,7 +172,7 @@ export function SessionStatusV2Title({
       : state === "starting"
       ? "You are currently starting a session from this launcher"
       : state === "stopping"
-      ? "You are currently stopping a session from this launcher"
+      ? "You are currently deleting a session from this launcher"
       : state === "hibernated"
       ? "You have a paused session from this launcher"
       : state === "failed"
@@ -227,12 +227,12 @@ function SessionStatusV2Text({
       <span>Created {startTimeText}</span>
     </div>
   ) : status === "stopping" ? (
-    <>Stopping Session...</>
+    <>Deleting Session...</>
   ) : status === "hibernated" && hibernationCullTimestamp ? (
     <div className={cx("d-flex", "align-items-center", "gap-2")}>
       <Clock size="16" className="flex-shrink-0" />
       <span>
-        Session will be stopped in{" "}
+        Session will be deleted in{" "}
         <TimeCaption
           datetime={hibernationCullTimestamp}
           enableTooltip


### PR DESCRIPTION
PR to remove copy text Inconsistencies referring to stopping/deleting sessions.


/deploy