### PR TITLE
feat!: allow copying projects (#3393)

### DIFF
--- a/client/.eslintignore
+++ b/client/.eslintignore
@@ -1,6 +1,7 @@
 *.css
 *.svg
 # Generated files should not be linted
+src/features/projectsV2/api/projectV2.api.ts
 src/features/projectsV2/api/storagesV2.api.ts
 src/features/dataConnectorsV2/api/data-connectors.api.ts
 src/features/usersV2/api/users.generated-api.ts

--- a/client/src/components/PrimaryAlert.module.scss
+++ b/client/src/components/PrimaryAlert.module.scss
@@ -1,0 +1,9 @@
+@import "~bootstrap/scss/functions";
+@import "~bootstrap/scss/variables";
+@import "~bootstrap/scss/variables-dark";
+@import "../styles/renku_bootstrap_customization.scss";
+
+.primaryAlert {
+  --bs-primary-bg-subtle: #{tint-color($primary, 90%)};
+  max-height: 50vh;
+}

--- a/client/src/components/PrimaryAlert.module.scss
+++ b/client/src/components/PrimaryAlert.module.scss
@@ -5,5 +5,4 @@
 
 .primaryAlert {
   --bs-primary-bg-subtle: #{tint-color($primary, 90%)};
-  max-height: 50vh;
 }

--- a/client/src/components/PrimaryAlert.tsx
+++ b/client/src/components/PrimaryAlert.tsx
@@ -1,0 +1,47 @@
+/*!
+ * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import cx from "classnames";
+import { Alert } from "reactstrap";
+import styles from "./PrimaryAlert.module.scss";
+
+interface PrimaryAlertProps {
+  children: React.ReactNode;
+  "data-cy"?: string;
+  icon?: React.ReactNode;
+  className?: string;
+}
+export default function PrimaryAlert({
+  children,
+  icon,
+  ...props
+}: PrimaryAlertProps) {
+  return (
+    <Alert
+      color="primary"
+      isOpen
+      data-cy={props["data-cy"]}
+      className={cx(styles.primaryAlert, props.className, "overflow-y-auto")}
+    >
+      <div className={cx("d-flex", "gap-3")}>
+        {icon && <div>{icon}</div>}
+        <div className={cx("my-auto", "w-100")}>{children}</div>
+      </div>
+    </Alert>
+  );
+}

--- a/client/src/components/buttons/Button.tsx
+++ b/client/src/components/buttons/Button.tsx
@@ -27,7 +27,13 @@ import { faSyncAlt } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import cx from "classnames";
 import { Fragment, ReactNode, useRef, useState } from "react";
-import { ArrowRight, ChevronDown, Pencil, PlusLg } from "react-bootstrap-icons";
+import {
+  ArrowRight,
+  ChevronDown,
+  Pencil,
+  PlusLg,
+  ThreeDotsVertical,
+} from "react-bootstrap-icons";
 import { Link } from "react-router-dom";
 import {
   Button,
@@ -114,7 +120,7 @@ function ButtonWithMenu(props: ButtonWithMenuProps) {
   );
 }
 
-interface BButtonWithMenuV2Props {
+interface ButtonWithMenuV2Props {
   children?: React.ReactNode;
   className?: string;
   color?: string;
@@ -125,7 +131,9 @@ interface BButtonWithMenuV2Props {
   preventPropagation?: boolean;
   size?: string;
 }
-export function ButtonWithMenuV2({
+export const ButtonWithMenuV2 = SplitButtonWithMenu;
+
+export function SplitButtonWithMenu({
   children,
   className,
   color,
@@ -135,7 +143,7 @@ export function ButtonWithMenuV2({
   id,
   preventPropagation,
   size,
-}: BButtonWithMenuV2Props) {
+}: ButtonWithMenuV2Props) {
   // ! Temporary workaround to quickly implement a design solution -- to be removed ASAP #3250
   const additionalProps = preventPropagation
     ? { onClick: (e: React.MouseEvent) => e.stopPropagation() }
@@ -143,7 +151,7 @@ export function ButtonWithMenuV2({
   return (
     <UncontrolledDropdown
       {...additionalProps}
-      className={cx(className)}
+      className={className}
       color={color ?? "primary"}
       direction={direction ?? "down"}
       disabled={disabled}
@@ -160,6 +168,44 @@ export function ButtonWithMenuV2({
         data-cy="button-with-menu-dropdown"
         disabled={disabled}
       />
+      <DropdownMenu end>{children}</DropdownMenu>
+    </UncontrolledDropdown>
+  );
+}
+
+export function SingleButtonWithMenu({
+  children,
+  className,
+  color,
+  direction,
+  disabled,
+  id,
+  preventPropagation,
+  size,
+}: Omit<ButtonWithMenuV2Props, "default">) {
+  // ! Temporary workaround to quickly implement a design solution -- to be removed ASAP #3250
+  const additionalProps = preventPropagation
+    ? { onClick: (e: React.MouseEvent) => e.stopPropagation() }
+    : {};
+  return (
+    <UncontrolledDropdown
+      {...additionalProps}
+      className={className}
+      color={color ?? "primary"}
+      direction={direction ?? "down"}
+      disabled={disabled}
+      id={id}
+      size={size ?? "md"}
+    >
+      <DropdownToggle
+        caret={false}
+        data-bs-toggle="dropdown"
+        color={color ?? "primary"}
+        data-cy="button-with-menu-dropdown"
+        disabled={disabled}
+      >
+        <ThreeDotsVertical />
+      </DropdownToggle>
       <DropdownMenu end>{children}</DropdownMenu>
     </UncontrolledDropdown>
   );

--- a/client/src/components/buttons/Button.tsx
+++ b/client/src/components/buttons/Button.tsx
@@ -180,16 +180,10 @@ export function SingleButtonWithMenu({
   direction,
   disabled,
   id,
-  preventPropagation,
   size,
-}: Omit<ButtonWithMenuV2Props, "default">) {
-  // ! Temporary workaround to quickly implement a design solution -- to be removed ASAP #3250
-  const additionalProps = preventPropagation
-    ? { onClick: (e: React.MouseEvent) => e.stopPropagation() }
-    : {};
+}: Omit<ButtonWithMenuV2Props, "default" | "preventPropagation">) {
   return (
     <UncontrolledDropdown
-      {...additionalProps}
       className={className}
       color={color ?? "primary"}
       direction={direction ?? "down"}

--- a/client/src/features/ProjectPageV2/ProjectPageContent/ProjectInformation/ProjectInformation.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/ProjectInformation/ProjectInformation.tsx
@@ -16,11 +16,13 @@
  * limitations under the License.
  */
 
+import { skipToken } from "@reduxjs/toolkit/query";
 import cx from "classnames";
 import { useMemo } from "react";
 import {
   Bookmarks,
   Clock,
+  Diagram3Fill,
   Eye,
   InfoCircle,
   JournalAlbum,
@@ -28,28 +30,100 @@ import {
 } from "react-bootstrap-icons";
 import { Link, generatePath } from "react-router-dom-v5-compat";
 import { Badge, Card, CardBody, CardHeader } from "reactstrap";
+
+import { Loader } from "../../../../components/Loader";
 import { TimeCaption } from "../../../../components/TimeCaption";
-import {
-  EditButtonLink,
-  UnderlineArrowLink,
-} from "../../../../components/buttons/Button";
+import { UnderlineArrowLink } from "../../../../components/buttons/Button";
 import { ABSOLUTE_ROUTES } from "../../../../routing/routes.constants";
 import projectPreviewImg from "../../../../styles/assets/projectImagePreview.svg";
-import PermissionsGuard from "../../../permissionsV2/PermissionsGuard";
 import type {
   ProjectMemberListResponse,
   ProjectMemberResponse,
 } from "../../../projectsV2/api/projectV2.api";
 import {
   useGetNamespacesByNamespaceSlugQuery,
+  useGetProjectsByProjectIdQuery,
   useGetProjectsByProjectIdMembersQuery,
 } from "../../../projectsV2/api/projectV2.enhanced-api";
+import type { Project } from "../../../projectsV2/api/projectV2.api";
 import { useProject } from "../../ProjectPageContainer/ProjectPageContainer";
 import { getMemberNameToDisplay, toSortedMembers } from "../../utils/roleUtils";
 import useProjectPermissions from "../../utils/useProjectPermissions.hook";
+
+import ProjectInformationButton from "./ProjectInformationButton";
 import styles from "./ProjectInformation.module.scss";
 
 const MAX_MEMBERS_DISPLAYED = 5;
+
+function ProjectCopyTemplateInformationBox({ project }: { project: Project }) {
+  const { data: templateProject, isLoading: isLoadingTemplateInformation } =
+    useGetProjectsByProjectIdQuery(
+      project.template_id
+        ? {
+            projectId: project.template_id,
+          }
+        : skipToken
+    );
+  const { data: templateProjectNamespace } =
+    useGetNamespacesByNamespaceSlugQuery(
+      templateProject
+        ? {
+            namespaceSlug: templateProject.namespace,
+          }
+        : skipToken
+    );
+
+  if (!project.template_id) return null;
+  if (isLoadingTemplateInformation) return <Loader />;
+  if (!templateProject || !templateProjectNamespace) {
+    const projectUrl = generatePath(ABSOLUTE_ROUTES.v2.projects.showById, {
+      id: project.template_id,
+    });
+    return (
+      <ProjectInformationBox
+        icon={<Diagram3Fill className="bi" />}
+        title="Copied from:"
+      >
+        <div className="mb-0">
+          <div>
+            <Link
+              color="outline-secondary"
+              className={cx("d-flex", "align-items-center")}
+              data-cy="copy-project-template-link"
+              to={projectUrl}
+            >
+              {project.template_id}
+            </Link>
+          </div>
+        </div>
+      </ProjectInformationBox>
+    );
+  }
+  const projectUrl = generatePath(ABSOLUTE_ROUTES.v2.projects.show.root, {
+    namespace: templateProject.namespace,
+    slug: templateProject.slug,
+  });
+  return (
+    <ProjectInformationBox
+      icon={<Diagram3Fill className="bi" />}
+      title="Copied from:"
+    >
+      <div className="mb-0">
+        <div>
+          <Link
+            color="outline-secondary"
+            className={cx("d-flex", "align-items-center")}
+            data-cy="copy-project-template-link"
+            to={projectUrl}
+          >
+            {templateProjectNamespace.name ?? templateProjectNamespace.slug} /{" "}
+            {templateProject.name}
+          </Link>
+        </div>
+      </div>
+    </ProjectInformationBox>
+  );
+}
 
 interface ProjectInformationProps {
   output?: "plain" | "card";
@@ -140,6 +214,7 @@ export default function ProjectInformation({
           </p>
         ))}
       </ProjectInformationBox>
+      <ProjectCopyTemplateInformationBox project={project} />
     </div>
   );
   return output === "plain" ? (
@@ -160,23 +235,9 @@ export default function ProjectInformation({
           </h4>
 
           <div>
-            <PermissionsGuard
-              disabled={
-                <EditButtonLink
-                  disabled={true}
-                  to={settingsUrl}
-                  tooltip="Your role does not allow modifying project information"
-                />
-              }
-              enabled={
-                <EditButtonLink
-                  data-cy="project-settings-edit"
-                  to={settingsUrl}
-                  tooltip="Modify project information"
-                />
-              }
-              requestedPermission="write"
+            <ProjectInformationButton
               userPermissions={permissions}
+              project={project}
             />
           </div>
         </div>

--- a/client/src/features/ProjectPageV2/ProjectPageContent/ProjectInformation/ProjectInformationButton.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/ProjectInformation/ProjectInformationButton.tsx
@@ -1,0 +1,74 @@
+/*!
+ * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import cx from "classnames";
+import { useCallback, useState } from "react";
+
+import { DropdownItem } from "reactstrap";
+
+import { SingleButtonWithMenu } from "../../../../components/buttons/Button";
+import BootstrapCopyIcon from "../../../../components/icons/BootstrapCopyIcon";
+import useLegacySelector from "../../../../utils/customHooks/useLegacySelector.hook";
+
+import type { Project } from "../../../projectsV2/api/projectV2.api";
+import { useGetUserQuery } from "../../../usersV2/api/users.api";
+
+import useProjectPermissions from "../../utils/useProjectPermissions.hook";
+import ProjectCopyModal from "../../ProjectPageHeader/ProjectCopyModal";
+
+export default function ProjectInformationButton({
+  project,
+}: {
+  userPermissions: ReturnType<typeof useProjectPermissions>;
+  project: Project;
+}) {
+  const { data: currentUser } = useGetUserQuery();
+  const [isCopyModalOpen, setCopyModalOpen] = useState(false);
+  const toggleCopyModal = useCallback(() => {
+    setCopyModalOpen((open) => !open);
+  }, []);
+  const userLogged = useLegacySelector<boolean>(
+    (state) => state.stateModel.user.logged
+  );
+  if (!userLogged) return null;
+  return (
+    <>
+      <SingleButtonWithMenu
+        color="outline-primary"
+        preventPropagation
+        size="sm"
+      >
+        <DropdownItem
+          data-cy="project-copy-menu-item"
+          onClick={toggleCopyModal}
+        >
+          <BootstrapCopyIcon className={cx("bi")} />
+          <span className={cx("ms-2")}>Copy project</span>
+        </DropdownItem>
+      </SingleButtonWithMenu>
+      {
+        <ProjectCopyModal
+          currentUser={currentUser}
+          isOpen={isCopyModalOpen}
+          project={project}
+          toggle={toggleCopyModal}
+        />
+      }
+    </>
+  );
+}

--- a/client/src/features/ProjectPageV2/ProjectPageContent/ProjectInformation/ProjectInformationButton.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/ProjectInformation/ProjectInformationButton.tsx
@@ -48,11 +48,7 @@ export default function ProjectInformationButton({
   if (!userLogged) return null;
   return (
     <>
-      <SingleButtonWithMenu
-        color="outline-primary"
-        preventPropagation
-        size="sm"
-      >
+      <SingleButtonWithMenu color="outline-primary" size="sm">
         <DropdownItem
           data-cy="project-copy-menu-item"
           onClick={toggleCopyModal}

--- a/client/src/features/ProjectPageV2/ProjectPageContent/ProjectOverviewPage.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/ProjectOverviewPage.tsx
@@ -43,7 +43,9 @@ export default function ProjectOverviewPage() {
         </Row>
       </Col>
       <Col xs={12} md={4} xl={3}>
-        <ProjectInformation output="card" />
+        <div className="mb-3">
+          <ProjectInformation output="card" />
+        </div>
       </Col>
     </Row>
   );

--- a/client/src/features/ProjectPageV2/ProjectPageContent/Settings/ProjectSettings.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/Settings/ProjectSettings.tsx
@@ -59,6 +59,7 @@ import useProjectPermissions from "../../utils/useProjectPermissions.hook";
 import ProjectSessionSecrets from "../SessionSecrets/ProjectSessionSecrets";
 import ProjectPageDelete from "./ProjectDelete";
 import ProjectPageSettingsMembers from "./ProjectSettingsMembers";
+import ProjectUnlinkTemplate from "./ProjectUnlinkTemplate";
 
 function notificationProjectUpdated(
   notifications: NotificationsManager,
@@ -381,30 +382,6 @@ function ProjectSettingsDisplay({ project }: ProjectPageSettingsProps) {
   );
 }
 
-function ProjectSettingsTemplateLink({ project }: { project: Project }) {
-  if (project.template_id === null) return null;
-  return (
-    <Card id="copy">
-      <CardHeader>
-        <h4>
-          <Diagram3Fill className={cx("bi", "me-1")} />
-          Break template link
-        </h4>
-        <p className="m-0">
-          This will break the link between this project and the template it was
-          created from.
-        </p>
-      </CardHeader>
-      <CardBody>
-        <div className="d-flex">
-          <div className="fst-italic me-2">(Not yet implemented)</div>
-          <div className="flex-grow-1"></div>
-        </div>
-      </CardBody>
-    </Card>
-  );
-}
-
 function ProjectSettingsMetadata({ project }: ProjectPageSettingsProps) {
   const permissions = useProjectPermissions({ projectId: project.id });
 
@@ -480,7 +457,7 @@ export default function ProjectPageSettings() {
       <ProjectSessionSecrets />
       <PermissionsGuard
         disabled={null}
-        enabled={<ProjectSettingsTemplateLink project={project} />}
+        enabled={<ProjectUnlinkTemplate project={project} />}
         requestedPermission="write"
         userPermissions={permissions}
       />

--- a/client/src/features/ProjectPageV2/ProjectPageContent/Settings/ProjectUnlinkTemplate.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/Settings/ProjectUnlinkTemplate.tsx
@@ -1,0 +1,122 @@
+/*!
+ * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import cx from "classnames";
+import { useCallback, useContext, useEffect, useState } from "react";
+import { Diagram3Fill, NodeMinus } from "react-bootstrap-icons";
+import { Button, Card, CardBody, CardHeader, Input } from "reactstrap";
+
+import { Loader } from "../../../../components/Loader";
+import { NOTIFICATION_TOPICS } from "../../../../notifications/Notifications.constants";
+import { NotificationsManager } from "../../../../notifications/notifications.types";
+import AppContext from "../../../../utils/context/appContext";
+import { Project } from "../../../projectsV2/api/projectV2.api";
+import { usePatchProjectsByProjectIdMutation } from "../../../projectsV2/api/projectV2.enhanced-api";
+
+export function notificationProjectDeleted(
+  notifications: NotificationsManager,
+  projectName: string
+) {
+  notifications.addSuccess(
+    NOTIFICATION_TOPICS.PROJECT_UPDATED,
+    <>
+      Project <code>{projectName}</code> successfully unlinked.
+    </>
+  );
+}
+
+interface ProjectUnlinkTemplateProps {
+  project: Project;
+}
+export default function ProjectUnlinkTemplate({
+  project,
+}: ProjectUnlinkTemplateProps) {
+  const [patchProject, result] = usePatchProjectsByProjectIdMutation();
+  const { notifications } = useContext(AppContext);
+  const onUnlink = useCallback(() => {
+    patchProject({
+      projectId: project.id,
+      "If-Match": project.etag ?? "",
+      projectPatch: {
+        template_id: "",
+      },
+    });
+  }, [patchProject, project.etag, project.id]);
+
+  useEffect(() => {
+    if (result.isSuccess) {
+      if (notifications)
+        notificationProjectDeleted(notifications, project.name);
+      result.reset();
+    }
+  }, [notifications, project.name, result]);
+
+  const [typedName, setTypedName] = useState("");
+  const onChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setTypedName(e.target.value.trim());
+    },
+    [setTypedName]
+  );
+
+  if (project.template_id == null) return null;
+  return (
+    <Card id="copy">
+      <CardHeader>
+        <h4>
+          <Diagram3Fill className={cx("bi", "me-1")} />
+          Break template link
+        </h4>
+        <p className="m-0">
+          This will break the link between this project and the template it was
+          created from.
+        </p>
+      </CardHeader>
+      <CardBody>
+        <p className="fw-bold">
+          Are you sure you want to unlink this project from its template?
+        </p>
+        <p>
+          This cannot be undone. Please type <strong>{project.slug}</strong>,
+          the slug of the project, to confirm.
+        </p>
+        <div className="mb-3">
+          <Input
+            data-cy="unlink-confirmation-input"
+            value={typedName}
+            onChange={onChange}
+          />
+        </div>
+        <div className="text-end">
+          <Button
+            color="danger"
+            disabled={typedName !== project.slug?.trim() || result.isLoading}
+            onClick={onUnlink}
+          >
+            {result.isLoading ? (
+              <Loader className="me-1" inline size={16} />
+            ) : (
+              <NodeMinus className={cx("bi", "me-1")} />
+            )}
+            Unlink project
+          </Button>
+        </div>
+      </CardBody>
+    </Card>
+  );
+}

--- a/client/src/features/ProjectPageV2/ProjectPageHeader/ProjectCopyBanner.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageHeader/ProjectCopyBanner.tsx
@@ -1,0 +1,309 @@
+/*!
+ * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+import cx from "classnames";
+import { useCallback, useState } from "react";
+import { Button } from "reactstrap";
+import {
+  ArrowRight,
+  BoxArrowInRight,
+  Diagram3Fill,
+} from "react-bootstrap-icons";
+import { Link, generatePath } from "react-router-dom-v5-compat";
+
+import useLegacySelector from "../../../utils/customHooks/useLegacySelector.hook";
+import { useLoginUrl } from "../../../authentication/useLoginUrl.hook";
+import { Loader } from "../../../components/Loader";
+import PrimaryAlert from "../../../components/PrimaryAlert";
+import { ABSOLUTE_ROUTES } from "../../../routing/routes.constants";
+
+import PermissionsGuard from "../../permissionsV2/PermissionsGuard";
+import type { Project } from "../../projectsV2/api/projectV2.api";
+import { useGetProjectsByProjectIdCopiesQuery } from "../../projectsV2/api/projectV2.enhanced-api";
+import { useGetUserQuery } from "../../usersV2/api/users.api";
+
+import useProjectPermissions from "../utils/useProjectPermissions.hook";
+
+import ProjectCopyModal from "./ProjectCopyModal";
+import { ProjectCopyListModal } from "./ProjectTemplateInfoBanner";
+
+import BootstrapCopyIcon from "../../../components/icons/BootstrapCopyIcon";
+
+interface ProjectCopyBannerComponentProps {
+  currentUser: ReturnType<typeof useGetUserQuery>["data"];
+  project: Project;
+  toggleModalOpen: () => void;
+}
+
+interface ProjectCopyButtonProps
+  extends Omit<ProjectCopyBannerComponentProps, "currentUser"> {
+  color: string;
+}
+function ProjectCopyButton({ color, toggleModalOpen }: ProjectCopyButtonProps) {
+  const buttonColor = `outline-${color}`;
+
+  return (
+    <div className={cx("d-flex", "flex-column", "gap-3")}>
+      <Button
+        color={buttonColor}
+        data-cy="copy-project-button"
+        onClick={toggleModalOpen}
+      >
+        <BootstrapCopyIcon className={cx("bi")} />
+        <span className={cx("ms-2")}>Copy project</span>
+      </Button>
+    </div>
+  );
+}
+
+function ProjectViewerMakeCopyBanner({
+  project,
+  toggleModalOpen,
+}: Omit<ProjectCopyBannerComponentProps, "currentUser">) {
+  const isUserLoggedIn = useLegacySelector(
+    (state) => state.stateModel.user.logged
+  );
+  const loginUrl = useLoginUrl();
+  return (
+    <PrimaryAlert icon={<Diagram3Fill className="bi" />}>
+      <div
+        className={cx(
+          "d-flex",
+          "align-items-center",
+          "justify-content-between",
+          "flex-wrap",
+          "w-100"
+        )}
+      >
+        <div>
+          <div>
+            <b>This project is a template</b>
+          </div>
+          <div>
+            To work with this project, first make a copy.
+            {!isUserLoggedIn && (
+              <span> To make a copy, you must first log in.</span>
+            )}
+          </div>
+        </div>
+        <div>
+          {isUserLoggedIn ? (
+            <ProjectCopyButton
+              color="primary"
+              project={project}
+              toggleModalOpen={toggleModalOpen}
+            />
+          ) : (
+            <div>
+              <a className={cx("btn", "btn-primary")} href={loginUrl.href}>
+                <BoxArrowInRight className={cx("bi", "me-1")} />
+                Log in
+              </a>
+            </div>
+          )}
+        </div>
+      </div>
+    </PrimaryAlert>
+  );
+}
+
+interface ProjectGoToCopyBannerProps
+  extends Omit<
+    ProjectCopyBannerComponentProps,
+    "currentUser" | "toggleModalOpen"
+  > {
+  writableCopies: ReturnType<
+    typeof useGetProjectsByProjectIdCopiesQuery
+  >["data"];
+}
+
+function ProjectViewerGoToCopyBanner({
+  project,
+  writableCopies,
+}: ProjectGoToCopyBannerProps) {
+  const [isModalOpen, setModalOpen] = useState(false);
+  const toggleOpen = useCallback(() => {
+    setModalOpen((open) => !open);
+  }, []);
+  const firstCopy: Project = writableCopies[0];
+  const firstUrl = generatePath(ABSOLUTE_ROUTES.v2.projects.show.root, {
+    namespace: firstCopy.namespace,
+    slug: firstCopy.slug,
+  });
+  return (
+    <>
+      <PrimaryAlert icon={<Diagram3Fill className="bi" />}>
+        <div
+          className={cx(
+            "d-flex",
+            "align-items-center",
+            "justify-content-between",
+            "flex-wrap",
+            "w-100"
+          )}
+        >
+          <div>
+            <div>This project is a template</div>
+            <div>
+              {writableCopies.length > 1 ? (
+                <span>
+                  You have{" "}
+                  <span className={cx("badge", "text-bg-secondary")}>
+                    {writableCopies.length}
+                  </span>{" "}
+                  copies of this project.
+                </span>
+              ) : (
+                <b>You already have a project created from this template.</b>
+              )}
+            </div>
+          </div>
+          <div>
+            <div>
+              {writableCopies.length > 1 ? (
+                <Button
+                  color="primary"
+                  className={cx("d-flex", "align-items-center")}
+                  data-cy="list-copies-button"
+                  outline={true}
+                  onClick={toggleOpen}
+                >
+                  <ArrowRight className={cx("bi", "me-1")} />
+                  View my copies
+                </Button>
+              ) : (
+                <Link
+                  to={firstUrl}
+                  className={cx("btn", "btn-outline-primary")}
+                >
+                  <ArrowRight className={cx("bi", "me-1")} />
+                  Go to my copy
+                </Link>
+              )}
+            </div>
+          </div>
+        </div>
+      </PrimaryAlert>
+      {isModalOpen && (
+        <ProjectCopyListModal
+          copies={writableCopies}
+          isOpen={isModalOpen}
+          project={project}
+          title="My copies of project"
+          toggle={toggleOpen}
+        />
+      )}
+    </>
+  );
+}
+
+function ProjectViewerCopyBanner({
+  currentUser,
+  project,
+  toggleModalOpen,
+}: ProjectCopyBannerComponentProps) {
+  const { data: writableCopies } = useGetProjectsByProjectIdCopiesQuery({
+    projectId: project.id,
+    writable: true,
+  });
+  const isUserLoggedIn = useLegacySelector(
+    (state) => state.stateModel.user.logged
+  );
+  if (currentUser == null) return null;
+  if (project.template_id === null) return null;
+  if (!isUserLoggedIn)
+    return (
+      <ProjectViewerMakeCopyBanner
+        project={project}
+        toggleModalOpen={toggleModalOpen}
+      />
+    );
+  if (writableCopies == null)
+    return (
+      <PrimaryAlert icon={<Diagram3Fill className="bi" />}>
+        <div
+          className={cx(
+            "d-flex",
+            "align-items-center",
+            "justify-content-between",
+            "flex-wrap",
+            "w-100"
+          )}
+        >
+          <div>
+            <div>
+              <b>This project is a template</b>
+            </div>
+          </div>
+          <div>
+            <Loader inline size={16} />
+          </div>
+        </div>
+      </PrimaryAlert>
+    );
+
+  if (writableCopies.length > 0)
+    return (
+      <ProjectViewerGoToCopyBanner
+        project={project}
+        writableCopies={writableCopies}
+      />
+    );
+
+  return (
+    <ProjectViewerMakeCopyBanner
+      project={project}
+      toggleModalOpen={toggleModalOpen}
+    />
+  );
+}
+
+export default function ProjectCopyBanner({ project }: { project: Project }) {
+  const { data: currentUser } = useGetUserQuery();
+  const userPermissions = useProjectPermissions({ projectId: project.id });
+
+  const [isModalOpen, setModalOpen] = useState(false);
+  const toggleOpen = useCallback(() => {
+    setModalOpen((open) => !open);
+  }, []);
+  if (currentUser == null) return null;
+  if (project.template_id === null) return null;
+  return (
+    <>
+      <PermissionsGuard
+        disabled={
+          <ProjectViewerCopyBanner
+            currentUser={currentUser}
+            project={project}
+            toggleModalOpen={toggleOpen}
+          />
+        }
+        enabled={null}
+        requestedPermission="write"
+        userPermissions={userPermissions}
+      />
+      {isModalOpen && (
+        <ProjectCopyModal
+          currentUser={currentUser}
+          isOpen={isModalOpen}
+          project={project}
+          toggle={toggleOpen}
+        />
+      )}
+    </>
+  );
+}

--- a/client/src/features/ProjectPageV2/ProjectPageHeader/ProjectCopyButton.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageHeader/ProjectCopyButton.tsx
@@ -1,0 +1,63 @@
+/*!
+ * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+import cx from "classnames";
+import { useCallback, useState } from "react";
+import { Button } from "reactstrap";
+
+import BootstrapCopyIcon from "../../../components/icons/BootstrapCopyIcon";
+
+import { type Project } from "../../projectsV2/api/projectV2.api";
+import { useGetUserQuery } from "../../usersV2/api/users.api";
+import ProjectCopyModal from "./ProjectCopyModal";
+
+export default function ProjectCopyButton({
+  color,
+  project,
+}: {
+  color: string;
+  project: Project;
+}) {
+  const { data: currentUser } = useGetUserQuery();
+  const buttonColor = `outline-${color}`;
+
+  const [isModalOpen, setModalOpen] = useState(false);
+  const toggleOpen = useCallback(() => {
+    setModalOpen((open) => !open);
+  }, []);
+  return (
+    <div className={cx("d-flex", "flex-column", "gap-3")}>
+      <Button
+        color={buttonColor}
+        data-cy="copy-project-button"
+        onClick={toggleOpen}
+      >
+        <BootstrapCopyIcon className={cx("bi")} />
+        <span className={cx("ms-2")}>Copy project</span>
+      </Button>
+      {isModalOpen && (
+        <ProjectCopyModal
+          currentUser={currentUser}
+          isOpen={isModalOpen}
+          project={project}
+          toggle={toggleOpen}
+        />
+      )}
+    </div>
+  );
+}

--- a/client/src/features/ProjectPageV2/ProjectPageHeader/ProjectCopyModal.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageHeader/ProjectCopyModal.tsx
@@ -1,0 +1,233 @@
+/*!
+ * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+import cx from "classnames";
+import { useCallback, useEffect } from "react";
+import { XLg } from "react-bootstrap-icons";
+import { useForm } from "react-hook-form";
+import { generatePath, useNavigate } from "react-router-dom-v5-compat";
+import {
+  Button,
+  Form,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+} from "reactstrap";
+
+import { SuccessAlert } from "../../../components/Alert";
+import { RtkOrNotebooksError } from "../../../components/errors/RtkErrorAlert";
+import BootstrapCopyIcon from "../../../components/icons/BootstrapCopyIcon";
+import { ABSOLUTE_ROUTES } from "../../../routing/routes.constants";
+import { slugFromTitle } from "../../../utils/helpers/HelperFunctions";
+
+import {
+  type Project,
+  type Visibility,
+} from "../../projectsV2/api/projectV2.api";
+import { usePostProjectsByProjectIdCopiesMutation } from "../../projectsV2/api/projectV2.enhanced-api";
+import { useGetUserQuery } from "../../usersV2/api/users.api";
+import ProjectNameFormField from "../../projectsV2/fields/ProjectNameFormField";
+import ProjectNamespaceFormField from "../../projectsV2/fields/ProjectNamespaceFormField";
+import ProjectOwnerSlugFormField from "../../projectsV2/fields/ProjectOwnerSlugFormField";
+import ProjectVisibilityFormField from "../../projectsV2/fields/ProjectVisibilityFormField";
+
+interface ProjectCopyModalProps {
+  currentUser: ReturnType<typeof useGetUserQuery>["data"];
+  isOpen: boolean;
+  project: Project;
+  toggle: () => void;
+}
+
+interface ProjectCopyFormValues {
+  name: string;
+  namespace: string;
+  slug: string;
+  visibility: Visibility;
+}
+
+export default function ProjectCopyModal({
+  currentUser,
+  isOpen,
+  project,
+  toggle,
+}: ProjectCopyModalProps) {
+  const [copyProject, copyProjectResult] =
+    usePostProjectsByProjectIdCopiesMutation();
+
+  useEffect(() => {
+    if (!isOpen) copyProjectResult.reset();
+  }, [copyProjectResult, isOpen]);
+  const {
+    control,
+    formState: { errors },
+    getValues,
+    handleSubmit,
+    setValue,
+    watch,
+  } = useForm({
+    defaultValues: {
+      name: project.name,
+      namespace: currentUser ? currentUser.username : project.namespace,
+      slug: project.slug,
+      visibility: project.visibility,
+    },
+  });
+  const name = watch("name");
+  useEffect(() => {
+    setValue("slug", slugFromTitle(name, true, true));
+  }, [setValue, name]);
+  const onSubmit = useCallback(
+    (values: ProjectCopyFormValues) => {
+      copyProject({
+        projectId: project.id,
+        projectPost: {
+          name: values.name,
+          namespace: values.namespace,
+          slug: values.slug,
+          visibility: values.visibility,
+        },
+      });
+    },
+    [copyProject, project.id]
+  );
+  return (
+    <Modal
+      data-cy="copy-modal"
+      backdrop="static"
+      isOpen={isOpen}
+      toggle={toggle}
+      size="lg"
+      centered
+    >
+      <Form noValidate onSubmit={handleSubmit(onSubmit)}>
+        <ModalHeader toggle={toggle}>
+          <span className="fw-normal">Make a copy of </span>
+          {project.namespace}/{project.slug}
+        </ModalHeader>
+        <ModalBody>
+          <div
+            className={cx("fs-6", "fst-italic", "text-body-secondary", "mb-4")}
+          >
+            Copying a project will create a new project with the same data
+            connectors, repositories, and launchers as the original.
+          </div>
+          {copyProjectResult.error != null && (
+            <div className="w-100">
+              <RtkOrNotebooksError error={copyProjectResult.error} />
+            </div>
+          )}
+          <ProjectNameFormField control={control} errors={errors} name="name" />
+          <ProjectNamespaceFormField
+            control={control}
+            entityName="project"
+            errors={errors}
+            name="namespace"
+          />
+          <ProjectOwnerSlugFormField
+            control={control}
+            errors={errors}
+            getValues={getValues}
+            name="slug"
+            namespaceName="namespace"
+            watch={watch}
+          />
+          <ProjectVisibilityFormField
+            name="visibility"
+            control={control}
+            errors={errors}
+          />
+          {copyProjectResult.data != null && (
+            <div>
+              <ProjectCopySuccessAlert
+                project={copyProjectResult.data}
+                hasError={copyProjectResult.error != null}
+                toggle={toggle}
+              />
+            </div>
+          )}
+        </ModalBody>
+        <ModalFooter>
+          <Button
+            disabled={copyProjectResult.isLoading}
+            color="outline-primary"
+            onClick={toggle}
+          >
+            <XLg className={cx("bi", "me-1")} />
+            Close
+          </Button>
+          <Button
+            disabled={
+              copyProjectResult.isLoading || copyProjectResult.isSuccess
+            }
+            color="primary"
+            type="submit"
+          >
+            <BootstrapCopyIcon className={cx("bi", "me-1")} />
+            Copy
+          </Button>
+        </ModalFooter>
+      </Form>
+    </Modal>
+  );
+}
+
+interface ProjectCopySuccessAlertProps
+  extends Pick<ProjectCopyModalProps, "toggle"> {
+  project: Project;
+  hasError: boolean;
+}
+
+function ProjectCopySuccessAlert({
+  hasError,
+  project,
+  toggle,
+}: ProjectCopySuccessAlertProps) {
+  const navigate = useNavigate();
+  const namespace = project.namespace;
+  const slug = project.slug;
+  const projectUrl = generatePath(ABSOLUTE_ROUTES.v2.projects.show.root, {
+    namespace,
+    slug,
+  });
+  return (
+    <SuccessAlert dismissible={false} timeout={0}>
+      <div className="d-flex align-items-baseline justify-content-between">
+        <div>
+          Your project has been copied.
+          {hasError && (
+            <span className={cx("fw-bold")}>
+              Check the error message for limitations on the new project.
+            </span>
+          )}
+        </div>
+        <div>
+          <Button
+            color="outline-primary"
+            onClick={() => {
+              toggle();
+              navigate(projectUrl);
+            }}
+          >
+            Go to new project
+          </Button>
+        </div>
+      </div>
+    </SuccessAlert>
+  );
+}

--- a/client/src/features/ProjectPageV2/ProjectPageHeader/ProjectPageHeader.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageHeader/ProjectPageHeader.tsx
@@ -24,6 +24,9 @@ import { ABSOLUTE_ROUTES } from "../../../routing/routes.constants";
 import { Project } from "../../projectsV2/api/projectV2.api";
 import { ProjectImageView } from "../ProjectPageContent/ProjectInformation/ProjectInformation";
 
+import ProjectCopyBanner from "./ProjectCopyBanner";
+import ProjectTemplateInfoBanner from "./ProjectTemplateInfoBanner";
+
 interface ProjectPageHeaderProps {
   project: Project;
 }
@@ -60,8 +63,16 @@ export default function ProjectPageHeader({ project }: ProjectPageHeaderProps) {
                   />
                 </p>
               )}
+              {project.is_template && (
+                <ProjectTemplateInfoBanner project={project} />
+              )}
             </div>
           </Col>
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          {project.is_template && <ProjectCopyBanner project={project} />}
         </Col>
       </Row>
     </header>

--- a/client/src/features/ProjectPageV2/ProjectPageHeader/ProjectTemplateInfoBanner.module.css
+++ b/client/src/features/ProjectPageV2/ProjectPageHeader/ProjectTemplateInfoBanner.module.css
@@ -1,0 +1,9 @@
+.modalBody {
+  max-height: 50vh;
+}
+
+/* this is needed for correct alignment */
+.projectCopiesButton {
+  position: relative;
+  top: -2px;
+}

--- a/client/src/features/ProjectPageV2/ProjectPageHeader/ProjectTemplateInfoBanner.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageHeader/ProjectTemplateInfoBanner.tsx
@@ -91,15 +91,15 @@ function ProjectTemplateEditorBanner({ project }: { project: Project }) {
             (copies.length > 1 ? (
               <span>
                 There are{" "}
+                <span className={cx("badge", "text-bg-primary")}>
+                  {copies.length}
+                </span>{" "}
                 <Button
                   className={cx("p-0", styles.projectCopiesButton)}
                   color="link"
                   data-cy="list-copies-link"
                   onClick={toggleOpen}
                 >
-                  <span className={cx("badge", "text-bg-primary")}>
-                    {copies.length}
-                  </span>{" "}
                   copies
                 </Button>{" "}
                 visible to you.
@@ -107,13 +107,14 @@ function ProjectTemplateEditorBanner({ project }: { project: Project }) {
             ) : copies.length === 1 ? (
               <span>
                 There is{" "}
+                <span className={cx("badge", "text-bg-primary")}>1</span>{" "}
                 <Button
                   className={cx("p-0", styles.projectCopiesButton)}
                   color="link"
                   data-cy="list-copies-link"
                   onClick={toggleOpen}
                 >
-                  <span className={cx("badge", "text-bg-primary")}>1</span> copy
+                  copy
                 </Button>{" "}
                 visible to you.
               </span>

--- a/client/src/features/ProjectPageV2/ProjectPageHeader/ProjectTemplateInfoBanner.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageHeader/ProjectTemplateInfoBanner.tsx
@@ -1,0 +1,159 @@
+/*!
+ * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+import cx from "classnames";
+import { useCallback, useState } from "react";
+import { Button, ListGroup, Modal, ModalBody, ModalHeader } from "reactstrap";
+import { Diagram3Fill } from "react-bootstrap-icons";
+
+import PrimaryAlert from "../../../components/PrimaryAlert";
+
+import PermissionsGuard from "../../permissionsV2/PermissionsGuard";
+import type { Project } from "../../projectsV2/api/projectV2.api";
+import ProjectShortHandDisplay from "../../projectsV2/show/ProjectShortHandDisplay";
+import { useGetProjectsByProjectIdCopiesQuery } from "../../projectsV2/api/projectV2.api";
+import { useGetUserQuery } from "../../usersV2/api/users.api";
+
+import useProjectPermissions from "../utils/useProjectPermissions.hook";
+import styles from "./ProjectTemplateInfoBanner.module.css";
+
+interface ProjectCopyListModalProps {
+  copies: Project[];
+  isOpen: boolean;
+  project: Project;
+  title: string;
+  toggle: () => void;
+}
+
+export function ProjectCopyListModal({
+  copies,
+  isOpen,
+  project,
+  title,
+  toggle,
+}: ProjectCopyListModalProps) {
+  return (
+    <Modal
+      data-cy="copy-list-modal"
+      backdrop="static"
+      isOpen={isOpen}
+      toggle={toggle}
+      size="lg"
+      centered
+    >
+      <ModalHeader toggle={toggle}>
+        <span className="fw-normal">{title} </span>
+        {project.namespace}/{project.slug}
+      </ModalHeader>
+      <ModalBody className={cx("overflow-y-scroll", styles.modalBody)}>
+        <ListGroup flush data-cy="dashboard-project-list">
+          {copies.map((project) => (
+            <ProjectShortHandDisplay key={project.id} project={project} />
+          ))}
+        </ListGroup>
+      </ModalBody>
+    </Modal>
+  );
+}
+
+function ProjectTemplateEditorBanner({ project }: { project: Project }) {
+  const { data: currentUser } = useGetUserQuery();
+  const { data: copies } = useGetProjectsByProjectIdCopiesQuery({
+    projectId: project.id,
+  });
+  const [isModalOpen, setModalOpen] = useState(false);
+  const toggleOpen = useCallback(() => {
+    setModalOpen((open) => !open);
+  }, []);
+  if (currentUser == null) return null;
+  if (project.template_id === null) return null;
+  return (
+    <>
+      <PrimaryAlert className="p-2" icon={null}>
+        <div className="py-0">
+          <Diagram3Fill className={cx("bi", "me-1")} />
+          This project is a template.{" "}
+          {copies != null &&
+            (copies.length > 1 ? (
+              <span>
+                There are{" "}
+                <Button
+                  className={cx("p-0", styles.projectCopiesButton)}
+                  color="link"
+                  data-cy="list-copies-link"
+                  onClick={toggleOpen}
+                >
+                  <span className={cx("badge", "text-bg-primary")}>
+                    {copies.length}
+                  </span>{" "}
+                  copies
+                </Button>{" "}
+                visible to you.
+              </span>
+            ) : copies.length === 1 ? (
+              <span>
+                There is{" "}
+                <Button
+                  className={cx("p-0", styles.projectCopiesButton)}
+                  color="link"
+                  data-cy="list-copies-link"
+                  onClick={toggleOpen}
+                >
+                  <span className={cx("badge", "text-bg-primary")}>1</span> copy
+                </Button>{" "}
+                visible to you.
+              </span>
+            ) : (
+              <span>
+                There are{" "}
+                <span className={cx("badge", "text-bg-secondary")}>0</span>{" "}
+                copies visible to you.
+              </span>
+            ))}
+        </div>
+      </PrimaryAlert>
+      {isModalOpen && (
+        <ProjectCopyListModal
+          copies={copies ?? []}
+          isOpen={isModalOpen}
+          project={project}
+          title="Projects copied from"
+          toggle={toggleOpen}
+        />
+      )}
+    </>
+  );
+}
+
+export default function ProjectTemplateInfoBanner({
+  project,
+}: {
+  project: Project;
+}) {
+  const { data: currentUser } = useGetUserQuery();
+  const userPermissions = useProjectPermissions({ projectId: project.id });
+  if (currentUser == null) return null;
+  if (project.template_id === null) return null;
+  return (
+    <PermissionsGuard
+      disabled={null}
+      enabled={<ProjectTemplateEditorBanner project={project} />}
+      requestedPermission="write"
+      userPermissions={userPermissions}
+    />
+  );
+}

--- a/client/src/features/ProjectPageV2/ProjectPageHeader/ProjectTemplateInfoBanner.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageHeader/ProjectTemplateInfoBanner.tsx
@@ -17,10 +17,11 @@
  */
 import cx from "classnames";
 import { useCallback, useState } from "react";
-import { Button, ListGroup, Modal, ModalBody, ModalHeader } from "reactstrap";
+import { Button, ListGroup, ModalBody, ModalHeader } from "reactstrap";
 import { Diagram3Fill } from "react-bootstrap-icons";
 
 import PrimaryAlert from "../../../components/PrimaryAlert";
+import ScrollableModal from "../../../components/modal/ScrollableModal";
 
 import PermissionsGuard from "../../permissionsV2/PermissionsGuard";
 import type { Project } from "../../projectsV2/api/projectV2.api";
@@ -47,7 +48,7 @@ export function ProjectCopyListModal({
   toggle,
 }: ProjectCopyListModalProps) {
   return (
-    <Modal
+    <ScrollableModal
       data-cy="copy-list-modal"
       backdrop="static"
       isOpen={isOpen}
@@ -66,7 +67,7 @@ export function ProjectCopyListModal({
           ))}
         </ListGroup>
       </ModalBody>
-    </Modal>
+    </ScrollableModal>
   );
 }
 

--- a/client/src/features/ProjectPageV2/ProjectPageHeader/ProjectTemplateInfoBanner.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageHeader/ProjectTemplateInfoBanner.tsx
@@ -60,7 +60,7 @@ export function ProjectCopyListModal({
         <span className="fw-normal">{title} </span>
         {project.namespace}/{project.slug}
       </ModalHeader>
-      <ModalBody className={cx("overflow-y-scroll", styles.modalBody)}>
+      <ModalBody className={cx(styles.modalBody)}>
         <ListGroup flush data-cy="dashboard-project-list">
           {copies.map((project) => (
             <ProjectShortHandDisplay key={project.id} project={project} />

--- a/client/src/features/projectsV2/api/projectV2.enhanced-api.ts
+++ b/client/src/features/projectsV2/api/projectV2.enhanced-api.ts
@@ -242,6 +242,9 @@ const enhancedApi = injectedApi.enhanceEndpoints({
       }),
       providesTags: ["Project"],
     },
+    getProjectsByProjectIdCopies: {
+      providesTags: ["Project"],
+    },
     getProjectsByProjectIdDataConnectorLinks: {
       providesTags: ["DataConnectors"],
     },
@@ -330,6 +333,9 @@ const enhancedApi = injectedApi.enhanceEndpoints({
             ]
           : ["SessionSecretSlot"],
     },
+    postProjectsByProjectIdCopies: {
+      invalidatesTags: ["Project"],
+    },
   },
 });
 
@@ -346,17 +352,19 @@ const withInvalidation = enhancedApi.injectEndpoints({
 export { withInvalidation as projectV2Api };
 export const {
   // project hooks
+  useDeleteProjectsByProjectIdMembersAndMemberIdMutation,
   useGetProjectsPagedQuery: useGetProjectsQuery,
-  usePostProjectsMutation,
   useGetNamespacesByNamespaceProjectsAndSlugQuery,
+  useGetProjectsByProjectIdCopiesQuery,
+  useGetProjectsByProjectIdPermissionsQuery,
   useGetProjectsByProjectIdQuery,
   useGetProjectsByProjectIdsQuery,
   usePatchProjectsByProjectIdMutation,
   useDeleteProjectsByProjectIdMutation,
   useGetProjectsByProjectIdMembersQuery,
   usePatchProjectsByProjectIdMembersMutation,
-  useDeleteProjectsByProjectIdMembersAndMemberIdMutation,
-  useGetProjectsByProjectIdPermissionsQuery,
+  usePostProjectsMutation,
+  usePostProjectsByProjectIdCopiesMutation,
 
   // project session secret hooks
   useGetProjectsByProjectIdSessionSecretSlotsQuery,

--- a/client/src/features/projectsV2/api/projectV2.openapi.json
+++ b/client/src/features/projectsV2/api/projectV2.openapi.json
@@ -122,6 +122,14 @@
             "schema": {
               "$ref": "#/components/schemas/WithDocumentation"
             }
+          },
+          {
+            "in": "query",
+            "name": "with_documentation",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/WithDocumentation"
+            }
           }
         ],
         "responses": {

--- a/client/src/features/projectsV2/fields/ProjectOwnerSlugFormField.tsx
+++ b/client/src/features/projectsV2/fields/ProjectOwnerSlugFormField.tsx
@@ -1,0 +1,71 @@
+/*!
+ * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState } from "react";
+import type {
+  FieldValues,
+  UseFormGetValues,
+  UseFormWatch,
+} from "react-hook-form";
+
+import SlugFormField from "./SlugFormField";
+import type { GenericProjectFormFieldProps } from "./formField.types";
+import { Button } from "reactstrap";
+
+interface ProjectOwnerSlugFormFieldProps<T extends FieldValues>
+  extends GenericProjectFormFieldProps<T> {
+  getValues: UseFormGetValues<T>;
+  namespaceName: GenericProjectFormFieldProps<T>["name"];
+  watch: UseFormWatch<T>;
+}
+
+export default function ProjectOwnerSlugFormField<T extends FieldValues>({
+  control,
+  errors,
+  getValues,
+  name,
+  namespaceName,
+  watch,
+}: ProjectOwnerSlugFormFieldProps<T>) {
+  const [configure, setConfigure] = useState(false);
+  if (configure) {
+    return (
+      <div className="mb-3">
+        <SlugFormField
+          control={control}
+          entityName="project"
+          errors={errors}
+          name={name}
+        />
+      </div>
+    );
+  }
+  const slug = watch(name);
+  return (
+    <div className="mb-3">
+      The identifier for the copy will be{" "}
+      <i>
+        {getValues(namespaceName)}/{slug}
+      </i>
+      .{" "}
+      <Button size="sm" color="link" onClick={() => setConfigure(true)}>
+        Configure
+      </Button>
+    </div>
+  );
+}

--- a/tests/cypress/e2e/projectV2.spec.ts
+++ b/tests/cypress/e2e/projectV2.spec.ts
@@ -182,9 +182,10 @@ describe("Edit v2 project", () => {
       .click();
     cy.wait("@readProjectV2");
     cy.contains("test 2 v2-project").should("be.visible");
-    cy.getDataCy("project-settings-edit").should("be.visible").click();
+    cy.get("a[title='Settings']").should("be.visible").click();
     cy.getDataCy("project-name-input").clear().type("new name");
     cy.getDataCy("project-description-input").clear().type("new description");
+    cy.getDataCy("project-template").click();
     fixtures.readProjectV2({
       fixture: "projectV2/update-projectV2-metadata.json",
       name: "readPostUpdate",
@@ -210,7 +211,7 @@ describe("Edit v2 project", () => {
       .click();
     cy.wait("@readProjectV2");
     cy.contains("test 2 v2-project").should("be.visible");
-    cy.getDataCy("project-settings-edit").should("be.visible").click();
+    cy.get("a[title='Settings']").should("be.visible").click();
     // Fetch the second page of namespaces
     cy.wait("@listNamespaceV2");
     cy.wait("@readUserV2Namespace");
@@ -444,7 +445,7 @@ describe("Editor cannot maintain members", () => {
 
   it("can change project metadata", () => {
     cy.contains("test 2 v2-project").should("be.visible");
-    cy.getDataCy("project-settings-edit").should("be.visible").click();
+    cy.get("a[title='Settings']").should("be.visible").click();
     cy.contains("a", "Overview").click();
   });
 
@@ -509,5 +510,274 @@ describe("Viewer cannot edit project", () => {
     cy.getDataCy("add-session-launcher").should("not.exist");
     cy.getDataCy("add-data-connector").should("not.exist");
     cy.getDataCy("add-code-repository").should("not.exist");
+  });
+});
+
+describe("Project templates and copies", () => {
+  beforeEach(() => {
+    fixtures
+      .config()
+      .versions()
+      .userTest()
+      .namespaces()
+      .projects()
+      .landingUserProjects()
+      .readProjectV2();
+  });
+
+  it("copy a regular project with edit access", () => {
+    fixtures.getProjectV2Permissions().listNamespaceV2().copyProjectV2();
+    cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
+    cy.wait("@readProjectV2");
+
+    cy.getDataCy("project-info-card")
+      .find("[data-cy=button-with-menu-dropdown]")
+      .click();
+    cy.getDataCy("project-copy-menu-item").click();
+    cy.contains("Make a copy of user1-uuid/test-2-v2-project").should(
+      "be.visible"
+    );
+    cy.wait("@listNamespaceV2");
+    cy.getDataCy("copy-modal")
+      .find("[data-cy=project-name-input]")
+      .clear()
+      .type("copy project name");
+    cy.getDataCy("copy-modal").find("button").contains("Copy").click();
+    fixtures.readProjectV2({
+      namespace: "e2e",
+      projectSlug: "copy-project-name",
+      name: "readProjectCopy",
+    });
+    cy.wait("@copyProjectV2");
+    cy.contains("Go to new project").should("be.visible").click();
+    cy.wait("@readProjectCopy");
+    cy.location("pathname").should("eq", "/v2/projects/e2e/copy-project-name");
+  });
+
+  it("copy a regular project without edit access", () => {
+    fixtures.listNamespaceV2().copyProjectV2();
+    cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
+    cy.wait("@readProjectV2");
+
+    cy.getDataCy("project-info-card")
+      .find("[data-cy=button-with-menu-dropdown]")
+      .click();
+    cy.getDataCy("project-copy-menu-item").click();
+    cy.contains("Make a copy of user1-uuid/test-2-v2-project").should(
+      "be.visible"
+    );
+    cy.wait("@listNamespaceV2");
+    cy.getDataCy("project-name-input").clear().type("copy project name");
+    cy.getDataCy("copy-modal").find("button").contains("Copy").click();
+    fixtures.readProjectV2({
+      namespace: "e2e",
+      projectSlug: "copy-project-name",
+      name: "readProjectCopy",
+    });
+    cy.wait("@copyProjectV2");
+    cy.contains("Go to new project").should("be.visible").click();
+    cy.wait("@readProjectCopy");
+    cy.location("pathname").should("eq", "/v2/projects/e2e/copy-project-name");
+  });
+
+  it("copy a template project", () => {
+    fixtures
+      .readProjectV2({ overrides: { is_template: true } })
+      .listNamespaceV2()
+      .copyProjectV2()
+      .listProjectV2Copies({ count: 0, writeable: true });
+    cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
+    cy.wait("@readProjectV2");
+    cy.getDataCy("copy-project-button").click();
+    cy.contains("Make a copy of user1-uuid/test-2-v2-project").should(
+      "be.visible"
+    );
+    cy.wait("@listNamespaceV2");
+    cy.getDataCy("project-name-input").clear().type("copy project name");
+    cy.getDataCy("copy-modal").find("button").contains("Copy").click();
+    fixtures.readProjectV2({
+      namespace: "e2e",
+      projectSlug: "copy-project-name",
+      name: "readProjectCopy",
+    });
+    cy.wait("@copyProjectV2");
+    cy.contains("Go to new project").should("be.visible").click();
+    cy.wait("@readProjectCopy");
+    cy.location("pathname").should("eq", "/v2/projects/e2e/copy-project-name");
+  });
+
+  it("navigate to a template project copy", () => {
+    fixtures
+      .readProjectV2({
+        projectSlug: "test-2-v2-template",
+        overrides: { is_template: true },
+      })
+      .listNamespaceV2()
+      .copyProjectV2()
+      .listProjectV2Copies({ count: 1, writeable: true });
+    cy.visit("/v2/projects/user1-uuid/test-2-v2-template");
+    cy.wait("@readProjectV2");
+    cy.wait("@listProjectV2Copies");
+    cy.getDataCy("copy-project-button").should("not.exist");
+    cy.contains(
+      "You already have a project created from this template."
+    ).should("be.visible");
+    fixtures.readProjectV2({
+      projectSlug: "test-2-v2-project",
+      name: "readProjectCopy",
+    });
+    cy.contains("Go to my copy").should("be.visible").click();
+    cy.wait("@readProjectCopy");
+    cy.location("pathname").should(
+      "eq",
+      "/v2/projects/user1-uuid/test-2-v2-project"
+    );
+  });
+
+  it("list template project copies", () => {
+    fixtures
+      .readProjectV2({
+        projectSlug: "test-2-v2-template",
+        overrides: { is_template: true },
+      })
+      .listNamespaceV2()
+      .listProjectV2Copies({ writeable: true })
+      .copyProjectV2();
+    cy.visit("/v2/projects/user1-uuid/test-2-v2-template");
+    cy.wait("@readProjectV2");
+    cy.wait("@listProjectV2Copies");
+    cy.getDataCy("copy-project-button").should("not.exist");
+    cy.contains("copies of this project.").should("be.visible");
+    cy.contains("View my copies").should("be.visible").click();
+    cy.contains("My copies of").should("be.visible");
+  });
+
+  it("copy a project with data-connector-error", () => {
+    fixtures
+      .readProjectV2({ overrides: { is_template: true } })
+      .listNamespaceV2()
+      .listProjectV2Copies({ count: 0, writeable: true })
+      .copyProjectV2({ dataConnectorError: true });
+    cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
+    cy.wait("@readProjectV2");
+    cy.getDataCy("copy-project-button").click();
+    cy.contains("Make a copy of user1-uuid/test-2-v2-project").should(
+      "be.visible"
+    );
+    cy.wait("@listNamespaceV2");
+    cy.getDataCy("project-name-input").clear().type("copy project name");
+    cy.getDataCy("copy-modal").find("button").contains("Copy").click();
+    fixtures.readProjectV2({
+      namespace: "e2e",
+      projectSlug: "copy-project-name",
+      name: "readProjectCopy",
+    });
+    cy.wait("@copyProjectV2");
+    cy.contains("not all data connectors were included")
+      .should("be.visible")
+      .click();
+    cy.contains("Close").should("be.visible").click();
+    cy.getDataCy("copy-project-button").click();
+    cy.getDataCy("copy-modal")
+      .find("button")
+      .contains("Copy")
+      .should("be.enabled");
+  });
+
+  it("copy a project, overriding the slug", () => {
+    fixtures
+      .readProjectV2({ overrides: { is_template: true } })
+      .listNamespaceV2()
+      .listProjectV2Copies({ count: 0, writeable: true })
+      .copyProjectV2({ dataConnectorError: true, name: "copyProjectV2Fail" });
+    cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
+    cy.wait("@readProjectV2");
+    cy.getDataCy("copy-project-button").click();
+    cy.contains("Make a copy of user1-uuid/test-2-v2-project").should(
+      "be.visible"
+    );
+    cy.wait("@listNamespaceV2");
+    cy.getDataCy("project-name-input").clear().type("copy project name");
+    cy.getDataCy("copy-modal").find("button").contains("Copy").click();
+    cy.wait("@copyProjectV2Fail");
+    cy.get("button").contains("Configure").click();
+    cy.getDataCy("project-slug-input").clear().type("copy-of-test2");
+    fixtures.copyProjectV2().readProjectV2({
+      namespace: "e2e",
+      projectSlug: "copy-of-test2",
+      name: "readProjectCopy",
+    });
+    cy.getDataCy("copy-modal").find("button").contains("Copy").click();
+    cy.wait("@copyProjectV2");
+    cy.contains("Go to new project").should("be.visible").click();
+    cy.wait("@readProjectCopy");
+    cy.location("pathname").should("eq", "/v2/projects/e2e/copy-of-test2");
+  });
+
+  it("show a template project as editor", () => {
+    fixtures
+      .readProjectV2({ overrides: { is_template: true } })
+      .getProjectV2Permissions()
+      .listNamespaceV2()
+      .listProjectV2Copies({ count: 15 });
+    cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
+    cy.wait("@readProjectV2");
+    cy.wait("@getProjectV2Permissions");
+    cy.wait("@listProjectV2Copies");
+    cy.getDataCy("copy-project-button").should("not.exist");
+    cy.contains("copies visible to you").should("be.visible");
+    cy.getDataCy("list-copies-link").click();
+    cy.contains("Projects copied from").should("be.visible");
+  });
+
+  it("show a copied project", () => {
+    fixtures
+      .readProjectV2({
+        overrides: {
+          template_id: "TEMPLATE-ULID",
+        },
+      })
+      .readProjectV2ById({
+        projectId: "TEMPLATE-ULID",
+        overrides: {
+          name: "template project",
+          namespace: "user1-uuid",
+          slug: "template-project",
+        },
+      })
+      .readUserV2Namespace();
+    cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
+    cy.wait("@readProjectV2");
+    cy.wait("@readProjectV2ById");
+    cy.contains("Copied from:").should("be.visible");
+  });
+
+  it("break the template link", () => {
+    fixtures.getProjectV2Permissions().listNamespaceV2().copyProjectV2();
+    cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
+    cy.wait("@readProjectV2");
+
+    cy.get("a[title='Settings']").should("be.visible").click();
+    cy.contains("Break template link").should("be.visible").click();
+  });
+});
+
+describe("Anonymous project copy experience", () => {
+  beforeEach(() => {
+    fixtures
+      .config()
+      .versions()
+      .userNone()
+      .namespaces()
+      .projects()
+      .landingUserProjects()
+      .readProjectV2();
+  });
+
+  it("copy as an anonymous user", () => {
+    fixtures.readProjectV2({ overrides: { is_template: true } });
+    cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
+    cy.wait("@readProjectV2");
+    cy.contains("To make a copy, you must first log in.").should("be.visible");
   });
 });

--- a/tests/cypress/e2e/projectV2.spec.ts
+++ b/tests/cypress/e2e/projectV2.spec.ts
@@ -425,6 +425,7 @@ describe("Editor cannot maintain members", () => {
       .dataServicesUser({
         response: {
           id: "user3-uuid",
+          username: "user3",
         },
       })
       .namespaces();
@@ -477,6 +478,7 @@ describe("Viewer cannot edit project", () => {
       .dataServicesUser({
         response: {
           id: "user2-uuid",
+          username: "user2",
         },
       })
       .namespaces();
@@ -753,12 +755,25 @@ describe("Project templates and copies", () => {
   });
 
   it("break the template link", () => {
-    fixtures.getProjectV2Permissions().listNamespaceV2().copyProjectV2();
+    fixtures
+      .readProjectV2({
+        overrides: {
+          template_id: "TEMPLATE-ULID",
+        },
+      })
+      .getProjectV2Permissions()
+      .listNamespaceV2()
+      .copyProjectV2()
+      .updateProjectV2();
     cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
     cy.wait("@readProjectV2");
 
     cy.get("a[title='Settings']").should("be.visible").click();
-    cy.contains("Break template link").should("be.visible").click();
+    cy.contains("Break template link").should("be.visible");
+    cy.contains("Unlink project").should("be.disabled");
+    cy.getDataCy("unlink-confirmation-input").clear().type("test-2-v2-project");
+    cy.contains("Unlink project").should("be.enabled").click();
+    cy.wait("@updateProjectV2");
   });
 });
 

--- a/tests/cypress/e2e/projectV2SessionSecrets.spec.ts
+++ b/tests/cypress/e2e/projectV2SessionSecrets.spec.ts
@@ -31,7 +31,7 @@ describe("Project Session secret slots", () => {
   it("Shows the session secrets section", () => {
     cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
     cy.contains("test 2 v2-project").should("be.visible");
-    cy.getDataCy("project-settings-edit").click();
+    cy.get("a[title='Settings']").should("be.visible").click();
 
     cy.getDataCy("project-settings-session-secrets")
       .contains("Session secret slots")
@@ -43,7 +43,7 @@ describe("Project Session secret slots", () => {
 
     cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
     cy.contains("test 2 v2-project").should("be.visible");
-    cy.getDataCy("project-settings-edit").click();
+    cy.get("a[title='Settings']").should("be.visible").click();
 
     cy.getDataCy("project-settings-session-secrets")
       .contains("Session secret slots")
@@ -70,7 +70,7 @@ describe("Project Session secret slots", () => {
 
     cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
     cy.contains("test 2 v2-project").should("be.visible");
-    cy.getDataCy("project-settings-edit").click();
+    cy.get("a[title='Settings']").should("be.visible").click();
 
     cy.getDataCy("project-settings-session-secrets")
       .contains("Session secret slots")
@@ -125,7 +125,7 @@ describe("Project Session secret slots", () => {
 
     cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
     cy.contains("test 2 v2-project").should("be.visible");
-    cy.getDataCy("project-settings-edit").click();
+    cy.get("a[title='Settings']").should("be.visible").click();
 
     cy.getDataCy("project-settings-session-secrets")
       .contains("Session secret slots")
@@ -174,7 +174,7 @@ describe("Project Session secret slots", () => {
 
     cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
     cy.contains("test 2 v2-project").should("be.visible");
-    cy.getDataCy("project-settings-edit").click();
+    cy.get("a[title='Settings']").should("be.visible").click();
 
     cy.getDataCy("project-settings-session-secrets")
       .contains("Session secret slots")
@@ -224,7 +224,7 @@ describe("Project Session secret slots", () => {
 
     cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
     cy.contains("test 2 v2-project").should("be.visible");
-    cy.getDataCy("project-settings-edit").click();
+    cy.get("a[title='Settings']").should("be.visible").click();
 
     cy.getDataCy("project-settings-session-secrets")
       .contains("Session secret slots")
@@ -281,7 +281,7 @@ describe("Project Session secret slots", () => {
 
     cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
     cy.contains("test 2 v2-project").should("be.visible");
-    cy.getDataCy("project-settings-edit").click();
+    cy.get("a[title='Settings']").should("be.visible").click();
 
     cy.getDataCy("project-settings-session-secrets")
       .contains("Session secret slots")
@@ -344,7 +344,7 @@ describe("Project Session secret slots", () => {
 
     cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
     cy.contains("test 2 v2-project").should("be.visible");
-    cy.getDataCy("project-settings-edit").click();
+    cy.get("a[title='Settings']").should("be.visible").click();
 
     cy.getDataCy("project-settings-session-secrets")
       .contains("Session secret slots")

--- a/tests/cypress/fixtures/namespaceV2/list-namespaceV2.json
+++ b/tests/cypress/fixtures/namespaceV2/list-namespaceV2.json
@@ -6,6 +6,12 @@
     "namespace_kind": "user"
   },
   {
+    "id": "AB0134CD43Z3JF9DX88B7XB405N0",
+    "slug": "e2e",
+    "created_by": "user1-uuid",
+    "namespace_kind": "user"
+  },
+  {
     "id": "THEPROJECTULID26CHARACTERS",
     "name": "test 2 group-v2",
     "slug": "test-2-group-v2",

--- a/tests/cypress/fixtures/namespaceV2/namespaceV2-user1.json
+++ b/tests/cypress/fixtures/namespaceV2/namespaceV2-user1.json
@@ -2,5 +2,6 @@
   "id": "AB0134CD43Z3JF9DX88B7XB405N0",
   "slug": "user1-uuid",
   "created_by": "user1-uuid",
-  "namespace_kind": "user"
+  "namespace_kind": "user",
+  "name": "user1"
 }

--- a/tests/cypress/fixtures/projectV2/update-projectV2-metadata.json
+++ b/tests/cypress/fixtures/projectV2/update-projectV2-metadata.json
@@ -11,5 +11,6 @@
   ],
   "visibility": "public",
   "description": "new description",
+  "is_template": true,
   "secrets_mount_directory": "/secrets"
 }

--- a/tests/cypress/support/renkulab-fixtures/projectV2.ts
+++ b/tests/cypress/support/renkulab-fixtures/projectV2.ts
@@ -50,6 +50,11 @@ interface ListProjectV2MembersFixture extends ProjectV2IdArgs {
   };
 }
 
+interface ProjectV2CreateArgs extends SimpleFixture {
+  slug?: string;
+  namespace?: string;
+}
+
 interface ProjectV2IdArgs extends SimpleFixture {
   projectId?: string;
   overrides?: Partial<ProjectOverrides>;
@@ -66,7 +71,7 @@ interface ProjectV2DeleteFixture extends NameOnlyFixture {
 interface ProjectV2ListCopiesFixture
   extends Omit<ProjectV2IdArgs, "overrides"> {
   writeable?: boolean;
-  count?: 0 | 1 | undefined | null;
+  count?: number | null;
 }
 
 interface ProjectV2NameArgs extends SimpleFixture {
@@ -139,7 +144,7 @@ export function ProjectV2<T extends FixturesConstructor>(Parent: T) {
       return this;
     }
 
-    createProjectV2(args?: SimpleFixture) {
+    createProjectV2(args?: ProjectV2CreateArgs) {
       const {
         fixture = "projectV2/create-projectV2.json",
         name = "createProjectV2",


### PR DESCRIPTION
# Testing
- copy a regular project
- break the copy link
- mark a project as a template and see that banners are shown
  - when viewing a project that is a template, but for which you are not an owner
  - when viewing a project that is a template, where you are an owner
   
/deploy renku=release-0.63.0