### PR TITLE
fix: remove uses of icon-text class name

### DIFF
--- a/client/src/features/ProjectPageV2/ProjectPageContent/CodeRepositories/RepositoriesBox.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/CodeRepositories/RepositoriesBox.tsx
@@ -71,7 +71,7 @@ export function CodeRepositoriesDisplay({ project }: { project: Project }) {
                   onClick={toggle}
                   size="sm"
                 >
-                  <PlusLg className="icon-text" />
+                  <PlusLg className="bi" />
                 </Button>
               }
               requestedPermission="write"

--- a/client/src/features/ProjectPageV2/ProjectPageContent/DataConnectors/ProjectDataConnectorsBox.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/DataConnectors/ProjectDataConnectorsBox.tsx
@@ -150,7 +150,7 @@ function ProjectDataConnectorBoxHeader({
                 onClick={toggleOpen}
                 size="sm"
               >
-                <PlusLg className="icon-text" />
+                <PlusLg className="bi" />
               </Button>
             }
             requestedPermission="write"

--- a/client/src/features/ProjectPageV2/ProjectPageContent/Settings/ProjectSettingsMembers.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/Settings/ProjectSettingsMembers.tsx
@@ -324,7 +324,7 @@ function ProjectPageSettingsMembersContent({
                 onClick={toggleAddMemberModalOpen}
                 size="sm"
               >
-                <PlusLg className="icon-text" />
+                <PlusLg className="bi" />
               </Button>
             }
             requestedPermission="change_membership"

--- a/client/src/features/dataConnectorsV2/components/DataConnectorsBox.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorsBox.tsx
@@ -63,7 +63,7 @@ function AddButtonForGroupNamespace({
           onClick={toggleOpen}
           size="sm"
         >
-          <PlusLg className="icon-text" />
+          <PlusLg className="bi" />
         </Button>
       }
       requestedPermission="write"
@@ -86,7 +86,7 @@ function AddButtonForUserNamespace({
         onClick={toggleOpen}
         size="sm"
       >
-        <PlusLg className="icon-text" />
+        <PlusLg className="bi" />
       </Button>
     );
   }

--- a/client/src/features/projectsV2/fields/ProjectNamespaceFormField.tsx
+++ b/client/src/features/projectsV2/fields/ProjectNamespaceFormField.tsx
@@ -56,7 +56,7 @@ const selectComponents: SelectComponentsConfig<
   DropdownIndicator: (props) => {
     return (
       <components.DropdownIndicator {...props}>
-        <ChevronDown className="icon-text" />
+        <ChevronDown className="bi" />
       </components.DropdownIndicator>
     );
   },

--- a/client/src/features/projectsV2/fields/UserSelector.tsx
+++ b/client/src/features/projectsV2/fields/UserSelector.tsx
@@ -57,7 +57,7 @@ const selectComponents: SelectComponentsConfig<User, false, GroupBase<User>> = {
   DropdownIndicator: (props) => {
     return (
       <components.DropdownIndicator {...props}>
-        <ChevronDown className="icon-text" />
+        <ChevronDown className="bi" />
       </components.DropdownIndicator>
     );
   },

--- a/client/src/features/sessionsV2/AddSessionLauncherButton.tsx
+++ b/client/src/features/sessionsV2/AddSessionLauncherButton.tsx
@@ -39,7 +39,7 @@ export default function AddSessionLauncherButton({
     <>
       {styleBtn === "iconTextBtn" ? (
         <Button data-cy={dataCy} onClick={() => toggle()}>
-          <PlusLg className={cx("me-2", "icon-text")} />
+          <PlusLg className={cx("me-2", "bi")} />
           Add session
         </Button>
       ) : (
@@ -49,7 +49,7 @@ export default function AddSessionLauncherButton({
           onClick={toggle}
           size="sm"
         >
-          <PlusLg className="icon-text" />
+          <PlusLg className="bi" />
         </Button>
       )}
       <Step1AddSessionModal isOpen={isOpen} toggleModal={toggle} />

--- a/client/src/storybook/bootstrap/Button.stories.tsx
+++ b/client/src/storybook/bootstrap/Button.stories.tsx
@@ -85,10 +85,10 @@ export const IconOnly_: Story = {
   render: ({ ..._args }) => (
     <div className="d-flex gap-3">
       <Button {..._args} color="outline-primary">
-        <PlusLg className="icon-text" />
+        <PlusLg className="bi" />
       </Button>
       <Button {..._args} color="primary">
-        <PlusLg className="icon-text" />
+        <PlusLg className="bi" />
       </Button>
     </div>
   ),


### PR DESCRIPTION
Fixes icon alignment; the `icon-text` class does not exist. Only `bi` (bootstrap-icon) should be used for icon alignment.

Before (icon too low):
![image](https://github.com/user-attachments/assets/28a15117-75cc-4e6d-b3ed-823e41ccf955)

After (icon perfectly centered vertically):
![image](https://github.com/user-attachments/assets/19351f6a-f771-4d08-99b9-53fee9c1184e)

/deploy #notest