### PR TITLE
fix: use the correct entity name in the descriptions for creating groups

### DIFF
--- a/client/src/features/projectsV2/fields/DescriptionFormField.tsx
+++ b/client/src/features/projectsV2/fields/DescriptionFormField.tsx
@@ -51,7 +51,7 @@ export default function DescriptionFormField<T extends FieldValues>({
         rules={{ maxLength: 500, required: false }}
       />
       <FormText id={`${entityName}DescriptionHelp`} className="input-hint">
-        A brief (at most 500 character) description of the project.
+        A brief (at most 500 character) description of the {entityName}.
       </FormText>
       <div className="invalid-feedback">Please provide a description</div>
     </div>

--- a/client/src/features/projectsV2/fields/SlugFormField.tsx
+++ b/client/src/features/projectsV2/fields/SlugFormField.tsx
@@ -60,7 +60,7 @@ export default function SlugFormField<T extends FieldValues>({
         hyphens.
       </div>
       <FormText id={`${entityName}SlugHelp`} className="input-hint">
-        A short, machine-readable identifier for the project, restricted to
+        A short, machine-readable identifier for the {entityName}, restricted to
         lowercase letters, numbers, and hyphens.{" "}
         {entityName === "project" && (
           <b>Cannot be changed after project creation.</b>


### PR DESCRIPTION
This fixes the wrong text in the fields' descriptions on the group creation page.

![image](https://github.com/user-attachments/assets/621fb751-91fa-4308-9ce1-1d043c3debba)

/deploy
