### PR TITLE
fix: prevent querying sessions launchers without project id

### DIFF
--- a/client/src/features/sessionsV2/ShowSessionPage.tsx
+++ b/client/src/features/sessionsV2/ShowSessionPage.tsx
@@ -438,11 +438,11 @@ function SessionDetails({
       </div>
     );
   }
-  if (launchersError || !launcher)
+  if (launchersError || !launcher || !project)
     return (
       <div className={cx("d-flex", "align-items-center")}>
         <p className={cx("text-white", "mb-0")}>
-          <ExclamationTriangle className="bi" /> Session not accessible
+          <ExclamationTriangle className="bi" /> Session details unavailable
         </p>
       </div>
     );

--- a/client/src/features/sessionsV2/ShowSessionPage.tsx
+++ b/client/src/features/sessionsV2/ShowSessionPage.tsx
@@ -408,7 +408,7 @@ function SessionDetails({
     data: launchers,
     isLoading: isLoadingLaunchers,
     error: launchersError,
-  } = useGetProjectSessionLaunchersQuery({ projectId: projectId ?? "" });
+  } = useGetProjectSessionLaunchersQuery(projectId ? { projectId } : skipToken);
   const { data: project, isLoading: isLoadingProject } =
     useGetProjectsByNamespaceAndSlugQuery(
       namespace && slug ? { namespace, slug } : skipToken


### PR DESCRIPTION
When starting a session, the `session_launchers` endpoints is invoked too early when the project id isn't available yet. This prevents it

![image](https://github.com/user-attachments/assets/0df9bbad-86d1-455d-8815-2e2813cede94)

/deploy
