### PR TITLE
feat: save secrets on storage create

### DIFF
--- a/client/src/features/ProjectPageV2/ProjectPageContent/DataSources/DataSourceDisplay.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/DataSources/DataSourceDisplay.tsx
@@ -156,7 +156,7 @@ export function DataSourceActions({
           data-cy="data-source-credentials"
           onClick={toggleCredentials}
         >
-          <Lock className={cx("bi", "ms-1")} />
+          <Lock className={cx("bi", "me-1")} />
           Credentials
         </DropdownItem>
         <DropdownItem data-cy="data-source-delete" onClick={toggleDelete}>

--- a/client/src/features/ProjectPageV2/ProjectPageContent/DataSources/DataSourceDisplay.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/DataSources/DataSourceDisplay.tsx
@@ -152,16 +152,16 @@ export function DataSourceActions({
         preventPropagation
         size="sm"
       >
-        <DropdownItem data-cy="data-source-delete" onClick={toggleDelete}>
-          <Trash className={cx("bi", "me-1")} />
-          Remove
-        </DropdownItem>
         <DropdownItem
           data-cy="data-source-credentials"
           onClick={toggleCredentials}
         >
           <Lock className={cx("bi", "ms-1")} />
           Credentials
+        </DropdownItem>
+        <DropdownItem data-cy="data-source-delete" onClick={toggleDelete}>
+          <Trash className={cx("bi", "me-1")} />
+          Remove
         </DropdownItem>
       </ButtonWithMenuV2>
       <DataSourceCredentialsModal

--- a/client/src/features/ProjectPageV2/ProjectPageContent/DataSources/DataSourceView.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/DataSources/DataSourceView.tsx
@@ -156,8 +156,8 @@ export function DataSourceView({
                 </table>
               </div>
             )}
-          <div>
-            <p className={cx("fw-bold", "m-0")}>Access mode</p>
+          <div className="mt-3">
+            <p className={cx("fw-bold", "mb-0")}>Access mode</p>
             <p>
               {storageDefinition.readonly
                 ? "Force Read-only"

--- a/client/src/features/project/components/cloudStorage/AddOrEditCloudStorage.tsx
+++ b/client/src/features/project/components/cloudStorage/AddOrEditCloudStorage.tsx
@@ -70,6 +70,8 @@ import { ExternalLink } from "../../../../components/ExternalLinks";
 import { WarnAlert } from "../../../../components/Alert";
 import type { CloudStorageSecretGet } from "../../../../features/projectsV2/api/storagesV2.api";
 
+import AddStorageMountSaveCredentialsInfo from "./AddStorageMountSaveCredentialsInfo";
+
 import styles from "./CloudStorage.module.scss";
 
 interface AddOrEditCloudStorageProps {
@@ -1097,7 +1099,7 @@ function AddStorageOptions({
 
 // *** Add storage: page 3 of 3, with name and mount path *** //
 
-interface AddStorageMountForm {
+export interface AddStorageMountForm {
   name: string;
   mountPoint: string;
   readOnly: boolean;
@@ -1302,60 +1304,5 @@ function AddStorageMount({
           />
         )}
     </form>
-  );
-}
-
-type AddStorageMountSaveCredentialsInfoProps = {
-  control: Control<AddStorageMountForm>;
-  onFieldValueChange: (field: "saveCredentials", value: boolean) => void;
-  state: AddCloudStorageState;
-};
-
-function AddStorageMountSaveCredentialsInfo({
-  control,
-  onFieldValueChange,
-  state,
-}: AddStorageMountSaveCredentialsInfoProps) {
-  return (
-    <div className="mt-3">
-      <Label className="form-label" for="saveCredentials">
-        Save credentials
-      </Label>
-
-      <Controller
-        name="saveCredentials"
-        control={control}
-        render={({ field }) => (
-          <input
-            id="saveCredentials"
-            type="checkbox"
-            {...field}
-            className={cx("form-check-input", "ms-1")}
-            onChange={(e) => {
-              field.onChange(e);
-              onFieldValueChange("saveCredentials", e.target.checked);
-            }}
-            value=""
-            checked={state.saveCredentials}
-          />
-        )}
-        rules={{ required: true }}
-      />
-      {state.saveCredentials && (
-        <div className="mt-1">
-          <WarnAlert dismissible={false}>
-            <p className="mb-0">
-              The credentials will be stored as secrets and only be for your
-              use. Other users will have to supply their credentials to use this
-              data source.
-            </p>
-          </WarnAlert>
-        </div>
-      )}
-      <div className={cx("form-text", "text-muted")}>
-        Check this box to save credentials as secrets, so you will not have to
-        provide them again when starting a session.
-      </div>
-    </div>
   );
 }

--- a/client/src/features/project/components/cloudStorage/AddStorageMountSaveCredentialsInfo.tsx
+++ b/client/src/features/project/components/cloudStorage/AddStorageMountSaveCredentialsInfo.tsx
@@ -1,0 +1,81 @@
+/*!
+ * Copyright 2023 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import cx from "classnames";
+import { Control, Controller } from "react-hook-form";
+import { Label } from "reactstrap";
+
+import { AddCloudStorageState } from "./projectCloudStorage.types";
+import { WarnAlert } from "../../../../components/Alert";
+
+import { AddStorageMountForm } from "./AddOrEditCloudStorage";
+
+type AddStorageMountSaveCredentialsInfoProps = {
+  control: Control<AddStorageMountForm>;
+  onFieldValueChange: (field: "saveCredentials", value: boolean) => void;
+  state: AddCloudStorageState;
+};
+
+export default function AddStorageMountSaveCredentialsInfo({
+  control,
+  onFieldValueChange,
+  state,
+}: AddStorageMountSaveCredentialsInfoProps) {
+  return (
+    <div className="mt-3">
+      <Label className="form-label" for="saveCredentials">
+        Save credentials
+      </Label>
+
+      <Controller
+        name="saveCredentials"
+        control={control}
+        render={({ field }) => (
+          <input
+            id="saveCredentials"
+            type="checkbox"
+            {...field}
+            className={cx("form-check-input", "ms-1")}
+            onChange={(e) => {
+              field.onChange(e);
+              onFieldValueChange("saveCredentials", e.target.checked);
+            }}
+            value=""
+            checked={state.saveCredentials}
+          />
+        )}
+        rules={{ required: true }}
+      />
+      {state.saveCredentials && (
+        <div className="mt-1">
+          <WarnAlert dismissible={false}>
+            <p className="mb-0">
+              The credentials will be stored as secrets and only be for your
+              use. Other users will have to supply their credentials to use this
+              data source.
+            </p>
+          </WarnAlert>
+        </div>
+      )}
+      <div className={cx("form-text", "text-muted")}>
+        Check this box to save credentials as secrets, so you will not have to
+        provide them again when starting a session.
+      </div>
+    </div>
+  );
+}

--- a/client/src/features/project/components/cloudStorage/CloudStorageModal.tsx
+++ b/client/src/features/project/components/cloudStorage/CloudStorageModal.tsx
@@ -391,7 +391,8 @@ export default function CloudStorageModal({
     const shouldSaveCredentials = !!(
       isV2 &&
       storageDetails.options &&
-      state.saveCredentials
+      state.saveCredentials &&
+      validationSucceeded
     );
     if (!shouldSaveCredentials) {
       return;
@@ -423,6 +424,7 @@ export default function CloudStorageModal({
     schema,
     storageDetails.options,
     storageDetails.schema,
+    validationSucceeded,
   ]);
 
   // Visual elements

--- a/client/src/features/project/components/cloudStorage/cloudStorageModalComponents.tsx
+++ b/client/src/features/project/components/cloudStorage/cloudStorageModalComponents.tsx
@@ -109,6 +109,7 @@ interface AddCloudStorageBodyContentProps
   storageDetails: CloudStorageDetails;
   storageSecrets: CloudStorageSecretGet[];
   success: boolean;
+  validationSucceeded: boolean;
 }
 export function AddCloudStorageBodyContent({
   addResultStorageName,
@@ -124,6 +125,7 @@ export function AddCloudStorageBodyContent({
   storageId,
   storageSecrets,
   success,
+  validationSucceeded,
 }: AddCloudStorageBodyContentProps) {
   if (redraw) return <Loader />;
   if (success)
@@ -164,7 +166,7 @@ export function AddCloudStorageBodyContent({
         state={state}
         storage={storageDetails}
         storageSecrets={storageSecrets}
-        isV2={isV2}
+        validationSucceeded={validationSucceeded}
       />
     </>
   );
@@ -201,6 +203,7 @@ interface AddCloudStorageContinueButtonProps
   disableContinueButton: boolean;
   hasStoredCredentialsInConfig: boolean;
   isResultLoading: boolean;
+  setValidationSucceeded: (succeeded: boolean) => void;
   storageDetails: CloudStorageDetails;
   storageId: string | null;
   validateConnection: () => void;
@@ -212,8 +215,9 @@ export function AddCloudStorageContinueButton({
   disableContinueButton,
   hasStoredCredentialsInConfig,
   isResultLoading,
-  state,
   setStateSafe,
+  setValidationSucceeded,
+  state,
   storageDetails,
   storageId,
   validateConnection,
@@ -260,6 +264,7 @@ export function AddCloudStorageContinueButton({
           actionTest={validateConnection}
           continueId="add-cloud-storage-continue"
           resetTest={validationResult.reset}
+          setValidationSucceeded={setValidationSucceeded}
           step={state.step}
           testId="test-cloud-storage"
           testIsFailure={validationResult.isError}
@@ -341,6 +346,7 @@ interface TestConnectionAndContinueButtonsProps {
   actionTest: () => void;
   continueId: string;
   resetTest: () => void;
+  setValidationSucceeded: AddCloudStorageContinueButtonProps["setValidationSucceeded"];
   step: number;
   testId: string;
   testIsFailure: boolean;
@@ -352,6 +358,7 @@ function TestConnectionAndContinueButtons({
   actionTest,
   continueId,
   resetTest,
+  setValidationSucceeded,
   step,
   testId,
   testIsFailure,
@@ -419,6 +426,7 @@ function TestConnectionAndContinueButtons({
           className={cx(continueColorClass)}
           disabled={testIsOngoing}
           onClick={() => {
+            setValidationSucceeded(testIsSuccess);
             if (testIsFailure || testIsSuccess) {
               resetTest();
             }

--- a/client/src/features/project/components/cloudStorage/cloudStorageModalComponents.tsx
+++ b/client/src/features/project/components/cloudStorage/cloudStorageModalComponents.tsx
@@ -42,6 +42,7 @@ import {
   AddCloudStorageState,
   CloudStorageDetails,
   CloudStorageSchema,
+  CredentialSaveStatus,
 } from "./projectCloudStorage.types";
 import type { CloudStorageSecretGet } from "../../../../features/projectsV2/api/storagesV2.api";
 
@@ -97,6 +98,7 @@ export function AddCloudStorageBackButton({
 interface AddCloudStorageBodyContentProps
   extends AddCloudStorageHeaderContentProps {
   addResultStorageName: string | undefined;
+  credentialSaveStatus: CredentialSaveStatus;
   redraw: boolean;
   schema: CloudStorageSchema[] | undefined;
   schemaError: FetchBaseQueryError | SerializedError | undefined;
@@ -113,6 +115,7 @@ interface AddCloudStorageBodyContentProps
 }
 export function AddCloudStorageBodyContent({
   addResultStorageName,
+  credentialSaveStatus,
   isV2,
   redraw,
   schema,
@@ -128,15 +131,13 @@ export function AddCloudStorageBodyContent({
   validationSucceeded,
 }: AddCloudStorageBodyContentProps) {
   if (redraw) return <Loader />;
-  if (success)
+  if (success) {
     return (
-      <SuccessAlert dismissible={false} timeout={0}>
-        <p className="mb-0">
-          The storage {addResultStorageName} has been successfully{" "}
-          {storageId ? "updated" : "added"}.
-        </p>
-      </SuccessAlert>
+      <AddCloudStorageSuccessAlert
+        {...{ addResultStorageName, storageId, credentialSaveStatus }}
+      />
     );
+  }
   if (schemaIsFetching || !schema) return <Loader />;
   if (schemaError) return <RtkOrNotebooksError error={schemaError} />;
   if (!isV2) {
@@ -338,6 +339,57 @@ export function AddCloudStorageConnectionTestResult({
         <p className="p-0">The connection to the storage works correctly.</p>
       </SuccessAlert>
     </div>
+  );
+}
+
+type AddCloudStorageSuccessAlertProps = Pick<
+  AddCloudStorageBodyContentProps,
+  "addResultStorageName" | "credentialSaveStatus" | "storageId"
+>;
+
+function AddCloudStorageSuccessAlert({
+  addResultStorageName,
+  credentialSaveStatus,
+  storageId,
+}: AddCloudStorageSuccessAlertProps) {
+  if (credentialSaveStatus == "trying")
+    return (
+      <SuccessAlert dismissible={false} timeout={0}>
+        <p className="mb-0">
+          The storage {addResultStorageName} has been successfully{" "}
+          {storageId ? "updated" : "added"}; saving the credentials...
+        </p>
+      </SuccessAlert>
+    );
+
+  if (credentialSaveStatus == "success")
+    return (
+      <SuccessAlert dismissible={false} timeout={0}>
+        <p className="mb-0">
+          The storage {addResultStorageName} has been successfully{" "}
+          {storageId ? "updated" : "added"}, along with its credentials.
+        </p>
+      </SuccessAlert>
+    );
+  if (credentialSaveStatus == "failure")
+    return (
+      <SuccessAlert dismissible={false} timeout={0}>
+        <p className="mb-0">
+          The storage {addResultStorageName} has been successfully{" "}
+          {storageId ? "updated" : "added"},{" "}
+          <b>but the credentials were not saved</b>. You can re-enter them and
+          save by editing the storage.
+        </p>
+      </SuccessAlert>
+    );
+
+  return (
+    <SuccessAlert dismissible={false} timeout={0}>
+      <p className="mb-0">
+        The storage {addResultStorageName} has been successfully{" "}
+        {storageId ? "updated" : "added"}.
+      </p>
+    </SuccessAlert>
   );
 }
 

--- a/client/src/features/project/components/cloudStorage/projectCloudStorage.constants.ts
+++ b/client/src/features/project/components/cloudStorage/projectCloudStorage.constants.ts
@@ -138,6 +138,7 @@ export const EMPTY_CLOUD_STORAGE_STATE: AddCloudStorageState = {
   showAllSchema: false,
   showAllProviders: false,
   showAllOptions: false,
+  saveCredentials: true,
 };
 
 export const EMPTY_CLOUD_STORAGE_DETAILS: CloudStorageDetails = {

--- a/client/src/features/project/components/cloudStorage/projectCloudStorage.types.ts
+++ b/client/src/features/project/components/cloudStorage/projectCloudStorage.types.ts
@@ -139,6 +139,7 @@ export type AddCloudStorageState = {
   showAllSchema: boolean;
   showAllProviders: boolean;
   showAllOptions: boolean;
+  saveCredentials: boolean;
 };
 
 export type CloudStorageDetailsOptions = Record<

--- a/client/src/features/project/components/cloudStorage/projectCloudStorage.types.ts
+++ b/client/src/features/project/components/cloudStorage/projectCloudStorage.types.ts
@@ -158,6 +158,8 @@ export type CloudStorageDetails = {
   readOnly?: boolean;
 };
 
+export type CredentialSaveStatus = "failure" | "none" | "success" | "trying";
+
 export interface TestCloudStorageConnectionParams {
   configuration: CloudStorageDetailsOptions;
   source_path: string;

--- a/client/src/features/secrets/SecretDelete.tsx
+++ b/client/src/features/secrets/SecretDelete.tsx
@@ -21,8 +21,12 @@ import { useCallback, useEffect, useState } from "react";
 import { TrashFill, XLg } from "react-bootstrap-icons";
 import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from "reactstrap";
 
-import { useDeleteSecretMutation } from "./secrets.api";
 import { RtkOrNotebooksError } from "../../components/errors/RtkErrorAlert";
+import useAppDispatch from "../../utils/customHooks/useAppDispatch.hook";
+
+import { projectV2Api } from "../projectsV2/api/projectV2.enhanced-api";
+
+import { useDeleteSecretMutation } from "./secrets.api";
 import { SecretDetails } from "./secrets.types";
 
 interface SecretsDeleteProps {
@@ -34,12 +38,14 @@ export default function SecretDelete({ secret }: SecretsDeleteProps) {
   const toggleModal = useCallback(() => {
     setShowModal((showModal) => !showModal);
   }, []);
+  const dispatch = useAppDispatch();
 
   // Handle posting data
   const [deleteSecretMutation, result] = useDeleteSecretMutation();
   const deleteSecret = useCallback(() => {
     deleteSecretMutation(secret.id);
-  }, [deleteSecretMutation, secret.id]);
+    dispatch(projectV2Api.util.invalidateTags(["Storages"]));
+  }, [deleteSecretMutation, dispatch, secret.id]);
 
   // Automatically close the modal when the secret is modified
   useEffect(() => {

--- a/client/src/features/secrets/Secrets.tsx
+++ b/client/src/features/secrets/Secrets.tsx
@@ -68,9 +68,9 @@ function StorageSecretSection() {
             <h3>Storage Secrets</h3>
           </div>
           <p>
-            Storage secrets are used to connect to cloud storage. When adding
-            cloud storage, credentials can be stored as secrets. The credential
-            secrets cannot be added here, but the values can be udated.
+            Credentials used to access data sources can be persisted as storage
+            secrets. Credentials should be initially entered in the context of a
+            project data sources, but the values can be updated here.
           </p>
         </Col>
       </Row>

--- a/client/src/features/sessionsV2/CloudStorageSecretsModal.tsx
+++ b/client/src/features/sessionsV2/CloudStorageSecretsModal.tsx
@@ -147,7 +147,7 @@ function CloudStorageConfigurationSecrets({
       </div>
       {context === "session" && <SaveCredentialsInput control={control} />}
       {context === "storage" && hasIncompleteSavedCredentials && (
-        <div className={cx("text-danger", "mt-3")}>
+        <div className={cx("text-danger", "mb-3")}>
           The saved credentials for this data source are incomplete so they will
           be ignored at session launch.
         </div>
@@ -283,16 +283,14 @@ export default function CloudStorageSecretsModal({
       isOpen={isOpen}
       size="lg"
     >
-      <ModalHeader className={cx("fw-bold")}>
-        {CONTEXT_STRINGS[context].header}
-      </ModalHeader>
+      <ModalHeader>{CONTEXT_STRINGS[context].header}</ModalHeader>
       <Form
         noValidate
         className="form-rk-green"
         data-cy="cloud-storage-edit-options"
         onSubmit={handleSubmit(onContinue)}
       >
-        <ModalBody className="pt-0">
+        <ModalBody>
           <CloudStorageConfigurationSecrets
             cloudStorageConfig={cloudStorageConfigs[index]}
             context={context}
@@ -303,7 +301,7 @@ export default function CloudStorageSecretsModal({
             validationResult={validationResult}
           />
         </ModalBody>
-        <ModalFooter className={cx("d-flex", "align-items-baseline", "pt-0")}>
+        <ModalFooter className="gap-2">
           <div className="flex-grow-1">
             <ProgressBreadcrumbs
               cloudStorageConfigs={cloudStorageConfigs}
@@ -390,7 +388,7 @@ function CredentialsTestError({
   context,
   validationResult,
 }: Pick<CredentialsButtonsProps, "context" | "validationResult">) {
-  if (!validationResult.isError) return <div className="mt-3"></div>;
+  if (!validationResult.isError) return null;
   return (
     <div className="mt-3">
       <div className="text-danger">{CONTEXT_STRINGS[context].testError}</div>
@@ -451,7 +449,7 @@ function SaveCredentialsInput({
   control,
 }: Pick<SensitiveFieldWidgetProps, "control">) {
   return (
-    <div className="mt-2">
+    <div className="mb-3">
       <Controller
         name="saveCredentials"
         control={control}
@@ -545,7 +543,7 @@ function SensitiveFieldInput({
 
   const tooltipContainerId = `option-is-secret-${option.name}`;
   return (
-    <div>
+    <div className="mb-3">
       <Label htmlFor={option.name}>
         {friendlyName ?? option.name}
         <div id={tooltipContainerId} className="d-inline">

--- a/client/src/features/sessionsV2/CloudStorageSecretsModal.tsx
+++ b/client/src/features/sessionsV2/CloudStorageSecretsModal.tsx
@@ -126,7 +126,7 @@ function CloudStorageConfigurationSecrets({
 
   return (
     <>
-      <div className={cx("d-flex", "align-items-baseline")}>
+      <div className={cx("d-flex", "align-items-baseline", "mt-1")}>
         <h4>{storage.name}</h4>
         <div className="ms-2">({storage.source_path})</div>
       </div>

--- a/client/src/features/sessionsV2/SessionStartPage.tsx
+++ b/client/src/features/sessionsV2/SessionStartPage.tsx
@@ -43,8 +43,11 @@ import {
   storageDefinitionFromConfig,
 } from "../project/utils/projectCloudStorage.utils";
 import type { Project } from "../projectsV2/api/projectV2.api";
-import { useGetProjectsByNamespaceAndSlugQuery } from "../projectsV2/api/projectV2.enhanced-api";
-import { usePostStoragesV2SecretsForSessionLaunchMutation } from "../projectsV2/api/projectV2.enhanced-api";
+import {
+  projectV2Api,
+  useGetProjectsByNamespaceAndSlugQuery,
+  usePostStoragesV2SecretsForSessionLaunchMutation,
+} from "../projectsV2/api/projectV2.enhanced-api";
 import { storageSecretNameToFieldName } from "../secrets/secrets.utils";
 import { useStartRenku2SessionMutation } from "../session/sessions.api";
 import type { CloudStorageConfiguration } from "./CloudStorageSecretsModal";
@@ -152,6 +155,8 @@ function SaveCloudStorage({
       dispatch(
         startSessionOptionsV2Slice.actions.setCloudStorage(cloudStorageConfigs)
       );
+      // After all the changes have been made, indicate that the storages need to be reloaded
+      dispatch(projectV2Api.util.invalidateTags(["Storages"]));
     }
   }, [
     dispatch,

--- a/tests/cypress/e2e/projectV2DataSourceCredentials.spec.ts
+++ b/tests/cypress/e2e/projectV2DataSourceCredentials.spec.ts
@@ -587,13 +587,13 @@ describe("Set up multiple data sources", () => {
       "contain.text",
       "The storage example-storage has been successfully added."
     );
-    // cy.getDataCy("cloud-storage-edit-close-button").click();
-    // cy.wait("@getCloudStorageV2");
+    cy.getDataCy("cloud-storage-edit-close-button").click();
+    cy.wait("@getCloudStorageV2");
 
-    // cy.getDataCy("data-storage-name").should("contain.text", "example-storage");
-    // cy.getDataCy("data-storage-name").click();
-    // cy.getDataCy("data-source-title").should("contain.text", "example-storage");
-    // cy.getDataCy("access_key_id-value").should("contain.text", "<sensitive>");
-    // cy.getDataCy("data-source-view-back-button").click();
+    cy.getDataCy("data-storage-name").should("contain.text", "example-storage");
+    cy.getDataCy("data-storage-name").click();
+    cy.getDataCy("data-source-title").should("contain.text", "example-storage");
+    cy.getDataCy("access_key_id-value").should("contain.text", "<sensitive>");
+    cy.getDataCy("data-source-view-back-button").click();
   });
 });

--- a/tests/cypress/e2e/projectV2DataSourceCredentials.spec.ts
+++ b/tests/cypress/e2e/projectV2DataSourceCredentials.spec.ts
@@ -55,7 +55,12 @@ describe("Set up data sources with credentials", () => {
         fixture: "cloudStorage/cloud-storage-with-secrets-values-empty.json",
         name: "getCloudStorageV2",
       })
-      .testCloudStorage({ success: false });
+      .testCloudStorage({ success: false })
+      .postCloudStorageSecrets({
+        content: [],
+        // No call to postCloudStorageSecrets is expected
+        shouldNotBeCalled: true,
+      });
     cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
     cy.wait("@readProjectV2");
     // add data source

--- a/tests/cypress/e2e/projectV2DataSourceCredentials.spec.ts
+++ b/tests/cypress/e2e/projectV2DataSourceCredentials.spec.ts
@@ -55,6 +55,9 @@ describe("Set up data sources with credentials", () => {
         fixture: "cloudStorage/cloud-storage-with-secrets-values-empty.json",
         name: "getCloudStorageV2",
       })
+      .cloudStorageSecrets({
+        fixture: "cloudStorage/cloud-storage-secrets-empty.json",
+      })
       .testCloudStorage({ success: false })
       .postCloudStorageSecrets({
         content: [],
@@ -138,6 +141,10 @@ describe("Set up data sources with credentials", () => {
       cy.get("#saveCredentials").should("be.checked");
     });
     cy.getDataCy("cloud-storage-edit-update-button").click();
+    fixtures.cloudStorageSecrets({
+      fixture: "cloudStorage/cloud-storage-secrets.json",
+      name: "getCloudStorageSecrets2",
+    });
     cy.wait("@postCloudStorageV2");
     cy.wait("@postCloudStorageSecrets");
     cy.getDataCy("cloud-storage-edit-body").should(
@@ -146,7 +153,6 @@ describe("Set up data sources with credentials", () => {
     );
     cy.getDataCy("cloud-storage-edit-close-button").click();
     cy.wait("@getCloudStorageV2");
-
     cy.getDataCy("data-storage-name").should("contain.text", "example-storage");
     cy.getDataCy("data-storage-name").click();
     cy.getDataCy("data-source-title").should("contain.text", "example-storage");
@@ -169,6 +175,9 @@ describe("Set up data sources with credentials", () => {
         name: "getCloudStorageV2",
       })
       .getStorageSchema({ fixture: "cloudStorage/storage-schema-s3.json" })
+      .cloudStorageSecrets({
+        fixture: "cloudStorage/cloud-storage-secrets-empty.json",
+      })
       .sessionLaunchers({
         fixture: "projectV2/session-launchers.json",
       });
@@ -200,10 +209,17 @@ describe("Set up data sources with credentials", () => {
           },
         ],
       })
+      .cloudStorageSecrets({
+        fixture: "cloudStorage/cloud-storage-secrets.json",
+      })
       .cloudStorage({
         isV2: true,
         fixture: "cloudStorage/cloud-storage-with-secrets-values-full.json",
         name: "getCloudStorageV2",
+      })
+      .cloudStorageSecrets({
+        fixture: "cloudStorage/cloud-storage-secrets.json",
+        name: "getCloudStorageSecrets2",
       });
 
     cy.getDataCy("cloud-storage-credentials-modal")
@@ -234,7 +250,7 @@ describe("Set up data sources with credentials", () => {
     cy.getDataCy("cloud-storage-edit-modal")
       .find("#access_key_id")
       .invoke("attr", "value")
-      .should("eq", "<sensitive>");
+      .should("eq", "<saved secret>");
     cy.getDataCy("cloud-storage-edit-modal")
       .find("#secret_access_key")
       .invoke("attr", "value")
@@ -252,6 +268,9 @@ describe("Set up data sources with credentials", () => {
         isV2: true,
         fixture: "cloudStorage/cloud-storage-with-secrets-values-partial.json",
         name: "getCloudStorageV2",
+      })
+      .cloudStorageSecrets({
+        fixture: "cloudStorage/cloud-storage-secrets-partial.json",
       })
       .getStorageSchema({ fixture: "cloudStorage/storage-schema-s3.json" })
       .postCloudStorage({
@@ -304,6 +323,9 @@ describe("Set up data sources with credentials", () => {
         isV2: true,
         fixture: "cloudStorage/cloud-storage-with-secrets-values-partial.json",
         name: "getCloudStorageV2",
+      })
+      .cloudStorageSecrets({
+        fixture: "cloudStorage/cloud-storage-secrets-partial.json",
       })
       .sessionLaunchers({
         fixture: "projectV2/session-launchers.json",
@@ -358,6 +380,9 @@ describe("Set up data sources with credentials", () => {
         isV2: true,
         fixture: "cloudStorage/cloud-storage-with-secrets-values-full.json",
         name: "getCloudStorageV2",
+      })
+      .cloudStorageSecrets({
+        fixture: "cloudStorage/cloud-storage-secrets.json",
       });
 
     cy.getDataCy("cloud-storage-credentials-modal")
@@ -372,7 +397,6 @@ describe("Set up data sources with credentials", () => {
       .click();
     cy.wait("@testCloudStorage");
     cy.wait("@postCloudStorageSecrets");
-    cy.wait("@getCloudStorageV2");
 
     // Credentials should be stored
     cy.getDataCy("data-storage-name").should("contain.text", "example-storage");
@@ -394,6 +418,9 @@ describe("Set up data sources with credentials", () => {
         isV2: true,
         fixture: "cloudStorage/cloud-storage-with-secrets-values-partial.json",
         name: "getCloudStorageV2",
+      })
+      .cloudStorageSecrets({
+        fixture: "cloudStorage/cloud-storage-secrets-partial.json",
       })
       .sessionLaunchers({
         fixture: "projectV2/session-launchers.json",
@@ -417,7 +444,9 @@ describe("Set up data sources with credentials", () => {
     openDataSourceMenu();
     cy.getDataCy("data-source-credentials").click();
 
-    fixtures.deleteCloudStorageSecrets();
+    fixtures.deleteCloudStorageSecrets().cloudStorageSecrets({
+      fixture: "cloudStorage/cloud-storage-secrets-empty.json",
+    });
 
     cy.getDataCy("cloud-storage-credentials-modal")
       .contains("The saved credentials for this data source are incomplete")

--- a/tests/cypress/e2e/projectV2setup.spec.ts
+++ b/tests/cypress/e2e/projectV2setup.spec.ts
@@ -59,6 +59,7 @@ describe("Set up project components", () => {
     cy.getDataCy("add-cloud-storage-continue-button").click();
     cy.getDataCy("cloud-storage-edit-mount").within(() => {
       cy.get("#name").type("giab");
+      cy.get("#saveCredentials").should("not.exist");
     });
     cy.getDataCy("cloud-storage-edit-update-button").click();
     cy.wait("@postCloudStorageV2");

--- a/tests/cypress/fixtures/cloudStorage/cloud-storage-secrets-partial.json
+++ b/tests/cypress/fixtures/cloudStorage/cloud-storage-secrets-partial.json
@@ -1,5 +1,6 @@
 [
   {
-    "name": "2-secret_access_key"
+    "name": "secret_access_key",
+    "secret_id": "ULID1"
   }
 ]

--- a/tests/cypress/fixtures/cloudStorage/cloud-storage-secrets.json
+++ b/tests/cypress/fixtures/cloudStorage/cloud-storage-secrets.json
@@ -1,8 +1,10 @@
 [
   {
-    "name": "2-access_key_id"
+    "name": "access_key_id",
+    "secret_id": "ULID2"
   },
   {
-    "name": "2-secret_access_key"
+    "name": "secret_access_key",
+    "secret_id": "ULID1"
   }
 ]

--- a/tests/cypress/fixtures/cloudStorage/cloud-storage-with-secrets-values-full.json
+++ b/tests/cypress/fixtures/cloudStorage/cloud-storage-with-secrets-values-full.json
@@ -41,7 +41,7 @@
     ],
     "secrets": [
       {
-        "name": "2-access_key_id",
+        "name": "access_key_id",
         "secret_id": "ULID2"
       },
       {

--- a/tests/cypress/support/renkulab-fixtures/cloudStorage.ts
+++ b/tests/cypress/support/renkulab-fixtures/cloudStorage.ts
@@ -36,6 +36,7 @@ interface PostCloudStorageSecretsArgs extends CloudStorageSecretsArgs {
     name: string;
     value: string;
   }[];
+  shouldNotBeCalled?: boolean;
 }
 
 interface TestCloudStorageArgs extends SimpleFixture {
@@ -112,6 +113,7 @@ export function CloudStorage<T extends FixturesConstructor>(Parent: T) {
         content,
         fixture = "cloudStorage/cloud-storage-secrets.json",
         name = "postCloudStorageSecrets",
+        shouldNotBeCalled = false,
         storageId = 2,
       } = args ?? {};
       cy.fixture(fixture).then((secrets) => {
@@ -120,6 +122,8 @@ export function CloudStorage<T extends FixturesConstructor>(Parent: T) {
           "POST",
           `/ui-server/api/data/storages_v2/${storageId}/secrets`,
           (req) => {
+            if (shouldNotBeCalled)
+              throw new Error("No call to post secrets expected");
             const newSecrets = req.body;
             expect(newSecrets.length).equal(content.length);
             newSecrets.forEach((secret, index) => {

--- a/tests/cypress/support/renkulab-fixtures/secrets.ts
+++ b/tests/cypress/support/renkulab-fixtures/secrets.ts
@@ -27,21 +27,50 @@ interface SecretArgs extends NameOnlyFixture {
   secretsKind?: "general" | "storage";
 }
 
-function generateFakeSecrets(
-  num: number,
-  kind: ListSecretsArgs["secretsKind"]
-) {
+function generateFakeSecretsGeneral(num: number) {
   const secrets = [];
   for (let i = 0; i < num; ++i) {
-    const secretName =
-      kind === "general" ? `secret_${i}` : `storage-secret_${i}`;
+    const secretName = `secret_${i}`;
     secrets.push({
       id: `id_${i}`,
       modification_date: new Date(),
       name: secretName,
+      kind: "general",
     });
   }
   return secrets;
+}
+
+function generateFakeSecretsStorage(num: number) {
+  const secrets = [];
+  // The first part of the id is the data-source id.
+  // Make two secrets per data-source.
+  const dataSourcesCount = Math.ceil(num / 2);
+  for (let i = 0; i < dataSourcesCount; ++i) {
+    const dataSourceId = `data_source_${i}`;
+    for (let j = 0; j < 2; ++j) {
+      const secretName = `${dataSourceId}-secret_${i}`;
+      secrets.push({
+        id: `id_${i}_${j}`,
+        modification_date: new Date(),
+        name: secretName,
+        kind: "storage",
+      });
+    }
+  }
+  return secrets;
+}
+
+function generateFakeSecrets(
+  num: number,
+  kind: ListSecretsArgs["secretsKind"]
+) {
+  if (kind === "general") {
+    return generateFakeSecretsGeneral(num);
+  } else if (kind === "storage") {
+    return generateFakeSecretsStorage(num);
+  }
+  return [];
 }
 
 export function Secrets<T extends FixturesConstructor>(Parent: T) {


### PR DESCRIPTION
Allow storing credentials when a storage is created.

# Screenshots

Add an option to save credentials to the last page of the add data source flow

<img width="814" alt="image" src="https://github.com/user-attachments/assets/5180b588-991d-438d-b76a-f6d6b4b63d43">

When checked, the credentials will be stored after the data source is added. This can be verified by looking at the data source, the credential field will be displayed as <saved secret>

<img width="493" alt="image" src="https://github.com/user-attachments/assets/58b8c266-520b-4857-b081-bc38af9940b2">


# Testing

Add a data source that requires credentials to a project (or example an S3 or polybox data source). Check that the credentials used to test are stored. Also, check that there is no option to store credentials for a public data source (like a public S3 bucket).


/deploy renku-notebooks=master renku-data-services=main