### PR TITLE
feat: nice-to-haves for the build

### DIFF
--- a/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/AddSessionSecretButton.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/AddSessionSecretButton.tsx
@@ -35,8 +35,11 @@ import { RtkOrNotebooksError } from "../../../../components/errors/RtkErrorAlert
 import { usePostSessionSecretSlotsMutation } from "../../../projectsV2/api/projectV2.enhanced-api";
 import { useProject } from "../../ProjectPageContainer/ProjectPageContainer";
 import DescriptionField from "./fields/DescriptionField";
+import type { SessionSecretSlot } from "../../../projectsV2/api/projectV2.api";
 import FilenameField from "./fields/FilenameField";
 import NameField from "./fields/NameField";
+import ProvideSessionSecretModalContent from "./ProvideSessionSecretModalContent";
+import { SuccessAlert } from "../../../../components/Alert";
 
 export default function AddSessionSecretButton() {
   const ref = useRef<HTMLButtonElement>(null);
@@ -64,6 +67,97 @@ interface AddSessionSecretModalProps {
 }
 
 function AddSessionSecretModal({ isOpen, toggle }: AddSessionSecretModalProps) {
+  const [state, setState] = useState<AddSessionSecretModalState>({
+    step: "add-secret-slot",
+  });
+  const { step } = state;
+  const onFirstStepSuccess = useCallback(
+    (secretSlot: SessionSecretSlot) =>
+      setState({ step: "provide-secret", secretSlot }),
+    []
+  );
+
+  const slotSavedAlert = step === "provide-secret" && (
+    <SuccessAlert timeout={0} dismissible={false}>
+      The session secret slot{" "}
+      <span className="fw-bold">{state.secretSlot.name}</span> has been
+      successfully added. You can now provide a value for it.
+    </SuccessAlert>
+  );
+
+  return (
+    <Modal backdrop="static" centered isOpen={isOpen} size="lg" toggle={toggle}>
+      {step === "add-secret-slot" && (
+        <AddSessionSecretModalContentStep1
+          isOpen={isOpen}
+          onSuccess={onFirstStepSuccess}
+          toggle={toggle}
+        />
+      )}
+      {step === "provide-secret" && (
+        <ProvideSessionSecretModalContent
+          isOpen={isOpen}
+          previousStepAlert={slotSavedAlert}
+          secretSlot={state.secretSlot}
+          toggle={toggle}
+        />
+      )}
+
+      {/* <Form noValidate onSubmit={onSubmit}>
+        <ModalHeader toggle={toggle}>Add session secret slot</ModalHeader>
+        <ModalBody>
+          <p>Add a new slot for a secret to be mounted in sessions.</p>
+
+          {result.error && (
+            <RtkOrNotebooksError error={result.error} dismissible={false} />
+          )}
+
+          <NameField control={control} errors={errors} name="name" />
+          <DescriptionField
+            control={control}
+            errors={errors}
+            name="description"
+          />
+          <FilenameField
+            control={control}
+            errors={errors}
+            name="filename"
+            secretsMountDirectory={secretsMountDirectory}
+          />
+        </ModalBody>
+        <ModalFooter>
+          <Button color="outline-primary" onClick={toggle}>
+            <XLg className={cx("bi", "me-1")} />
+            Close
+          </Button>
+          <Button color="primary" disabled={result.isLoading} type="submit">
+            {result.isLoading ? (
+              <Loader className="me-1" inline size={16} />
+            ) : (
+              <PlusLg className={cx("bi", "me-1")} />
+            )}
+            Add session secret slot
+          </Button>
+        </ModalFooter>
+      </Form> */}
+    </Modal>
+  );
+}
+
+type AddSessionSecretModalState =
+  | { step: "add-secret-slot" }
+  | { step: "provide-secret"; secretSlot: SessionSecretSlot };
+
+interface AddSessionSecretModalContentStep1Props
+  extends AddSessionSecretModalProps {
+  onSuccess: (secretSlot: SessionSecretSlot) => void;
+}
+
+function AddSessionSecretModalContentStep1({
+  isOpen,
+  onSuccess,
+  toggle,
+}: AddSessionSecretModalContentStep1Props) {
   const { project } = useProject();
   const { id: projectId, secrets_mount_directory: secretsMountDirectory } =
     project;
@@ -112,50 +206,48 @@ function AddSessionSecretModal({ isOpen, toggle }: AddSessionSecretModalProps) {
 
   useEffect(() => {
     if (result.isSuccess) {
-      toggle();
+      onSuccess(result.data);
     }
-  }, [result.isSuccess, toggle]);
+  }, [onSuccess, result.data, result.isSuccess]);
 
   return (
-    <Modal backdrop="static" centered isOpen={isOpen} size="lg" toggle={toggle}>
-      <Form noValidate onSubmit={onSubmit}>
-        <ModalHeader toggle={toggle}>Add session secret slot</ModalHeader>
-        <ModalBody>
-          <p>Add a new slot for a secret to be mounted in sessions.</p>
+    <Form noValidate onSubmit={onSubmit}>
+      <ModalHeader toggle={toggle}>Add session secret slot</ModalHeader>
+      <ModalBody>
+        <p>Add a new slot for a secret to be mounted in sessions.</p>
 
-          {result.error && (
-            <RtkOrNotebooksError error={result.error} dismissible={false} />
+        {result.error && (
+          <RtkOrNotebooksError error={result.error} dismissible={false} />
+        )}
+
+        <NameField control={control} errors={errors} name="name" />
+        <DescriptionField
+          control={control}
+          errors={errors}
+          name="description"
+        />
+        <FilenameField
+          control={control}
+          errors={errors}
+          name="filename"
+          secretsMountDirectory={secretsMountDirectory}
+        />
+      </ModalBody>
+      <ModalFooter>
+        <Button color="outline-primary" onClick={toggle}>
+          <XLg className={cx("bi", "me-1")} />
+          Close
+        </Button>
+        <Button color="primary" disabled={result.isLoading} type="submit">
+          {result.isLoading ? (
+            <Loader className="me-1" inline size={16} />
+          ) : (
+            <PlusLg className={cx("bi", "me-1")} />
           )}
-
-          <NameField control={control} errors={errors} name="name" />
-          <DescriptionField
-            control={control}
-            errors={errors}
-            name="description"
-          />
-          <FilenameField
-            control={control}
-            errors={errors}
-            name="filename"
-            secretsMountDirectory={secretsMountDirectory}
-          />
-        </ModalBody>
-        <ModalFooter>
-          <Button color="outline-primary" onClick={toggle}>
-            <XLg className={cx("bi", "me-1")} />
-            Close
-          </Button>
-          <Button color="primary" disabled={result.isLoading} type="submit">
-            {result.isLoading ? (
-              <Loader className="me-1" inline size={16} />
-            ) : (
-              <PlusLg className={cx("bi", "me-1")} />
-            )}
-            Add session secret slot
-          </Button>
-        </ModalFooter>
-      </Form>
-    </Modal>
+          Add session secret slot
+        </Button>
+      </ModalFooter>
+    </Form>
   );
 }
 
@@ -164,3 +256,48 @@ interface AddSessionSecretForm {
   description: string | undefined;
   filename: string;
 }
+
+// function AddSessionSecretModalContentStep2({
+//   isOpen,
+//   toggle,
+// }: AddSessionSecretModalProps) {
+//   return (
+//     <Form noValidate onSubmit={onSubmit}>
+//       <ModalHeader toggle={toggle}>Add session secret slot</ModalHeader>
+//       <ModalBody>
+//         <p>Add a new slot for a secret to be mounted in sessions.</p>
+
+//         {result.error && (
+//           <RtkOrNotebooksError error={result.error} dismissible={false} />
+//         )}
+
+//         <NameField control={control} errors={errors} name="name" />
+//         <DescriptionField
+//           control={control}
+//           errors={errors}
+//           name="description"
+//         />
+//         <FilenameField
+//           control={control}
+//           errors={errors}
+//           name="filename"
+//           secretsMountDirectory={secretsMountDirectory}
+//         />
+//       </ModalBody>
+//       <ModalFooter>
+//         <Button color="outline-primary" onClick={toggle}>
+//           <XLg className={cx("bi", "me-1")} />
+//           Close
+//         </Button>
+//         <Button color="primary" disabled={result.isLoading} type="submit">
+//           {result.isLoading ? (
+//             <Loader className="me-1" inline size={16} />
+//           ) : (
+//             <PlusLg className={cx("bi", "me-1")} />
+//           )}
+//           Add session secret slot
+//         </Button>
+//       </ModalFooter>
+//     </Form>
+//   );
+// }

--- a/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/AddSessionSecretButton.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/AddSessionSecretButton.tsx
@@ -77,6 +77,12 @@ function AddSessionSecretModal({ isOpen, toggle }: AddSessionSecretModalProps) {
     []
   );
 
+  useEffect(() => {
+    if (!isOpen) {
+      setState({ step: "add-secret-slot" });
+    }
+  }, [isOpen]);
+
   const slotSavedAlert = step === "provide-secret" && (
     <SuccessAlert timeout={0} dismissible={false}>
       The session secret slot{" "}

--- a/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/AddSessionSecretButton.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/AddSessionSecretButton.tsx
@@ -102,44 +102,6 @@ function AddSessionSecretModal({ isOpen, toggle }: AddSessionSecretModalProps) {
           toggle={toggle}
         />
       )}
-
-      {/* <Form noValidate onSubmit={onSubmit}>
-        <ModalHeader toggle={toggle}>Add session secret slot</ModalHeader>
-        <ModalBody>
-          <p>Add a new slot for a secret to be mounted in sessions.</p>
-
-          {result.error && (
-            <RtkOrNotebooksError error={result.error} dismissible={false} />
-          )}
-
-          <NameField control={control} errors={errors} name="name" />
-          <DescriptionField
-            control={control}
-            errors={errors}
-            name="description"
-          />
-          <FilenameField
-            control={control}
-            errors={errors}
-            name="filename"
-            secretsMountDirectory={secretsMountDirectory}
-          />
-        </ModalBody>
-        <ModalFooter>
-          <Button color="outline-primary" onClick={toggle}>
-            <XLg className={cx("bi", "me-1")} />
-            Close
-          </Button>
-          <Button color="primary" disabled={result.isLoading} type="submit">
-            {result.isLoading ? (
-              <Loader className="me-1" inline size={16} />
-            ) : (
-              <PlusLg className={cx("bi", "me-1")} />
-            )}
-            Add session secret slot
-          </Button>
-        </ModalFooter>
-      </Form> */}
     </Modal>
   );
 }
@@ -256,48 +218,3 @@ interface AddSessionSecretForm {
   description: string | undefined;
   filename: string;
 }
