### PR TITLE
fix: reset state of data connectors on modal close

### DIFF
--- a/client/src/features/ProjectPageV2/ProjectPageContent/DataConnectors/ProjectDataConnectorsBox.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/DataConnectors/ProjectDataConnectorsBox.tsx
@@ -101,12 +101,14 @@ function ProjectDataConnectorBoxContent({
           )}
         </CardBody>
       </Card>
-      <ProjectConnectDataConnectorsModal
-        isOpen={isModalOpen}
-        namespace={project.namespace}
-        project={project}
-        toggle={toggleOpen}
-      />
+      {isModalOpen && (
+        <ProjectConnectDataConnectorsModal
+          isOpen={isModalOpen}
+          namespace={project.namespace}
+          project={project}
+          toggle={toggleOpen}
+        />
+      )}
     </div>
   );
 }

--- a/client/src/features/dataConnectorsV2/components/DataConnectorActions.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorActions.tsx
@@ -462,18 +462,21 @@ export default function DataConnectorActions({
           )}
         </DropdownItem>
       </ButtonWithMenuV2>
+      {/* This component needs to be always be in the DOM for some reason... */}
       <DataConnectorCredentialsModal
         dataConnector={dataConnector}
         setOpen={setCredentialsOpen}
         isOpen={isCredentialsOpen}
       />
-      {removeModal}
-      <DataConnectorModal
-        dataConnector={dataConnector}
-        isOpen={isEditOpen}
-        namespace={dataConnector.namespace}
-        toggle={toggleEdit}
-      />
+      {isDeleteOpen && removeModal}
+      {isEditOpen && (
+        <DataConnectorModal
+          dataConnector={dataConnector}
+          isOpen={isEditOpen}
+          namespace={dataConnector.namespace}
+          toggle={toggleEdit}
+        />
+      )}
     </>
   );
 }

