### PR TITLE
refactor: use URL hash to control session offcanvas

### DIFF
--- a/client/src/features/dashboardV2/DashboardV2Sessions.tsx
+++ b/client/src/features/dashboardV2/DashboardV2Sessions.tsx
@@ -91,6 +91,10 @@ function DashboardSession({ session }: DashboardSessionProps) {
         id: projectId,
       })
     : ABSOLUTE_ROUTES.v2.root;
+  const sessionHash =
+    project && annotations["launcherId"]
+      ? `launcher-${annotations["launcherId"]}`
+      : "";
   const showSessionUrl = project
     ? generatePath(ABSOLUTE_ROUTES.v2.projects.show.sessions.show, {
         namespace: project.namespace,
@@ -112,7 +116,7 @@ function DashboardSession({ session }: DashboardSessionProps) {
         "text-decoration-none"
       )}
       data-cy="list-session"
-      to={projectUrl}
+      to={{ pathname: projectUrl, hash: sessionHash }}
     >
       <Row className="g-2">
         <Col className="order-1" xs={12} md={9} lg={10}>

--- a/client/src/features/sessionsV2/SessionList/SessionItemDisplay.tsx
+++ b/client/src/features/sessionsV2/SessionList/SessionItemDisplay.tsx
@@ -33,6 +33,8 @@ export function SessionItemDisplay({
   launcher,
   project,
 }: SessionLauncherDisplayProps) {
+  // TODO: here!
+
   const { name } = launcher;
   const [toggleSessionView, setToggleSessionView] = useState(false);
   const { data: sessions } = sessionsApi.endpoints.getSessions.useQueryState();

--- a/client/src/features/sessionsV2/SessionList/SessionItemDisplay.tsx
+++ b/client/src/features/sessionsV2/SessionList/SessionItemDisplay.tsx
@@ -38,17 +38,17 @@ export function SessionItemDisplay({
   const { name } = launcher;
 
   const [hash, setHash] = useLocationHash();
-  const hashMatch = useMemo(() => `launcher-${launcher.id}`, [launcher.id]);
+  const launcherHash = useMemo(() => `launcher-${launcher.id}`, [launcher.id]);
   const isSessionViewOpen = useMemo(
-    () => hash === hashMatch,
-    [hash, hashMatch]
+    () => hash === launcherHash,
+    [hash, launcherHash]
   );
   const toggleSessionView = useCallback(() => {
     setHash((prev) => {
-      const isOpen = prev === hashMatch;
-      return isOpen ? "" : hashMatch;
+      const isOpen = prev === launcherHash;
+      return isOpen ? "" : launcherHash;
     });
-  }, [hashMatch, setHash]);
+  }, [launcherHash, setHash]);
 
   const { data: sessions } = sessionsApi.endpoints.getSessions.useQueryState();
   const filteredSessions = useMemo(
@@ -92,6 +92,7 @@ export function SessionItemDisplay({
         />
       )}
       <SessionView
+        id={launcherHash}
         launcher={launcher}
         project={project}
         sessions={filteredSessions}

--- a/client/src/features/sessionsV2/SessionView/SessionView.tsx
+++ b/client/src/features/sessionsV2/SessionView/SessionView.tsx
@@ -255,6 +255,7 @@ function EnvironmentCard({
   );
 }
 interface SessionViewProps {
+  id?: string;
   isOpen: boolean;
   launcher?: SessionLauncher;
   project: Project;
@@ -262,6 +263,7 @@ interface SessionViewProps {
   toggle: () => void;
 }
 export function SessionView({
+  id,
   launcher,
   sessions,
   toggle: setToggleSessionView,
@@ -352,6 +354,7 @@ export function SessionView({
 
   return (
     <Offcanvas
+      id={id}
       key={`launcher-details-${key}`}
       toggle={setToggleSessionView}
       isOpen={toggleSessionView}

--- a/client/src/features/sessionsV2/SessionView/SessionView.tsx
+++ b/client/src/features/sessionsV2/SessionView/SessionView.tsx
@@ -255,17 +255,17 @@ function EnvironmentCard({
   );
 }
 interface SessionViewProps {
+  isOpen: boolean;
   launcher?: SessionLauncher;
-  sessions?: Sessions;
-  toggleSessionView: boolean;
-  setToggleSessionView: () => void;
   project: Project;
+  sessions?: Sessions;
+  toggle: () => void;
 }
 export function SessionView({
   launcher,
   sessions,
-  setToggleSessionView,
-  toggleSessionView,
+  toggle: setToggleSessionView,
+  isOpen: toggleSessionView,
   project,
 }: SessionViewProps) {
   const [isUpdateOpen, setIsUpdateOpen] = useState(false);

--- a/client/src/features/sessionsV2/SessionsV2.tsx
+++ b/client/src/features/sessionsV2/SessionsV2.tsx
@@ -259,8 +259,8 @@ function OrphanSession({ session, project }: OrphanSessionProps) {
       <SessionView
         sessions={sessions}
         project={project}
-        setToggleSessionView={openSessionDetails}
-        toggleSessionView={toggleSessionView}
+        toggle={openSessionDetails}
+        isOpen={toggleSessionView}
       />
     </>
   );

--- a/client/src/features/sessionsV2/SessionsV2.tsx
+++ b/client/src/features/sessionsV2/SessionsV2.tsx
@@ -52,6 +52,7 @@ import { SessionLauncher } from "./sessionsV2.types";
 
 // Required for logs formatting
 import "../../notebooks/Notebooks.css";
+import useLocationHash from "../../utils/customHooks/useLocationHash.hook";
 
 export function getShowSessionUrlByProject(
   project: Project,
@@ -241,26 +242,39 @@ interface OrphanSessionProps {
 }
 
 function OrphanSession({ session, project }: OrphanSessionProps) {
-  const [toggleSessionView, setToggleSessionView] = useState(false);
   const sessions = {
     [session.name]: session,
   };
-  const openSessionDetails = () => {
-    setToggleSessionView((open) => !open);
-  };
+
+  const [hash, setHash] = useLocationHash();
+  const sessionHash = useMemo(
+    () => `orphan-session-${session.name}`,
+    [session.name]
+  );
+  const isSessionViewOpen = useMemo(
+    () => hash === sessionHash,
+    [hash, sessionHash]
+  );
+  const toggleSessionView = useCallback(() => {
+    setHash((prev) => {
+      const isOpen = prev === sessionHash;
+      return isOpen ? "" : sessionHash;
+    });
+  }, [sessionHash, setHash]);
 
   return (
     <>
       <SessionItem
         project={project}
         session={session}
-        toggleSessionDetails={openSessionDetails}
+        toggleSessionDetails={toggleSessionView}
       />
       <SessionView
+        id={sessionHash}
         sessions={sessions}
         project={project}
-        toggle={openSessionDetails}
-        isOpen={toggleSessionView}
+        toggle={toggleSessionView}
+        isOpen={isSessionViewOpen}
       />
     </>
   );

--- a/client/src/features/sessionsV2/SessionsV2.tsx
+++ b/client/src/features/sessionsV2/SessionsV2.tsx
@@ -35,6 +35,7 @@ import { ButtonWithMenuV2 } from "../../components/buttons/Button";
 import { RtkErrorAlert } from "../../components/errors/RtkErrorAlert";
 import { NotebookAnnotations } from "../../notebooks/components/session.types";
 import { ABSOLUTE_ROUTES } from "../../routing/routes.constants";
+import useLocationHash from "../../utils/customHooks/useLocationHash.hook";
 import useProjectPermissions from "../ProjectPageV2/utils/useProjectPermissions.hook";
 import PermissionsGuard from "../permissionsV2/PermissionsGuard";
 import type { Project } from "../projectsV2/api/projectV2.api";
@@ -52,7 +53,6 @@ import { SessionLauncher } from "./sessionsV2.types";
 
 // Required for logs formatting
 import "../../notebooks/Notebooks.css";
-import useLocationHash from "../../utils/customHooks/useLocationHash.hook";
 
 export function getShowSessionUrlByProject(
   project: Project,

--- a/client/src/utils/customHooks/useLocationHash.hook.ts
+++ b/client/src/utils/customHooks/useLocationHash.hook.ts
@@ -1,0 +1,50 @@
+/*!
+ * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCallback, useMemo } from "react";
+import {
+  type NavigateOptions,
+  useLocation,
+  useNavigate,
+} from "react-router-dom-v5-compat";
+
+export default function useLocationHash(): [string, SetLocationHash] {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const hash = useMemo(
+    () =>
+      location.hash.startsWith("#") ? location.hash.slice(1) : location.hash,
+    [location.hash]
+  );
+
+  const setLocationHash = useCallback<SetLocationHash>(
+    (next, options) => {
+      const newHash = typeof next === "function" ? next(hash) : next;
+      navigate({ hash: newHash ?? "" }, options);
+    },
+    [hash, navigate]
+  );
+
+  return [hash, setLocationHash];
+}
+
+export type SetLocationHash = (
+  next?: string | ((prev: string) => string),
+  options?: NavigateOptions
+) => void;

--- a/client/src/utils/customHooks/useLocationHash.hook.ts
+++ b/client/src/utils/customHooks/useLocationHash.hook.ts
@@ -23,6 +23,10 @@ import {
   useNavigate,
 } from "react-router-dom-v5-compat";
 
+/**
+ * useLocationHash() is a hook similar to react-router's useSearchParams but for the URL hash.
+ * See: https://reactrouter.com/en/main/hooks/use-search-params
+ */
 export default function useLocationHash(): [string, SetLocationHash] {
   const location = useLocation();
   const navigate = useNavigate();


### PR DESCRIPTION
Controls the session offcanvas with a URL hash, e.g.

- `https://renku-ci-ui-3382.dev.renku.ch/v2/projects/flora.thiebaut/flora-test` -> project page
- `https://renku-ci-ui-3382.dev.renku.ch/v2/projects/flora.thiebaut/flora-test#launcher-01JAWVJ544MHTX98Y5FGDSCHTK`-> project page with session offcanvas open

The session row on the dashboard page has also been updated: clicking on the session row now opens the offcanvas for that session. Note that it will not work for orphan sessions.

/deploy