-
-// function AddSessionSecretModalContentStep2({
-//   isOpen,
-//   toggle,
-// }: AddSessionSecretModalProps) {
-//   return (
-//     <Form noValidate onSubmit={onSubmit}>
-//       <ModalHeader toggle={toggle}>Add session secret slot</ModalHeader>
-//       <ModalBody>
-//         <p>Add a new slot for a secret to be mounted in sessions.</p>
-
-//         {result.error && (
-//           <RtkOrNotebooksError error={result.error} dismissible={false} />
-//         )}
-
-//         <NameField control={control} errors={errors} name="name" />
-//         <DescriptionField
-//           control={control}
-//           errors={errors}
-//           name="description"
-//         />
-//         <FilenameField
-//           control={control}
-//           errors={errors}
-//           name="filename"
-//           secretsMountDirectory={secretsMountDirectory}
-//         />
-//       </ModalBody>
-//       <ModalFooter>
-//         <Button color="outline-primary" onClick={toggle}>
-//           <XLg className={cx("bi", "me-1")} />
-//           Close
-//         </Button>
-//         <Button color="primary" disabled={result.isLoading} type="submit">
-//           {result.isLoading ? (
-//             <Loader className="me-1" inline size={16} />
-//           ) : (
-//             <PlusLg className={cx("bi", "me-1")} />
-//           )}
-//           Add session secret slot
-//         </Button>
-//       </ModalFooter>
-//     </Form>
-//   );
-// }

