### PR TITLE
Some minor improvements to data connectors

### DIFF
--- a/client/src/features/ProjectPageV2/ProjectPageContent/DataConnectors/ProjectConnectDataConnectorsModal.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/DataConnectors/ProjectConnectDataConnectorsModal.tsx
@@ -269,7 +269,8 @@ function ProjectLinkDataConnectorBodyAndFooter({
             }}
           />
           <div className="form-text">
-            The the info sidebar for a data connector shows the identifier.
+            Copy a data connector identifier from the data connector&apos;s side
+            panel
           </div>
           <div className="invalid-feedback">
             Please provide an identifier (namespace/group) for the data
@@ -297,7 +298,7 @@ function ProjectLinkDataConnectorBodyAndFooter({
           ) : (
             <NodePlus className={cx("bi", "me-1")} />
           )}
-          Link data
+          Link data connector
         </Button>
       </ModalFooter>
     </Form>

--- a/client/src/features/ProjectPageV2/ProjectPageContent/DataConnectors/ProjectConnectDataConnectorsModal.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/DataConnectors/ProjectConnectDataConnectorsModal.tsx
@@ -35,6 +35,7 @@ import {
 import { RtkOrNotebooksError } from "../../../../components/errors/RtkErrorAlert";
 import { Loader } from "../../../../components/Loader";
 import useAppDispatch from "../../../../utils/customHooks/useAppDispatch.hook";
+import { isRenkuErrorResponse } from "../../../../utils/helpers/ApiErrors";
 
 import {
   dataConnectorsApi,
@@ -215,12 +216,20 @@ function ProjectLinkDataConnectorBodyAndFooter({
           { namespace, slug }
         )
       );
-      const { data: dataConnector, isSuccess } = await dataConnectorPromise;
+      const {
+        data: dataConnector,
+        isSuccess,
+        error,
+      } = await dataConnectorPromise;
       dataConnectorPromise.unsubscribe();
       if (!isSuccess || dataConnector == null) {
+        const errorMessage = isRenkuErrorResponse(error)
+          ? error.data.error.message
+          : "Data connector not found";
+
         setError("dataConnectorIdentifier", {
           type: "manual",
-          message: "Data connector not found",
+          message: errorMessage,
         });
         return false;
       }
@@ -273,8 +282,12 @@ function ProjectLinkDataConnectorBodyAndFooter({
             panel
           </div>
           <div className="invalid-feedback">
-            Please provide an identifier (namespace/group) for the data
-            connector
+            {errors.dataConnectorIdentifier == null
+              ? undefined
+              : errors.dataConnectorIdentifier.message != null &&
+                errors.dataConnectorIdentifier.message.length > 0
+              ? errors.dataConnectorIdentifier.message
+              : "Please provide an identifier (namespace/group) for the data connector"}
           </div>
         </div>
         {isSuccess != null && !isSuccess && (

--- a/client/src/features/ProjectPageV2/ProjectPageContent/DataConnectors/ProjectConnectDataConnectorsModal.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/DataConnectors/ProjectConnectDataConnectorsModal.tsx
@@ -17,6 +17,8 @@
  */
 
 import cx from "classnames";
+import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
+import { SerializedError } from "@reduxjs/toolkit";
 import { useCallback, useEffect, useState } from "react";
 import { Database, NodePlus, PlusLg, XLg } from "react-bootstrap-icons";
 import { Controller, useForm } from "react-hook-form";
@@ -193,6 +195,9 @@ function ProjectLinkDataConnectorBodyAndFooter({
   toggle,
 }: ProjectConnectDataConnectorsModalProps) {
   const dispatch = useAppDispatch();
+  const [lookupDataConnectorError, setLookupDataConnectorError] = useState<
+    FetchBaseQueryError | SerializedError | undefined
+  >(undefined);
   const [
     linkDataConnector,
     { error: linkDataConnectorError, isLoading, isSuccess },
@@ -201,7 +206,6 @@ function ProjectLinkDataConnectorBodyAndFooter({
     control,
     formState: { errors },
     handleSubmit,
-    setError,
   } = useForm<DataConnectorLinkFormFields>({
     defaultValues: {
       dataConnectorIdentifier: "",
@@ -223,14 +227,7 @@ function ProjectLinkDataConnectorBodyAndFooter({
       } = await dataConnectorPromise;
       dataConnectorPromise.unsubscribe();
       if (!isSuccess || dataConnector == null) {
-        const errorMessage = isRenkuErrorResponse(error)
-          ? error.data.error.message
-          : "Data connector not found";
-
-        setError("dataConnectorIdentifier", {
-          type: "manual",
-          message: errorMessage,
-        });
+        setLookupDataConnectorError(error);
         return false;
       }
       linkDataConnector({
@@ -240,7 +237,7 @@ function ProjectLinkDataConnectorBodyAndFooter({
         },
       });
     },
-    [dispatch, linkDataConnector, project.id, setError]
+    [dispatch, linkDataConnector, project.id]
   );
 
   useEffect(() => {
@@ -292,6 +289,9 @@ function ProjectLinkDataConnectorBodyAndFooter({
         </div>
         {isSuccess != null && !isSuccess && (
           <RtkOrNotebooksError error={linkDataConnectorError} />
+        )}
+        {lookupDataConnectorError != null && (
+          <RtkOrNotebooksError error={lookupDataConnectorError} />
         )}
       </ModalBody>
 

--- a/client/src/features/ProjectPageV2/ProjectPageContent/DataConnectors/ProjectConnectDataConnectorsModal.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/DataConnectors/ProjectConnectDataConnectorsModal.tsx
@@ -37,7 +37,6 @@ import {
 import { RtkOrNotebooksError } from "../../../../components/errors/RtkErrorAlert";
 import { Loader } from "../../../../components/Loader";
 import useAppDispatch from "../../../../utils/customHooks/useAppDispatch.hook";
-import { isRenkuErrorResponse } from "../../../../utils/helpers/ApiErrors";
 
 import {
   dataConnectorsApi,

--- a/client/src/features/ProjectPageV2/ProjectPageContent/DataConnectors/ProjectConnectDataConnectorsModal.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/DataConnectors/ProjectConnectDataConnectorsModal.tsx
@@ -287,7 +287,7 @@ function ProjectLinkDataConnectorBodyAndFooter({
               : errors.dataConnectorIdentifier.message != null &&
                 errors.dataConnectorIdentifier.message.length > 0
               ? errors.dataConnectorIdentifier.message
-              : "Please provide an identifier (namespace/group) for the data connector"}
+              : "Please provide an identifier for the data connector"}
           </div>
         </div>
         {isSuccess != null && !isSuccess && (

--- a/client/src/features/dataConnectorsV2/components/DataConnectorActions.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorActions.tsx
@@ -37,7 +37,6 @@ import { Loader } from "../../../components/Loader";
 import { ABSOLUTE_ROUTES } from "../../../routing/routes.constants";
 import useAppDispatch from "../../../utils/customHooks/useAppDispatch.hook";
 
-import useGroupPermissions from "../../groupsV2/utils/useGroupPermissions.hook";
 import PermissionsGuard from "../../permissionsV2/PermissionsGuard";
 import useProjectPermissions from "../../ProjectPageV2/utils/useProjectPermissions.hook";
 import { projectV2Api } from "../../projectsV2/api/projectV2.enhanced-api";
@@ -55,6 +54,7 @@ import {
 import DataConnectorCredentialsModal from "./DataConnectorCredentialsModal";
 import DataConnectorModal from "./DataConnectorModal";
 import { useGetProjectsByNamespaceAndSlugQuery } from "../../projectsV2/api/projectV2.api";
+import useDataConnectorPermissions from "../utils/useDataConnectorPermissions.hook";
 
 interface DataConnectorRemoveModalProps {
   dataConnector: DataConnectorRead;
@@ -70,9 +70,8 @@ function DataConnectorRemoveDeleteModal({
   toggleModal,
   isOpen,
 }: DataConnectorRemoveModalProps) {
-  const { permissions, isLoading: isLoadingPermissions } = useGroupPermissions({
-    groupSlug: dataConnector.namespace,
-  });
+  const { permissions, isLoading: isLoadingPermissions } =
+    useDataConnectorPermissions({ dataConnectorId: dataConnector.id });
 
   const dispatch = useAppDispatch();
   const {

--- a/client/src/features/dataConnectorsV2/components/DataConnectorActions.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorActions.tsx
@@ -180,18 +180,7 @@ function DataConnectorRemoveDeleteModal({
             Cancel
           </Button>
           <PermissionsGuard
-            disabled={
-              <Button
-                color="danger"
-                className={cx("float-right", "ms-2")}
-                disabled={true}
-                data-cy="delete-data-connector-modal-button"
-                onClick={toggleModal}
-              >
-                <Trash className={cx("bi", "me-1")} />
-                Delete data connector
-              </Button>
-            }
+            disabled={null}
             enabled={
               <Button
                 color="danger"
@@ -204,7 +193,7 @@ function DataConnectorRemoveDeleteModal({
                 {isLoading ? (
                   <>
                     <Loader className="me-1" inline size={16} />
-                    Deleting data connector
+                    Remove data connector
                   </>
                 ) : (
                   <>
@@ -318,18 +307,7 @@ function DataConnectorRemoveUnlinkModal({
                 Cancel
               </Button>
               <PermissionsGuard
-                disabled={
-                  <Button
-                    color="danger"
-                    className={cx("float-right", "ms-2")}
-                    disabled={true}
-                    data-cy="delete-data-connector-modal-button"
-                    onClick={toggleModal}
-                  >
-                    <NodeMinus className={cx("bi", "me-1")} />
-                    Unlink data connector
-                  </Button>
-                }
+                disabled={null}
                 enabled={
                   <Button
                     color="danger"
@@ -342,7 +320,7 @@ function DataConnectorRemoveUnlinkModal({
                     {isLoadingUnlink ? (
                       <>
                         <Loader className="me-1" inline size={16} />
-                        Unlinking data connector
+                        Unlink data connector
                       </>
                     ) : (
                       <>

--- a/client/src/features/dataConnectorsV2/components/DataConnectorActions.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorActions.tsx
@@ -112,65 +112,77 @@ function DataConnectorRemoveDeleteModal({
       <ModalBody>
         {isLoadingLinks || isLoadingPermissions ? (
           <Loader />
-        ) : permissions == null || permissions["delete"] != true ? (
-          <Row>
-            <Col>
-              <p>
-                You do not have the required permissions to delete this data
-                connector.
-              </p>
-            </Col>
-          </Row>
-        ) : dataConnectorLinks == null || isLoadingLinksError ? (
-          <Row>
-            <Col>
-              <p>
-                Are you sure you want to delete this data connector? It is
-                possible that it is used in some projects.
-              </p>
-              <p>
-                Please type <strong>{dataConnector.slug}</strong>, the slug of
-                the data connector, to confirm.
-              </p>
-              <Input
-                data-cy="delete-confirmation-input"
-                value={typedName}
-                onChange={onChange}
-              />
-            </Col>
-          </Row>
         ) : (
-          <Row>
-            <Col>
-              <p>
-                Are you sure you want to delete this data connector?{" "}
-                {dataConnectorLinks.length < 1 ? (
-                  <>
-                    It is not used in any projects that are visible to you, but
-                    it will affect any projects where it is used.
-                  </>
-                ) : dataConnectorLinks.length === 1 ? (
-                  <>
-                    It will affect at least <b>1 project that uses it</b>.
-                  </>
-                ) : (
-                  <>
-                    It will affect at least{" "}
-                    <b>{dataConnectorLinks.length} projects that use it</b>.
-                  </>
-                )}
-              </p>
-              <p>
-                Please type <strong>{dataConnector.slug}</strong>, the slug of
-                the data connector, to confirm.
-              </p>
-              <Input
-                data-cy="delete-confirmation-input"
-                value={typedName}
-                onChange={onChange}
-              />
-            </Col>
-          </Row>
+          <PermissionsGuard
+            disabled={
+              <Row>
+                <Col>
+                  <p>
+                    You do not have the required permissions to delete this data
+                    connector.
+                  </p>
+                </Col>
+              </Row>
+            }
+            enabled={
+              dataConnectorLinks == null || isLoadingLinksError ? (
+                <Row>
+                  <Col>
+                    <p>
+                      Are you sure you want to delete this data connector? It is
+                      possible that it is used in some projects.
+                    </p>
+                    <p>
+                      Please type <strong>{dataConnector.slug}</strong>, the
+                      slug of the data connector, to confirm.
+                    </p>
+                    <Input
+                      data-cy="delete-confirmation-input"
+                      value={typedName}
+                      onChange={onChange}
+                    />
+                  </Col>
+                </Row>
+              ) : (
+                <Row>
+                  <Col>
+                    <p>
+                      Are you sure you want to delete this data connector?{" "}
+                      {dataConnectorLinks.length < 1 ? (
+                        <>
+                          It is not used in any projects that are visible to
+                          you, but it will affect any projects where it is used.
+                        </>
+                      ) : dataConnectorLinks.length === 1 ? (
+                        <>
+                          It will affect at least <b>1 project that uses it</b>.
+                        </>
+                      ) : (
+                        <>
+                          It will affect at least{" "}
+                          <b>
+                            {dataConnectorLinks.length} projects that use it
+                          </b>
+                          .
+                        </>
+                      )}
+                    </p>
+                    <p>
+                      Please type <strong>{dataConnector.slug}</strong>, the
+                      slug of the data connector, to confirm.
+                    </p>
+                    <Input
+                      data-cy="delete-confirmation-input"
+                      value={typedName}
+                      onChange={onChange}
+                    />
+                  </Col>
+                </Row>
+              )
+            }
+            requestedPermission="delete"
+            userPermissions={permissions}
+          />
         )}
       </ModalBody>
       <ModalFooter>
@@ -275,27 +287,32 @@ function DataConnectorRemoveUnlinkModal({
           <ModalBody>
             <Row>
               <Col>
-                {permissions == null || permissions["write"] != true ? (
-                  <p>
-                    You do not have the required permissions to unlink this data
-                    connector.
-                  </p>
-                ) : (
-                  <>
+                <PermissionsGuard
+                  disabled={
                     <p>
-                      Are you sure you want to unlink the data connector{" "}
-                      <strong>{dataConnector.slug}</strong> from the project{" "}
-                      <strong>
-                        {projectNamespace}/{projectSlug}
-                      </strong>
-                      ?
+                      You do not have the required permissions to unlink this
+                      data connector.
                     </p>
-                    <p>
-                      The data from the data connector will no longer be
-                      available in sessions.
-                    </p>
-                  </>
-                )}
+                  }
+                  enabled={
+                    <>
+                      <p>
+                        Are you sure you want to unlink the data connector{" "}
+                        <strong>{dataConnector.slug}</strong> from the project{" "}
+                        <strong>
+                          {projectNamespace}/{projectSlug}
+                        </strong>
+                        ?
+                      </p>
+                      <p>
+                        The data from the data connector will no longer be
+                        available in sessions.
+                      </p>
+                    </>
+                  }
+                  requestedPermission="write"
+                  userPermissions={permissions}
+                />
               </Col>
             </Row>
           </ModalBody>

--- a/client/src/features/dataConnectorsV2/components/DataConnectorModal/DataConnectorSaveCredentialsInfo.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorModal/DataConnectorSaveCredentialsInfo.tsx
@@ -62,7 +62,7 @@ export default function DataConnectorSaveCredentialsInfo({
       />
       {state.saveCredentials && (
         <div className="mt-1">
-          <InfoAlert dismissible={false}>
+          <InfoAlert timeout={0} dismissible={false}>
             <p className="mb-0">
               The credentials will be stored as secrets and only be for your
               use. Other users will have to supply their credentials to use this

--- a/client/src/features/dataConnectorsV2/components/DataConnectorModal/index.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorModal/index.tsx
@@ -56,6 +56,7 @@ import {
 } from "../../api/data-connectors.enhanced-api";
 import type { DataConnectorRead } from "../../api/data-connectors.api";
 
+import PermissionsGuard from "../../../permissionsV2/PermissionsGuard";
 import type { Project } from "../../../projectsV2/api/projectV2.api";
 import { projectV2Api } from "../../../projectsV2/api/projectV2.enhanced-api";
 
@@ -574,10 +575,23 @@ export default function DataConnectorModal({
       <ModalHeader toggle={toggle} data-cy="data-connector-edit-header">
         <DataConnectorModalHeader dataConnectorId={dataConnectorId} />
       </ModalHeader>
-      {!isLoadingPermissions &&
-      dataConnectorId != null &&
-      (permissions == null || permissions["write"] != true) ? (
-        <DataConnectorModalBodyAndFooterUnauthorized />
+      {!isLoadingPermissions && dataConnectorId != null ? (
+        <PermissionsGuard
+          disabled={<DataConnectorModalBodyAndFooterUnauthorized />}
+          enabled={
+            <DataConnectorModalBodyAndFooter
+              {...{
+                dataConnector,
+                isOpen,
+                namespace,
+                project,
+                toggle,
+              }}
+            />
+          }
+          requestedPermission={"write"}
+          userPermissions={permissions}
+        />
       ) : (
         <DataConnectorModalBodyAndFooter
           {...{

--- a/client/src/features/dataConnectorsV2/components/DataConnectorModal/index.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorModal/index.tsx
@@ -57,10 +57,9 @@ import {
 import type { DataConnectorRead } from "../../api/data-connectors.api";
 
 import type { Project } from "../../../projectsV2/api/projectV2.api";
-import {
-  projectV2Api,
-  useGetGroupsByGroupSlugPermissionsQuery,
-} from "../../../projectsV2/api/projectV2.enhanced-api";
+import { projectV2Api } from "../../../projectsV2/api/projectV2.enhanced-api";
+
+import useDataConnectorPermissions from "../../utils/useDataConnectorPermissions.hook";
 
 import styles from "./DataConnectorModal.module.scss";
 
@@ -555,14 +554,8 @@ export default function DataConnectorModal({
   toggle,
 }: DataConnectorModalProps) {
   const dataConnectorId = dataConnector?.id ?? null;
-  const { data: permissions, isLoading: isLoadingPermissions } =
-    useGetGroupsByGroupSlugPermissionsQuery(
-      dataConnector != null
-        ? {
-            groupSlug: dataConnector.namespace,
-          }
-        : skipToken
-    );
+  const { permissions, isLoading: isLoadingPermissions } =
+    useDataConnectorPermissions({ dataConnectorId: dataConnectorId ?? "" });
 
   return (
     <Modal
@@ -582,6 +575,7 @@ export default function DataConnectorModal({
         <DataConnectorModalHeader dataConnectorId={dataConnectorId} />
       </ModalHeader>
       {!isLoadingPermissions &&
+      dataConnectorId != null &&
       (permissions == null || permissions["write"] != true) ? (
         <DataConnectorModalBodyAndFooterUnauthorized />
       ) : (

--- a/client/src/features/dataConnectorsV2/components/DataConnectorView.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorView.tsx
@@ -23,6 +23,8 @@ import {
   InfoCircleFill,
   Folder,
   Gear,
+  Key,
+  Lock,
   PersonBadge,
 } from "react-bootstrap-icons";
 
@@ -33,7 +35,7 @@ import { toCapitalized } from "../../../utils/helpers/HelperFunctions";
 import { EntityPill } from "../../searchV2/components/SearchV2Results";
 
 import { CredentialMoreInfo } from "../../project/components/cloudStorage/CloudStorageItem";
-import { CLOUD_STORAGE_SAVED_SECRET_DISPLAY_VALUE } from "../../project/components/cloudStorage/projectCloudStorage.constants";
+import { CLOUD_STORAGE_SENSITIVE_FIELD_TOKEN } from "../../project/components/cloudStorage/projectCloudStorage.constants";
 import { getCredentialFieldDefinitions } from "../../project/utils/projectCloudStorage.utils";
 import { useGetNamespacesByNamespaceSlugQuery } from "../../projectsV2/api/projectV2.enhanced-api";
 
@@ -166,21 +168,45 @@ function DataConnectorViewAccess({
           requiredCredentials.length > 0 && (
             <div className="mt-3">
               <p className={cx("fw-bold", "m-0")}>Required credentials</p>
-              <table className={cx("ps-4", "mb-0", "table", "table-sm")}>
-                <thead>
-                  <tr>
-                    <th>Field</th>
-                    <th>Value</th>
-                  </tr>
-                </thead>
+              <table
+                className={cx(
+                  "ps-4",
+                  "mb-0",
+                  "table",
+                  "table-sm",
+                  "table-borderless"
+                )}
+              >
                 <tbody>
                   {requiredCredentials.map(({ name, help }, index) => {
                     const value =
-                      name == null
-                        ? "unknown"
-                        : savedCredentialFields[name]
-                        ? CLOUD_STORAGE_SAVED_SECRET_DISPLAY_VALUE
-                        : storageDefinition.configuration[name]?.toString();
+                      name == null ? (
+                        "unknown"
+                      ) : savedCredentialFields[name] ? (
+                        <span
+                          className={cx(
+                            "badge",
+                            "rounded-pill",
+                            "text-bg-success"
+                          )}
+                        >
+                          <Key className={cx("bi", "me-2")} /> Credentials saved
+                        </span>
+                      ) : storageDefinition.configuration[name]?.toString() ==
+                        CLOUD_STORAGE_SENSITIVE_FIELD_TOKEN ? (
+                        <span
+                          className={cx(
+                            "badge",
+                            "rounded-pill",
+                            "text-bg-secondary"
+                          )}
+                        >
+                          <Lock className={cx("bi", "me-2")} /> Requires
+                          credentials
+                        </span>
+                      ) : (
+                        storageDefinition.configuration[name]?.toString()
+                      );
                     return (
                       <tr key={index}>
                         <td>

--- a/client/src/features/dataConnectorsV2/components/DataConnectorView.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorView.tsx
@@ -328,6 +328,20 @@ function DataConnectorViewMetadata({
       namespaceSlug: dataConnector.namespace,
     });
 
+  const namespaceUrl = useMemo(
+    () =>
+      namespace == null
+        ? null
+        : namespace.namespace_kind == "user"
+        ? generatePath(ABSOLUTE_ROUTES.v2.users.show, {
+            username: dataConnector.namespace,
+          })
+        : generatePath(ABSOLUTE_ROUTES.v2.groups.show.root, {
+            slug: dataConnector.namespace,
+          }),
+    [namespace, dataConnector.namespace]
+  );
+
   return (
     <section className={cx("pt-3")} data-cy="data-connector-metadata-section">
       <DataConnectorPropertyValue title="ID">
@@ -348,7 +362,15 @@ function DataConnectorViewMetadata({
           <div className="me-1">
             <UserAvatar username={dataConnector.namespace} />{" "}
           </div>
-          <div className="me-1">{dataConnector.namespace}</div>
+          {namespaceUrl == null ? (
+            <div className="me-1">{dataConnector.namespace}</div>
+          ) : (
+            <div>
+              <Link className="me-1" to={namespaceUrl}>
+                {dataConnector.namespace}
+              </Link>
+            </div>
+          )}
           <div>
             {isLoadingNamespace ? (
               <Loader inline size={16} />

--- a/client/src/features/dataConnectorsV2/components/DataConnectorView.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorView.tsx
@@ -27,18 +27,24 @@ import {
 } from "react-bootstrap-icons";
 
 import { Clipboard } from "../../../components/clipboard/Clipboard";
+import { Loader } from "../../../components/Loader";
 import { ABSOLUTE_ROUTES } from "../../../routing/routes.constants";
+import { toCapitalized } from "../../../utils/helpers/HelperFunctions";
+import { EntityPill } from "../../searchV2/components/SearchV2Results";
 
 import { CredentialMoreInfo } from "../../project/components/cloudStorage/CloudStorageItem";
 import { CLOUD_STORAGE_SAVED_SECRET_DISPLAY_VALUE } from "../../project/components/cloudStorage/projectCloudStorage.constants";
 import { getCredentialFieldDefinitions } from "../../project/utils/projectCloudStorage.utils";
+import { useGetNamespacesByNamespaceSlugQuery } from "../../projectsV2/api/projectV2.enhanced-api";
+
 import type {
   DataConnectorRead,
   DataConnectorToProjectLink,
 } from "../api/data-connectors.api";
 import { useGetDataConnectorsByDataConnectorIdSecretsQuery } from "../api/data-connectors.enhanced-api";
 import { storageSecretNameToFieldName } from "../../secrets/secrets.utils";
-import { toCapitalized } from "../../../utils/helpers/HelperFunctions";
+
+import UserAvatar from "../../usersV2/show/UserAvatar";
 
 import DataConnectorActions from "./DataConnectorActions";
 import useDataConnectorProjects from "./useDataConnectorProjects.hook";
@@ -317,6 +323,10 @@ function DataConnectorViewMetadata({
   const nonRequiredCredentialConfigurationKeys = Object.keys(
     storageDefinition.configuration
   ).filter((k) => !requiredCredentials?.some((f) => f.name === k));
+  const { data: namespace, isLoading: isLoadingNamespace } =
+    useGetNamespacesByNamespaceSlugQuery({
+      namespaceSlug: dataConnector.namespace,
+    });
 
   return (
     <section className={cx("pt-3")} data-cy="data-connector-metadata-section">
@@ -334,7 +344,30 @@ function DataConnectorViewMetadata({
         </div>
       </DataConnectorPropertyValue>
       <DataConnectorPropertyValue title="Owner">
-        {dataConnector.namespace}
+        <div className={cx("d-flex", "align-items-center")}>
+          <div className="me-1">
+            <UserAvatar username={dataConnector.namespace} />{" "}
+          </div>
+          <div className="me-1">{dataConnector.namespace}</div>
+          <div>
+            {isLoadingNamespace ? (
+              <Loader inline size={16} />
+            ) : namespace == null ? null : namespace.namespace_kind ==
+              "user" ? (
+              <EntityPill
+                entityType="User"
+                size="sm"
+                tooltipPlacement="bottom"
+              />
+            ) : (
+              <EntityPill
+                entityType="Group"
+                size="sm"
+                tooltipPlacement="bottom"
+              />
+            )}
+          </div>
+        </div>
       </DataConnectorPropertyValue>
       {nonRequiredCredentialConfigurationKeys.map((key) => {
         const title = toCapitalized(key);

--- a/client/src/features/dataConnectorsV2/components/DataConnectorView.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorView.tsx
@@ -18,13 +18,13 @@
 import cx from "classnames";
 import { useMemo, useRef } from "react";
 import { Link, generatePath } from "react-router-dom-v5-compat";
+import { Offcanvas, OffcanvasBody, UncontrolledTooltip } from "reactstrap";
 import {
-  Offcanvas,
-  OffcanvasBody,
-  PopoverBody,
-  UncontrolledPopover,
-} from "reactstrap";
-import { InfoCircleFill, Gear, PersonBadge } from "react-bootstrap-icons";
+  InfoCircleFill,
+  Folder,
+  Gear,
+  PersonBadge,
+} from "react-bootstrap-icons";
 
 import { Clipboard } from "../../../components/clipboard/Clipboard";
 import { ABSOLUTE_ROUTES } from "../../../routing/routes.constants";
@@ -42,6 +42,13 @@ import { toCapitalized } from "../../../utils/helpers/HelperFunctions";
 
 import DataConnectorActions from "./DataConnectorActions";
 import useDataConnectorProjects from "./useDataConnectorProjects.hook";
+
+const SECTION_CLASSES = [
+  "border-top",
+  "border-dark",
+  "border-opacity-50",
+  "pt-3",
+];
 
 interface DataConnectorPropertyProps {
   title: string | React.ReactNode;
@@ -135,7 +142,7 @@ function DataConnectorViewAccess({
   );
   return (
     <section
-      className={cx("border-top", "border-dark", "pt-3")}
+      className={cx(SECTION_CLASSES)}
       data-cy="data-connector-access-section"
     >
       <h4 className="mb-4">
@@ -199,7 +206,7 @@ function DataConnectorViewConfiguration({
 
   return (
     <section
-      className={cx("border-top", "border-dark", "pt-3")}
+      className={cx(SECTION_CLASSES)}
       data-cy="data-connector-configuration-section"
     >
       <div>
@@ -249,11 +256,13 @@ function DataConnectorViewProjects({
   const { projects, isLoading } = useDataConnectorProjects({ dataConnector });
   return (
     <section
-      className={cx("border-top", "boarder-dark", "pt-3")}
+      className={cx(SECTION_CLASSES)}
       data-cy="data-connector-projects-section"
     >
       <div>
-        <h4>Projects</h4>
+        <h4>
+          <Folder className={cx("bi", "me-1")} /> Projects
+        </h4>
       </div>
       <div>
         {isLoading && <p>Retrieving projects...</p>}
@@ -348,11 +357,9 @@ function MountPointHead() {
       <span ref={ref}>
         <InfoCircleFill className={cx("bi ms-1")} />
       </span>
-      <UncontrolledPopover target={ref} trigger="hover" placement="bottom">
-        <PopoverBody>
-          This is where the storage will be mounted during sessions.
-        </PopoverBody>
-      </UncontrolledPopover>
+      <UncontrolledTooltip target={ref} placement="bottom">
+        This is where the data connector will be mounted during sessions.
+      </UncontrolledTooltip>
     </>
   );
 }

--- a/client/src/features/dataConnectorsV2/components/DataConnectorView.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorView.tsx
@@ -344,7 +344,7 @@ function DataConnectorViewMetadata({
 
   return (
     <section className={cx("pt-3")} data-cy="data-connector-metadata-section">
-      <DataConnectorPropertyValue title="ID">
+      <DataConnectorPropertyValue title="Identifier">
         <div className={cx("d-flex", "justify-content-between", "mx-0")}>
           <div>
             {dataConnector.namespace}/{dataConnector.slug}

--- a/client/src/features/dataConnectorsV2/components/DataConnectorView.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorView.tsx
@@ -186,6 +186,7 @@ function DataConnectorViewAccess({
                         <span
                           className={cx(
                             "badge",
+                            "bg-opacity-25",
                             "rounded-pill",
                             "text-bg-success"
                           )}

--- a/client/src/features/dataConnectorsV2/components/DataConnectorsBox.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorsBox.tsx
@@ -51,7 +51,7 @@ function AddButtonForGroupNamespace({
   namespace,
   toggleOpen,
 }: Pick<DataConnectorBoxHeaderProps, "namespace" | "toggleOpen">) {
-  const permissions = useGroupPermissions({ groupSlug: namespace });
+  const { permissions } = useGroupPermissions({ groupSlug: namespace });
 
   return (
     <PermissionsGuard

--- a/client/src/features/dataConnectorsV2/utils/useDataConnectorPermissions.hook.ts
+++ b/client/src/features/dataConnectorsV2/utils/useDataConnectorPermissions.hook.ts
@@ -26,17 +26,20 @@ interface UseDataConnectorPermissionsArgs {
 
 export default function useDataConnectorPermissions({
   dataConnectorId,
-}: UseDataConnectorPermissionsArgs): Permissions {
+}: UseDataConnectorPermissionsArgs): {
+  permissions: Permissions;
+  isLoading: boolean;
+} {
   const { data, isLoading, isError } =
     useGetDataConnectorsByDataConnectorIdPermissionsQuery({ dataConnectorId });
 
   if (isLoading || isError || !data) {
-    return DEFAULT_PERMISSIONS;
+    return { permissions: DEFAULT_PERMISSIONS, isLoading };
   }
 
   const permissions: Permissions = {
     ...DEFAULT_PERMISSIONS,
     ...data,
   };
-  return permissions;
+  return { permissions, isLoading };
 }

--- a/client/src/features/groupsV2/settings/GroupSettingsMembers.tsx
+++ b/client/src/features/groupsV2/settings/GroupSettingsMembers.tsx
@@ -54,7 +54,7 @@ interface GroupSettingsMembersProps {
 export default function GroupSettingsMembers({
   group,
 }: GroupSettingsMembersProps) {
-  const permissions = useGroupPermissions({ groupSlug: group.slug });
+  const { permissions } = useGroupPermissions({ groupSlug: group.slug });
 
   const { data, isLoading } = useGetGroupsByGroupSlugMembersQuery({
     groupSlug: group.slug,
@@ -269,7 +269,7 @@ function GroupMemberAction({
   onRemove,
 }: GroupMemberActionProps) {
   const logged = useLegacySelector((state) => state.stateModel.user.logged);
-  const permissions = useGroupPermissions({ groupSlug: group.slug });
+  const { permissions } = useGroupPermissions({ groupSlug: group.slug });
   const {
     data: user,
     isLoading: isUserLoading,

--- a/client/src/features/groupsV2/show/GroupV2Show.tsx
+++ b/client/src/features/groupsV2/show/GroupV2Show.tsx
@@ -152,7 +152,7 @@ interface GroupSettingsButtonProps {
 }
 
 function GroupSettingsButton({ group }: GroupSettingsButtonProps) {
-  const permissions = useGroupPermissions({ groupSlug: group.slug });
+  const { permissions } = useGroupPermissions({ groupSlug: group.slug });
 
   return (
     <PermissionsGuard

--- a/client/src/features/groupsV2/utils/useGroupPermissions.hook.ts
+++ b/client/src/features/groupsV2/utils/useGroupPermissions.hook.ts
@@ -26,18 +26,18 @@ interface UseGroupPermissionsArgs {
 
 export default function useGroupPermissions({
   groupSlug,
-}: UseGroupPermissionsArgs): Permissions {
+}: UseGroupPermissionsArgs): { permissions: Permissions; isLoading: boolean } {
   const { data, isLoading, isError } = useGetGroupsByGroupSlugPermissionsQuery({
     groupSlug,
   });
 
   if (isLoading || isError || !data) {
-    return DEFAULT_PERMISSIONS;
+    return { permissions: DEFAULT_PERMISSIONS, isLoading };
   }
 
   const permissions: Permissions = {
     ...DEFAULT_PERMISSIONS,
     ...data,
   };
-  return permissions;
+  return { permissions, isLoading };
 }

--- a/client/src/features/sessionsV2/DataConnectorSecretsModal.tsx
+++ b/client/src/features/sessionsV2/DataConnectorSecretsModal.tsx
@@ -79,7 +79,8 @@ function ClearCredentialsButton({
     <>
       <span ref={clearButtonRef}>
         <Button
-          className={cx("ms-2", "btn-outline-rk-green")}
+          color="outline-primary"
+          className={cx("ms-2")}
           onClick={onSkip}
           disabled={!hasSavedCredentials}
         >
@@ -350,11 +351,16 @@ function CredentialsButtons({
         />
       )}
       <Button
-        className={cx(
-          "ms-2",
-          validationResult.isSuccess && "btn-rk-green",
-          validationResult.isError && "btn-danger"
-        )}
+        color={
+          validationResult == null
+            ? "primary"
+            : validationResult.isSuccess
+            ? "primary"
+            : validationResult.isError
+            ? "danger"
+            : "primary"
+        }
+        className={cx("ms-2")}
         disabled={validationResult.isLoading}
         type="submit"
       >
@@ -606,7 +612,7 @@ function SkipConnectionTestButton({
   return (
     <>
       <span ref={skipButtonRef}>
-        <Button className={cx("ms-2", "btn-outline-rk-green")} onClick={onSkip}>
+        <Button color="outline-primary" className={cx("ms-2")} onClick={onSkip}>
           Skip <SkipForward className={cx("bi", "me-1")} />
         </Button>
       </span>

--- a/client/src/utils/helpers/ApiErrors.ts
+++ b/client/src/utils/helpers/ApiErrors.ts
@@ -18,6 +18,18 @@
 
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query/react";
 
+interface RenkuError {
+  code: number;
+  message: string;
+}
+
+interface RenkuErrorResponse {
+  data: {
+    error: RenkuError;
+  };
+  status: number;
+}
+
 export const isFetchBaseQueryError = (
   error: FetchBaseQueryError | unknown
 ): error is FetchBaseQueryError => {
@@ -28,3 +40,30 @@ export const isFetchBaseQueryError = (
   }
   return false;
 };
+
+// See also CoreErrorHelpers.js
+export function isRenkuError(error: unknown): error is RenkuError {
+  if (error == null) return false;
+  if (typeof error !== "object") return false;
+  if (!("code" in error)) return false;
+  if (!("message" in error)) return false;
+  const errorCode = (error as RenkuError).code;
+  if (errorCode >= 1000 || errorCode < 0) return true;
+  return false;
+}
+
+export function isRenkuErrorResponse(
+  response: unknown
+): response is RenkuErrorResponse {
+  if (!isFetchBaseQueryError(response)) return false;
+
+  if (
+    !("data" in response) ||
+    typeof response.data !== "object" ||
+    response.data == null
+  )
+    return false;
+  if (!("error" in response.data) || typeof response.data.error !== "object")
+    return false;
+  return isRenkuError(response.data.error);
+}

--- a/tests/cypress/e2e/groupV2.spec.ts
+++ b/tests/cypress/e2e/groupV2.spec.ts
@@ -262,6 +262,7 @@ describe("Work with group data connectors", () => {
         dataConnectorId: "ULID-2",
         fixture: "dataConnector/project-data-connector-links-multiple.json",
       })
+      .readGroupV2Namespace()
       .readProjectV2ById({ projectId: "PROJECT-ULID-1", name: "readProject1" })
       .readProjectV2ById({ projectId: "PROJECT-ULID-2", name: "readProject2" })
       .readProjectV2ById({ projectId: "PROJECT-ULID-3", name: "readProject2" });

--- a/tests/cypress/e2e/groupV2.spec.ts
+++ b/tests/cypress/e2e/groupV2.spec.ts
@@ -277,9 +277,10 @@ describe("Work with group data connectors", () => {
   });
 
   it("add a group data connector", () => {
-    fixtures
-      .testCloudStorage({ success: false })
-      .postDataConnector({ namespace: "test-2-group-v2" });
+    fixtures.testCloudStorage({ success: false }).postDataConnector({
+      namespace: "test-2-group-v2",
+      slug: "example-storage-no-credentials",
+    });
     cy.contains("test 2 group-v2").should("be.visible").click();
     cy.wait("@readGroupV2");
     cy.contains("public-storage").should("be.visible");
@@ -298,12 +299,19 @@ describe("Work with group data connectors", () => {
     cy.getDataCy("add-data-connector-continue-button").contains("Skip").click();
     cy.getDataCy("data-connector-edit-mount").within(() => {
       cy.get("#name").type("example storage without credentials");
+      cy.get("#data-connector-slug").should(
+        "have.value",
+        "example-storage-without-credentials"
+      );
+      cy.get("#data-connector-slug")
+        .clear()
+        .type("example-storage-no-credentials");
     });
     cy.getDataCy("data-connector-edit-update-button").click();
     cy.wait("@postDataConnector");
     cy.getDataCy("data-connector-edit-body").should(
       "contain.text",
-      "The data connector test-2-group-v2/example-storage-without-credentials has been successfully added."
+      "The data connector test-2-group-v2/example-storage-no-credentials has been successfully added."
     );
     cy.getDataCy("data-connector-edit-close-button").click();
     cy.wait("@listDataConnectors");

--- a/tests/cypress/e2e/groupV2.spec.ts
+++ b/tests/cypress/e2e/groupV2.spec.ts
@@ -320,6 +320,7 @@ describe("Work with group data connectors", () => {
 
   it("edit a group data connector", () => {
     fixtures
+      .getDataConnectorPermissions({ dataConnectorId: "ULID-2" })
       .testCloudStorage({ success: true })
       .patchDataConnector({ namespace: "test-2-group-v2" });
     cy.contains("test 2 group-v2").should("be.visible").click();
@@ -342,10 +343,13 @@ describe("Work with group data connectors", () => {
   });
 
   it("delete a group data connector", () => {
-    fixtures.deleteDataConnector().listDataConnectorProjectLinks({
-      dataConnectorId: "ULID-2",
-      fixture: "dataConnector/project-data-connector-links-multiple.json",
-    });
+    fixtures
+      .deleteDataConnector()
+      .getDataConnectorPermissions({ dataConnectorId: "ULID-2" })
+      .listDataConnectorProjectLinks({
+        dataConnectorId: "ULID-2",
+        fixture: "dataConnector/project-data-connector-links-multiple.json",
+      });
     cy.contains("test 2 group-v2").should("be.visible").click();
     cy.wait("@readGroupV2");
     cy.contains("public-storage").should("be.visible").click();

--- a/tests/cypress/e2e/groupV2DataConnectorCredentials.spec.ts
+++ b/tests/cypress/e2e/groupV2DataConnectorCredentials.spec.ts
@@ -61,7 +61,10 @@ describe("Set up data connectors with credentials", () => {
       "contain.text",
       "private-storage-1"
     );
-    cy.getDataCy("access_key_id-value").should("contain.text", "<sensitive>");
+    cy.getDataCy("access_key_id-value").should(
+      "contain.text",
+      "Requires credentials"
+    );
     cy.getDataCy("data-connector-view-back-button").click();
   });
 
@@ -190,7 +193,10 @@ describe("Set up data connectors with credentials", () => {
       "contain.text",
       "example storage"
     );
-    cy.getDataCy("access_key_id-value").should("contain.text", "<sensitive>");
+    cy.getDataCy("access_key_id-value").should(
+      "contain.text",
+      "Requires credentials"
+    );
 
     // set credentials
     openDataConnectorMenu();
@@ -236,7 +242,7 @@ describe("Set up data connectors with credentials", () => {
     );
     cy.getDataCy("access_key_id-value").should(
       "contain.text",
-      "<saved secret>"
+      "Credentials saved"
     );
 
     // edit data connector, without touching the credentials
@@ -278,7 +284,7 @@ describe("Set up data connectors with credentials", () => {
     );
     cy.getDataCy("access_key_id-value").should(
       "contain.text",
-      "<saved secret>"
+      "Credentials saved"
     );
 
     // clear credentials
@@ -301,7 +307,10 @@ describe("Set up data connectors with credentials", () => {
       "contain.text",
       "example storage"
     );
-    cy.getDataCy("access_key_id-value").should("contain.text", "<sensitive>");
+    cy.getDataCy("access_key_id-value").should(
+      "contain.text",
+      "Requires credentials"
+    );
   });
 
   describe("Set up multiple data connectors", () => {

--- a/tests/cypress/e2e/groupV2DataConnectorCredentials.spec.ts
+++ b/tests/cypress/e2e/groupV2DataConnectorCredentials.spec.ts
@@ -175,6 +175,7 @@ describe("Set up data connectors with credentials", () => {
 
   it("set credentials for a data connector", () => {
     fixtures
+      .getDataConnectorPermissions()
       .listDataConnectors({
         fixture: "dataConnector/data-connector.json",
         namespace: "test-2-group-v2",

--- a/tests/cypress/e2e/projectV2DataConnectorCredentials.spec.ts
+++ b/tests/cypress/e2e/projectV2DataConnectorCredentials.spec.ts
@@ -56,11 +56,6 @@ describe("Set up data connectors with credentials", () => {
         // No call to postCloudStorageSecrets is expected
         shouldNotBeCalled: true,
       });
-    // .cloudStorage({
-    //   isV2: true,
-    //   fixture: "cloudStorage/cloud-storage-with-secrets-values-empty.json",
-    //   name: "getCloudStorageV2",
-    // })
     cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
     cy.wait("@readProjectV2");
     cy.wait("@listProjectDataConnectors");
@@ -103,7 +98,10 @@ describe("Set up data connectors with credentials", () => {
       "contain.text",
       "example storage"
     );
-    cy.getDataCy("access_key_id-value").should("contain.text", "<sensitive>");
+    cy.getDataCy("access_key_id-value").should(
+      "contain.text",
+      "Requires credentials"
+    );
   });
 
   it("set up data connector with credentials", () => {
@@ -180,7 +178,7 @@ describe("Set up data connectors with credentials", () => {
     );
     cy.getDataCy("access_key_id-value").should(
       "contain.text",
-      "<saved secret>"
+      "Credentials saved"
     );
   });
 });

--- a/tests/cypress/e2e/projectV2Session.spec.ts
+++ b/tests/cypress/e2e/projectV2Session.spec.ts
@@ -85,12 +85,12 @@ describe("launch sessions with data connectors", () => {
       });
 
     // start session
-    cy.fixture("sessions/sessionsV2.json").then((sessions) => {
+    cy.fixture("sessions/sessionV2.json").then((session) => {
       // eslint-disable-next-line max-nested-callbacks
       cy.intercept("POST", "/ui-server/api/notebooks/v2/servers", (req) => {
         const csConfig = req.body.cloudstorage;
         expect(csConfig.length).equal(1);
-        req.reply({ body: sessions[0] });
+        req.reply({ body: session, delay: 2000 });
       }).as("createSession");
     });
     fixtures.getSessions({ fixture: "sessions/sessionsV2.json" });
@@ -98,9 +98,9 @@ describe("launch sessions with data connectors", () => {
       cy.getDataCy("start-session-button").click();
     });
     cy.wait("@getResourceClass");
-    cy.wait("@createSession");
-
     cy.url().should("match", /\/projects\/.*\/sessions\/.*\/start$/);
+    cy.wait("@createSession");
+    cy.url().should("match", /\/projects\/.*\/sessions\/show\/.*/);
   });
 
   it("launch session with data connector requiring credentials", () => {
@@ -143,7 +143,7 @@ describe("launch sessions with data connectors", () => {
       });
 
     // start session
-    cy.fixture("sessions/sessionsV2.json").then((sessions) => {
+    cy.fixture("sessions/sessionV2.json").then((session) => {
       // eslint-disable-next-line max-nested-callbacks
       cy.intercept("POST", "/ui-server/api/notebooks/v2/servers", (req) => {
         const csConfig = req.body.cloudstorage;
@@ -155,7 +155,7 @@ describe("launch sessions with data connectors", () => {
         expect(storage.configuration["secret_access_key"]).to.equal(
           "secret key"
         );
-        req.reply({ body: sessions[0] });
+        req.reply({ body: session, delay: 2000 });
       }).as("createSession");
     });
     fixtures.getSessions({ fixture: "sessions/sessionsV2.json" });
@@ -165,6 +165,7 @@ describe("launch sessions with data connectors", () => {
         cy.getDataCy("start-session-button").click();
       });
     cy.wait("@getResourceClass");
+    cy.url().should("match", /\/projects\/.*\/sessions\/.*\/start$/);
     cy.getDataCy("session-data-connector-credentials-modal")
       .should("be.visible")
       .contains("Please provide")
@@ -190,7 +191,7 @@ describe("launch sessions with data connectors", () => {
       .click();
     cy.wait("@testCloudStorage");
     cy.wait("@createSession");
-    cy.url().should("match", /\/projects\/.*\/sessions\/.*\/start$/);
+    cy.url().should("match", /\/projects\/.*\/sessions\/show\/.*/);
   });
 
   it("launch session with data connector, saving credentials", () => {
@@ -218,7 +219,7 @@ describe("launch sessions with data connectors", () => {
     cy.wait("@sessionLaunchers");
     cy.wait("@listProjectDataConnectors");
 
-    cy.fixture("sessions/sessionsV2.json").then((sessions) => {
+    cy.fixture("sessions/sessionV2.json").then((session) => {
       // eslint-disable-next-line max-nested-callbacks
       cy.intercept("POST", "/ui-server/api/notebooks/v2/servers", (req) => {
         const csConfig = req.body.cloudstorage;
@@ -236,7 +237,7 @@ describe("launch sessions with data connectors", () => {
         expect(storage.configuration["secret_access_key"]).to.equal(
           "secret key"
         );
-        req.reply({ body: sessions[0] });
+        req.reply({ body: session, delay: 2000 });
       }).as("createSession");
     });
 
@@ -274,7 +275,7 @@ describe("launch sessions with data connectors", () => {
     cy.contains("Saving credentials...").should("be.visible");
     cy.wait("@patchDataConnectorSecrets");
     cy.wait("@createSession");
-    cy.url().should("match", /\/projects\/.*\/sessions\/.*\/start$/);
+    cy.url().should("match", /\/projects\/.*\/sessions\/show\/.*/);
   });
 
   it("launch session with data connector, saving credentials on skip", () => {
@@ -302,7 +303,7 @@ describe("launch sessions with data connectors", () => {
     cy.wait("@sessionLaunchers");
     cy.wait("@listProjectDataConnectors");
 
-    cy.fixture("sessions/sessionsV2.json").then((sessions) => {
+    cy.fixture("sessions/sessionV2.json").then((session) => {
       // eslint-disable-next-line max-nested-callbacks
       cy.intercept("POST", "/ui-server/api/notebooks/v2/servers", (req) => {
         const csConfig = req.body.cloudstorage;
@@ -314,7 +315,7 @@ describe("launch sessions with data connectors", () => {
         expect(storage.configuration["secret_access_key"]).to.equal(
           "secret key"
         );
-        req.reply({ body: sessions[0] });
+        req.reply({ body: session, delay: 2000 });
       }).as("createSession");
     });
 
@@ -345,7 +346,7 @@ describe("launch sessions with data connectors", () => {
     cy.contains("Saving credentials...").should("be.visible");
     cy.wait("@patchDataConnectorSecrets");
     cy.wait("@createSession");
-    cy.url().should("match", /\/projects\/.*\/sessions\/.*\/start$/);
+    cy.url().should("match", /\/projects\/.*\/sessions\/show\/.*/);
   });
 
   it("launch session with saved credentials", () => {
@@ -362,7 +363,7 @@ describe("launch sessions with data connectors", () => {
     cy.wait("@listProjectDataConnectors");
 
     // start session
-    cy.fixture("sessions/sessionsV2.json").then((sessions) => {
+    cy.fixture("sessions/sessionV2.json").then((session) => {
       // eslint-disable-next-line max-nested-callbacks
       cy.intercept("POST", "/ui-server/api/notebooks/v2/servers", (req) => {
         const csConfig = req.body.cloudstorage;
@@ -371,7 +372,7 @@ describe("launch sessions with data connectors", () => {
         expect(storage.storage_id).to.equal("ULID-1");
         expect(storage.configuration).to.not.have.property("access_key_id");
         expect(storage.configuration).to.not.have.property("secret_access_key");
-        req.reply({ body: sessions[0] });
+        req.reply({ body: session, delay: 2000 });
       }).as("createSession");
     });
 
@@ -382,10 +383,10 @@ describe("launch sessions with data connectors", () => {
         cy.getDataCy("start-session-button").click();
       });
     cy.wait("@createSession");
-    cy.url().should("match", /\/projects\/.*\/sessions\/.*\/start$/);
+    cy.url().should("match", /\/projects\/.*\/sessions\/show\/.*/);
   });
 
-  it.skip("launch session with incomplete saved credentials", () => {
+  it("launch session with incomplete saved credentials", () => {
     fixtures
       .testCloudStorage()
       .listProjectDataConnectors()
@@ -400,7 +401,7 @@ describe("launch sessions with data connectors", () => {
     cy.wait("@sessionLaunchers");
     cy.wait("@listProjectDataConnectors");
 
-    cy.fixture("sessions/sessionsV2.json").then((sessions) => {
+    cy.fixture("sessions/sessionV2.json").then((session) => {
       // eslint-disable-next-line max-nested-callbacks
       cy.intercept("POST", "/ui-server/api/notebooks/v2/servers", (req) => {
         const csConfig = req.body.cloudstorage;
@@ -413,7 +414,7 @@ describe("launch sessions with data connectors", () => {
         expect(storage.configuration["secret_access_key"]).to.equal(
           "secret key"
         );
-        req.reply({ body: sessions[0] });
+        req.reply({ body: session, delay: 2000 });
       }).as("createSession");
     });
 
@@ -437,10 +438,116 @@ describe("launch sessions with data connectors", () => {
       .click();
     cy.wait("@testCloudStorage");
     cy.wait("@createSession");
-    cy.url().should("match", /\/projects\/.*\/sessions\/.*\/start$/);
+    cy.url().should("match", /\/projects\/.*\/sessions\/show\/.*/);
   });
 
-  it.skip("launch session multiple data connectors requiring multiple credentials", () => {
+  it.skip("launch session multiple data connectors requiring multiple credentials, saving all", () => {
+    fixtures
+      .testCloudStorage({ success: false })
+      .listProjectDataConnectors({
+        fixture: "dataConnector/project-data-connector-links-multiple.json",
+      })
+      .getDataConnector({
+        dataConnectorId: "ULID-1",
+        fixture: "dataConnector/data-connector-public.json",
+      })
+      .getDataConnector({
+        dataConnectorId: "ULID-2",
+      })
+      .getDataConnector({
+        dataConnectorId: "ULID-3",
+        fixture: "dataConnector/data-connector-webdav.json",
+      })
+      .dataConnectorSecrets({
+        fixture: "dataConnector/data-connector-secrets-empty.json",
+      })
+      .patchDataConnectorSecrets({
+        dataConnectorId: "ULID-2",
+        content: [
+          {
+            name: "access_key_id",
+            value: "access key",
+          },
+          {
+            name: "secret_access_key",
+            value: "secret key",
+          },
+        ],
+      })
+      .patchDataConnectorSecrets({
+        dataConnectorId: "ULID-3",
+        content: [
+          {
+            name: "pass",
+            value: "webDav pass",
+          },
+        ],
+      });
+
+    cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
+    cy.wait("@readProjectV2");
+    cy.wait("@getSessionServers");
+    cy.wait("@sessionLaunchers");
+    cy.wait("@listProjectDataConnectors");
+
+    // start session
+    cy.fixture("sessions/sessionV2.json").then((session) => {
+      // eslint-disable-next-line max-nested-callbacks
+      cy.intercept("POST", "/ui-server/api/notebooks/v2/servers", (req) => {
+        const csConfig = req.body.cloudstorage;
+        expect(csConfig.length).equal(3);
+        const s3Storage = csConfig[0];
+        expect(s3Storage.configuration).to.not.have.property("access_key_id");
+        expect(s3Storage.configuration).to.not.have.property(
+          "secret_access_key"
+        );
+
+        const s3Storage1 = csConfig[1];
+        expect(s3Storage1.configuration).to.have.property("access_key_id");
+        expect(s3Storage1.configuration).to.have.property("secret_access_key");
+        expect(s3Storage1.configuration["access_key_id"]).to.equal(
+          "access key"
+        );
+        expect(s3Storage1.configuration["secret_access_key"]).to.equal(
+          "secret key"
+        );
+        const webDavStorage = csConfig[2];
+        expect(webDavStorage.configuration).to.have.property("pass");
+        expect(webDavStorage.configuration["pass"]).to.equal("webDav pass");
+        req.reply({ body: session, delay: 2000 });
+      }).as("createSession");
+    });
+    fixtures.getSessions({ fixture: "sessions/sessionsV2.json" });
+    cy.getDataCy("session-launcher-item")
+      .first()
+      .within(() => {
+        cy.getDataCy("start-session-button").click();
+      });
+    cy.getDataCy("session-data-connector-credentials-modal")
+      .find("#access_key_id")
+      .type("access key");
+    cy.getDataCy("session-data-connector-credentials-modal")
+      .find("#secret_access_key")
+      .type("secret key");
+    cy.get("#saveCredentials").click();
+    fixtures.testCloudStorage({ success: true });
+    cy.getDataCy("session-data-connector-credentials-modal")
+      .contains("Continue")
+      .click();
+    cy.getDataCy("session-data-connector-credentials-modal")
+      .find("#pass")
+      .type("webDav pass");
+    cy.get("#saveCredentials").click();
+    cy.getDataCy("session-data-connector-credentials-modal")
+      .contains("Continue")
+      .click();
+    cy.wait("@testCloudStorage");
+    cy.wait("@getResourceClass");
+    cy.wait("@createSession");
+    cy.url().should("match", /\/projects\/.*\/sessions\/show\/.*/);
+  });
+
+  it("launch session multiple data connectors requiring multiple credentials, skipping some", () => {
     fixtures
       .testCloudStorage({ success: false })
       .listProjectDataConnectors({
@@ -468,7 +575,7 @@ describe("launch sessions with data connectors", () => {
     cy.wait("@listProjectDataConnectors");
 
     // start session
-    cy.fixture("sessions/sessionsV2.json").then((sessions) => {
+    cy.fixture("sessions/sessionV2.json").then((session) => {
       // eslint-disable-next-line max-nested-callbacks
       cy.intercept("POST", "/ui-server/api/notebooks/v2/servers", (req) => {
         const csConfig = req.body.cloudstorage;
@@ -491,7 +598,7 @@ describe("launch sessions with data connectors", () => {
         const webDavStorage = csConfig[2];
         expect(webDavStorage.configuration).to.have.property("pass");
         expect(webDavStorage.configuration["pass"]).to.equal("webDav pass");
-        req.reply({ body: sessions[0] });
+        req.reply({ body: session, delay: 2000 });
       }).as("createSession");
     });
     fixtures.getSessions({ fixture: "sessions/sessionsV2.json" });
@@ -532,7 +639,7 @@ describe("launch sessions with data connectors", () => {
     cy.wait("@testCloudStorage");
     cy.wait("@getResourceClass");
     cy.wait("@createSession");
-    cy.url().should("match", /\/projects\/.*\/sessions\/.*\/start$/);
+    cy.url().should("match", /\/projects\/.*\/sessions\/show\/.*/);
   });
 
   it.skip("launch session with multiple data connectors requiring credentials, skipping all", () => {
@@ -563,7 +670,7 @@ describe("launch sessions with data connectors", () => {
     cy.wait("@listProjectDataConnectors");
 
     // start session
-    cy.fixture("sessions/sessionsV2.json").then((sessions) => {
+    cy.fixture("sessions/sessionV2.json").then((session) => {
       // eslint-disable-next-line max-nested-callbacks
       cy.intercept("POST", "/ui-server/api/notebooks/v2/servers", (req) => {
         const csConfig = req.body.cloudstorage;
@@ -586,7 +693,7 @@ describe("launch sessions with data connectors", () => {
         const webDavStorage = csConfig[2];
         expect(webDavStorage.configuration).to.have.property("pass");
         expect(webDavStorage.configuration["pass"]).to.equal("webDav pass");
-        req.reply({ body: sessions[0] });
+        req.reply({ body: session, delay: 2000 });
       }).as("createSession");
     });
 
@@ -621,6 +728,6 @@ describe("launch sessions with data connectors", () => {
     cy.wait("@testCloudStorage");
     cy.wait("@getResourceClass");
     cy.wait("@createSession");
-    cy.url().should("match", /\/projects\/.*\/sessions\/.*\/start$/);
+    cy.url().should("match", /\/projects\/.*\/sessions\/show\/.*/);
   });
 });

--- a/tests/cypress/e2e/projectV2setup.spec.ts
+++ b/tests/cypress/e2e/projectV2setup.spec.ts
@@ -275,7 +275,7 @@ describe("Set up data connectors", () => {
     ).should("be.visible");
   });
 
-  it("delete a data connector", () => {
+  it("unlink a data connector", () => {
     fixtures
       .readProjectV2({ fixture: "projectV2/read-projectV2-empty.json" })
       .listProjectDataConnectors()
@@ -289,6 +289,7 @@ describe("Set up data connectors", () => {
     cy.contains("example storage").should("be.visible").click();
     openDataConnectorMenu();
     cy.getDataCy("data-connector-delete").should("be.visible").click();
+    cy.wait("@getProjectV2Permissions");
     cy.contains("Are you sure you want to unlink the data connector").should(
       "be.visible"
     );
@@ -297,5 +298,27 @@ describe("Set up data connectors", () => {
       .click();
     cy.wait("@deleteDataConnectorProjectLink");
     cy.wait("@listProjectDataConnectors");
+  });
+
+  it("unlink data connector not allowed", () => {
+    fixtures
+      .readProjectV2({ fixture: "projectV2/read-projectV2-empty.json" })
+      .listProjectDataConnectors()
+      .getDataConnector()
+      .getProjectV2Permissions({
+        fixture: "projectV2/projectV2-permissions-viewer.json",
+      })
+      .deleteDataConnectorProjectLinkNotAllowed();
+    cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
+    cy.wait("@readProjectV2");
+    cy.wait("@listProjectDataConnectors");
+
+    cy.contains("example storage").should("be.visible").click();
+    openDataConnectorMenu();
+    cy.getDataCy("data-connector-delete").should("be.visible").click();
+    cy.contains(
+      "You do not have the required permissions to unlink this data connector."
+    ).should("be.visible");
+    cy.getDataCy("delete-data-connector-modal-button").should("be.disabled");
   });
 });

--- a/tests/cypress/e2e/projectV2setup.spec.ts
+++ b/tests/cypress/e2e/projectV2setup.spec.ts
@@ -44,99 +44,6 @@ describe("Set up project components", () => {
     fixtures.projects().landingUserProjects().readProjectV2();
   });
 
-  it("create a simple data connector", () => {
-    fixtures
-      .readProjectV2({ fixture: "projectV2/read-projectV2-empty.json" })
-      .listProjectDataConnectors()
-      .getDataConnector()
-      .getStorageSchema({ fixture: "cloudStorage/storage-schema-s3.json" })
-      .testCloudStorage({ success: false })
-      .postDataConnector({ namespace: "user1-uuid", visibility: "public" })
-      .postDataConnectorProjectLink({ dataConnectorId: "ULID-5" });
-    cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
-    cy.wait("@readProjectV2");
-    cy.wait("@listProjectDataConnectors");
-
-    // add data connector
-    cy.getDataCy("add-data-connector").should("be.visible").click();
-    cy.getDataCy("project-data-controller-mode-create").click();
-    // Pick a provider
-    cy.getDataCy("data-storage-s3").click();
-    cy.getDataCy("data-provider-AWS").click();
-    cy.getDataCy("data-connector-edit-next-button").click();
-
-    // Fill out the details
-    cy.get("#sourcePath").type("bucket/my-source");
-    cy.get("#access_key_id").type("access key");
-    cy.get("#secret_access_key").type("secret key");
-    cy.getDataCy("test-data-connector-button").click();
-    cy.getDataCy("add-data-connector-continue-button").contains("Skip").click();
-    cy.getDataCy("data-connector-edit-mount").within(() => {
-      cy.get("#name").type("example storage without credentials");
-      cy.get("#visibility")
-        .children()
-        .first()
-        .should("have.value", "public")
-        .should("be.checked");
-    });
-
-    cy.getDataCy("data-connector-edit-update-button").click();
-    cy.wait("@postDataConnector");
-    cy.getDataCy("data-connector-edit-body").should(
-      "contain.text",
-      "The data connector user1-uuid/example-storage-without-credentials has been successfully added"
-    );
-    cy.getDataCy("data-connector-edit-body").should(
-      "contain.text",
-      "project was linked"
-    );
-    cy.getDataCy("data-connector-edit-close-button").click();
-    cy.wait("@listProjectDataConnectors");
-  });
-
-  it("link a data connector", () => {
-    fixtures
-      .readProjectV2({ fixture: "projectV2/read-projectV2-empty.json" })
-      .listProjectDataConnectors()
-      .getDataConnectorByNamespaceAndSlug()
-      .postDataConnectorProjectLink({ dataConnectorId: "ULID-1" });
-    cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
-    cy.wait("@readProjectV2");
-    cy.wait("@listProjectDataConnectors");
-
-    // add data connector
-    cy.getDataCy("add-data-connector").should("be.visible").click();
-    cy.getDataCy("project-data-controller-mode-link").click();
-    cy.get("#data-connector-identifier").type("user1-uuid/example-storage");
-    cy.getDataCy("link-data-connector-button").click();
-    cy.wait("@postDataConnectorProjectLink");
-    cy.wait("@listProjectDataConnectors");
-  });
-
-  it("delete a data connector", () => {
-    fixtures
-      .readProjectV2({ fixture: "projectV2/read-projectV2-empty.json" })
-      .listProjectDataConnectors()
-      .getDataConnector()
-      .deleteDataConnectorProjectLink();
-
-    cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
-    cy.wait("@readProjectV2");
-    cy.wait("@listProjectDataConnectors");
-
-    cy.contains("example storage").should("be.visible").click();
-    openDataConnectorMenu();
-    cy.getDataCy("data-connector-delete").should("be.visible").click();
-    cy.contains("Are you sure you want to unlink the data connector").should(
-      "be.visible"
-    );
-    cy.getDataCy("delete-data-connector-modal-button")
-      .should("be.enabled")
-      .click();
-    cy.wait("@deleteDataConnectorProjectLink");
-    cy.wait("@listProjectDataConnectors");
-  });
-
   it("set up repositories", () => {
     fixtures
       .readProjectV2({ fixture: "projectV2/read-projectV2-empty.json" })
@@ -258,5 +165,137 @@ describe("Set up project components", () => {
       cy.getDataCy("session-status").should("contain.text", "Not Running");
       cy.getDataCy("start-session-button").should("contain.text", "Launch");
     });
+  });
+});
+
+describe("Set up data connectors", () => {
+  beforeEach(() => {
+    fixtures
+      .config()
+      .versions()
+      .userTest()
+      .listNamespaceV2()
+      .dataServicesUser({
+        response: {
+          id: "0945f006-e117-49b7-8966-4c0842146313",
+          email: "user1@email.com",
+        },
+      })
+      .getProjectV2Permissions()
+      .listProjectV2Members();
+    fixtures.projects().landingUserProjects().readProjectV2();
+  });
+
+  it("create a simple data connector", () => {
+    fixtures
+      .readProjectV2({ fixture: "projectV2/read-projectV2-empty.json" })
+      .listProjectDataConnectors()
+      .getDataConnector()
+      .getStorageSchema({ fixture: "cloudStorage/storage-schema-s3.json" })
+      .testCloudStorage({ success: false })
+      .postDataConnector({ namespace: "user1-uuid", visibility: "public" })
+      .postDataConnectorProjectLink({ dataConnectorId: "ULID-5" });
+    cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
+    cy.wait("@readProjectV2");
+    cy.wait("@listProjectDataConnectors");
+
+    // add data connector
+    cy.getDataCy("add-data-connector").should("be.visible").click();
+    cy.getDataCy("project-data-controller-mode-create").click();
+    // Pick a provider
+    cy.getDataCy("data-storage-s3").click();
+    cy.getDataCy("data-provider-AWS").click();
+    cy.getDataCy("data-connector-edit-next-button").click();
+
+    // Fill out the details
+    cy.get("#sourcePath").type("bucket/my-source");
+    cy.get("#access_key_id").type("access key");
+    cy.get("#secret_access_key").type("secret key");
+    cy.getDataCy("test-data-connector-button").click();
+    cy.getDataCy("add-data-connector-continue-button").contains("Skip").click();
+    cy.getDataCy("data-connector-edit-mount").within(() => {
+      cy.get("#name").type("example storage without credentials");
+      cy.get("#visibility")
+        .children()
+        .first()
+        .should("have.value", "public")
+        .should("be.checked");
+    });
+
+    cy.getDataCy("data-connector-edit-update-button").click();
+    cy.wait("@postDataConnector");
+    cy.getDataCy("data-connector-edit-body").should(
+      "contain.text",
+      "The data connector user1-uuid/example-storage-without-credentials has been successfully added"
+    );
+    cy.getDataCy("data-connector-edit-body").should(
+      "contain.text",
+      "project was linked"
+    );
+    cy.getDataCy("data-connector-edit-close-button").click();
+    cy.wait("@listProjectDataConnectors");
+  });
+
+  it("link a data connector", () => {
+    fixtures
+      .readProjectV2({ fixture: "projectV2/read-projectV2-empty.json" })
+      .listProjectDataConnectors()
+      .getDataConnectorByNamespaceAndSlug()
+      .postDataConnectorProjectLink({ dataConnectorId: "ULID-1" });
+    cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
+    cy.wait("@readProjectV2");
+    cy.wait("@listProjectDataConnectors");
+
+    // add data connector
+    cy.getDataCy("add-data-connector").should("be.visible").click();
+    cy.getDataCy("project-data-controller-mode-link").click();
+    cy.get("#data-connector-identifier").type("user1-uuid/example-storage");
+    cy.getDataCy("link-data-connector-button").click();
+    cy.wait("@postDataConnectorProjectLink");
+    cy.wait("@listProjectDataConnectors");
+  });
+
+  it("link a data connector not found", () => {
+    fixtures
+      .readProjectV2({ fixture: "projectV2/read-projectV2-empty.json" })
+      .listProjectDataConnectors()
+      .getDataConnectorByNamespaceAndSlugNotFound();
+    cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
+    cy.wait("@readProjectV2");
+    cy.wait("@listProjectDataConnectors");
+
+    // add data connector
+    cy.getDataCy("add-data-connector").should("be.visible").click();
+    cy.getDataCy("project-data-controller-mode-link").click();
+    cy.get("#data-connector-identifier").type("user1-uuid/example-storage");
+    cy.getDataCy("link-data-connector-button").click();
+    cy.wait("@getDataConnectorByNamespaceAndSlugNotFound");
+    cy.contains(
+      "Data connector with identifier 'user1-uuid/example-storage' does not exist or you do not have access to it."
+    ).should("be.visible");
+  });
+
+  it("delete a data connector", () => {
+    fixtures
+      .readProjectV2({ fixture: "projectV2/read-projectV2-empty.json" })
+      .listProjectDataConnectors()
+      .getDataConnector()
+      .deleteDataConnectorProjectLink();
+
+    cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
+    cy.wait("@readProjectV2");
+    cy.wait("@listProjectDataConnectors");
+
+    cy.contains("example storage").should("be.visible").click();
+    openDataConnectorMenu();
+    cy.getDataCy("data-connector-delete").should("be.visible").click();
+    cy.contains("Are you sure you want to unlink the data connector").should(
+      "be.visible"
+    );
+    cy.getDataCy("delete-data-connector-modal-button")
+      .should("be.enabled")
+      .click();
+    cy.wait("@deleteDataConnectorProjectLink");
+    cy.wait("@listProjectDataConnectors");
   });
 });

--- a/tests/cypress/e2e/projectV2setup.spec.ts
+++ b/tests/cypress/e2e/projectV2setup.spec.ts
@@ -319,6 +319,6 @@ describe("Set up data connectors", () => {
     cy.contains(
       "You do not have the required permissions to unlink this data connector."
     ).should("be.visible");
-    cy.getDataCy("delete-data-connector-modal-button").should("be.disabled");
+    cy.getDataCy("delete-data-connector-modal-button").should("not.exist");
   });
 });

--- a/tests/cypress/fixtures/dataConnector/data-connector-permissions.json
+++ b/tests/cypress/fixtures/dataConnector/data-connector-permissions.json
@@ -1,0 +1,5 @@
+{
+  "write": true,
+  "delete": true,
+  "change_membership": true
+}

--- a/tests/cypress/fixtures/groupV2/groupV2-permissions-none.json
+++ b/tests/cypress/fixtures/groupV2/groupV2-permissions-none.json
@@ -1,0 +1,5 @@
+{
+  "write": false,
+  "delete": false,
+  "change_membership": false
+}

--- a/tests/cypress/fixtures/sessions/sessionV2.json
+++ b/tests/cypress/fixtures/sessions/sessionV2.json
@@ -1,0 +1,67 @@
+{
+  "annotations": {
+    "renku.io/branch": "master",
+    "renku.io/commit-sha": "172a784d465a7bd45bacc165df2b64a591ac6b18",
+    "renku.io/default_image_used": "False",
+    "renku.io/git-host": "dev.renku.ch",
+    "renku.io/gitlabProjectId": "39646",
+    "renku.io/namespace": "e2e",
+    "renku.io/projectName": "local-test-project",
+    "renku.io/repository": "https://dev.renku.ch/gitlab/e2e/local-test-project",
+    "renku.io/username": "e2e@renku.ch"
+  },
+  "image": "registry.dev.renku.ch/e2e/local-test-project:172a784",
+  "name": "e2e-40renk-local-2dtest-2dproject-84756d7d",
+  "resources": {
+    "requests": {
+      "cpu": "0.5",
+      "memory": "1G",
+      "storage": "1G"
+    },
+    "usage": {
+      "cpu": 0.007691289,
+      "memory": "0.09G",
+      "storage": "0.00G"
+    }
+  },
+  "started": "2022-02-28T14:15:59+00:00",
+  "state": {
+    "pod_name": "e2e-40renk-local-2dtest-2dproject-84756d7d-0"
+  },
+  "status": {
+    "details": [
+      {
+        "status": "ready",
+        "step": "Initialization"
+      },
+      {
+        "status": "ready",
+        "step": "Downloading server image"
+      },
+      {
+        "status": "ready",
+        "step": "Cloning and configuring the repository"
+      },
+      {
+        "status": "ready",
+        "step": "Git credentials services"
+      },
+      {
+        "status": "ready",
+        "step": "Authentication and proxying services"
+      },
+      {
+        "status": "ready",
+        "step": "Auxiliary session services"
+      },
+      {
+        "status": "ready",
+        "step": "Starting session"
+      }
+    ],
+    "readyNumContainers": 7,
+    "state": "running",
+    "totalNumContainers": 7
+  },
+  "url": "https://dev.renku.ch/sessions/e2e-40renk-local-2dtest-2dproject-84756d7d"
+}

--- a/tests/cypress/support/renkulab-fixtures/dataConnectors.ts
+++ b/tests/cypress/support/renkulab-fixtures/dataConnectors.ts
@@ -43,6 +43,7 @@ interface DataConnectorIdentifierArgs extends SimpleFixture {
 
 interface DeleteDataConnectorProjectLinkArgs extends DataConnectorIdArgs {
   linkId?: string;
+  projectId?: string;
 }
 
 interface PatchDataConnectorSecretsArgs extends DataConnectorIdArgs {
@@ -96,6 +97,32 @@ export function DataConnector<T extends FixturesConstructor>(Parent: T) {
         linkId = "LINK-ULID-1",
       } = args ?? {};
       const response = { statusCode: 204 };
+      cy.intercept(
+        "DELETE",
+        `/ui-server/api/data/data_connectors/${dataConnectorId}/project_links/${linkId}`,
+        response
+      ).as(name);
+      return this;
+    }
+
+    deleteDataConnectorProjectLinkNotAllowed(
+      args?: DeleteDataConnectorProjectLinkArgs
+    ) {
+      const {
+        name = "deleteDataConnectorProjectLinkNotAllowed",
+        dataConnectorId = "ULID-1",
+        linkId = "LINK-ULID-1",
+        projectId = "THEPROJECTULID26CHARACTERS",
+      } = args ?? {};
+      const response = {
+        body: {
+          error: {
+            code: 1404,
+            message: `The user with ID 'userId' cannot perform operation delete_link on the data connector to project link with ID ${projectId} or the resource does not exist.`,
+          },
+        },
+        statusCode: 404,
+      };
       cy.intercept(
         "DELETE",
         `/ui-server/api/data/data_connectors/${dataConnectorId}/project_links/${linkId}`,

--- a/tests/cypress/support/renkulab-fixtures/dataConnectors.ts
+++ b/tests/cypress/support/renkulab-fixtures/dataConnectors.ts
@@ -28,6 +28,10 @@ interface DataConnectorListArgs extends SimpleFixture {
   visibility?: string;
 }
 
+interface DataConnectorPostArgs extends DataConnectorListArgs {
+  slug?: string;
+}
+
 interface DataConnectorIdArgs extends SimpleFixture {
   dataConnectorId?: string;
 }
@@ -298,11 +302,12 @@ export function DataConnector<T extends FixturesConstructor>(Parent: T) {
       return this;
     }
 
-    postDataConnector(args?: DataConnectorListArgs) {
+    postDataConnector(args?: DataConnectorPostArgs) {
       const {
         fixture = "dataConnector/new-data-connector.json",
         name = "postDataConnector",
         namespace,
+        slug,
         visibility = "private",
       } = args ?? {};
       cy.fixture(fixture).then((dataConnector) => {
@@ -315,6 +320,9 @@ export function DataConnector<T extends FixturesConstructor>(Parent: T) {
           expect(newDataConnector.visibility).equal(visibility);
           if (namespace) {
             expect(newDataConnector.namespace).equal(namespace);
+          }
+          if (slug) {
+            expect(newDataConnector.slug).equal(slug);
           }
           dataConnector.namespace = newDataConnector.namespace;
           dataConnector.slug = newDataConnector.slug;

--- a/tests/cypress/support/renkulab-fixtures/dataConnectors.ts
+++ b/tests/cypress/support/renkulab-fixtures/dataConnectors.ts
@@ -168,6 +168,31 @@ export function DataConnector<T extends FixturesConstructor>(Parent: T) {
       return this;
     }
 
+    getDataConnectorByNamespaceAndSlugNotFound(
+      args?: DataConnectorIdentifierArgs
+    ) {
+      const {
+        name = "getDataConnectorByNamespaceAndSlugNotFound",
+        namespace = "user1-uuid",
+        slug = "example-storage",
+      } = args ?? {};
+      const response = {
+        body: {
+          error: {
+            code: 1404,
+            message: `Data connector with identifier '${namespace}/${slug}' does not exist or you do not have access to it.`,
+          },
+        },
+        statusCode: 404,
+      };
+      cy.intercept(
+        "GET",
+        `/ui-server/api/data/namespaces/${namespace}/data_connectors/${slug}`,
+        response
+      ).as(name);
+      return this;
+    }
+
     listDataConnectorProjectLinks(args?: DataConnectorIdArgs) {
       const {
         fixture = "dataConnector/project-data-connector-links.json",

--- a/tests/cypress/support/renkulab-fixtures/dataConnectors.ts
+++ b/tests/cypress/support/renkulab-fixtures/dataConnectors.ts
@@ -220,6 +220,25 @@ export function DataConnector<T extends FixturesConstructor>(Parent: T) {
       return this;
     }
 
+    getDataConnectorPermissions(args?: DataConnectorIdArgs) {
+      const {
+        fixture = "dataConnector/data-connector-permissions.json",
+        name = "getDataConnectorPermissions",
+        dataConnectorId = "ULID-1",
+      } = args ?? {};
+      cy.fixture(fixture).then((permissions) => {
+        // eslint-disable-next-line max-nested-callbacks
+        cy.intercept(
+          "GET",
+          `/ui-server/api/data/data_connectors/${dataConnectorId}/permissions`,
+          (req) => {
+            req.reply({ body: permissions });
+          }
+        ).as(name);
+      });
+      return this;
+    }
+
     listDataConnectorProjectLinks(args?: DataConnectorIdArgs) {
       const {
         fixture = "dataConnector/project-data-connector-links.json",


### PR DESCRIPTION
### minor: cosmetic improvements to data connector view
![image](https://github.com/user-attachments/assets/61d0a84d-8cf6-4f21-b6ae-083e91133822)

### minor: show the avatar and icon for the data connector owner (with owner as link)
<img width="264" alt="image" src="https://github.com/user-attachments/assets/39f95a3b-be6e-45fe-8f49-dd0e824f2d6f">

### minor: make the credentials feedback an info alert
![image](https://github.com/user-attachments/assets/a45a0283-da7d-497a-a0d6-583aa7d57a28)

### minor: fix terminology on the data connectors link page
![image](https://github.com/user-attachments/assets/574085ad-0b44-43a7-920b-a62c682da0e1)

### minor: nicer display of credentials

<img width="496" alt="image" src="https://github.com/user-attachments/assets/b43b7d61-a95d-40ce-8472-c9b3d0ca18f3">


### minor: add permission guards to data connector edit/delete/unlink
### minor: fix colors of buttons in the credentials prompt
### minor: use "Identifier" instead of "ID"
### minor: nicer error messages when a link fails

/deploy
