### PR TITLE
temp: restore the admin interface using the legacy manual API file

### DIFF
--- a/client/src/features/admin/AddConnectedServiceButton.tsx
+++ b/client/src/features/admin/AddConnectedServiceButton.tsx
@@ -34,7 +34,7 @@ import {
   ConnectedServiceForm,
   CreateProviderParams,
 } from "../connectedServices/api/connectedServices.types";
-import { useCreateProviderMutation } from "../connectedServices/connectedServices.api";
+import { useCreateProviderMutation } from "../connectedServices/connectedServicesLegacy.api";
 import { RtkOrNotebooksError } from "../../components/errors/RtkErrorAlert";
 import { Loader } from "../../components/Loader";
 import ConnectedServiceFormContent from "./ConnectedServiceFormContent";
@@ -75,6 +75,7 @@ function AddConnectedServiceModal({
     defaultValues: {
       id: "",
       kind: "gitlab",
+      app_slug: "",
       client_id: "",
       client_secret: "",
       display_name: "",
@@ -88,6 +89,7 @@ function AddConnectedServiceModal({
       createProvider({
         id: data.id,
         kind: data.kind,
+        app_slug: data.app_slug,
         client_id: data.client_id,
         client_secret: data.client_secret,
         display_name: data.display_name,

--- a/client/src/features/admin/ConnectedServiceFormContent.tsx
+++ b/client/src/features/admin/ConnectedServiceFormContent.tsx
@@ -58,6 +58,31 @@ export default function ConnectedServiceFormContent({
       </div>
 
       <div className="mb-3">
+        <Label className="form-label" for="addConnectedServiceAppSlug">
+          Application Slug
+        </Label>
+        <Controller
+          control={control}
+          name="app_slug"
+          render={({ field }) => (
+            <>
+              <Input
+                className={cx("form-control", errors.app_slug && "is-invalid")}
+                id="addConnectedServiceAppSlug"
+                placeholder="Application slug"
+                type="text"
+                {...field}
+              />
+            </>
+          )}
+          rules={{ required: true }}
+        />
+        <div className="invalid-feedback">
+          Please provide the appllication slug
+        </div>
+      </div>
+
+      <div className="mb-3">
         <Label className="form-label" for="addConnectedServiceDisplayName">
           Display Name
         </Label>

--- a/client/src/features/admin/ConnectedServicesSection.tsx
+++ b/client/src/features/admin/ConnectedServicesSection.tsx
@@ -29,7 +29,7 @@ import {
 } from "reactstrap";
 import { RtkOrNotebooksError } from "../../components/errors/RtkErrorAlert";
 import { Loader } from "../../components/Loader";
-import { useGetProvidersQuery } from "../connectedServices/connectedServices.api";
+import { useGetProvidersQuery } from "../connectedServices/connectedServicesLegacy.api";
 import {
   Provider,
   ProviderList,
@@ -131,6 +131,9 @@ function ConnectedService({ provider }: ConnectedServiceProps) {
           <CardBody className="pt-0">
             <CardText className="mb-2">ID: {provider.id}</CardText>
             <CardText className="mb-2">Kind: {provider.kind}</CardText>
+            <CardText className="mb-2">
+              Application slug: {provider.app_slug}
+            </CardText>
             <CardText className="mb-2">URL: {provider.url}</CardText>
             <CardText className="mb-2">
               Client ID: {provider.client_id}

--- a/client/src/features/admin/DeleteConnectedServiceButton.tsx
+++ b/client/src/features/admin/DeleteConnectedServiceButton.tsx
@@ -23,7 +23,7 @@ import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from "reactstrap";
 import { TrashFill, XLg } from "react-bootstrap-icons";
 
 import { Provider } from "../connectedServices/api/connectedServices.types";
-import { useDeleteProviderMutation } from "../connectedServices/connectedServices.api";
+import { useDeleteProviderMutation } from "../connectedServices/connectedServicesLegacy.api";
 import { RtkOrNotebooksError } from "../../components/errors/RtkErrorAlert";
 
 interface DeleteConnectedServiceButtonProps {

--- a/client/src/features/admin/UpdateConnectedServiceButton.tsx
+++ b/client/src/features/admin/UpdateConnectedServiceButton.tsx
@@ -33,7 +33,7 @@ import {
 
 import { Loader } from "../../components/Loader";
 import { RtkOrNotebooksError } from "../../components/errors/RtkErrorAlert";
-import { useUpdateProviderMutation } from "../connectedServices/connectedServices.api";
+import { useUpdateProviderMutation } from "../connectedServices/connectedServicesLegacy.api";
 import {
   ConnectedServiceForm,
   Provider,
@@ -88,6 +88,7 @@ function UpdateConnectedServiceModal({
   } = useForm<ConnectedServiceForm>({
     defaultValues: {
       kind: "",
+      app_slug: "",
       client_id: "",
       client_secret: "",
       display_name: "",
@@ -101,6 +102,7 @@ function UpdateConnectedServiceModal({
       updateProvider({
         id: provider.id,
         kind: data.kind,
+        app_slug: data.app_slug,
         client_id: data.client_id,
         client_secret: data.client_secret,
         display_name: data.display_name,
@@ -129,6 +131,7 @@ function UpdateConnectedServiceModal({
   useEffect(() => {
     reset({
       kind: provider.kind,
+      app_slug: provider.app_slug,
       client_id: provider.client_id,
       display_name: provider.display_name,
       scope: provider.scope,

--- a/client/src/features/connectedServices/api/connectedServices.types.ts
+++ b/client/src/features/connectedServices/api/connectedServices.types.ts
@@ -39,6 +39,7 @@ export interface Provider {
   client_secret: string;
   display_name: string;
   scope: string;
+  app_slug: string;
   url: string;
   use_pkce: boolean;
 }
@@ -67,6 +68,7 @@ export interface GetConnectedAccountParams {
 export interface CreateProviderParams {
   id: string;
   kind: string;
+  app_slug: string;
   client_id: string;
   client_secret?: string;
   display_name: string;
@@ -78,6 +80,7 @@ export interface CreateProviderParams {
 export interface UpdateProviderParams {
   id: string;
   kind?: string;
+  app_slug?: string;
   client_id?: string;
   client_secret?: string;
   display_name?: string;

--- a/client/src/features/connectedServices/connectedServicesLegacy.api.ts
+++ b/client/src/features/connectedServices/connectedServicesLegacy.api.ts
@@ -28,8 +28,8 @@ import {
   UpdateProviderParams,
 } from "./api/connectedServices.types";
 
-const connectedServicesApi = createApi({
-  reducerPath: "connectedServicesApi",
+const connectedServicesLegacyApi = createApi({
+  reducerPath: "connectedServicesLegacyApi",
   baseQuery: fetchBaseQuery({
     baseUrl: "/ui-server/api/data/oauth2",
   }),
@@ -132,7 +132,7 @@ const connectedServicesApi = createApi({
   }),
 });
 
-export default connectedServicesApi;
+export default connectedServicesLegacyApi;
 export const {
   useCreateProviderMutation,
   useDeleteProviderMutation,
@@ -140,4 +140,4 @@ export const {
   useGetConnectionsQuery,
   useGetProvidersQuery,
   useUpdateProviderMutation,
-} = connectedServicesApi;
+} = connectedServicesLegacyApi;

--- a/client/src/features/projectsV2/api/namespace.api.ts
+++ b/client/src/features/projectsV2/api/namespace.api.ts
@@ -184,7 +184,7 @@ export type UserFirstLastName = string;
 export type GroupRole = "owner" | "editor" | "viewer";
 export type GroupMemberResponse = {
   id: UserId;
-  namespace?: Slug;
+  email?: UserEmail;
   first_name?: UserFirstLastName;
   last_name?: UserFirstLastName;
   role: GroupRole;

--- a/client/src/features/projectsV2/show/groupEditForms.tsx
+++ b/client/src/features/projectsV2/show/groupEditForms.tsx
@@ -272,7 +272,7 @@ export function GroupMembersForm({ group }: GroupMetadataFormProps) {
               >
                 <p className={cx("d-flex", "mb-0", "gap-2")}>
                   <span>{name ?? "Unknown user"}</span>
-                  <span className="fst-italic">{`@${d.namespace}`}</span>
+                  <span className="fst-italic">{`@${d.email}`}</span>
                   <span className="fw-bold">({capitalize(d.role)})</span>
                 </p>
                 <div>

--- a/client/src/utils/helpers/EnhancedState.ts
+++ b/client/src/utils/helpers/EnhancedState.ts
@@ -67,6 +67,7 @@ import { versionsApi } from "../../features/versions/versions.api";
 import { workflowsApi } from "../../features/workflows/WorkflowsApi";
 import { workflowsSlice } from "../../features/workflows/WorkflowsSlice";
 import featureFlagsSlice from "../feature-flags/featureFlags.slice";
+import connectedServicesLegacyApi from "../../features/connectedServices/connectedServicesLegacy.api";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const createStore = <S = any, A extends Action = AnyAction>(
@@ -92,6 +93,8 @@ export const createStore = <S = any, A extends Action = AnyAction>(
     [adminSessionsApi.reducerPath]: adminSessionsApi.reducer,
     [computeResourcesApi.reducerPath]: computeResourcesApi.reducer,
     [connectedServicesApi.reducerPath]: connectedServicesApi.reducer,
+    [connectedServicesLegacyApi.reducerPath]:
+      connectedServicesLegacyApi.reducer,
     [dataServicesUserApi.reducerPath]: dataServicesUserApi.reducer,
     [datasetsCoreApi.reducerPath]: datasetsCoreApi.reducer,
     [inactiveKgProjectsApi.reducerPath]: inactiveKgProjectsApi.reducer,
@@ -130,6 +133,7 @@ export const createStore = <S = any, A extends Action = AnyAction>(
         .concat(adminKeycloakApi.middleware)
         .concat(adminSessionsApi.middleware)
         .concat(connectedServicesApi.middleware)
+        .concat(connectedServicesLegacyApi.middleware)
         // this is causing some problems, and I do not know why
         .concat(dataServicesUserApi.middleware)
         .concat(datasetsCoreApi.middleware)


### PR DESCRIPTION
Just a temporary deployment; this won't be the solution merged to the feature branch.

/deploy #notest renku-data-services=leafty/richer-github-integration
