### PR TITLE
fix: provide empty auth header

### DIFF
--- a/server/src/authentication/authenticator.ts
+++ b/server/src/authentication/authenticator.ts
@@ -115,7 +115,7 @@ export class Authenticator {
         return next();
       }
 
-      const authHeader = req.header(config.auth.authHeaderField);
+      const authHeader = req.header(config.auth.authHeaderField) ?? "";
       const sessionId =
         getCookieValueByName(req.header("cookie"), config.auth.cookiesKey) ??
         "";


### PR DESCRIPTION
Fixes `uiserver` crash looping when Sentry is enabled.

See also: #3319.

/deploy

Tested:
* Running `3.35.0` with Sentry enabled -> crash loop
* Running this version with Sentry enabled -> start and no error logs