### PR TITLE
Set default to read only in add data source

### DIFF
--- a/client/src/features/project/components/cloudStorage/projectCloudStorage.constants.ts
+++ b/client/src/features/project/components/cloudStorage/projectCloudStorage.constants.ts
@@ -148,5 +148,5 @@ export const EMPTY_CLOUD_STORAGE_DETAILS: CloudStorageDetails = {
   name: undefined,
   sourcePath: undefined,
   mountPoint: undefined,
-  readOnly: undefined,
+  readOnly: true,
 };

--- a/tests/cypress/e2e/projectSettings.spec.ts
+++ b/tests/cypress/e2e/projectSettings.spec.ts
@@ -430,7 +430,7 @@ describe("Cloud storage settings page", () => {
       const { name, readonly, target_path } = body;
 
       expect(name).to.equal("fake-storage");
-      expect(readonly).to.be.false;
+      expect(readonly).to.be.true;
       expect(target_path).to.equal("external_storage/fake-storage");
     });
 


### PR DESCRIPTION
Change default to read-only when a data source is added. See 

* https://www.notion.so/renku/When-I-add-a-data-connector-the-default-should-be-read-only-with-the-read-write-an-optional-overrid-716f02eb42354f709a1cfb1607a0d447

/deploy renku=ciyer/ui-3275-data-source