--- a/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/ProjectSessionSecrets.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/ProjectSessionSecrets.tsx
@@ -108,8 +108,6 @@ export default function ProjectSessionSecrets() {
         >
           <div className={cx("align-items-center", "d-flex")}>
             <h4 className={cx("m-0", "me-2")}>
-              {/* <ShieldLock className={cx("me-1", "bi")} />
-              Session Secrets */}
               <ShieldLock className={cx("me-1", "bi")} />
               Session secret slots
             </h4>

--- a/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/ProjectSessionSecrets.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/ProjectSessionSecrets.tsx
@@ -108,8 +108,10 @@ export default function ProjectSessionSecrets() {
         >
           <div className={cx("align-items-center", "d-flex")}>
             <h4 className={cx("m-0", "me-2")}>
+              {/* <ShieldLock className={cx("me-1", "bi")} />
+              Session Secrets */}
               <ShieldLock className={cx("me-1", "bi")} />
-              Session Secrets
+              Session secret slots
             </h4>
             {sessionSecretSlots && <Badge>{sessionSecretSlots.length}</Badge>}
           </div>

--- a/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/ProjectSessionSecrets.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/ProjectSessionSecrets.tsx
@@ -42,7 +42,9 @@ import AddSessionSecretButton from "./AddSessionSecretButton";
 import { SESSION_SECRETS_CARD_ID } from "./sessionSecrets.constants";
 import { getSessionSecretSlotsWithSecrets } from "./sessionSecrets.utils";
 import SessionSecretSlotItem from "./SessionSecretSlotItem";
-import UpdateSecretsMountDirectoryButton from "./UpdateSecretsMountDirectoryButton";
+import UpdateSecretsMountDirectoryButton, {
+  SecretsMountDirectoryComponent,
+} from "./UpdateSecretsMountDirectoryButton";
 
 export default function ProjectSessionSecrets() {
   const userLogged = useLegacySelector<boolean>(
@@ -123,28 +125,14 @@ export default function ProjectSessionSecrets() {
             />
           </div>
         </div>
-
         <p className="mb-1">
           Use session secrets to connect to resources from inside a session that
           require a password or credential.
         </p>
-        <div className={cx("align-items-center", "d-flex", "gap-2")}>
-          <p className="mb-0">
-            Session secrets will be mounted at{" "}
-            <code>
-              {secretsMountDirectory.startsWith("/")
-                ? secretsMountDirectory
-                : `<work-dir>/${secretsMountDirectory}`}
-            </code>
-            .
-          </p>
-          <PermissionsGuard
-            disabled={null}
-            enabled={<UpdateSecretsMountDirectoryButton />}
-            requestedPermission="write"
-            userPermissions={permissions}
-          />
-        </div>
+        <p className="mb-0">
+          Session secrets will be mounted at the following location:
+        </p>
+        <SecretsMountDirectoryComponent />
 
         {!userLogged && (
           <InfoAlert

--- a/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/ProjectSessionSecrets.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/ProjectSessionSecrets.tsx
@@ -42,9 +42,7 @@ import AddSessionSecretButton from "./AddSessionSecretButton";
 import { SESSION_SECRETS_CARD_ID } from "./sessionSecrets.constants";
 import { getSessionSecretSlotsWithSecrets } from "./sessionSecrets.utils";
 import SessionSecretSlotItem from "./SessionSecretSlotItem";
-import UpdateSecretsMountDirectoryButton, {
-  SecretsMountDirectoryComponent,
-} from "./UpdateSecretsMountDirectoryButton";
+import { SecretsMountDirectoryComponent } from "./UpdateSecretsMountDirectoryButton";
 
 export default function ProjectSessionSecrets() {
   const userLogged = useLegacySelector<boolean>(

--- a/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/ProjectSessionSecrets.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/ProjectSessionSecrets.tsx
@@ -39,10 +39,10 @@ import {
 import { useProject } from "../../ProjectPageContainer/ProjectPageContainer";
 import useProjectPermissions from "../../utils/useProjectPermissions.hook";
 import AddSessionSecretButton from "./AddSessionSecretButton";
+import SecretsMountDirectoryComponent from "./SecretsMountDirectoryComponent";
 import { SESSION_SECRETS_CARD_ID } from "./sessionSecrets.constants";
 import { getSessionSecretSlotsWithSecrets } from "./sessionSecrets.utils";
 import SessionSecretSlotItem from "./SessionSecretSlotItem";
-import { SecretsMountDirectoryComponent } from "./UpdateSecretsMountDirectoryButton";
 
 export default function ProjectSessionSecrets() {
   const userLogged = useLegacySelector<boolean>(

--- a/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/ProvideSessionSecretModalContent.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/ProvideSessionSecretModalContent.tsx
@@ -1,0 +1,318 @@
+/*!
+ * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import cx from "classnames";
+import { ReactNode, useCallback, useEffect, useMemo, useState } from "react";
+import { BoxArrowInLeft, PlusLg, XLg } from "react-bootstrap-icons";
+import { Controller, useForm } from "react-hook-form";
+import {
+  Button,
+  ButtonGroup,
+  Form,
+  Input,
+  Label,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+} from "reactstrap";
+
+import { RtkOrNotebooksError } from "../../../../components/errors/RtkErrorAlert";
+import { Loader } from "../../../../components/Loader";
+import type { SessionSecretSlot } from "../../../projectsV2/api/projectV2.api";
+import { usePatchProjectsByProjectIdSessionSecretsMutation } from "../../../projectsV2/api/projectV2.enhanced-api";
+import SelectUserSecretField from "./fields/SelectUserSecretField";
+
+interface ProvideSessionSecretModalContentProps {
+  isOpen: boolean;
+  previousStepAlert?: ReactNode;
+  secretSlot: SessionSecretSlot;
+  toggle: () => void;
+}
+
+export default function ProvideSessionSecretModalContent({
+  isOpen,
+  previousStepAlert,
+  secretSlot,
+  toggle,
+}: ProvideSessionSecretModalContentProps) {
+  const [mode, setMode] = useState<"new-value" | "existing">("new-value");
+
+  useEffect(() => {
+    if (!isOpen) {
+      setMode("new-value");
+    }
+  }, [isOpen]);
+
+  return (
+    <>
+      <ModalHeader toggle={toggle}>Provide session secret</ModalHeader>
+      <ModalBody className="pb-0">
+        {previousStepAlert}
+
+        <ButtonGroup>
+          <Input
+            type="radio"
+            className="btn-check"
+            id="provide-session-secret-mode-new-value"
+            value="new-value"
+            checked={mode == "new-value"}
+            onChange={() => setMode("new-value")}
+          />
+          <Label
+            for="provide-session-secret-mode-new-value"
+            className={cx("btn", "btn-outline-primary")}
+          >
+            <PlusLg className={cx("bi", "me-1")} />
+            Provide a new secret value
+          </Label>
+          <Input
+            type="radio"
+            className="btn-check"
+            id="provide-session-secret-mode-existing"
+            value="existing"
+            checked={mode == "existing"}
+            onChange={() => setMode("existing")}
+          />
+          <Label
+            for="provide-session-secret-mode-existing"
+            className={cx("btn", "btn-outline-primary")}
+          >
+            <BoxArrowInLeft className={cx("bi", "me-1")} />
+            Use an existing secret value
+          </Label>
+        </ButtonGroup>
+      </ModalBody>
+      {mode === "new-value" ? (
+        <ProvideSessionSecretModalNewValueContent
+          isOpen={isOpen}
+          secretSlot={secretSlot}
+          toggle={toggle}
+        />
+      ) : (
+        <ProvideSessionSecretModalExistingContent
+          isOpen={isOpen}
+          secretSlot={secretSlot}
+          toggle={toggle}
+        />
+      )}
+    </>
+  );
+}
+
+interface ProvideSessionSecretModalNewValueContentProps {
+  isOpen: boolean;
+  secretSlot: SessionSecretSlot;
+  toggle: () => void;
+}
+
+function ProvideSessionSecretModalNewValueContent({
+  isOpen,
+  secretSlot,
+  toggle,
+}: ProvideSessionSecretModalNewValueContentProps) {
+  const { id: slotId, project_id: projectId } = secretSlot;
+
+  const [patchSessionSecrets, result] =
+    usePatchProjectsByProjectIdSessionSecretsMutation();
+
+  const {
+    control,
+    formState: { errors },
+    handleSubmit,
+    reset,
+  } = useForm<ProvideNewSecretValueForm>({
+    defaultValues: { value: "" },
+  });
+
+  const submitHandler = useCallback(
+    (data: ProvideNewSecretValueForm) => {
+      patchSessionSecrets({
+        projectId,
+        sessionSecretPatchList: [{ secret_slot_id: slotId, value: data.value }],
+      });
+    },
+    [patchSessionSecrets, projectId, slotId]
+  );
+  const onSubmit = useMemo(
+    () => handleSubmit(submitHandler),
+    [handleSubmit, submitHandler]
+  );
+
+  useEffect(() => {
+    reset({ value: "" });
+  }, [reset, secretSlot]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      reset();
+      result.reset();
+    }
+  }, [isOpen, reset, result]);
+
+  useEffect(() => {
+    if (result.isSuccess) {
+      toggle();
+    }
+  }, [result.isSuccess, toggle]);
+
+  return (
+    <Form noValidate onSubmit={onSubmit}>
+      <ModalBody>
+        {result.error && (
+          <RtkOrNotebooksError error={result.error} dismissible={false} />
+        )}
+
+        <div className="mb-3">
+          <Label for="provide-session-secret-new-value">Secret value</Label>
+          <Controller
+            name="value"
+            control={control}
+            render={({ field }) => (
+              <textarea
+                id="provide-session-secret-new-value"
+                className={cx("form-control", errors.value && "is-invalid")}
+                placeholder="Your secret value..."
+                rows={6}
+                {...field}
+              />
+            )}
+            rules={{ required: "Please provide a value" }}
+          />
+          <div className="invalid-feedback">
+            {errors.value?.message ? (
+              <>{errors.value?.message}</>
+            ) : (
+              <>Invalid secret value</>
+            )}
+          </div>
+        </div>
+      </ModalBody>
+      <ModalFooter>
+        <Button color="outline-primary" onClick={toggle}>
+          <XLg className={cx("bi", "me-1")} />
+          Close
+        </Button>
+        <Button color="primary" disabled={result.isLoading} type="submit">
+          {result.isLoading ? (
+            <Loader className="me-1" inline size={16} />
+          ) : (
+            <PlusLg className={cx("bi", "me-1")} />
+          )}
+          Save new secret
+        </Button>
+      </ModalFooter>
+    </Form>
+  );
+}
+
+interface ProvideNewSecretValueForm {
+  value: string;
+}
+
+interface ProvideSessionSecretModalExistingContentProps {
+  isOpen: boolean;
+  secretSlot: SessionSecretSlot;
+  toggle: () => void;
+}
+
+function ProvideSessionSecretModalExistingContent({
+  isOpen,
+  secretSlot,
+  toggle,
+}: ProvideSessionSecretModalExistingContentProps) {
+  const { id: slotId, project_id: projectId } = secretSlot;
+
+  const [patchSessionSecrets, result] =
+    usePatchProjectsByProjectIdSessionSecretsMutation();
+
+  const {
+    control,
+    formState: { errors },
+    handleSubmit,
+    reset,
+  } = useForm<ProvideExistingSecretForm>({
+    defaultValues: { secretId: "" },
+  });
+
+  const submitHandler = useCallback(
+    (data: ProvideExistingSecretForm) => {
+      patchSessionSecrets({
+        projectId,
+        sessionSecretPatchList: [
+          { secret_slot_id: slotId, secret_id: data.secretId },
+        ],
+      });
+    },
+    [patchSessionSecrets, projectId, slotId]
+  );
+  const onSubmit = useMemo(
+    () => handleSubmit(submitHandler),
+    [handleSubmit, submitHandler]
+  );
+
+  useEffect(() => {
+    reset({ secretId: "" });
+  }, [reset, secretSlot]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      reset();
+      result.reset();
+    }
+  }, [isOpen, reset, result]);
+
+  useEffect(() => {
+    if (result.isSuccess) {
+      toggle();
+    }
+  }, [result.isSuccess, toggle]);
+
+  return (
+    <Form noValidate onSubmit={onSubmit}>
+      <ModalBody>
+        {result.error && (
+          <RtkOrNotebooksError error={result.error} dismissible={false} />
+        )}
+
+        <SelectUserSecretField
+          control={control}
+          errors={errors}
+          name="secretId"
+        />
+      </ModalBody>
+      <ModalFooter>
+        <Button color="outline-primary" onClick={toggle}>
+          <XLg className={cx("bi", "me-1")} />
+          Close
+        </Button>
+        <Button color="primary" disabled={result.isLoading} type="submit">
+          {result.isLoading ? (
+            <Loader className="me-1" inline size={16} />
+          ) : (
+            <BoxArrowInLeft className={cx("bi", "me-1")} />
+          )}
+          Use secret
+        </Button>
+      </ModalFooter>
+    </Form>
+  );
+}
+
+interface ProvideExistingSecretForm {
+  secretId: string;
+}

--- a/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/SecretsMountDirectoryComponent.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/SecretsMountDirectoryComponent.tsx
@@ -39,7 +39,7 @@ import SecretsMountDirectoryField from "../../../projectsV2/fields/SecretsMountD
 import useProjectPermissions from "../../utils/useProjectPermissions.hook";
 import PermissionsGuard from "../../../permissionsV2/PermissionsGuard";
 
-export function SecretsMountDirectoryComponent() {
+export default function SecretsMountDirectoryComponent() {
   const { project } = useProject();
   const { id: projectId, secrets_mount_directory: secretsMountDirectory } =
     project;
@@ -75,21 +75,6 @@ export function SecretsMountDirectoryComponent() {
           userPermissions={permissions}
         />
       </InputGroup>
-      <UpdateSecretsMountDirectoryModal isOpen={isOpen} toggle={toggle} />
-    </>
-  );
-}
-
-export default function UpdateSecretsMountDirectoryButton() {
-  const [isOpen, setIsOpen] = useState(false);
-  const toggle = useCallback(() => setIsOpen((isOpen) => !isOpen), []);
-
-  return (
-    <>
-      <Button color="outline-primary" onClick={toggle} size="sm">
-        <Pencil className={cx("bi", "me-1")} />
-        Update the secrets mount location
-      </Button>
       <UpdateSecretsMountDirectoryModal isOpen={isOpen} toggle={toggle} />
     </>
   );

--- a/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/SessionSecretActions.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/SessionSecretActions.tsx
@@ -20,24 +20,19 @@ import { skipToken } from "@reduxjs/toolkit/query";
 import cx from "classnames";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
-  BoxArrowInLeft,
   Download,
   Pencil,
-  PlusLg,
   ShieldMinus,
   ShieldPlus,
   Trash,
   XLg,
 } from "react-bootstrap-icons";
-import { Controller, useForm } from "react-hook-form";
+import { useForm } from "react-hook-form";
 import {
   Button,
-  ButtonGroup,
   Col,
   DropdownItem,
   Form,
-  Input,
-  Label,
   Modal,
   ModalBody,
   ModalFooter,
@@ -61,7 +56,7 @@ import useProjectPermissions from "../../utils/useProjectPermissions.hook";
 import DescriptionField from "./fields/DescriptionField";
 import FilenameField from "./fields/FilenameField";
 import NameField from "./fields/NameField";
-import SelectUserSecretField from "./fields/SelectUserSecretField";
+import ProvideSessionSecretModalContent from "./ProvideSessionSecretModalContent";
 import type { SessionSecretSlotWithSecret } from "./sessionSecrets.types";
 
 interface SessionSecretActionsProps {
@@ -465,269 +460,15 @@ function ProvideSessionSecretModal({
   secretSlot,
   toggle,
 }: ProvideSessionSecretModalProps) {
-  const [mode, setMode] = useState<"new-value" | "existing">("new-value");
-
-  useEffect(() => {
-    if (!isOpen) {
-      setMode("new-value");
-    }
-  }, [isOpen]);
-
   return (
     <Modal backdrop="static" centered isOpen={isOpen} size="lg" toggle={toggle}>
-      <ModalHeader toggle={toggle}>Provide session secret</ModalHeader>
-      <ModalBody className="pb-0">
-        <ButtonGroup>
-          <Input
-            type="radio"
-            className="btn-check"
-            id="provide-session-secret-mode-new-value"
-            value="new-value"
-            checked={mode == "new-value"}
-            onChange={() => setMode("new-value")}
-          />
-          <Label
-            for="provide-session-secret-mode-new-value"
-            className={cx("btn", "btn-outline-primary")}
-          >
-            <PlusLg className={cx("bi", "me-1")} />
-            Provide a new secret value
-          </Label>
-          <Input
-            type="radio"
-            className="btn-check"
-            id="provide-session-secret-mode-existing"
-            value="existing"
-            checked={mode == "existing"}
-            onChange={() => setMode("existing")}
-          />
-          <Label
-            for="provide-session-secret-mode-existing"
-            className={cx("btn", "btn-outline-primary")}
-          >
-            <BoxArrowInLeft className={cx("bi", "me-1")} />
-            Use an existing secret value
-          </Label>
-        </ButtonGroup>
-      </ModalBody>
-      {mode === "new-value" ? (
-        <ProvideSessionSecretModalNewValueContent
-          isOpen={isOpen}
-          secretSlot={secretSlot}
-          toggle={toggle}
-        />
-      ) : (
-        <ProvideSessionSecretModalExistingContent
-          isOpen={isOpen}
-          secretSlot={secretSlot}
-          toggle={toggle}
-        />
-      )}
+      <ProvideSessionSecretModalContent
+        isOpen={isOpen}
+        secretSlot={secretSlot}
+        toggle={toggle}
+      />
     </Modal>
   );
-}
-
-interface ProvideSessionSecretModalNewValueContentProps {
-  isOpen: boolean;
-  secretSlot: SessionSecretSlot;
-  toggle: () => void;
-}
-
-function ProvideSessionSecretModalNewValueContent({
-  isOpen,
-  secretSlot,
-  toggle,
-}: ProvideSessionSecretModalNewValueContentProps) {
-  const { id: slotId, project_id: projectId } = secretSlot;
-
-  const [patchSessionSecrets, result] =
-    usePatchProjectsByProjectIdSessionSecretsMutation();
-
-  const {
-    control,
-    formState: { errors },
-    handleSubmit,
-    reset,
-  } = useForm<ProvideNewSecretValueForm>({
-    defaultValues: { value: "" },
-  });
-
-  const submitHandler = useCallback(
-    (data: ProvideNewSecretValueForm) => {
-      patchSessionSecrets({
-        projectId,
-        sessionSecretPatchList: [{ secret_slot_id: slotId, value: data.value }],
-      });
-    },
-    [patchSessionSecrets, projectId, slotId]
-  );
-  const onSubmit = useMemo(
-    () => handleSubmit(submitHandler),
-    [handleSubmit, submitHandler]
-  );
-
-  useEffect(() => {
-    reset({ value: "" });
-  }, [reset, secretSlot]);
-
-  useEffect(() => {
-    if (!isOpen) {
-      reset();
-      result.reset();
-    }
-  }, [isOpen, reset, result]);
-
-  useEffect(() => {
-    if (result.isSuccess) {
-      toggle();
-    }
-  }, [result.isSuccess, toggle]);
-
-  return (
-    <Form noValidate onSubmit={onSubmit}>
-      <ModalBody>
-        {result.error && (
-          <RtkOrNotebooksError error={result.error} dismissible={false} />
-        )}
-
-        <div className="mb-3">
-          <Label for="provide-session-secret-new-value">Secret value</Label>
-          <Controller
-            name="value"
-            control={control}
-            render={({ field }) => (
-              <textarea
-                id="provide-session-secret-new-value"
-                className={cx("form-control", errors.value && "is-invalid")}
-                placeholder="Your secret value..."
-                rows={6}
-                {...field}
-              />
-            )}
-            rules={{ required: "Please provide a value" }}
-          />
-          <div className="invalid-feedback">
-            {errors.value?.message ? (
-              <>{errors.value?.message}</>
-            ) : (
-              <>Invalid secret value</>
-            )}
-          </div>
-        </div>
-      </ModalBody>
-      <ModalFooter>
-        <Button color="outline-primary" onClick={toggle}>
-          <XLg className={cx("bi", "me-1")} />
-          Close
-        </Button>
-        <Button color="primary" disabled={result.isLoading} type="submit">
-          {result.isLoading ? (
-            <Loader className="me-1" inline size={16} />
-          ) : (
-            <PlusLg className={cx("bi", "me-1")} />
-          )}
-          Save new secret
-        </Button>
-      </ModalFooter>
-    </Form>
-  );
-}
-
-interface ProvideNewSecretValueForm {
-  value: string;
-}
-
-interface ProvideSessionSecretModalExistingContentProps {
-  isOpen: boolean;
-  secretSlot: SessionSecretSlot;
-  toggle: () => void;
-}
-
-function ProvideSessionSecretModalExistingContent({
-  isOpen,
-  secretSlot,
-  toggle,
-}: ProvideSessionSecretModalExistingContentProps) {
-  const { id: slotId, project_id: projectId } = secretSlot;
-
-  const [patchSessionSecrets, result] =
-    usePatchProjectsByProjectIdSessionSecretsMutation();
-
-  const {
-    control,
-    formState: { errors },
-    handleSubmit,
-    reset,
-  } = useForm<ProvideExistingSecretForm>({
-    defaultValues: { secretId: "" },
-  });
-
-  const submitHandler = useCallback(
-    (data: ProvideExistingSecretForm) => {
-      patchSessionSecrets({
-        projectId,
-        sessionSecretPatchList: [
-          { secret_slot_id: slotId, secret_id: data.secretId },
-        ],
-      });
-    },
-    [patchSessionSecrets, projectId, slotId]
-  );
-  const onSubmit = useMemo(
-    () => handleSubmit(submitHandler),
-    [handleSubmit, submitHandler]
-  );
-
-  useEffect(() => {
-    reset({ secretId: "" });
-  }, [reset, secretSlot]);
-
-  useEffect(() => {
-    if (!isOpen) {
-      reset();
-      result.reset();
-    }
-  }, [isOpen, reset, result]);
-
-  useEffect(() => {
-    if (result.isSuccess) {
-      toggle();
-    }
-  }, [result.isSuccess, toggle]);
-
-  return (
-    <Form noValidate onSubmit={onSubmit}>
-      <ModalBody>
-        {result.error && (
-          <RtkOrNotebooksError error={result.error} dismissible={false} />
-        )}
-
-        <SelectUserSecretField
-          control={control}
-          errors={errors}
-          name="secretId"
-        />
-      </ModalBody>
-      <ModalFooter>
-        <Button color="outline-primary" onClick={toggle}>
-          <XLg className={cx("bi", "me-1")} />
-          Close
-        </Button>
-        <Button color="primary" disabled={result.isLoading} type="submit">
-          {result.isLoading ? (
-            <Loader className="me-1" inline size={16} />
-          ) : (
-            <BoxArrowInLeft className={cx("bi", "me-1")} />
-          )}
-          Use secret
-        </Button>
-      </ModalFooter>
-    </Form>
-  );
-}
-
-interface ProvideExistingSecretForm {
-  secretId: string;
 }
 
 interface ClearSessionSecretModalProps {

--- a/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/SessionSecretActions.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/SessionSecretActions.tsx
@@ -20,8 +20,8 @@ import { skipToken } from "@reduxjs/toolkit/query";
 import cx from "classnames";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
-  Download,
   Pencil,
+  Save,
   ShieldMinus,
   ShieldPlus,
   Trash,
@@ -140,7 +140,7 @@ export default function SessionSecretActions({
             onClick: toggleReplace,
             content: (
               <>
-                <Download className={cx("bi", "me-1")} />
+                <Save className={cx("bi", "me-1")} />
                 Replace secret value
               </>
             ),

--- a/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/SessionSecretSlotItem.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/SessionSecretSlotItem.tsx
@@ -17,7 +17,7 @@
  */
 
 import cx from "classnames";
-import { Key, Lock, NodePlus } from "react-bootstrap-icons";
+import { Key, Lock } from "react-bootstrap-icons";
 import { Badge, Col, ListGroupItem, Row } from "reactstrap";
 
 import { useGetUserSecretByIdQuery } from "../../../usersV2/api/users.api";
@@ -62,7 +62,6 @@ export default function SessionSecretSlotItem({
                   <Key className={cx("bi", "me-1")} />
                   Secret saved
                 </Badge>
-                {/* <NodePlus className={cx("bi", "ms-2", "me-1")} /> */}
                 <Key className={cx("bi", "ms-2", "me-1")} />
                 <span>
                   Secret name:{" "}

--- a/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/SessionSecretSlotItem.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/SessionSecretSlotItem.tsx
@@ -65,7 +65,7 @@ export default function SessionSecretSlotItem({
                 <NodePlus className={cx("bi", "ms-2", "me-1")} />
                 <span>
                   Secret name:{" "}
-                  <span className="fw-semibold">
+                  <span className="fw-bold">
                     <SessionSecretSlotItemSecretReference
                       userSecretId={secretSlot.secretId}
                     />

--- a/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/SessionSecretSlotItem.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/SessionSecretSlotItem.tsx
@@ -17,7 +17,7 @@
  */
 
 import cx from "classnames";
-import { ArrowRight, Key, Lock } from "react-bootstrap-icons";
+import { Key, Lock, NodePlus } from "react-bootstrap-icons";
 import { Badge, Col, ListGroupItem, Row } from "reactstrap";
 
 import { useGetUserSecretByIdQuery } from "../../../usersV2/api/users.api";
@@ -49,22 +49,29 @@ export default function SessionSecretSlotItem({
           <div className={cx("align-items-center", "d-flex")}>
             <span className={cx("fw-bold", "me-2")}>{name}</span>
             {secretSlot.secretId ? (
-              <Badge
-                className={cx(
-                  "border",
-                  "border-success",
-                  "bg-success-subtle",
-                  "text-success-emphasis"
-                )}
-                pill
-              >
-                <Key className={cx("bi", "me-1")} />
-                Secret saved
-                <ArrowRight className={cx("bi", "mx-1")} />
-                <SessionSecretSlotItemSecretReference
-                  userSecretId={secretSlot.secretId}
-                />
-              </Badge>
+              <>
+                <Badge
+                  className={cx(
+                    "border",
+                    "border-success",
+                    "bg-success-subtle",
+                    "text-success-emphasis"
+                  )}
+                  pill
+                >
+                  <Key className={cx("bi", "me-1")} />
+                  Secret saved
+                </Badge>
+                <NodePlus className={cx("bi", "ms-2", "me-1")} />
+                <span>
+                  Secret name:{" "}
+                  <span className="fw-semibold">
+                    <SessionSecretSlotItemSecretReference
+                      userSecretId={secretSlot.secretId}
+                    />
+                  </span>
+                </span>
+              </>
             ) : (
               <Badge
                 className={cx(

--- a/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/SessionSecretSlotItem.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/SessionSecretSlotItem.tsx
@@ -62,7 +62,8 @@ export default function SessionSecretSlotItem({
                   <Key className={cx("bi", "me-1")} />
                   Secret saved
                 </Badge>
-                <NodePlus className={cx("bi", "ms-2", "me-1")} />
+                {/* <NodePlus className={cx("bi", "ms-2", "me-1")} /> */}
+                <Key className={cx("bi", "ms-2", "me-1")} />
                 <span>
                   Secret name:{" "}
                   <span className="fw-bold">

--- a/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/SessionSecretSlotItem.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/SessionSecretSlotItem.tsx
@@ -80,10 +80,10 @@ export default function SessionSecretSlotItem({
               </Badge>
             )}
           </div>
+          {description && <p className="mb-0">{description}</p>}
           <div>
             Location in sessions: <code>{fullPath}</code>
           </div>
-          {description && <p className="mb-0">{description}</p>}
         </Col>
         {!noActions && <SessionSecretActions secretSlot={secretSlot} />}
       </Row>

--- a/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/SessionViewSessionSecrets.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/SessionViewSessionSecrets.tsx
@@ -18,13 +18,15 @@
 
 import { skipToken } from "@reduxjs/toolkit/query";
 import cx from "classnames";
-import { ShieldLock } from "react-bootstrap-icons";
-
 import { useMemo } from "react";
+import { ShieldLock } from "react-bootstrap-icons";
+import { generatePath, Link } from "react-router-dom-v5-compat";
 import { Badge, ListGroup } from "reactstrap";
+
 import { InfoAlert } from "../../../../components/Alert";
 import { RtkOrNotebooksError } from "../../../../components/errors/RtkErrorAlert";
 import { Loader } from "../../../../components/Loader";
+import { ABSOLUTE_ROUTES } from "../../../../routing/routes.constants";
 import useLegacySelector from "../../../../utils/customHooks/useLegacySelector.hook";
 import type {
   SessionSecret,
@@ -35,6 +37,7 @@ import {
   useGetProjectsByProjectIdSessionSecretsQuery,
 } from "../../../projectsV2/api/projectV2.enhanced-api";
 import { useProject } from "../../ProjectPageContainer/ProjectPageContainer";
+import { SESSION_SECRETS_CARD_ID } from "./sessionSecrets.constants";
 import { getSessionSecretSlotsWithSecrets } from "./sessionSecrets.utils";
 import SessionSecretSlotItem from "./SessionSecretSlotItem";
 
@@ -60,6 +63,11 @@ export default function SessionViewSessionSecrets() {
   );
   const isLoading = isLoadingSessionSecretSlots || isLoadingSessionSecrets;
   const error = sessionSecretSlotsError ?? sessionSecretsError;
+
+  const projectUrl = generatePath(ABSOLUTE_ROUTES.v2.projects.show.settings, {
+    namespace: project.namespace,
+    slug: project.slug,
+  });
 
   const content = isLoading ? (
     <Loader />
@@ -93,6 +101,14 @@ export default function SessionViewSessionSecrets() {
           </p>
         </InfoAlert>
       )}
+
+      <p className="mb-2">
+        To modify session secrets, go to{" "}
+        <Link to={{ pathname: projectUrl, hash: SESSION_SECRETS_CARD_ID }}>
+          the project&apos;s settings
+        </Link>
+        .
+      </p>
 
       {content}
     </div>

--- a/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/UpdateSecretsMountDirectoryButton.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/UpdateSecretsMountDirectoryButton.tsx
@@ -17,16 +17,68 @@
  */
 
 import cx from "classnames";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ArrowCounterclockwise, Pencil, XLg } from "react-bootstrap-icons";
 import { useForm } from "react-hook-form";
-import { Button, Form, ModalBody, ModalFooter, ModalHeader } from "reactstrap";
+import {
+  Button,
+  Form,
+  Input,
+  InputGroup,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  UncontrolledTooltip,
+} from "reactstrap";
 import { RtkOrNotebooksError } from "../../../../components/errors/RtkErrorAlert";
 import { Loader } from "../../../../components/Loader";
 import ScrollableModal from "../../../../components/modal/ScrollableModal";
 import { usePatchProjectsByProjectIdMutation } from "../../../projectsV2/api/projectV2.enhanced-api";
 import { useProject } from "../../ProjectPageContainer/ProjectPageContainer";
 import SecretsMountDirectoryField from "../../../projectsV2/fields/SecretsMountDirectoryField";
+import useProjectPermissions from "../../utils/useProjectPermissions.hook";
+import PermissionsGuard from "../../../permissionsV2/PermissionsGuard";
+
+export function SecretsMountDirectoryComponent() {
+  const { project } = useProject();
+  const { id: projectId, secrets_mount_directory: secretsMountDirectory } =
+    project;
+  const permissions = useProjectPermissions({ projectId });
+
+  const [isOpen, setIsOpen] = useState(false);
+  const toggle = useCallback(() => setIsOpen((isOpen) => !isOpen), []);
+
+  const ref = useRef<HTMLButtonElement>(null);
+
+  const mountDir = secretsMountDirectory.startsWith("/")
+    ? secretsMountDirectory
+    : `<work-dir>/${secretsMountDirectory}`;
+
+  return (
+    <>
+      <InputGroup>
+        <Input type="text" value={mountDir} readOnly />
+        <PermissionsGuard
+          disabled={null}
+          enabled={
+            <>
+              <Button color="outline-primary" innerRef={ref} onClick={toggle}>
+                <Pencil className="bi" />
+                <span className="visually-hidden">Edit</span>
+              </Button>
+              <UncontrolledTooltip target={ref}>
+                Edit the secrets mount location
+              </UncontrolledTooltip>
+            </>
+          }
+          requestedPermission="write"
+          userPermissions={permissions}
+        />
+      </InputGroup>
+      <UpdateSecretsMountDirectoryModal isOpen={isOpen} toggle={toggle} />
+    </>
+  );
+}
 
 export default function UpdateSecretsMountDirectoryButton() {
   const [isOpen, setIsOpen] = useState(false);

--- a/client/src/features/secrets/Secrets.tsx
+++ b/client/src/features/secrets/Secrets.tsx
@@ -45,7 +45,7 @@ function GeneralSecretSection() {
             the User Secrets section and select the secrets you would like to
             include in the session. The secrets you select will be mounted in
             the session as files in a directory of your choice as{" "}
-            <code>secret-name</code>.
+            <code>secret-filename</code>.
           </p>
         </Col>
       </Row>

--- a/client/src/features/secrets/SecretsListItem.tsx
+++ b/client/src/features/secrets/SecretsListItem.tsx
@@ -17,7 +17,7 @@
  */
 
 import cx from "classnames";
-import { Card, CardBody } from "reactstrap";
+import { Card, CardBody, Col } from "reactstrap";
 
 import { TimeCaption } from "../../components/TimeCaption";
 import SecretItemActions from "../secretsV2/SecretItemActions";
@@ -54,7 +54,9 @@ export default function SecretsListItem({ secret }: SecretsListItemProps) {
               prefix=""
             />
           </span>
-          <SecretItemActions secret={secret} />
+          <Col xs={12} sm="auto" className="ms-auto">
+            <SecretItemActions secret={secret} />
+          </Col>
         </div>
         <div>
           Filename: <code>{secret.default_filename}</code>

--- a/client/src/features/secretsV2/DataConnectorSecretItem.tsx
+++ b/client/src/features/secretsV2/DataConnectorSecretItem.tsx
@@ -231,7 +231,7 @@ function DataConnectorSecretUsedForItem({
       </div>
       <div>
         <div className={cx("d-flex", "flex-row", "gap-4")}>
-          <LinkTag className={cx("fw-semibold")}>{dataConnector.name}</LinkTag>
+          <LinkTag className={cx("fw-bold")}>{dataConnector.name}</LinkTag>
           <div
             className={cx("d-flex", "flex-row", "align-items-center", "gap-1")}
           >
@@ -246,7 +246,7 @@ function DataConnectorSecretUsedForItem({
         <div>
           {dcSecret ? (
             <>
-              Field: <span className="fw-semibold">{dcSecret.name}</span>
+              Field: <span className="fw-bold">{dcSecret.name}</span>
             </>
           ) : (
             <span className="fst-italic">

--- a/client/src/features/secretsV2/DataConnectorSecretItem.tsx
+++ b/client/src/features/secretsV2/DataConnectorSecretItem.tsx
@@ -111,7 +111,7 @@ function DataConnectorSecretUsedFor({
         This secret is used in <Badge>{dataConnectorIds.length}</Badge>{" "}
         {dataConnectorsStr}
       </p>
-      <ul className={cx("list-unstyled", "d-flex", "flex-column", "gap-1")}>
+      <ul className={cx("list-unstyled", "d-flex", "flex-column", "gap-2")}>
         {dataConnectorIds.map((dataConnectorId) => (
           <DataConnectorSecretUsedForItem
             key={dataConnectorId}

--- a/client/src/features/secretsV2/DataConnectorSecretItem.tsx
+++ b/client/src/features/secretsV2/DataConnectorSecretItem.tsx
@@ -59,13 +59,25 @@ export default function DataConnectorSecretItem({
               has been deleted.
             </p>
           )}
+          <DataConnectorSecretUsedFor secret={secret} />
+        </Col>
+        <Col
+          xs={12}
+          sm="auto"
+          className={cx(
+            "ms-auto",
+            "d-flex",
+            "flex-column",
+            "align-items-end",
+            "gap-1"
+          )}
+        >
           <div className={cx("text-light-emphasis", "small")}>
             Edited{" "}
             <TimeCaption datetime={modification_date} enableTooltip noCaption />
           </div>
-          <DataConnectorSecretUsedFor secret={secret} />
+          <SecretItemActions isV2 secret={secret} />
         </Col>
-        <SecretItemActions isV2 secret={secret} />
       </Row>
     </ListGroupItem>
   );
@@ -86,7 +98,7 @@ function DataConnectorSecretUsedFor({
 
   return (
     <div>
-      <p className={cx("mb-0", "fw-medium")}>Used for:</p>
+      <p className={cx("mb-0", "fw-medium")}>This secret is used in:</p>
       <ul>
         {dataConnectorIds.map((dataConnectorId) => (
           <DataConnectorSecretUsedForItem

--- a/client/src/features/secretsV2/DataConnectorSecretItem.tsx
+++ b/client/src/features/secretsV2/DataConnectorSecretItem.tsx
@@ -53,6 +53,12 @@ export default function DataConnectorSecretItem({
             <span className={cx("fw-bold", "me-2")}>{name}</span>
             {isOrphanSecret && <Badge color="danger">Orphan Secret</Badge>}
           </div>
+          {isOrphanSecret && (
+            <p className={cx("mb-0", "fst-italic")}>
+              This secret was used as a credential for a data connector which
+              has been deleted.
+            </p>
+          )}
           <div className={cx("text-light-emphasis", "small")}>
             Edited{" "}
             <TimeCaption datetime={modification_date} enableTooltip noCaption />

--- a/client/src/features/secretsV2/GeneralSecretItem.tsx
+++ b/client/src/features/secretsV2/GeneralSecretItem.tsx
@@ -24,6 +24,7 @@ import { Badge, Col, Collapse, ListGroupItem, Row } from "reactstrap";
 import { skipToken } from "@reduxjs/toolkit/query";
 import { Folder, NodePlus } from "react-bootstrap-icons";
 import { RtkOrNotebooksError } from "../../components/errors/RtkErrorAlert";
+import ChevronFlippedIcon from "../../components/icons/ChevronFlippedIcon";
 import { Loader } from "../../components/Loader";
 import { TimeCaption } from "../../components/TimeCaption";
 import { ABSOLUTE_ROUTES } from "../../routing/routes.constants";
@@ -40,7 +41,6 @@ import {
 import UserAvatar from "../usersV2/show/UserAvatar";
 import SecretItemActions from "./SecretItemActions";
 import useGetRelatedProjects from "./useGetRelatedProjects.hook";
-import ChevronFlippedIcon from "../../components/icons/ChevronFlippedIcon";
 
 interface GeneralSecretItemProps {
   secret: SecretWithId;
@@ -53,9 +53,6 @@ export default function GeneralSecretItem({ secret }: GeneralSecretItemProps) {
     secret,
   });
 
-  const [isOpen, setIsOpen] = useState(false);
-  const toggle = useCallback(() => setIsOpen((isOpen) => !isOpen), []);
-
   const usedInContent = isLoading ? (
     <div>
       <Loader className="me-1" inline size={16} />
@@ -67,11 +64,7 @@ export default function GeneralSecretItem({ secret }: GeneralSecretItemProps) {
       {error && <RtkOrNotebooksError error={error} dismissible={false} />}
     </div>
   ) : (
-    <GeneralSecretUsedIn
-      isOpen={isOpen}
-      projects={projects}
-      secretSlots={secretSlots}
-    />
+    <GeneralSecretUsedIn projects={projects} secretSlots={secretSlots} />
   );
 
   return (
@@ -79,20 +72,7 @@ export default function GeneralSecretItem({ secret }: GeneralSecretItemProps) {
       <Row>
         <Col>
           <div className={cx("align-items-center", "d-flex", "mb-2")}>
-            {projects && projects.length > 0 ? (
-              <button
-                className={cx("fw-bold", "me-2", "bg-transparent", "border-0")}
-                onClick={toggle}
-              >
-                {name}
-                <ChevronFlippedIcon
-                  className={cx("bi", "ms-1")}
-                  flipped={isOpen}
-                />
-              </button>
-            ) : (
-              <span className={cx("fw-bold", "me-2")}>{name}</span>
-            )}
+            <span className={cx("fw-bold", "me-2")}>{name}</span>
           </div>
           {usedInContent}
         </Col>
@@ -119,16 +99,17 @@ export default function GeneralSecretItem({ secret }: GeneralSecretItemProps) {
 }
 
 interface GeneralSecretUsedInProps {
-  isOpen: boolean;
   projects: Project[];
   secretSlots: SessionSecretSlot[];
 }
 
 function GeneralSecretUsedIn({
-  isOpen,
   projects,
   secretSlots,
 }: GeneralSecretUsedInProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const toggle = useCallback(() => setIsOpen((isOpen) => !isOpen), []);
+
   if (projects.length == 0) {
     return null;
   }
@@ -137,10 +118,14 @@ function GeneralSecretUsedIn({
 
   return (
     <div>
-      <p className={cx("mb-1", "fw-medium")}>
+      <button
+        className={cx("me-2", "bg-transparent", "border-0", "fw-medium")}
+        onClick={toggle}
+      >
         <NodePlus className={cx("bi", "me-1")} />
         This secret is used in <Badge>{projects.length}</Badge> {projectStr}
-      </p>
+        <ChevronFlippedIcon className={cx("bi", "ms-1")} flipped={isOpen} />
+      </button>
       <Collapse isOpen={isOpen}>
         <ul className={cx("list-unstyled", "d-flex", "flex-column", "gap-2")}>
           {projects.map((project) => (

--- a/client/src/features/secretsV2/GeneralSecretItem.tsx
+++ b/client/src/features/secretsV2/GeneralSecretItem.tsx
@@ -204,7 +204,7 @@ function GeneralSecretUsedInProject({
           <div>
             <div className={cx("d-flex", "flex-row", "gap-4")}>
               <Link
-                className={cx("fw-semibold")}
+                className={cx("fw-bold")}
                 to={{ pathname: projectUrl, hash: SESSION_SECRETS_CARD_ID }}
               >
                 {project.name}
@@ -226,8 +226,7 @@ function GeneralSecretUsedInProject({
               </div>
             </div>
             <div>
-              Secret slot:{" "}
-              <span className="fw-semibold">{secretSlot.name}</span>
+              Secret slot: <span className="fw-bold">{secretSlot.name}</span>
             </div>
           </div>
         </li>

--- a/client/src/features/secretsV2/GeneralSecretItem.tsx
+++ b/client/src/features/secretsV2/GeneralSecretItem.tsx
@@ -79,7 +79,6 @@ export default function GeneralSecretItem({ secret }: GeneralSecretItemProps) {
       <Row>
         <Col>
           <div className={cx("align-items-center", "d-flex", "mb-2")}>
-            {/* <span className={cx("fw-bold", "me-2")}>{name}</span> */}
             {projects && projects.length > 0 ? (
               <button
                 className={cx("fw-bold", "me-2", "bg-transparent", "border-0")}
@@ -143,7 +142,7 @@ function GeneralSecretUsedIn({
         This secret is used in <Badge>{projects.length}</Badge> {projectStr}
       </p>
       <Collapse isOpen={isOpen}>
-        <ul className={cx("list-unstyled", "d-flex", "flex-column", "gap-1")}>
+        <ul className={cx("list-unstyled", "d-flex", "flex-column", "gap-2")}>
           {projects.map((project) => (
             <GeneralSecretUsedInProject
               key={project.id}

--- a/client/src/features/secretsV2/GeneralSecretItem.tsx
+++ b/client/src/features/secretsV2/GeneralSecretItem.tsx
@@ -22,7 +22,7 @@ import { generatePath, Link } from "react-router-dom-v5-compat";
 import { Badge, Col, Collapse, ListGroupItem, Row } from "reactstrap";
 
 import { skipToken } from "@reduxjs/toolkit/query";
-import { Folder, NodePlus, ShieldLock } from "react-bootstrap-icons";
+import { Folder, ShieldLock } from "react-bootstrap-icons";
 import { RtkOrNotebooksError } from "../../components/errors/RtkErrorAlert";
 import ChevronFlippedIcon from "../../components/icons/ChevronFlippedIcon";
 import { Loader } from "../../components/Loader";
@@ -119,10 +119,15 @@ function GeneralSecretUsedIn({
   return (
     <div>
       <button
-        className={cx("me-2", "bg-transparent", "border-0", "fw-medium")}
+        className={cx(
+          "px-0",
+          "mb-1",
+          "bg-transparent",
+          "border-0",
+          "fw-medium"
+        )}
         onClick={toggle}
       >
-        {/* <NodePlus className={cx("bi", "me-1")} /> */}
         <ShieldLock className={cx("bi", "me-1")} />
         This secret is used in <Badge>{projects.length}</Badge> {projectStr}
         <ChevronFlippedIcon className={cx("bi", "ms-1")} flipped={isOpen} />

--- a/client/src/features/secretsV2/GeneralSecretItem.tsx
+++ b/client/src/features/secretsV2/GeneralSecretItem.tsx
@@ -22,7 +22,7 @@ import { generatePath, Link } from "react-router-dom-v5-compat";
 import { Badge, Col, Collapse, ListGroupItem, Row } from "reactstrap";
 
 import { skipToken } from "@reduxjs/toolkit/query";
-import { Folder, NodePlus } from "react-bootstrap-icons";
+import { Folder, NodePlus, ShieldLock } from "react-bootstrap-icons";
 import { RtkOrNotebooksError } from "../../components/errors/RtkErrorAlert";
 import ChevronFlippedIcon from "../../components/icons/ChevronFlippedIcon";
 import { Loader } from "../../components/Loader";
@@ -122,7 +122,8 @@ function GeneralSecretUsedIn({
         className={cx("me-2", "bg-transparent", "border-0", "fw-medium")}
         onClick={toggle}
       >
-        <NodePlus className={cx("bi", "me-1")} />
+        {/* <NodePlus className={cx("bi", "me-1")} /> */}
+        <ShieldLock className={cx("bi", "me-1")} />
         This secret is used in <Badge>{projects.length}</Badge> {projectStr}
         <ChevronFlippedIcon className={cx("bi", "ms-1")} flipped={isOpen} />
       </button>

--- a/client/src/features/secretsV2/ReplaceSecretValueModal.tsx
+++ b/client/src/features/secretsV2/ReplaceSecretValueModal.tsx
@@ -1,0 +1,184 @@
+/*!
+ * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import cx from "classnames";
+import { useCallback, useEffect, useMemo } from "react";
+import { Pencil, XLg } from "react-bootstrap-icons";
+import { useForm } from "react-hook-form";
+import {
+  Button,
+  Form,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+} from "reactstrap";
+
+import { InfoAlert } from "../../components/Alert";
+import { RtkOrNotebooksError } from "../../components/errors/RtkErrorAlert";
+import { Loader } from "../../components/Loader";
+import {
+  usePatchUserSecretMutation,
+  type SecretWithId,
+} from "../usersV2/api/users.api";
+import SecretValueField from "./fields/SecretValueField";
+
+interface ReplaceSecretValueModalProps {
+  isOpen: boolean;
+  isV2?: boolean;
+  secret: SecretWithId;
+  toggle: () => void;
+}
+
+export default function ReplaceSecretValueModal({
+  isOpen,
+  isV2,
+  secret,
+  toggle,
+}: ReplaceSecretValueModalProps) {
+  const {
+    id: secretId,
+    data_connector_ids: dataConnectorIds,
+    session_secret_ids: sessionSecretIds,
+  } = secret;
+
+  const [patchUserSecret, result] = usePatchUserSecretMutation();
+
+  const {
+    control,
+    formState: { errors, isDirty },
+    handleSubmit,
+    reset,
+  } = useForm<ReplaceSecretValueForm>({
+    defaultValues: {
+      value: "",
+    },
+  });
+
+  const submitHandler = useCallback(
+    (data: ReplaceSecretValueForm) => {
+      patchUserSecret({
+        secretId,
+        secretPatch: {
+          value: data.value,
+        },
+      });
+    },
+    [patchUserSecret, secretId]
+  );
+  const onSubmit = useMemo(
+    () => handleSubmit(submitHandler),
+    [handleSubmit, submitHandler]
+  );
+
+  useEffect(() => {
+    reset({
+      value: "",
+    });
+  }, [reset, secret]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      reset();
+      result.reset();
+    }
+  }, [isOpen, reset, result]);
+
+  useEffect(() => {
+    if (result.isSuccess) {
+      toggle();
+    }
+  }, [result.isSuccess, toggle]);
+
+  const usageAlert =
+    (sessionSecretIds.length > 0 || dataConnectorIds.length > 0) && isV2 ? (
+      <InfoAlert dismissible={false} timeout={0}>
+        This secret is used for{" "}
+        {sessionSecretIds.length > 1 ? (
+          <>{sessionSecretIds.length} session secrets</>
+        ) : sessionSecretIds.length == 1 ? (
+          <>1 session secret</>
+        ) : null}
+        {sessionSecretIds.length > 0 && dataConnectorIds.length > 0 ? (
+          <> and </>
+        ) : null}
+        {dataConnectorIds.length > 1 ? (
+          <>{dataConnectorIds.length} data connectors</>
+        ) : dataConnectorIds.length == 1 ? (
+          <>1 data connector</>
+        ) : null}
+        .
+      </InfoAlert>
+    ) : sessionSecretIds.length > 0 || dataConnectorIds.length > 0 ? (
+      <InfoAlert dismissible={false} timeout={0}>
+        This secret is in use in Renku 2.0.
+      </InfoAlert>
+    ) : null;
+
+  return (
+    <Modal backdrop="static" centered isOpen={isOpen} size="lg" toggle={toggle}>
+      <Form
+        className={cx(!isV2 && "form-rk-green")}
+        noValidate
+        onSubmit={onSubmit}
+      >
+        <ModalHeader toggle={toggle}>Replace secret value</ModalHeader>
+        <ModalBody>
+          <p>
+            Here you can replace the value of the secret named{" "}
+            <span className="fw-bold">{secret.name}</span>. The change will
+            apply only to new sessions.
+          </p>
+
+          {usageAlert}
+
+          {result.error && (
+            <RtkOrNotebooksError error={result.error} dismissible={false} />
+          )}
+
+          <SecretValueField control={control} errors={errors} name="value" />
+        </ModalBody>
+        <ModalFooter>
+          <Button
+            color={isV2 ? "outline-primary" : "outline-rk-green"}
+            onClick={toggle}
+          >
+            <XLg className={cx("bi", "me-1")} />
+            Close
+          </Button>
+          <Button
+            color={isV2 ? "primary" : "rk-green"}
+            disabled={!isDirty || result.isLoading}
+            type="submit"
+          >
+            {result.isLoading ? (
+              <Loader className="me-1" inline size={16} />
+            ) : (
+              <Pencil className={cx("bi", "me-1")} />
+            )}
+            Replace value
+          </Button>
+        </ModalFooter>
+      </Form>
+    </Modal>
+  );
+}
+
+interface ReplaceSecretValueForm {
+  value: string;
+}

--- a/client/src/features/secretsV2/ReplaceSecretValueModal.tsx
+++ b/client/src/features/secretsV2/ReplaceSecretValueModal.tsx
@@ -134,6 +134,7 @@ export default function ReplaceSecretValueModal({
     <Modal backdrop="static" centered isOpen={isOpen} size="lg" toggle={toggle}>
       <Form
         className={cx(!isV2 && "form-rk-green")}
+        data-cy="replace-secret-value-form"
         noValidate
         onSubmit={onSubmit}
       >

--- a/client/src/features/secretsV2/ReplaceSecretValueModal.tsx
+++ b/client/src/features/secretsV2/ReplaceSecretValueModal.tsx
@@ -54,7 +54,7 @@ export default function ReplaceSecretValueModal({
   const {
     id: secretId,
     data_connector_ids: dataConnectorIds,
-    session_secret_ids: sessionSecretIds,
+    session_secret_slot_ids: sessionSecretSlotIds,
   } = secret;
 
   const [patchUserSecret, result] = usePatchUserSecretMutation();
@@ -106,15 +106,15 @@ export default function ReplaceSecretValueModal({
   }, [result.isSuccess, toggle]);
 
   const usageAlert =
-    (sessionSecretIds.length > 0 || dataConnectorIds.length > 0) && isV2 ? (
+    (sessionSecretSlotIds.length > 0 || dataConnectorIds.length > 0) && isV2 ? (
       <InfoAlert dismissible={false} timeout={0}>
         This secret is used for{" "}
-        {sessionSecretIds.length > 1 ? (
-          <>{sessionSecretIds.length} session secrets</>
-        ) : sessionSecretIds.length == 1 ? (
+        {sessionSecretSlotIds.length > 1 ? (
+          <>{sessionSecretSlotIds.length} session secrets</>
+        ) : sessionSecretSlotIds.length == 1 ? (
           <>1 session secret</>
         ) : null}
-        {sessionSecretIds.length > 0 && dataConnectorIds.length > 0 ? (
+        {sessionSecretSlotIds.length > 0 && dataConnectorIds.length > 0 ? (
           <> and </>
         ) : null}
         {dataConnectorIds.length > 1 ? (
@@ -124,7 +124,7 @@ export default function ReplaceSecretValueModal({
         ) : null}
         .
       </InfoAlert>
-    ) : sessionSecretIds.length > 0 || dataConnectorIds.length > 0 ? (
+    ) : sessionSecretSlotIds.length > 0 || dataConnectorIds.length > 0 ? (
       <InfoAlert dismissible={false} timeout={0}>
         This secret is in use in Renku 2.0.
       </InfoAlert>

--- a/client/src/features/secretsV2/SecretItemActions.tsx
+++ b/client/src/features/secretsV2/SecretItemActions.tsx
@@ -83,29 +83,31 @@ export default function SecretItemActions({
 
   return (
     <>
-      <ButtonWithMenuTag
-        color={buttonColor as any} // eslint-disable-line @typescript-eslint/no-explicit-any
-        default={
-          <Button
-            color={isV2 ? "outline-primary" : "outline-rk-green"}
-            onClick={toggleReplace}
-            size="sm"
-          >
-            <Save className={cx("bi", "me-1")} />
-            Replace
-          </Button>
-        }
-        size="sm"
-      >
-        <DropdownItem onClick={toggleEdit}>
-          <Pencil className={cx("bi", "me-1")} />
-          Edit
-        </DropdownItem>
-        <DropdownItem onClick={toggleDelete}>
-          <Trash className={cx("bi", "me-1")} />
-          Delete
-        </DropdownItem>
-      </ButtonWithMenuTag>
+      <div data-cy="user-secret-actions">
+        <ButtonWithMenuTag
+          color={buttonColor as any} // eslint-disable-line @typescript-eslint/no-explicit-any
+          default={
+            <Button
+              color={isV2 ? "outline-primary" : "outline-rk-green"}
+              onClick={toggleReplace}
+              size="sm"
+            >
+              <Save className={cx("bi", "me-1")} />
+              Replace
+            </Button>
+          }
+          size="sm"
+        >
+          <DropdownItem onClick={toggleEdit}>
+            <Pencil className={cx("bi", "me-1")} />
+            Edit
+          </DropdownItem>
+          <DropdownItem onClick={toggleDelete}>
+            <Trash className={cx("bi", "me-1")} />
+            Delete
+          </DropdownItem>
+        </ButtonWithMenuTag>
+      </div>
       <ReplaceSecretValueModal
         isOpen={isReplaceOpen}
         isV2={isV2}

--- a/client/src/features/secretsV2/SecretItemActions.tsx
+++ b/client/src/features/secretsV2/SecretItemActions.tsx
@@ -18,7 +18,7 @@
 
 import cx from "classnames";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Download, Pencil, Trash, XLg } from "react-bootstrap-icons";
+import { Pencil, Save, Trash, XLg } from "react-bootstrap-icons";
 import { useForm } from "react-hook-form";
 import {
   Button,
@@ -91,7 +91,7 @@ export default function SecretItemActions({
             onClick={toggleReplace}
             size="sm"
           >
-            <Download className={cx("bi", "me-1")} />
+            <Save className={cx("bi", "me-1")} />
             Replace
           </Button>
         }

--- a/client/src/features/secretsV2/SecretItemActions.tsx
+++ b/client/src/features/secretsV2/SecretItemActions.tsx
@@ -39,13 +39,13 @@ import { RtkOrNotebooksError } from "../../components/errors/RtkErrorAlert";
 import { Loader } from "../../components/Loader";
 import useLegacySelector from "../../utils/customHooks/useLegacySelector.hook";
 import {
-  usePatchUserSecretMutation,
   useDeleteUserSecretMutation,
+  usePatchUserSecretMutation,
   type SecretWithId,
 } from "../usersV2/api/users.api";
-import SecretValueField from "./fields/SecretValueField";
-import NameField from "./fields/NameField";
 import FilenameField from "./fields/FilenameField";
+import NameField from "./fields/NameField";
+import ReplaceSecretValueModal from "./ReplaceSecretValueModal";
 
 interface SecretItemActionsProps {
   isV2?: boolean;
@@ -128,121 +128,6 @@ export default function SecretItemActions({
       />
     </>
   );
-}
-
-interface ReplaceSecretValueModalProps {
-  isOpen: boolean;
-  isV2?: boolean;
-  secret: SecretWithId;
-  toggle: () => void;
-}
-
-function ReplaceSecretValueModal({
-  isOpen,
-  isV2,
-  secret,
-  toggle,
-}: ReplaceSecretValueModalProps) {
-  const { id: secretId } = secret;
-
-  const [patchUserSecret, result] = usePatchUserSecretMutation();
-
-  const {
-    control,
-    formState: { errors, isDirty },
-    handleSubmit,
-    reset,
-  } = useForm<ReplaceSecretValueForm>({
-    defaultValues: {
-      value: "",
-    },
-  });
-
-  const submitHandler = useCallback(
-    (data: ReplaceSecretValueForm) => {
-      patchUserSecret({
-        secretId,
-        secretPatch: {
-          value: data.value,
-        },
-      });
-    },
-    [patchUserSecret, secretId]
-  );
-  const onSubmit = useMemo(
-    () => handleSubmit(submitHandler),
-    [handleSubmit, submitHandler]
-  );
-
-  useEffect(() => {
-    reset({
-      value: "",
-    });
-  }, [reset, secret]);
-
-  useEffect(() => {
-    if (!isOpen) {
-      reset();
-      result.reset();
-    }
-  }, [isOpen, reset, result]);
-
-  useEffect(() => {
-    if (result.isSuccess) {
-      toggle();
-    }
-  }, [result.isSuccess, toggle]);
-
-  return (
-    <Modal backdrop="static" centered isOpen={isOpen} size="lg" toggle={toggle}>
-      <Form
-        className={cx(!isV2 && "form-rk-green")}
-        data-cy="replace-secret-value-form"
-        noValidate
-        onSubmit={onSubmit}
-      >
-        <ModalHeader toggle={toggle}>Replace secret value</ModalHeader>
-        <ModalBody>
-          <p>
-            Here you can replace the value of the secret named{" "}
-            <span className="fw-bold">{secret.name}</span>. The change will
-            apply only to new sessions.
-          </p>
-
-          {result.error && (
-            <RtkOrNotebooksError error={result.error} dismissible={false} />
-          )}
-
-          <SecretValueField control={control} errors={errors} name="value" />
-        </ModalBody>
-        <ModalFooter>
-          <Button
-            color={isV2 ? "outline-primary" : "outline-rk-green"}
-            onClick={toggle}
-          >
-            <XLg className={cx("bi", "me-1")} />
-            Close
-          </Button>
-          <Button
-            color={isV2 ? "primary" : "rk-green"}
-            disabled={!isDirty || result.isLoading}
-            type="submit"
-          >
-            {result.isLoading ? (
-              <Loader className="me-1" inline size={16} />
-            ) : (
-              <Pencil className={cx("bi", "me-1")} />
-            )}
-            Replace value
-          </Button>
-        </ModalFooter>
-      </Form>
-    </Modal>
-  );
-}
-
-interface ReplaceSecretValueForm {
-  value: string;
 }
 
 interface EditSecretModalProps {

--- a/client/src/features/secretsV2/SecretItemActions.tsx
+++ b/client/src/features/secretsV2/SecretItemActions.tsx
@@ -22,7 +22,6 @@ import { Download, Pencil, Trash, XLg } from "react-bootstrap-icons";
 import { useForm } from "react-hook-form";
 import {
   Button,
-  Col,
   DropdownItem,
   Form,
   Modal,
@@ -84,31 +83,29 @@ export default function SecretItemActions({
 
   return (
     <>
-      <Col xs={12} sm="auto" className="ms-auto" data-cy="user-secret-actions">
-        <ButtonWithMenuTag
-          color={buttonColor as any} // eslint-disable-line @typescript-eslint/no-explicit-any
-          default={
-            <Button
-              color={isV2 ? "outline-primary" : "outline-rk-green"}
-              onClick={toggleReplace}
-              size="sm"
-            >
-              <Download className={cx("bi", "me-1")} />
-              Replace
-            </Button>
-          }
-          size="sm"
-        >
-          <DropdownItem onClick={toggleEdit}>
-            <Pencil className={cx("bi", "me-1")} />
-            Edit
-          </DropdownItem>
-          <DropdownItem onClick={toggleDelete}>
-            <Trash className={cx("bi", "me-1")} />
-            Delete
-          </DropdownItem>
-        </ButtonWithMenuTag>
-      </Col>
+      <ButtonWithMenuTag
+        color={buttonColor as any} // eslint-disable-line @typescript-eslint/no-explicit-any
+        default={
+          <Button
+            color={isV2 ? "outline-primary" : "outline-rk-green"}
+            onClick={toggleReplace}
+            size="sm"
+          >
+            <Download className={cx("bi", "me-1")} />
+            Replace
+          </Button>
+        }
+        size="sm"
+      >
+        <DropdownItem onClick={toggleEdit}>
+          <Pencil className={cx("bi", "me-1")} />
+          Edit
+        </DropdownItem>
+        <DropdownItem onClick={toggleDelete}>
+          <Trash className={cx("bi", "me-1")} />
+          Delete
+        </DropdownItem>
+      </ButtonWithMenuTag>
       <ReplaceSecretValueModal
         isOpen={isReplaceOpen}
         isV2={isV2}

--- a/client/src/features/secretsV2/SecretsV2.tsx
+++ b/client/src/features/secretsV2/SecretsV2.tsx
@@ -18,7 +18,7 @@
 
 import cx from "classnames";
 import { useMemo } from "react";
-import { DatabaseLock, Key, ShieldLock, ShieldX } from "react-bootstrap-icons";
+import { DatabaseLock, Key, ShieldX } from "react-bootstrap-icons";
 import {
   Badge,
   Card,
@@ -87,7 +87,7 @@ function SecretsPageInfo() {
     );
   }
 
-  return <p>Here you can store secrets to use in your sessions.</p>;
+  return <p>Here you can manage data connector and session secrets.</p>;
 }
 
 function SessionSecrets() {
@@ -124,8 +124,6 @@ function SessionSecrets() {
       <CardHeader>
         <div className={cx("align-items-center", "d-flex")}>
           <h4 className={cx("m-0", "me-2")}>
-            {/* <ShieldLock className={cx("me-1", "bi")} />
-             */}
             <Key className={cx("me-1", "bi")} />
             Session Secrets
           </h4>

--- a/client/src/features/secretsV2/SecretsV2.tsx
+++ b/client/src/features/secretsV2/SecretsV2.tsx
@@ -18,7 +18,7 @@
 
 import cx from "classnames";
 import { useMemo } from "react";
-import { DatabaseLock, ShieldLock, ShieldX } from "react-bootstrap-icons";
+import { DatabaseLock, Key, ShieldLock, ShieldX } from "react-bootstrap-icons";
 import {
   Badge,
   Card,
@@ -124,7 +124,9 @@ function SessionSecrets() {
       <CardHeader>
         <div className={cx("align-items-center", "d-flex")}>
           <h4 className={cx("m-0", "me-2")}>
-            <ShieldLock className={cx("me-1", "bi")} />
+            {/* <ShieldLock className={cx("me-1", "bi")} />
+             */}
+            <Key className={cx("me-1", "bi")} />
             Session Secrets
           </h4>
           {secretsUsedInSessions && (

--- a/client/src/features/secretsV2/SecretsV2.tsx
+++ b/client/src/features/secretsV2/SecretsV2.tsx
@@ -56,11 +56,17 @@ export default function SecretsV2() {
         </Col>
       </Row>
       {user.logged && (
-        <div className={cx("d-flex", "flex-column", "gap-4")}>
-          <SessionSecrets />
-          <DataConnectorSecrets />
-          <UnusedSecrets />
-        </div>
+        <Row className={cx("g-4", "row-cols-1", "row-cols-lg-2")}>
+          <Col>
+            <SessionSecrets />
+          </Col>
+          <Col>
+            <DataConnectorSecrets />
+          </Col>
+          <Col>
+            <UnusedSecrets />
+          </Col>
+        </Row>
       )}
     </>
   );
@@ -114,7 +120,7 @@ function SessionSecrets() {
   );
 
   return (
-    <Card>
+    <Card className="h-100">
       <CardHeader>
         <div className={cx("align-items-center", "d-flex")}>
           <h4 className={cx("m-0", "me-2")}>
@@ -179,7 +185,7 @@ function DataConnectorSecrets() {
   );
 
   return (
-    <Card>
+    <Card className="h-100">
       <CardHeader>
         <div className={cx("align-items-center", "d-flex")}>
           <h4 className={cx("m-0", "me-2")}>
@@ -239,7 +245,7 @@ function UnusedSecrets() {
   }
 
   return (
-    <Card>
+    <Card className="h-100">
       <CardHeader>
         <div className={cx("align-items-center", "d-flex")}>
           <h4 className={cx("m-0", "me-2")}>

--- a/client/src/features/secretsV2/SecretsV2.tsx
+++ b/client/src/features/secretsV2/SecretsV2.tsx
@@ -18,7 +18,7 @@
 
 import cx from "classnames";
 import { useMemo } from "react";
-import { Database, QuestionSquare, ShieldLock } from "react-bootstrap-icons";
+import { DatabaseLock, ShieldLock, ShieldX } from "react-bootstrap-icons";
 import {
   Badge,
   Card,
@@ -183,7 +183,7 @@ function DataConnectorSecrets() {
       <CardHeader>
         <div className={cx("align-items-center", "d-flex")}>
           <h4 className={cx("m-0", "me-2")}>
-            <Database className={cx("me-1", "bi")} />
+            <DatabaseLock className={cx("me-1", "bi")} />
             Data Connector Secrets
           </h4>
           {secrets && <Badge>{secrets.length}</Badge>}
@@ -243,7 +243,7 @@ function UnusedSecrets() {
       <CardHeader>
         <div className={cx("align-items-center", "d-flex")}>
           <h4 className={cx("m-0", "me-2")}>
-            <QuestionSquare className={cx("me-1", "bi")} />
+            <ShieldX className={cx("me-1", "bi")} />
             Unused Secrets
           </h4>
           <Badge>{unusedSecrets.length}</Badge>

--- a/client/src/features/sessionsV2/SessionSecretsModal.tsx
+++ b/client/src/features/sessionsV2/SessionSecretsModal.tsx
@@ -43,6 +43,8 @@ import {
   Row,
 } from "reactstrap";
 
+import { useLoginUrl } from "../../authentication/useLoginUrl.hook";
+import { WarnAlert } from "../../components/Alert";
 import { RtkOrNotebooksError } from "../../components/errors/RtkErrorAlert";
 import { Loader } from "../../components/Loader";
 import ScrollableModal from "../../components/modal/ScrollableModal";
@@ -51,14 +53,13 @@ import useAppDispatch from "../../utils/customHooks/useAppDispatch.hook";
 import useLegacySelector from "../../utils/customHooks/useLegacySelector.hook";
 import SelectUserSecretField from "../ProjectPageV2/ProjectPageContent/SessionSecrets/fields/SelectUserSecretField";
 import type { SessionSecretSlotWithSecret } from "../ProjectPageV2/ProjectPageContent/SessionSecrets/sessionSecrets.types";
+import SessionSecretSlotItem from "../ProjectPageV2/ProjectPageContent/SessionSecrets/SessionSecretSlotItem";
 import {
   usePatchProjectsByProjectIdSessionSecretsMutation,
   type Project,
   type SessionSecretSlot,
 } from "../projectsV2/api/projectV2.api";
 import startSessionOptionsV2Slice from "./startSessionOptionsV2.slice";
-import { WarnAlert } from "../../components/Alert";
-import SessionSecretSlotItem from "../ProjectPageV2/ProjectPageContent/SessionSecrets/SessionSecretSlotItem";
 
 interface SessionSecretsModalProps {
   isOpen: boolean;
@@ -90,6 +91,7 @@ export default function SessionSecretsModal({
     dispatch(startSessionOptionsV2Slice.actions.setUserSecretsReady(true));
   }, [dispatch]);
 
+  const loginUrl = useLoginUrl();
   const content = userLogged ? (
     <>
       <ReadySessionSecrets
@@ -103,8 +105,14 @@ export default function SessionSecretsModal({
     <>
       <WarnAlert dismissible={false} timeout={0}>
         <p className="mb-0">
-          This session is expecting some secrets but as an anonymous user, you
-          cannot use session secrets.
+          This session is expecting some secrets.{" "}
+          <a
+            className={cx("btn", "btn-primary", "btn-sm")}
+            href={loginUrl.href}
+          >
+            Log in
+          </a>{" "}
+          to provide a value for these secrets.
         </p>
       </WarnAlert>
 

--- a/client/src/features/sessionsV2/useSessionSecrets.hook.ts
+++ b/client/src/features/sessionsV2/useSessionSecrets.hook.ts
@@ -69,7 +69,7 @@ export default function useSessionSecrets({
 
   useEffect(() => {
     if (
-      !userLogged ||
+      // !userLogged ||
       sessionSecretSlotsWithSecrets?.every(({ secretId }) => secretId)
     ) {
       dispatch(startSessionOptionsV2Slice.actions.setUserSecretsReady(true));

--- a/client/src/features/sessionsV2/useSessionSecrets.hook.ts
+++ b/client/src/features/sessionsV2/useSessionSecrets.hook.ts
@@ -69,7 +69,6 @@ export default function useSessionSecrets({
 
   useEffect(() => {
     if (
-      // !userLogged ||
       sessionSecretSlotsWithSecrets?.every(({ secretId }) => secretId)
     ) {
       dispatch(startSessionOptionsV2Slice.actions.setUserSecretsReady(true));

--- a/client/src/features/sessionsV2/useSessionSecrets.hook.ts
+++ b/client/src/features/sessionsV2/useSessionSecrets.hook.ts
@@ -68,9 +68,7 @@ export default function useSessionSecrets({
   const dispatch = useAppDispatch();
 
   useEffect(() => {
-    if (
-      sessionSecretSlotsWithSecrets?.every(({ secretId }) => secretId)
-    ) {
+    if (sessionSecretSlotsWithSecrets?.every(({ secretId }) => secretId)) {
       dispatch(startSessionOptionsV2Slice.actions.setUserSecretsReady(true));
     }
   }, [dispatch, sessionSecretSlotsWithSecrets, userLogged]);

--- a/tests/cypress/e2e/projectV2SessionSecrets.spec.ts
+++ b/tests/cypress/e2e/projectV2SessionSecrets.spec.ts
@@ -18,7 +18,7 @@
 
 import fixtures from "../support/renkulab-fixtures";
 
-describe("Project Session Secrets", () => {
+describe("Project Session secret slots", () => {
   beforeEach(() => {
     fixtures
       .config()
@@ -34,7 +34,7 @@ describe("Project Session Secrets", () => {
     cy.getDataCy("project-settings-edit").click();
 
     cy.getDataCy("project-settings-session-secrets")
-      .contains("Session Secrets")
+      .contains("Session secret slots")
       .should("be.visible");
   });
 
@@ -46,7 +46,7 @@ describe("Project Session Secrets", () => {
     cy.getDataCy("project-settings-edit").click();
 
     cy.getDataCy("project-settings-session-secrets")
-      .contains("Session Secrets")
+      .contains("Session secret slots")
       .should("be.visible");
     cy.wait("@sessionSecretSlots").wait("@sessionSecrets");
     cy.contains(`[data-cy=session-secret-slot-item]`, "A Secret")
@@ -73,7 +73,7 @@ describe("Project Session Secrets", () => {
     cy.getDataCy("project-settings-edit").click();
 
     cy.getDataCy("project-settings-session-secrets")
-      .contains("Session Secrets")
+      .contains("Session secret slots")
       .should("be.visible");
     cy.wait("@sessionSecretSlots").wait("@sessionSecrets");
     cy.getDataCy("project-settings-session-secrets")
@@ -106,7 +106,7 @@ describe("Project Session Secrets", () => {
     cy.wait("@postSessionSecretSlot").wait("@updatedSessionSecretSlots");
 
     cy.getDataCy("project-settings-session-secrets")
-      .contains("Session Secrets")
+      .contains("Session secret slots")
       .should("be.visible");
     cy.contains(`[data-cy=session-secret-slot-item]`, "A new secret")
       .should("be.visible")
@@ -128,7 +128,7 @@ describe("Project Session Secrets", () => {
     cy.getDataCy("project-settings-edit").click();
 
     cy.getDataCy("project-settings-session-secrets")
-      .contains("Session Secrets")
+      .contains("Session secret slots")
       .should("be.visible");
     cy.wait("@sessionSecretSlots").wait("@sessionSecrets");
     cy.contains(`[data-cy=session-secret-slot-item]`, "A Secret")
@@ -177,7 +177,7 @@ describe("Project Session Secrets", () => {
     cy.getDataCy("project-settings-edit").click();
 
     cy.getDataCy("project-settings-session-secrets")
-      .contains("Session Secrets")
+      .contains("Session secret slots")
       .should("be.visible");
     cy.wait("@sessionSecretSlots").wait("@sessionSecrets");
     cy.contains(`[data-cy=session-secret-slot-item]`, "A Secret")
@@ -227,7 +227,7 @@ describe("Project Session Secrets", () => {
     cy.getDataCy("project-settings-edit").click();
 
     cy.getDataCy("project-settings-session-secrets")
-      .contains("Session Secrets")
+      .contains("Session secret slots")
       .should("be.visible");
     cy.wait("@sessionSecretSlots").wait("@sessionSecrets");
     cy.contains(`[data-cy=session-secret-slot-item]`, "Another Secret")
@@ -284,7 +284,7 @@ describe("Project Session Secrets", () => {
     cy.getDataCy("project-settings-edit").click();
 
     cy.getDataCy("project-settings-session-secrets")
-      .contains("Session Secrets")
+      .contains("Session secret slots")
       .should("be.visible");
     cy.wait("@sessionSecretSlots").wait("@sessionSecrets");
     cy.contains(`[data-cy=session-secret-slot-item]`, "Another Secret")
@@ -347,7 +347,7 @@ describe("Project Session Secrets", () => {
     cy.getDataCy("project-settings-edit").click();
 
     cy.getDataCy("project-settings-session-secrets")
-      .contains("Session Secrets")
+      .contains("Session secret slots")
       .should("be.visible");
     cy.wait("@sessionSecretSlots").wait("@sessionSecrets");
     cy.contains(`[data-cy=session-secret-slot-item]`, "A Secret")

--- a/tests/cypress/support/renkulab-fixtures/secrets.ts
+++ b/tests/cypress/support/renkulab-fixtures/secrets.ts
@@ -36,6 +36,8 @@ function generateFakeSecretsGeneral(num: number) {
       modification_date: new Date(),
       name: secretName,
       kind: "general",
+      session_secret_slot_ids: [],
+      data_connector_ids: [],
     });
   }
   return secrets;
@@ -55,6 +57,8 @@ function generateFakeSecretsStorage(num: number) {
         modification_date: new Date(),
         name: secretName,
         kind: "storage",
+        session_secret_slot_ids: [],
+        data_connector_ids: [dataSourceId],
       });
     }
   }


### PR DESCRIPTION
Part of #3412, merging into `build/session-secrets`.

Polishes the session secrets feature.

* Launch interrupt for anon users
* Re-designed user secrets page v2
* Updated UI for session secrets and session secret slots
* Ask for secret value after creating a new secret slot

![Screenshot 2024-12-10 at 15 10 40](https://github.com/user-attachments/assets/b1c63d15-3dac-4a69-9d0e-0ad33da463e0)
![Screenshot 2024-12-10 at 15 11 16](https://github.com/user-attachments/assets/ae760c97-c352-47aa-8875-57f819e964a2)
![Screenshot 2024-12-10 at 15 11 33](https://github.com/user-attachments/assets/8550d187-e0d5-41fc-881d-163016f4b4db)

/deploy renku=build/session-secrets renku-data-services=build/session-secrets