--- a/client/src/features/dataConnectorsV2/components/DataConnectorModal/DataConnectorModalFooter.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorModal/DataConnectorModalFooter.tsx
@@ -62,12 +62,14 @@ import {
 
 interface DataConnectorModalFooterProps {
   dataConnector?: DataConnectorRead | null;
+  isOpen: boolean;
   project?: Project;
   toggle: () => void;
 }
 
 export default function DataConnectorModalFooter({
   dataConnector = null,
+  isOpen,
   project,
   toggle,
 }: DataConnectorModalFooterProps) {
@@ -131,6 +133,13 @@ export default function DataConnectorModalFooter({
     createProjectLinkResult,
     updateResult,
   ]);
+
+  // Reset the state when the modal is closed
+  useEffect(() => {
+    if (!isOpen) {
+      reset();
+    }
+  }, [isOpen, reset]);
 
   const addOrEditStorage = useCallback(() => {
     const dataConnectorPost = dataConnectorPostFromFlattened(
@@ -271,10 +280,6 @@ export default function DataConnectorModalFooter({
         credentialSaveStatus: status,
       })
     );
-    // If the saving attempt has completed, reset the result
-    if (saveCredentialsResult.isSuccess || saveCredentialsResult.isError) {
-      saveCredentialsResult.reset();
-    }
   }, [
     credentialSaveStatus,
     dataConnectorResultId,
@@ -331,10 +336,6 @@ export default function DataConnectorModalFooter({
         projectLinkStatus: status,
       })
     );
-    // If the linking attempt has completed, reset the result
-    if (createProjectLinkResult.isSuccess || createProjectLinkResult.isError) {
-      createProjectLinkResult.reset();
-    }
   }, [
     createProjectLinkResult,
     dataConnectorResultId,

--- a/client/src/features/dataConnectorsV2/components/DataConnectorModal/dataConnectorModalButtons.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorModal/dataConnectorModalButtons.tsx
@@ -218,11 +218,12 @@ export function DataConnectorModalContinueButton({
 }
 
 export function DataConnectorConnectionTestResult() {
-  const { cloudStorageState, isActionOngoing, validationResult } =
+  const { cloudStorageState, isActionOngoing, success, validationResult } =
     useAppSelector((state) => state.dataConnectorFormSlice);
   if (
     cloudStorageState.step !== 2 ||
     cloudStorageState.completedSteps < 2 ||
+    success ||
     validationResult == null ||
     isActionOngoing
   )

--- a/client/src/features/dataConnectorsV2/components/DataConnectorModal/dataConnectorModalButtons.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorModal/dataConnectorModalButtons.tsx
@@ -222,7 +222,7 @@ export function DataConnectorConnectionTestResult() {
     useAppSelector((state) => state.dataConnectorFormSlice);
   if (
     cloudStorageState.step !== 2 ||
-    cloudStorageState.completedSteps < 2 ||
+    cloudStorageState.completedSteps < 1 ||
     success ||
     validationResult == null ||
     isActionOngoing

--- a/client/src/features/dataConnectorsV2/components/DataConnectorModal/index.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorModal/index.tsx
@@ -109,6 +109,7 @@ export function DataConnectorModalBodyAndFooter({
       <ModalFooter className="border-top" data-cy="data-connector-edit-footer">
         <DataConnectorModalFooter
           dataConnector={dataConnector}
+          isOpen={isOpen}
           project={project}
           toggle={toggle}
         />

--- a/client/src/features/dataConnectorsV2/state/dataConnectors.slice.ts
+++ b/client/src/features/dataConnectorsV2/state/dataConnectors.slice.ts
@@ -45,6 +45,7 @@ interface BackendResult {
 const initialState = {
   cloudStorageState: EMPTY_CLOUD_STORAGE_STATE,
   credentialSaveStatus: "none" as AuxiliaryCommandStatus,
+  dataConnectorResultId: undefined as string | undefined,
   dataConnectorResultName: undefined as string | undefined,
   flatDataConnector: EMPTY_DATA_CONNECTOR_FLAT,
   isActionOngoing: false,
@@ -197,11 +198,13 @@ const dataConnectorFormSlice = createSlice({
       state,
       action: PayloadAction<{
         success: boolean;
+        dataConnectorResultId: string | undefined;
         dataConnectorResultName: string | undefined;
       }>
     ) => {
       state.success = action.payload.success;
       state.dataConnectorResultName = action.payload.dataConnectorResultName;
+      state.dataConnectorResultId = action.payload.dataConnectorResultId;
     },
     setValidationResult: (
       state,

--- a/tests/cypress/e2e/projectV2DataConnectorCredentials.spec.ts
+++ b/tests/cypress/e2e/projectV2DataConnectorCredentials.spec.ts
@@ -74,6 +74,7 @@ describe("Set up data connectors with credentials", () => {
     cy.get("#access_key_id").type("access key");
     cy.get("#secret_access_key").type("secret key");
     cy.getDataCy("test-data-connector-button").click();
+    cy.contains("Error 1422").should("be.visible");
     cy.getDataCy("add-data-connector-continue-button").contains("Skip").click();
     cy.getDataCy("data-connector-edit-mount").within(() => {
       cy.get("#name").type("example storage without credentials");
@@ -144,6 +145,9 @@ describe("Set up data connectors with credentials", () => {
     cy.get("#secret_access_key").type("secret key");
     cy.getDataCy("test-data-connector-button").click();
     cy.wait("@testCloudStorage");
+    cy.contains("The connection to the storage works correctly.").should(
+      "be.visible"
+    );
     cy.getDataCy("add-data-connector-continue-button")
       .contains("Continue")
       .click();

--- a/tests/cypress/e2e/projectV2DataConnectorCredentials.spec.ts
+++ b/tests/cypress/e2e/projectV2DataConnectorCredentials.spec.ts
@@ -184,6 +184,7 @@ describe("Set up data connectors with credentials", () => {
 
     // Check that the state was reset
     cy.getDataCy("add-data-connector").should("be.visible").click();
+    cy.getDataCy("project-data-controller-mode-create").click();
     cy.getDataCy("data-storage-s3").click();
     cy.getDataCy("data-provider-AWS").click();
   });

--- a/tests/cypress/e2e/projectV2setup.spec.ts
+++ b/tests/cypress/e2e/projectV2setup.spec.ts
@@ -183,6 +183,7 @@ describe("Set up data connectors", () => {
           email: "user1@email.com",
         },
       })
+      .getGroupV2Permissions()
       .getProjectV2Permissions()
       .listProjectV2Members();
     fixtures.projects().landingUserProjects().readProjectV2();
@@ -195,6 +196,7 @@ describe("Set up data connectors", () => {
       .getDataConnector()
       .getStorageSchema({ fixture: "cloudStorage/storage-schema-s3.json" })
       .testCloudStorage({ success: false })
+      .getDataConnectorPermissions()
       .postDataConnector({ namespace: "user1-uuid", visibility: "public" })
       .postDataConnectorProjectLink({ dataConnectorId: "ULID-5" });
     cy.visit("/v2/projects/user1-uuid/test-2-v2-project");

--- a/tests/cypress/e2e/projectV2setup.spec.ts
+++ b/tests/cypress/e2e/projectV2setup.spec.ts
@@ -323,4 +323,80 @@ describe("Set up data connectors", () => {
     ).should("be.visible");
     cy.getDataCy("delete-data-connector-modal-button").should("not.exist");
   });
+
+  it("should clear state after a data connector has been created", () => {
+    fixtures
+      .readProjectV2({ fixture: "projectV2/read-projectV2-empty.json" })
+      .listProjectDataConnectors()
+      .getDataConnector()
+      .getStorageSchema({ fixture: "cloudStorage/storage-schema-s3.json" })
+      .testCloudStorage({ success: false })
+      .postDataConnector({ namespace: "user1-uuid", visibility: "public" })
+      .postDataConnectorProjectLink({ dataConnectorId: "ULID-5" });
+    cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
+    cy.wait("@readProjectV2");
+    cy.wait("@listProjectDataConnectors");
+
+    // add data connector
+    cy.getDataCy("add-data-connector").should("be.visible").click();
+    cy.getDataCy("project-data-controller-mode-create").click();
+    // Pick a provider
+    cy.getDataCy("data-storage-s3").click();
+    cy.getDataCy("data-provider-AWS").click();
+    cy.getDataCy("data-connector-edit-next-button").click();
+
+    // Fill out the details
+    cy.get("#sourcePath").type("bucket/my-source");
+    cy.get("#access_key_id").type("access key");
+    cy.get("#secret_access_key").type("secret key");
+    cy.getDataCy("test-data-connector-button").click();
+    cy.getDataCy("add-data-connector-continue-button").contains("Skip").click();
+    cy.getDataCy("data-connector-edit-mount").within(() => {
+      cy.get("#name").type("example storage without credentials");
+      cy.get("#visibility")
+        .children()
+        .first()
+        .should("have.value", "public")
+        .should("be.checked");
+    });
+
+    cy.getDataCy("data-connector-edit-update-button").click();
+    cy.wait("@postDataConnector");
+    cy.getDataCy("data-connector-edit-body").should(
+      "contain.text",
+      "The data connector user1-uuid/example-storage-without-credentials has been successfully added"
+    );
+    cy.getDataCy("data-connector-edit-body").should(
+      "contain.text",
+      "project was linked"
+    );
+    cy.getDataCy("data-connector-edit-close-button").click();
+    cy.wait("@listProjectDataConnectors");
+
+    // Start adding a second data connector, but cancel
+    fixtures.postDataConnectorProjectLink({ shouldNotBeCalled: true });
+    cy.getDataCy("add-data-connector").should("be.visible").click();
+    cy.getDataCy("project-data-controller-mode-create").click();
+    cy.getDataCy("data-storage-s3").click();
+    cy.getDataCy("data-provider-AWS").click();
+    cy.getDataCy("data-connector-edit-next-button").click();
+
+    // Fill out the details
+    cy.get("#sourcePath").type("bucket/my-source");
+    cy.get("#access_key_id").type("access key");
+    cy.get("#secret_access_key").type("secret key");
+    cy.getDataCy("test-data-connector-button").click();
+    cy.getDataCy("add-data-connector-continue-button").contains("Skip").click();
+    cy.getDataCy("data-connector-edit-mount").within(() => {
+      cy.get("#name").type("example storage 2");
+      cy.get("#visibility")
+        .children()
+        .first()
+        .should("have.value", "public")
+        .should("be.checked");
+    });
+    cy.getDataCy("project-data-connector-connect-header")
+      .find("button.btn-close[aria-label='Close']")
+      .click();
+  });
 });

--- a/tests/cypress/e2e/projectV2setup.spec.ts
+++ b/tests/cypress/e2e/projectV2setup.spec.ts
@@ -196,7 +196,6 @@ describe("Set up data connectors", () => {
       .getDataConnector()
       .getStorageSchema({ fixture: "cloudStorage/storage-schema-s3.json" })
       .testCloudStorage({ success: false })
-      .getDataConnectorPermissions()
       .postDataConnector({ namespace: "user1-uuid", visibility: "public" })
       .postDataConnectorProjectLink({ dataConnectorId: "ULID-5" });
     cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
@@ -400,5 +399,28 @@ describe("Set up data connectors", () => {
     cy.getDataCy("project-data-connector-connect-header")
       .find("button.btn-close[aria-label='Close']")
       .click();
+
+    // Now edit a data connector
+    fixtures
+      .testCloudStorage({ success: true })
+      .getDataConnectorPermissions()
+      .patchDataConnector({ namespace: "user1-uuid" })
+      .patchDataConnectorSecrets({
+        shouldNotBeCalled: true,
+      });
+
+    cy.contains("example storage").should("be.visible").click();
+    cy.getDataCy("data-connector-edit").should("be.visible").click();
+    // Fill out the details
+    cy.getDataCy("test-data-connector-button").click();
+    cy.getDataCy("add-data-connector-continue-button")
+      .contains("Continue")
+      .click();
+    cy.getDataCy("data-connector-edit-update-button").click();
+    cy.wait("@patchDataConnector");
+    cy.getDataCy("data-connector-edit-body").should(
+      "contain.text",
+      "The data connector user1-uuid/example-storage has been successfully updated."
+    );
   });
 });

--- a/tests/cypress/support/renkulab-fixtures/dataConnectors.ts
+++ b/tests/cypress/support/renkulab-fixtures/dataConnectors.ts
@@ -60,6 +60,7 @@ interface ProjectDataConnectorArgs extends SimpleFixture {
 
 interface PostDataConnectorProjectLinkArgs extends DataConnectorIdArgs {
   projectId?: string;
+  shouldNotBeCalled?: boolean;
 }
 
 export function DataConnector<T extends FixturesConstructor>(Parent: T) {
@@ -410,13 +411,17 @@ export function DataConnector<T extends FixturesConstructor>(Parent: T) {
         name = "postDataConnectorProjectLink",
         dataConnectorId = "ULID-1",
         projectId = "THEPROJECTULID26CHARACTERS",
+        shouldNotBeCalled = false,
       } = args ?? {};
       cy.fixture(fixture).then((dataConnectorProjectLinks) => {
+        const dcId = shouldNotBeCalled ? "*" : dataConnectorId;
         // eslint-disable-next-line max-nested-callbacks
         cy.intercept(
           "POST",
-          `/ui-server/api/data/data_connectors/${dataConnectorId}/project_links`,
+          `/ui-server/api/data/data_connectors/${dcId}/project_links`,
           (req) => {
+            if (shouldNotBeCalled)
+              throw new Error("No call to post project link expected");
             const newLink = req.body;
             expect(newLink.project_id).to.not.be.undefined;
             expect(newLink.project_id).equal(projectId);


### PR DESCRIPTION
After closing the data connector modal, some state would be retained, causing bugs.

## Testing

The bugs would occur when a second data connector was created immediately after the first. For example, one data connector was created, and then a second data connector was started, but canceled (e.g., by closing the dialog), the second would get created anyway. Check that these situations do not happen anymore

/deploy renku=release-0.61.0 