### PR TITLE
feat: break copy link

### DIFF
--- a/client/src/features/ProjectPageV2/ProjectPageContent/Settings/ProjectSettings.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/Settings/ProjectSettings.tsx
@@ -59,6 +59,7 @@ import useProjectPermissions from "../../utils/useProjectPermissions.hook";
 import ProjectSessionSecrets from "../SessionSecrets/ProjectSessionSecrets";
 import ProjectPageDelete from "./ProjectDelete";
 import ProjectPageSettingsMembers from "./ProjectSettingsMembers";
+import ProjectUnlinkTemplate from "./ProjectUnlinkTemplate";
 
 function notificationProjectUpdated(
   notifications: NotificationsManager,
@@ -381,30 +382,6 @@ function ProjectSettingsDisplay({ project }: ProjectPageSettingsProps) {
   );
 }
 
-function ProjectSettingsTemplateLink({ project }: { project: Project }) {
-  if (project.template_id === null) return null;
-  return (
-    <Card id="copy">
-      <CardHeader>
-        <h4>
-          <Diagram3Fill className={cx("bi", "me-1")} />
-          Break template link
-        </h4>
-        <p className="m-0">
-          This will break the link between this project and the template it was
-          created from.
-        </p>
-      </CardHeader>
-      <CardBody>
-        <div className="d-flex">
-          <div className="fst-italic me-2">(Not yet implemented)</div>
-          <div className="flex-grow-1"></div>
-        </div>
-      </CardBody>
-    </Card>
-  );
-}
-
 function ProjectSettingsMetadata({ project }: ProjectPageSettingsProps) {
   const permissions = useProjectPermissions({ projectId: project.id });
 
@@ -480,7 +457,7 @@ export default function ProjectPageSettings() {
       <ProjectSessionSecrets />
       <PermissionsGuard
         disabled={null}
-        enabled={<ProjectSettingsTemplateLink project={project} />}
+        enabled={<ProjectUnlinkTemplate project={project} />}
         requestedPermission="write"
         userPermissions={permissions}
       />

--- a/client/src/features/ProjectPageV2/ProjectPageContent/Settings/ProjectUnlinkTemplate.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/Settings/ProjectUnlinkTemplate.tsx
@@ -19,7 +19,6 @@
 import cx from "classnames";
 import { useCallback, useContext, useEffect, useState } from "react";
 import { Diagram3Fill, NodeMinus } from "react-bootstrap-icons";
-import { useNavigate } from "react-router-dom-v5-compat";
 import { Button, Card, CardBody, CardHeader, Input } from "reactstrap";
 
 import { Loader } from "../../../../components/Loader";
@@ -48,7 +47,6 @@ export default function ProjectUnlinkTemplate({
   project,
 }: ProjectUnlinkTemplateProps) {
   const [patchProject, result] = usePatchProjectsByProjectIdMutation();
-  const navigate = useNavigate();
   const { notifications } = useContext(AppContext);
   const onUnlink = useCallback(() => {
     patchProject({
@@ -64,8 +62,9 @@ export default function ProjectUnlinkTemplate({
     if (result.isSuccess) {
       if (notifications)
         notificationProjectDeleted(notifications, project.name);
+      result.reset();
     }
-  }, [result.isSuccess, navigate, notifications, project.name]);
+  }, [notifications, project.name, result]);
 
   const [typedName, setTypedName] = useState("");
   const onChange = useCallback(

--- a/client/src/features/ProjectPageV2/ProjectPageContent/Settings/ProjectUnlinkTemplate.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/Settings/ProjectUnlinkTemplate.tsx
@@ -1,0 +1,123 @@
+/*!
+ * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import cx from "classnames";
+import { useCallback, useContext, useEffect, useState } from "react";
+import { Diagram3Fill, NodeMinus } from "react-bootstrap-icons";
+import { useNavigate } from "react-router-dom-v5-compat";
+import { Button, Card, CardBody, CardHeader, Input } from "reactstrap";
+
+import { Loader } from "../../../../components/Loader";
+import { NOTIFICATION_TOPICS } from "../../../../notifications/Notifications.constants";
+import { NotificationsManager } from "../../../../notifications/notifications.types";
+import AppContext from "../../../../utils/context/appContext";
+import { Project } from "../../../projectsV2/api/projectV2.api";
+import { usePatchProjectsByProjectIdMutation } from "../../../projectsV2/api/projectV2.enhanced-api";
+
+export function notificationProjectDeleted(
+  notifications: NotificationsManager,
+  projectName: string
+) {
+  notifications.addSuccess(
+    NOTIFICATION_TOPICS.PROJECT_UPDATED,
+    <>
+      Project <code>{projectName}</code> successfully unlinked.
+    </>
+  );
+}
+
+interface ProjectUnlinkTemplateProps {
+  project: Project;
+}
+export default function ProjectUnlinkTemplate({
+  project,
+}: ProjectUnlinkTemplateProps) {
+  const [patchProject, result] = usePatchProjectsByProjectIdMutation();
+  const navigate = useNavigate();
+  const { notifications } = useContext(AppContext);
+  const onUnlink = useCallback(() => {
+    patchProject({
+      projectId: project.id,
+      "If-Match": project.etag ?? "",
+      projectPatch: {
+        template_id: "",
+      },
+    });
+  }, [patchProject, project.etag, project.id]);
+
+  useEffect(() => {
+    if (result.isSuccess) {
+      if (notifications)
+        notificationProjectDeleted(notifications, project.name);
+    }
+  }, [result.isSuccess, navigate, notifications, project.name]);
+
+  const [typedName, setTypedName] = useState("");
+  const onChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setTypedName(e.target.value.trim());
+    },
+    [setTypedName]
+  );
+
+  if (project.template_id == null) return null;
+  return (
+    <Card id="copy">
+      <CardHeader>
+        <h4>
+          <Diagram3Fill className={cx("bi", "me-1")} />
+          Break template link
+        </h4>
+        <p className="m-0">
+          This will break the link between this project and the template it was
+          created from.
+        </p>
+      </CardHeader>
+      <CardBody>
+        <p className="fw-bold">
+          Are you sure you want to unlink this project from its template?
+        </p>
+        <p>
+          This cannot be undone. Please type <strong>{project.slug}</strong>,
+          the slug of the project, to confirm.
+        </p>
+        <div className="mb-3">
+          <Input
+            data-cy="unlink-confirmation-input"
+            value={typedName}
+            onChange={onChange}
+          />
+        </div>
+        <div className="text-end">
+          <Button
+            color="danger"
+            disabled={typedName !== project.slug?.trim() || result.isLoading}
+            onClick={onUnlink}
+          >
+            {result.isLoading ? (
+              <Loader className="me-1" inline size={16} />
+            ) : (
+              <NodeMinus className={cx("bi", "me-1")} />
+            )}
+            Unlink project
+          </Button>
+        </div>
+      </CardBody>
+    </Card>
+  );
+}

--- a/tests/cypress/e2e/projectV2.spec.ts
+++ b/tests/cypress/e2e/projectV2.spec.ts
@@ -756,6 +756,11 @@ describe("Project templates and copies", () => {
 
   it("break the template link", () => {
     fixtures
+      .readProjectV2({
+        overrides: {
+          template_id: "TEMPLATE-ULID",
+        },
+      })
       .getProjectV2Permissions()
       .listNamespaceV2()
       .copyProjectV2()

--- a/tests/cypress/e2e/projectV2.spec.ts
+++ b/tests/cypress/e2e/projectV2.spec.ts
@@ -425,6 +425,7 @@ describe("Editor cannot maintain members", () => {
       .dataServicesUser({
         response: {
           id: "user3-uuid",
+          username: "user3",
         },
       })
       .namespaces();
@@ -477,6 +478,7 @@ describe("Viewer cannot edit project", () => {
       .dataServicesUser({
         response: {
           id: "user2-uuid",
+          username: "user2",
         },
       })
       .namespaces();

--- a/tests/cypress/e2e/projectV2.spec.ts
+++ b/tests/cypress/e2e/projectV2.spec.ts
@@ -755,12 +755,20 @@ describe("Project templates and copies", () => {
   });
 
   it("break the template link", () => {
-    fixtures.getProjectV2Permissions().listNamespaceV2().copyProjectV2();
+    fixtures
+      .getProjectV2Permissions()
+      .listNamespaceV2()
+      .copyProjectV2()
+      .updateProjectV2();
     cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
     cy.wait("@readProjectV2");
 
     cy.get("a[title='Settings']").should("be.visible").click();
-    cy.contains("Break template link").should("be.visible").click();
+    cy.contains("Break template link").should("be.visible");
+    cy.contains("Unlink project").should("be.disabled");
+    cy.getDataCy("unlink-confirmation-input").clear().type("test-2-v2-project");
+    cy.contains("Unlink project").should("be.enabled").click();
+    cy.wait("@updateProjectV2");
   });
 });
 

--- a/tests/cypress/e2e/projectV2SessionSecrets.spec.ts
+++ b/tests/cypress/e2e/projectV2SessionSecrets.spec.ts
@@ -31,7 +31,7 @@ describe("Project Session secret slots", () => {
   it("Shows the session secrets section", () => {
     cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
     cy.contains("test 2 v2-project").should("be.visible");
-    cy.getDataCy("project-settings-edit").click();
+    cy.get("a[title='Settings']").should("be.visible").click();
 
     cy.getDataCy("project-settings-session-secrets")
       .contains("Session secret slots")
@@ -43,7 +43,7 @@ describe("Project Session secret slots", () => {
 
     cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
     cy.contains("test 2 v2-project").should("be.visible");
-    cy.getDataCy("project-settings-edit").click();
+    cy.get("a[title='Settings']").should("be.visible").click();
 
     cy.getDataCy("project-settings-session-secrets")
       .contains("Session secret slots")
@@ -70,7 +70,7 @@ describe("Project Session secret slots", () => {
 
     cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
     cy.contains("test 2 v2-project").should("be.visible");
-    cy.getDataCy("project-settings-edit").click();
+    cy.get("a[title='Settings']").should("be.visible").click();
 
     cy.getDataCy("project-settings-session-secrets")
       .contains("Session secret slots")
@@ -125,7 +125,7 @@ describe("Project Session secret slots", () => {
 
     cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
     cy.contains("test 2 v2-project").should("be.visible");
-    cy.getDataCy("project-settings-edit").click();
+    cy.get("a[title='Settings']").should("be.visible").click();
 
     cy.getDataCy("project-settings-session-secrets")
       .contains("Session secret slots")
@@ -174,7 +174,7 @@ describe("Project Session secret slots", () => {
 
     cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
     cy.contains("test 2 v2-project").should("be.visible");
-    cy.getDataCy("project-settings-edit").click();
+    cy.get("a[title='Settings']").should("be.visible").click();
 
     cy.getDataCy("project-settings-session-secrets")
       .contains("Session secret slots")
@@ -224,7 +224,7 @@ describe("Project Session secret slots", () => {
 
     cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
     cy.contains("test 2 v2-project").should("be.visible");
-    cy.getDataCy("project-settings-edit").click();
+    cy.get("a[title='Settings']").should("be.visible").click();
 
     cy.getDataCy("project-settings-session-secrets")
       .contains("Session secret slots")
@@ -281,7 +281,7 @@ describe("Project Session secret slots", () => {
 
     cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
     cy.contains("test 2 v2-project").should("be.visible");
-    cy.getDataCy("project-settings-edit").click();
+    cy.get("a[title='Settings']").should("be.visible").click();
 
     cy.getDataCy("project-settings-session-secrets")
       .contains("Session secret slots")
@@ -344,7 +344,7 @@ describe("Project Session secret slots", () => {
 
     cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
     cy.contains("test 2 v2-project").should("be.visible");
-    cy.getDataCy("project-settings-edit").click();
+    cy.get("a[title='Settings']").should("be.visible").click();
 
     cy.getDataCy("project-settings-session-secrets")
       .contains("Session secret slots")

--- a/tests/cypress/support/renkulab-fixtures/projectV2.ts
+++ b/tests/cypress/support/renkulab-fixtures/projectV2.ts
@@ -50,6 +50,11 @@ interface ListProjectV2MembersFixture extends ProjectV2IdArgs {
   };
 }
 
+interface ProjectV2CreateArgs extends SimpleFixture {
+  slug?: string;
+  namespace?: string;
+}
+
 interface ProjectV2IdArgs extends SimpleFixture {
   projectId?: string;
   overrides?: Partial<ProjectOverrides>;
@@ -139,7 +144,7 @@ export function ProjectV2<T extends FixturesConstructor>(Parent: T) {
       return this;
     }
 
-    createProjectV2(args?: SimpleFixture) {
+    createProjectV2(args?: ProjectV2CreateArgs) {
       const {
         fixture = "projectV2/create-projectV2.json",
         name = "createProjectV2",

--- a/tests/cypress/support/renkulab-fixtures/projectV2.ts
+++ b/tests/cypress/support/renkulab-fixtures/projectV2.ts
@@ -71,7 +71,7 @@ interface ProjectV2DeleteFixture extends NameOnlyFixture {
 interface ProjectV2ListCopiesFixture
   extends Omit<ProjectV2IdArgs, "overrides"> {
   writeable?: boolean;
-  count?: 0 | 1 | undefined | null;
+  count?: number | null;
 }
 
 interface ProjectV2NameArgs extends SimpleFixture {


### PR DESCRIPTION
Support breaking the link to the template project

## Screenshot

![image](https://github.com/user-attachments/assets/96fa2430-908a-47d9-a902-f2c7bd7e978a)


## Testing

- Create a project
- Use the copy feature to copy the project
- On the copy, go to the settings page and fill out the form to unlink the project

After that, the project should no longer show a link to the template

/deploy renku=release-0.62.0