### PR TITLE
feat: make the session secret mount location configurable

### DIFF
--- a/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/AddSessionSecretButton.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/AddSessionSecretButton.tsx
@@ -65,7 +65,8 @@ interface AddSessionSecretModalProps {
 
 function AddSessionSecretModal({ isOpen, toggle }: AddSessionSecretModalProps) {
   const { project } = useProject();
-  const { id: projectId } = project;
+  const { id: projectId, secrets_mount_directory: secretsMountDirectory } =
+    project;
 
   const [postSessionSecretSlot, result] = usePostSessionSecretSlotsMutation();
 
@@ -132,7 +133,12 @@ function AddSessionSecretModal({ isOpen, toggle }: AddSessionSecretModalProps) {
             errors={errors}
             name="description"
           />
-          <FilenameField control={control} errors={errors} name="filename" />
+          <FilenameField
+            control={control}
+            errors={errors}
+            name="filename"
+            secretsMountDirectory={secretsMountDirectory}
+          />
         </ModalBody>
         <ModalFooter>
           <Button color="outline-primary" onClick={toggle}>

--- a/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/ProjectSessionSecrets.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/ProjectSessionSecrets.tsx
@@ -22,6 +22,7 @@ import { useMemo } from "react";
 import { Key, Lock, ShieldLock } from "react-bootstrap-icons";
 import {
   Badge,
+  Button,
   Card,
   CardBody,
   CardHeader,
@@ -99,7 +100,7 @@ export default function ProjectSessionSecrets() {
           )}
         >
           <div className={cx("align-items-center", "d-flex")}>
-            <h4 className={cx("m-0", "me-2")}>
+            <h4 className="me-2">
               <ShieldLock className={cx("me-1", "bi")} />
               Session Secrets
             </h4>
@@ -116,10 +117,18 @@ export default function ProjectSessionSecrets() {
           </div>
         </div>
 
-        <p className="mb-0">
+        <p className="mb-1">
           Use session secrets to connect to resources from inside a session that
           require a password or credential.
         </p>
+        <div className={cx("align-items-center", "d-flex", "gap-2")}>
+          <p className="mb-0">
+            Session secrets will be mounted at <code>{"/secrets"}</code>.
+          </p>
+          <Button color="outline-primary" size="sm">
+            Update the secrets mount location
+          </Button>
+        </div>
 
         {!userLogged && (
           <InfoAlert

--- a/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/ProjectSessionSecrets.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/ProjectSessionSecrets.tsx
@@ -131,7 +131,12 @@ export default function ProjectSessionSecrets() {
         <div className={cx("align-items-center", "d-flex", "gap-2")}>
           <p className="mb-0">
             Session secrets will be mounted at{" "}
-            <code>{secretsMountDirectory}</code>.
+            <code>
+              {secretsMountDirectory.startsWith("/")
+                ? secretsMountDirectory
+                : `<work-dir>/${secretsMountDirectory}`}
+            </code>
+            .
           </p>
           <PermissionsGuard
             disabled={null}

--- a/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/SessionSecretActions.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/SessionSecretActions.tsx
@@ -52,6 +52,7 @@ import {
   usePatchProjectsByProjectIdSessionSecretsMutation,
   usePatchSessionSecretSlotsBySlotIdMutation,
 } from "../../../projectsV2/api/projectV2.enhanced-api";
+import { useProject } from "../../ProjectPageContainer/ProjectPageContainer";
 import useProjectPermissions from "../../utils/useProjectPermissions.hook";
 import DescriptionField from "./fields/DescriptionField";
 import FilenameField from "./fields/FilenameField";
@@ -242,6 +243,9 @@ function EditSessionSecretModal({
 }: EditSessionSecretModalProps) {
   const { id: slotId } = secretSlot;
 
+  const { project } = useProject();
+  const { secrets_mount_directory: secretsMountDirectory } = project;
+
   const [patchSessionSecretSlot, result] =
     usePatchSessionSecretSlotsBySlotIdMutation();
 
@@ -321,7 +325,12 @@ function EditSessionSecretModal({
             errors={errors}
             name="description"
           />
-          <FilenameField control={control} errors={errors} name="filename" />
+          <FilenameField
+            control={control}
+            errors={errors}
+            name="filename"
+            secretsMountDirectory={secretsMountDirectory}
+          />
         </ModalBody>
         <ModalFooter>
           <Button color="outline-primary" onClick={toggle}>

--- a/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/SessionSecretSlotItem.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/SessionSecretSlotItem.tsx
@@ -36,7 +36,11 @@ export default function SessionSecretSlotItem({
   noActions,
 }: SessionSecretSlotItemProps) {
   const { filename, name, description } = secretSlot.secretSlot;
-  const fullPath = `${secretsMountDirectory}/${filename}`;
+
+  const mountDir = secretsMountDirectory.startsWith("/")
+    ? secretsMountDirectory
+    : `<work-dir>/${secretsMountDirectory}`;
+  const fullPath = `${mountDir}/${filename}`;
 
   return (
     <ListGroupItem action={!noActions} data-cy="session-secret-slot-item">

--- a/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/SessionSecretSlotItem.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/SessionSecretSlotItem.tsx
@@ -1,0 +1,106 @@
+/*!
+ * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import cx from "classnames";
+import { ArrowRight, Key, Lock } from "react-bootstrap-icons";
+import { Badge, Col, ListGroupItem, Row } from "reactstrap";
+
+import { useGetUserSecretByIdQuery } from "../../../usersV2/api/users.api";
+import SessionSecretActions from "./SessionSecretActions";
+import type { SessionSecretSlotWithSecret } from "./sessionSecrets.types";
+
+interface SessionSecretSlotItemProps {
+  secretsMountDirectory: string;
+  secretSlot: SessionSecretSlotWithSecret;
+  noActions?: boolean;
+}
+
+export default function SessionSecretSlotItem({
+  secretsMountDirectory,
+  secretSlot,
+  noActions,
+}: SessionSecretSlotItemProps) {
+  const { filename, name, description } = secretSlot.secretSlot;
+  const fullPath = `${secretsMountDirectory}/${filename}`;
+
+  return (
+    <ListGroupItem action={!noActions} data-cy="session-secret-slot-item">
+      <Row>
+        <Col>
+          <div className={cx("align-items-center", "d-flex")}>
+            <span className={cx("fw-bold", "me-2")}>{name}</span>
+            {secretSlot.secretId ? (
+              <Badge
+                className={cx(
+                  "border",
+                  "border-success",
+                  "bg-success-subtle",
+                  "text-success-emphasis"
+                )}
+                pill
+              >
+                <Key className={cx("bi", "me-1")} />
+                Secret saved
+                <ArrowRight className={cx("bi", "mx-1")} />
+                <SessionSecretSlotItemSecretReference
+                  userSecretId={secretSlot.secretId}
+                />
+              </Badge>
+            ) : (
+              <Badge
+                className={cx(
+                  "border",
+                  "border-dark-subtle",
+                  "bg-light",
+                  "text-dark-emphasis"
+                )}
+                pill
+              >
+                <Lock className={cx("bi", "me-1")} />
+                Secret not provided
+              </Badge>
+            )}
+          </div>
+          <div>
+            Location in sessions: <code>{fullPath}</code>
+          </div>
+          {description && <p className="mb-0">{description}</p>}
+        </Col>
+        {!noActions && <SessionSecretActions secretSlot={secretSlot} />}
+      </Row>
+    </ListGroupItem>
+  );
+}
+
+interface SessionSecretSlotItemSecretReferenceProps {
+  userSecretId: string;
+}
+
+function SessionSecretSlotItemSecretReference({
+  userSecretId,
+}: SessionSecretSlotItemSecretReferenceProps) {
+  const { data: userSecret, error } = useGetUserSecretByIdQuery({
+    secretId: userSecretId,
+  });
+
+  if (error || !userSecret) {
+    return null;
+  }
+
+  return <>{userSecret.name}</>;
+}

--- a/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/UpdateSecretsMountDirectoryButton.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/UpdateSecretsMountDirectoryButton.tsx
@@ -18,7 +18,7 @@
 
 import cx from "classnames";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Pencil, XLg } from "react-bootstrap-icons";
+import { ArrowCounterclockwise, Pencil, XLg } from "react-bootstrap-icons";
 import { useForm } from "react-hook-form";
 import { Button, Form, ModalBody, ModalFooter, ModalHeader } from "reactstrap";
 import { RtkOrNotebooksError } from "../../../../components/errors/RtkErrorAlert";
@@ -85,6 +85,16 @@ function UpdateSecretsMountDirectoryModal({
     [handleSubmit, submitHandler]
   );
 
+  const onReset = useCallback(() => {
+    patchProject({
+      "If-Match": project.etag ?? "",
+      projectId,
+      projectPatch: {
+        secrets_mount_directory: "",
+      },
+    });
+  }, [patchProject, project.etag, projectId]);
+
   useEffect(() => {
     reset({
       secretsMountDirectory: project.secrets_mount_directory,
@@ -134,6 +144,10 @@ function UpdateSecretsMountDirectoryModal({
           <Button color="outline-primary" onClick={toggle}>
             <XLg className={cx("bi", "me-1")} />
             Close
+          </Button>
+          <Button color="outline-primary" onClick={onReset}>
+            <ArrowCounterclockwise className={cx("bi", "me-1")} />
+            Reset to default value
           </Button>
           <Button
             color="primary"

--- a/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/UpdateSecretsMountDirectoryButton.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/UpdateSecretsMountDirectoryButton.tsx
@@ -1,0 +1,158 @@
+/*!
+ * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import cx from "classnames";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Pencil, XLg } from "react-bootstrap-icons";
+import { useForm } from "react-hook-form";
+import { Button, Form, ModalBody, ModalFooter, ModalHeader } from "reactstrap";
+import { RtkOrNotebooksError } from "../../../../components/errors/RtkErrorAlert";
+import { Loader } from "../../../../components/Loader";
+import ScrollableModal from "../../../../components/modal/ScrollableModal";
+import { usePatchProjectsByProjectIdMutation } from "../../../projectsV2/api/projectV2.enhanced-api";
+import { useProject } from "../../ProjectPageContainer/ProjectPageContainer";
+import SecretsMountDirectoryField from "../../../projectsV2/fields/SecretsMountDirectoryField";
+
+export default function UpdateSecretsMountDirectoryButton() {
+  const [isOpen, setIsOpen] = useState(false);
+  const toggle = useCallback(() => setIsOpen((isOpen) => !isOpen), []);
+
+  return (
+    <>
+      <Button color="outline-primary" onClick={toggle} size="sm">
+        <Pencil className={cx("bi", "me-1")} />
+        Update the secrets mount location
+      </Button>
+      <UpdateSecretsMountDirectoryModal isOpen={isOpen} toggle={toggle} />
+    </>
+  );
+}
+
+interface UpdateSecretsMountDirectoryModalProps {
+  isOpen: boolean;
+  toggle: () => void;
+}
+
+function UpdateSecretsMountDirectoryModal({
+  isOpen,
+  toggle,
+}: UpdateSecretsMountDirectoryModalProps) {
+  const { project } = useProject();
+  const { id: projectId } = project;
+
+  const [patchProject, result] = usePatchProjectsByProjectIdMutation();
+
+  const {
+    control,
+    formState: { errors, isDirty },
+    handleSubmit,
+    reset,
+  } = useForm<UpdateSecretsMountDirectoryFrom>({
+    defaultValues: {
+      secretsMountDirectory: project.secrets_mount_directory,
+    },
+  });
+
+  const submitHandler = useCallback(
+    (data: UpdateSecretsMountDirectoryFrom) => {
+      patchProject({
+        "If-Match": project.etag ?? "",
+        projectId,
+        projectPatch: {
+          secrets_mount_directory: data.secretsMountDirectory,
+        },
+      });
+    },
+    [patchProject, project.etag, projectId]
+  );
+  const onSubmit = useMemo(
+    () => handleSubmit(submitHandler),
+    [handleSubmit, submitHandler]
+  );
+
+  useEffect(() => {
+    reset({
+      secretsMountDirectory: project.secrets_mount_directory,
+    });
+  }, [project, reset]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      reset();
+      result.reset();
+    }
+  }, [isOpen, reset, result]);
+
+  useEffect(() => {
+    if (result.isSuccess) {
+      toggle();
+    }
+  }, [result.isSuccess, toggle]);
+
+  return (
+    <ScrollableModal
+      backdrop="static"
+      centered
+      isOpen={isOpen}
+      size="lg"
+      toggle={toggle}
+    >
+      <Form noValidate onSubmit={onSubmit}>
+        <ModalHeader toggle={toggle}>Update secrets mount location</ModalHeader>
+        <ModalBody>
+          <p>
+            Change the location where secrets will be mounted in sessions. Note
+            that the change will only apply to new sessions.
+          </p>
+
+          {result.error && (
+            <RtkOrNotebooksError error={result.error} dismissible={false} />
+          )}
+
+          <SecretsMountDirectoryField
+            control={control}
+            errors={errors}
+            name="secretsMountDirectory"
+          />
+        </ModalBody>
+        <ModalFooter>
+          <Button color="outline-primary" onClick={toggle}>
+            <XLg className={cx("bi", "me-1")} />
+            Close
+          </Button>
+          <Button
+            color="primary"
+            disabled={!isDirty || result.isLoading}
+            type="submit"
+          >
+            {result.isLoading ? (
+              <Loader className="me-1" inline size={16} />
+            ) : (
+              <Pencil className={cx("bi", "me-1")} />
+            )}
+            Update secrets mount location
+          </Button>
+        </ModalFooter>
+      </Form>
+    </ScrollableModal>
+  );
+}
+
+interface UpdateSecretsMountDirectoryFrom {
+  secretsMountDirectory: string;
+}

--- a/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/fields/FilenameField.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/fields/FilenameField.tsx
@@ -17,20 +17,29 @@
  */
 
 import cx from "classnames";
-import { Controller, type FieldValues } from "react-hook-form";
+import { Controller, useWatch, type FieldValues } from "react-hook-form";
 import { FormText, Input, Label } from "reactstrap";
 
 import type { SessionSecretFormFieldProps } from "./fields.types";
 
-type FilenameFieldProps<T extends FieldValues> = SessionSecretFormFieldProps<T>;
+interface FilenameFieldProps<T extends FieldValues>
+  extends SessionSecretFormFieldProps<T> {
+  secretsMountDirectory: string;
+}
 
 export default function FilenameField<T extends FieldValues>({
   control,
   errors,
   name,
+  secretsMountDirectory,
 }: FilenameFieldProps<T>) {
   const fieldId = `session-secret-${name}`;
   const fieldHelpId = `${fieldId}-help`;
+
+  const watch = useWatch({ control, name });
+  const fullPath = watch
+    ? `${secretsMountDirectory}/${watch}`
+    : `${secretsMountDirectory}/<filename>`;
 
   return (
     <div className="mb-3">
@@ -66,8 +75,14 @@ export default function FilenameField<T extends FieldValues>({
         )}
       </div>
       <FormText id={fieldHelpId} tag="div">
-        This is the filename which will be used when mounting the secret inside
-        sessions.
+        <p className="mb-0">
+          This is the filename which will be used when mounting the secret
+          inside sessions.
+        </p>
+        <p className="mb-0">
+          The secret will be populated at:{" "}
+          <code className={cx("bg-secondary-subtle", "p-1")}>{fullPath}</code>.
+        </p>
       </FormText>
     </div>
   );

--- a/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/sessionSecrets.constants.ts
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/sessionSecrets.constants.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const SESSION_SECRETS_CARD_ID = "project-settings-session-secrets";

--- a/client/src/features/projectsV2/api/projectV2.api.ts
+++ b/client/src/features/projectsV2/api/projectV2.api.ts
@@ -328,6 +328,7 @@ export type Keyword = string;
 export type KeywordsList = Keyword[];
 export type ProjectDocumentation = string;
 export type IsTemplate = boolean;
+export type SecretsMountDirectory = string;
 export type Project = {
   id: Ulid;
   name: ProjectName;
@@ -344,6 +345,7 @@ export type Project = {
   documentation?: ProjectDocumentation;
   template_id?: Ulid;
   is_template?: IsTemplate;
+  secrets_mount_directory: SecretsMountDirectory;
 };
 export type ProjectsList = Project[];
 export type ErrorResponse = {
@@ -374,8 +376,10 @@ export type ProjectPost = {
   description?: Description;
   keywords?: KeywordsList;
   documentation?: ProjectDocumentation;
+  secrets_mount_directory?: SecretsMountDirectory;
 };
 export type WithDocumentation = boolean;
+export type SecretsMountDirectoryPatch = string;
 export type ProjectPatch = {
   name?: ProjectName;
   namespace?: Slug;
@@ -387,6 +391,7 @@ export type ProjectPatch = {
   /** template_id is set when copying a project from a template project and it cannot be modified. This field can be either null or an empty string; a null value won't change it while an empty string value will delete it, meaning that the project is unlinked from its template */
   template_id?: string;
   is_template?: IsTemplate;
+  secrets_mount_directory?: SecretsMountDirectoryPatch;
 };
 export type UserFirstLastName = string;
 export type Role = "viewer" | "editor" | "owner";

--- a/client/src/features/projectsV2/api/projectV2.openapi.json
+++ b/client/src/features/projectsV2/api/projectV2.openapi.json
@@ -904,6 +904,9 @@
           "is_template": {
             "$ref": "#/components/schemas/IsTemplate",
             "default": false
+          },
+          "secrets_mount_directory": {
+            "$ref": "#/components/schemas/SecretsMountDirectory"
           }
         },
         "required": [
@@ -913,7 +916,8 @@
           "slug",
           "created_by",
           "creation_date",
-          "visibility"
+          "visibility",
+          "secrets_mount_directory"
         ],
         "example": {
           "id": "01AN4Z79ZS5XN0F25N3DB94T4R",
@@ -933,7 +937,8 @@
             }
           ],
           "keywords": ["keyword 1", "keyword 2"],
-          "template_id": "01JC3CB5426KC7P5STS5X3KSS8"
+          "template_id": "01JC3CB5426KC7P5STS5X3KSS8",
+          "secrets_mount_directory": "/secrets"
         }
       },
       "ProjectPost": {
@@ -964,6 +969,9 @@
           },
           "documentation": {
             "$ref": "#/components/schemas/ProjectDocumentation"
+          },
+          "secrets_mount_directory": {
+            "$ref": "#/components/schemas/SecretsMountDirectory"
           }
         },
         "required": ["name", "namespace"]
@@ -1002,6 +1010,9 @@
           },
           "is_template": {
             "$ref": "#/components/schemas/IsTemplate"
+          },
+          "secrets_mount_directory": {
+            "$ref": "#/components/schemas/SecretsMountDirectoryPatch"
           }
         }
       },
@@ -1104,6 +1115,17 @@
       "IsTemplate": {
         "description": "Shows if a project is a template or not",
         "type": "boolean"
+      },
+      "SecretsMountDirectory": {
+        "description": "The location where the secrets will be provided inside sessions, if left unset it will default to `/secrets`.",
+        "type": "string",
+        "minLength": 1,
+        "default": "/secrets",
+        "example": "/secrets"
+      },
+      "SecretsMountDirectoryPatch": {
+        "type": "string",
+        "example": "/secrets"
       },
       "ProjectMemberListPatchRequest": {
         "description": "List of members and their access level to the project",

--- a/client/src/features/projectsV2/fields/SecretsMountDirectoryField.tsx
+++ b/client/src/features/projectsV2/fields/SecretsMountDirectoryField.tsx
@@ -1,0 +1,69 @@
+/*!
+ * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import cx from "classnames";
+import { Controller, type FieldValues } from "react-hook-form";
+import { FormText, Input, Label } from "reactstrap";
+
+import { GenericProjectFormFieldProps } from "./formField.types";
+
+type SecretsMountDirectoryFieldProps<T extends FieldValues> =
+  GenericProjectFormFieldProps<T>;
+
+export default function SecretsMountDirectoryField<T extends FieldValues>({
+  control,
+  errors,
+  name,
+}: SecretsMountDirectoryFieldProps<T>) {
+  const fieldId = `project-${name}`;
+  const fieldHelpId = `${fieldId}-help`;
+
+  return (
+    <div className="mb-3">
+      <Label for={fieldId}>Secrets mount location</Label>
+      <Controller
+        name={name}
+        control={control}
+        render={({ field: { ref, ...rest } }) => (
+          <Input
+            className={cx(errors.name && "is-invalid")}
+            id={fieldId}
+            innerRef={ref}
+            placeholder="Secret name, e.g., API Token"
+            type="text"
+            {...rest}
+          />
+        )}
+        rules={{
+          required: "Please provide a location for the secrets",
+        }}
+      />
+      <div className="invalid-feedback">
+        {errors[name]?.message ? (
+          <>{errors[name]?.message}</>
+        ) : (
+          <>Invalid location</>
+        )}
+      </div>
+      <FormText id={fieldHelpId} tag="div">
+        This is the location which will be used when mounting secrets inside
+        sessions.
+      </FormText>
+    </div>
+  );
+}

--- a/client/src/features/projectsV2/fields/SecretsMountDirectoryField.tsx
+++ b/client/src/features/projectsV2/fields/SecretsMountDirectoryField.tsx
@@ -17,7 +17,7 @@
  */
 
 import cx from "classnames";
-import { Controller, type FieldValues } from "react-hook-form";
+import { Controller, useWatch, type FieldValues } from "react-hook-form";
 import { FormText, Input, Label } from "reactstrap";
 
 import { GenericProjectFormFieldProps } from "./formField.types";
@@ -32,6 +32,8 @@ export default function SecretsMountDirectoryField<T extends FieldValues>({
 }: SecretsMountDirectoryFieldProps<T>) {
   const fieldId = `project-${name}`;
   const fieldHelpId = `${fieldId}-help`;
+
+  const watch = useWatch({ control, name });
 
   return (
     <div className="mb-3">
@@ -61,8 +63,16 @@ export default function SecretsMountDirectoryField<T extends FieldValues>({
         )}
       </div>
       <FormText id={fieldHelpId} tag="div">
-        This is the location which will be used when mounting secrets inside
-        sessions.
+        <p className="mb-0">
+          This is the location which will be used when mounting secrets inside
+          sessions.
+        </p>
+        {!watch.startsWith("/") && (
+          <p>
+            Note that this location will be relative to the &quot;working
+            directory&quot;.
+          </p>
+        )}
       </FormText>
     </div>
   );

--- a/client/src/features/secretsV2/GeneralSecretItem.tsx
+++ b/client/src/features/secretsV2/GeneralSecretItem.tsx
@@ -17,14 +17,15 @@
  */
 
 import cx from "classnames";
-import { Col, ListGroupItem, Row } from "reactstrap";
-
 import { useMemo } from "react";
 import { generatePath, Link } from "react-router-dom-v5-compat";
+import { Col, ListGroupItem, Row } from "reactstrap";
+
 import { RtkOrNotebooksError } from "../../components/errors/RtkErrorAlert";
 import { Loader } from "../../components/Loader";
 import { TimeCaption } from "../../components/TimeCaption";
 import { ABSOLUTE_ROUTES } from "../../routing/routes.constants";
+import { SESSION_SECRETS_CARD_ID } from "../ProjectPageV2/ProjectPageContent/SessionSecrets/sessionSecrets.constants";
 import type {
   Project,
   SessionSecretSlot,
@@ -125,7 +126,7 @@ function GeneralSecretUsedInProject({
     return null;
   }
 
-  const projectUrl = generatePath(ABSOLUTE_ROUTES.v2.projects.show.root, {
+  const projectUrl = generatePath(ABSOLUTE_ROUTES.v2.projects.show.settings, {
     namespace: project.namespace,
     slug: project.slug,
   });
@@ -133,7 +134,7 @@ function GeneralSecretUsedInProject({
   return (
     <li>
       <div>
-        <Link to={projectUrl}>
+        <Link to={{ pathname: projectUrl, hash: SESSION_SECRETS_CARD_ID }}>
           {project.name}
           {" - "}
           <span className="fst-italic">

--- a/client/src/features/sessionsV2/SessionView/SessionView.tsx
+++ b/client/src/features/sessionsV2/SessionView/SessionView.tsx
@@ -42,6 +42,7 @@ import {
 import { TimeCaption } from "../../../components/TimeCaption";
 import { CommandCopy } from "../../../components/commandCopy/CommandCopy";
 import { RepositoryItem } from "../../ProjectPageV2/ProjectPageContent/CodeRepositories/CodeRepositoryDisplay";
+import SessionViewSessionSecrets from "../../ProjectPageV2/ProjectPageContent/SessionSecrets/SessionViewSessionSecrets";
 import useProjectPermissions from "../../ProjectPageV2/utils/useProjectPermissions.hook";
 import { useGetDataConnectorsListByDataConnectorIdsQuery } from "../../dataConnectorsV2/api/data-connectors.enhanced-api";
 import {
@@ -466,7 +467,7 @@ export function SessionView({
                 <Badge>{project?.repositories?.length}</Badge>
               )}
             </div>
-            {project?.repositories && project.repositories.length > 0 ? (
+            {project.repositories && project.repositories.length > 0 ? (
               <ListGroup>
                 {project.repositories.map((repositoryUrl, index) => (
                   <RepositoryItem
@@ -483,6 +484,8 @@ export function SessionView({
               </p>
             )}
           </div>
+
+          <SessionViewSessionSecrets />
         </div>
       </OffcanvasBody>
     </Offcanvas>

--- a/tests/cypress/fixtures/projectV2/create-projectV2.json
+++ b/tests/cypress/fixtures/projectV2/create-projectV2.json
@@ -5,5 +5,6 @@
   "created_by": {
     "id": "owner-KC-id"
   },
-  "visibility": "public"
+  "visibility": "public",
+  "secrets_mount_directory": "/secrets"
 }

--- a/tests/cypress/fixtures/projectV2/list-projectV2.json
+++ b/tests/cypress/fixtures/projectV2/list-projectV2.json
@@ -11,7 +11,8 @@
       "https://domain.name/repo2.git"
     ],
     "visibility": "public",
-    "description": "Project 2 description"
+    "description": "Project 2 description",
+    "secrets_mount_directory": "/secrets"
   },
   {
     "id": "01HF96BXZ3JF9DX88B7XB405S5",
@@ -22,6 +23,7 @@
     "created_by": { "id": "user1-uuid" },
     "repositories": [],
     "visibility": "private",
-    "description": "Project 1 description"
+    "description": "Project 1 description",
+    "secrets_mount_directory": "/secrets"
   }
 ]

--- a/tests/cypress/fixtures/projectV2/read-projectV2-empty.json
+++ b/tests/cypress/fixtures/projectV2/read-projectV2-empty.json
@@ -7,5 +7,6 @@
   "created_by": "user1-uuid",
   "repositories": [],
   "visibility": "public",
-  "description": "Project 2 description"
+  "description": "Project 2 description",
+  "secrets_mount_directory": "/secrets"
 }

--- a/tests/cypress/fixtures/projectV2/read-projectV2.json
+++ b/tests/cypress/fixtures/projectV2/read-projectV2.json
@@ -10,5 +10,6 @@
     "https://domain.name/repo2.git"
   ],
   "visibility": "public",
-  "description": "Project 2 description"
+  "description": "Project 2 description",
+  "secrets_mount_directory": "/secrets"
 }

--- a/tests/cypress/fixtures/projectV2/update-projectV2-metadata.json
+++ b/tests/cypress/fixtures/projectV2/update-projectV2-metadata.json
@@ -10,5 +10,6 @@
     "https://domain.name/repo2.git"
   ],
   "visibility": "public",
-  "description": "new description"
+  "description": "new description",
+  "secrets_mount_directory": "/secrets"
 }

--- a/tests/cypress/fixtures/projectV2/update-projectV2-one-repository.json
+++ b/tests/cypress/fixtures/projectV2/update-projectV2-one-repository.json
@@ -7,5 +7,6 @@
   "created_by": "user1-uuid",
   "repositories": ["https://gitlab.dev.renku.ch/url-repo.git"],
   "visibility": "public",
-  "description": "Project 2 description"
+  "description": "Project 2 description",
+  "secrets_mount_directory": "/secrets"
 }

--- a/tests/cypress/fixtures/projectV2/update-projectV2-repositories.json
+++ b/tests/cypress/fixtures/projectV2/update-projectV2-repositories.json
@@ -11,5 +11,6 @@
     "https://domain.name/repo3.git"
   ],
   "visibility": "public",
-  "description": "Project 2 description"
+  "description": "Project 2 description",
+  "secrets_mount_directory": "/secrets"
 }


### PR DESCRIPTION
Part of #3412, merging into `build/session-secrets`.

Update the "Session Secrets" section to allow for the mount location to be configured.

![Screenshot 2024-12-10 at 14 11 38](https://github.com/user-attachments/assets/4a1f7007-6172-4003-9b91-8f013bfb8aa1)

/deploy #notest renku=build/session-secrets renku-data-services=build/session-secrets