### PR TITLE
fix: break titles in offcanvas if too long

### DIFF
--- a/client/src/features/ProjectPageV2/ProjectPageContent/CodeRepositories/CodeRepositoryDisplay.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/CodeRepositories/CodeRepositoryDisplay.tsx
@@ -597,9 +597,7 @@ function RepositoryView({
 
         <div>
           <div className="mb-4">
-            <div
-            // className={cx("d-flex", "justify-content-between")}
-            >
+            <div>
               <div className={cx("float-end", "mt-1", "ms-1")}>
                 <CodeRepositoryActions project={project} url={repositoryUrl} />
               </div>

--- a/client/src/features/ProjectPageV2/ProjectPageContent/CodeRepositories/CodeRepositoryDisplay.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/CodeRepositories/CodeRepositoryDisplay.tsx
@@ -597,13 +597,18 @@ function RepositoryView({
 
         <div>
           <div className="mb-4">
-            <div className={cx("d-flex", "justify-content-between")}>
-              <h2 className="m-0" data-cy="data-source-title">
-                {title}
-              </h2>
-              <div className="my-auto">
+            <div
+            // className={cx("d-flex", "justify-content-between")}
+            >
+              <div className={cx("float-end", "mt-1", "ms-1")}>
                 <CodeRepositoryActions project={project} url={repositoryUrl} />
               </div>
+              <h2
+                className={cx("m-0", "text-break")}
+                data-cy="data-source-title"
+              >
+                {title}
+              </h2>
             </div>
             <p className={cx("fst-italic", "m-0")}>Code repository</p>
           </div>

--- a/client/src/features/dataConnectorsV2/components/DataConnectorView.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorView.tsx
@@ -267,17 +267,17 @@ function DataConnectorViewHeader({
 }: Omit<DataConnectorViewProps, "showView">) {
   return (
     <div className="mb-4">
-      <div className={cx("d-flex", "justify-content-between")}>
-        <h2 className="m-0" data-cy="data-connector-title">
-          {dataConnector.name}
-        </h2>
-        <div className="my-auto">
+      <div>
+        <div className={cx("float-end", "mt-1", "ms-1")}>
           <DataConnectorActions
             dataConnector={dataConnector}
             dataConnectorLink={dataConnectorLink}
             toggleView={toggleView}
           />
         </div>
+        <h2 className={cx("m-0", "text-break")} data-cy="data-connector-title">
+          {dataConnector.name}
+        </h2>
       </div>
     </div>
   );

--- a/client/src/features/sessionsV2/SessionView/SessionView.tsx
+++ b/client/src/features/sessionsV2/SessionView/SessionView.tsx
@@ -295,11 +295,16 @@ export function SessionView({
 
         <div className={cx("d-flex", "flex-column", "gap-4")}>
           <div>
-            <div className={cx("d-flex", "justify-content-between")}>
-              <h2 className="m-0" data-cy="session-view-title">
+            <div>
+              <div className={cx("float-end", "mt-1", "ms-1")}>
+                {launcherMenu}
+              </div>
+              <h2
+                className={cx("m-0", "text-break")}
+                data-cy="session-view-title"
+              >
                 {title}
               </h2>
-              <div className="my-auto">{launcherMenu}</div>
             </div>
             <p className={cx("fst-italic", "m-0")}>
               {launcher ? "Session launcher" : "Session without launcher"}


### PR DESCRIPTION
Fixes #3431.

Note that other broken UI elements for long titles are not fixed in this PR.

![renku-ci-ui-3432 dev renku ch_v2_projects_flora thiebaut_flora-test (2)](https://github.com/user-attachments/assets/0bf04d0a-3430-4343-a8a0-79475023a4ac)
![renku-ci-ui-3432 dev renku ch_v2_projects_flora thiebaut_flora-test (1)](https://github.com/user-attachments/assets/b4874f84-3fa4-4a2d-964b-307ff28b1582)
![renku-ci-ui-3432 dev renku ch_v2_projects_flora thiebaut_flora-test](https://github.com/user-attachments/assets/be0ce525-bf80-4ff4-8387-55330ad0780f)

/deploy