### PR TITLE
fix: correctly report session v2 status on launch

### DIFF
--- a/client/src/features/session/components/StartSessionProgressBar.tsx
+++ b/client/src/features/session/components/StartSessionProgressBar.tsx
@@ -71,7 +71,9 @@ export function StartSessionProgressBarV2({
 }: StartSessionProgressBarV2Props) {
   const statusData = session?.status;
   const description =
-    statusData?.ready_containers && statusData?.total_containers
+    statusData?.ready_containers != null &&
+    statusData?.total_containers != null &&
+    statusData?.total_containers > 0
       ? `${statusData.ready_containers} of ${statusData.total_containers} containers ready`
       : "Loading containers status";
 


### PR DESCRIPTION
Fixes #3423.

![image](https://github.com/user-attachments/assets/50bdc13e-6efd-493a-925c-a925651071eb)

/deploy