### PR TITLE
chore: add onclick coding guideline

### DIFF
--- a/CODING_GUIDELINES.md
+++ b/CODING_GUIDELINES.md
@@ -23,7 +23,7 @@ Rules:
 - [R004: Include a default export when appropriate](#r004-include-a-default-export-when-appropriate)
 - [R005: File naming conventions](#r005-file-naming-conventions)
 - [R006: Use existing Bootstrap classes or import from CSS modules](#r006-use-existing-bootstrap-classes-or-import-from-css-modules)
-- [R007: Do not perform async actions in React hooks](#r006-use-existing-bootstrap-classes-or-import-from-css-modules)
+- [R007: Do not perform async actions in React hooks](#r007-do-not-perform-async-actions-in-react-hooks)
 
 ### R001: Use utility functions to create CSS class names
 

--- a/CODING_GUIDELINES.md
+++ b/CODING_GUIDELINES.md
@@ -23,6 +23,7 @@ Rules:
 - [R004: Include a default export when appropriate](#r004-include-a-default-export-when-appropriate)
 - [R005: File naming conventions](#r005-file-naming-conventions)
 - [R006: Use existing Bootstrap classes or import from CSS modules](#r006-use-existing-bootstrap-classes-or-import-from-css-modules)
+- [R007: Do not perform async actions in React hooks](#r006-use-existing-bootstrap-classes-or-import-from-css-modules)
 
 ### R001: Use utility functions to create CSS class names
 
@@ -269,3 +270,58 @@ only minimally impacts the interface.
 
 E.G. If a Figma design reference file shows a distance between components
 of 14.5px and `m-3` is 16px, we should use `m-3` instead.
+
+### R007: Do not perform async actions in React hooks
+
+Do not use `.then()` or `.unwrap()` inside React hooks. Instead, listen to the result of the async action and act on the result.
+
+**✅ DO**
+
+```tsx
+function MyComponent() {
+  const [postRequest, result] = usePostRequest();
+
+  const onClick = useCallback(() => {
+    postRequest();
+  }, [postRequest]);
+
+  useEffect(() => {
+    if (result.isSuccess) {
+      // Do something...
+    }
+  }, [result.isSuccess]);
+
+  return (
+    <div>
+      <button onClick={onClick}>Some action</button>
+    </div>
+  );
+}
+```
+
+**❌ DON'T**
+
+```tsx
+function MyComponent() {
+  const [postRequest, result] = usePostRequest();
+
+  const onClick = useCallback(() => {
+    postRequest()
+      .unwrap()
+      .then(() => {
+        // Do something...
+      });
+  }, [postRequest]);
+
+  return (
+    <div>
+      <button onClick={onClick}>Some action</button>
+    </div>
+  );
+}
+```
+
+**💡 Rationale**
+
+Calling code after an async action may happen after a component has re-rendered or has been removed.
+In this case, if the corresponding code tries to access the component, it will cause an error.

--- a/CODING_GUIDELINES.md
+++ b/CODING_GUIDELINES.md
@@ -325,3 +325,61 @@ function MyComponent() {
 
 Calling code after an async action may happen after a component has re-rendered or has been removed.
 In this case, if the corresponding code tries to access the component, it will cause an error.
+
+### R008: Interactive handlers can only be used on interactive HTML tags
+
+Do not add interactive handlers, e.g. `onClick`, to HTML tags which are not interactive.
+
+**✅ DO**
+
+```tsx
+function MyComponent() {
+  return (
+    <ul>
+      <li>
+        <a href="...">
+          My Content
+        </a>
+      <li>
+    </ul>
+  );
+}
+```
+
+```tsx
+function MyComponent() {
+  const onClick = ...Some action...;
+
+  return (
+    <ul>
+      <li>
+        <button onClick={onClick}>
+          My Content
+        </button>
+      <li>
+    </ul>
+  );
+}
+```
+
+**❌ DON'T**
+
+```tsx
+function MyComponent() {
+  const onClick = ...Some action...;
+
+  return (
+    <ul>
+      <li onClick={onClick}>
+        My Content
+      <li>
+    </ul>
+  );
+}
+```
+
+**💡 Rationale**
+
+Browsers do not expect tags such as `<div>` or `<span>` to be interactive, which means they will
+not get focused with keyboard navigation. Adding interactive handlers to non-interactive tags will
+therefore hinder accessibility to users which do not have access to a mouse or touch screen.

--- a/CODING_GUIDELINES.md
+++ b/CODING_GUIDELINES.md
@@ -24,6 +24,7 @@ Rules:
 - [R005: File naming conventions](#r005-file-naming-conventions)
 - [R006: Use existing Bootstrap classes or import from CSS modules](#r006-use-existing-bootstrap-classes-or-import-from-css-modules)
 - [R007: Do not perform async actions in React hooks](#r007-do-not-perform-async-actions-in-react-hooks)
+- [R008: Interactive handlers can only be used on interactive HTML tags](#r008-interactive-handlers-can-only-be-used-on-interactive-html-tags)
 
 ### R001: Use utility functions to create CSS class names
 


### PR DESCRIPTION
Some counter-examples include the session row in the Renku 2.0 project page, it is not possible to open the session launcher offcanvas using the keyboard at the moment because we have `<li onclick={...}>`.