### PR TITLE
refactor(client): some migration step for `react-router@v6`

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -161,7 +161,7 @@ function CentralContentContainer(props) {
               model={props.model}
             />
           </Route>
-          <Route path="/datasets/:identifier">
+          <CompatRoute path="/datasets/:identifier">
             <LazyShowDataset
               insideProject={false}
               client={props.client}
@@ -175,7 +175,7 @@ function CentralContentContainer(props) {
               logged={props.user.logged}
               model={props.model}
             />
-          </Route>
+          </CompatRoute>
           <CompatRoute path="/datasets">
             <Redirect to="/search?type=dataset" />
           </CompatRoute>

--- a/client/src/dataset/Dataset.container.jsx
+++ b/client/src/dataset/Dataset.container.jsx
@@ -17,7 +17,6 @@
  */
 
 import { useEffect, useState } from "react";
-// import { useHistory, useParams } from "react-router";
 import { useLocation, useParams } from "react-router-dom-v5-compat";
 
 import { useCoreSupport } from "../features/project/useProjectCoreSupport";
@@ -25,7 +24,6 @@ import useLegacySelector from "../utils/customHooks/useLegacySelector.hook";
 import DatasetView from "./Dataset.present";
 
 export default function ShowDataset(props) {
-  // const history = useHistory();
   const location = useLocation();
 
   const { identifier: identifier_ } = useParams();
@@ -161,7 +159,6 @@ export default function ShowDataset(props) {
       fetchError={dataset?.fetchError}
       fetchedKg={dataset?.fetched}
       fileContentUrl={props.fileContentUrl}
-      // history={history}
       identifier={identifier}
       insideProject={props.insideProject}
       lineagesUrl={props.lineagesUrl}

--- a/client/src/dataset/Dataset.container.jsx
+++ b/client/src/dataset/Dataset.container.jsx
@@ -17,15 +17,16 @@
  */
 
 import { useEffect, useState } from "react";
-import { useHistory, useParams } from "react-router";
+// import { useHistory, useParams } from "react-router";
+import { useLocation, useParams } from "react-router-dom-v5-compat";
 
 import { useCoreSupport } from "../features/project/useProjectCoreSupport";
 import useLegacySelector from "../utils/customHooks/useLegacySelector.hook";
 import DatasetView from "./Dataset.present";
 
 export default function ShowDataset(props) {
-  const history = useHistory();
-  const location = history.location;
+  // const history = useHistory();
+  const location = useLocation();
 
   const { identifier: identifier_ } = useParams();
   const identifier = identifier_?.replaceAll("-", "");
@@ -160,7 +161,7 @@ export default function ShowDataset(props) {
       fetchError={dataset?.fetchError}
       fetchedKg={dataset?.fetched}
       fileContentUrl={props.fileContentUrl}
-      history={history}
+      // history={history}
       identifier={identifier}
       insideProject={props.insideProject}
       lineagesUrl={props.lineagesUrl}

--- a/client/src/dataset/Dataset.present.jsx
+++ b/client/src/dataset/Dataset.present.jsx
@@ -21,7 +21,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { groupBy, isEmpty } from "lodash-es";
 import { useState } from "react";
 import { Helmet } from "react-helmet";
-import { Link, useNavigate } from "react-router-dom-v5-compat";
+import { Link, useLocation, useNavigate } from "react-router-dom-v5-compat";
 import {
   Button,
   Card,
@@ -271,13 +271,14 @@ function DisplayInfoTable(props) {
 }
 
 function ErrorAfterCreation(props) {
+  const location = useLocation();
+
   const editButton = (
     <Link
       className="float-right me-1 mb-1"
       id="editDatasetTooltip"
-      to={(location) =>
-        cleanModifyLocation(location, { dataset: props.dataset })
-      }
+      to={cleanModifyLocation(location)}
+      state={{ dataset: props.dataset }}
     >
       <Button size="sm" color="danger" className="btn-icon-text">
         <FontAwesomeIcon icon={faPen} color="dark" /> Edit
@@ -285,7 +286,7 @@ function ErrorAfterCreation(props) {
     </Link>
   );
 
-  return props.location.state && props.location.state.errorOnCreation ? (
+  return location.state && location.state.errorOnCreation ? (
     <ErrorAlert>
       <strong>Error on creation</strong>
       <br />
@@ -345,6 +346,8 @@ function EditDatasetButton({
   locked,
   maintainer,
 }) {
+  const location = useLocation();
+
   if (!insideProject || !maintainer) return null;
   if (locked) {
     return (
@@ -368,14 +371,8 @@ function EditDatasetButton({
       className="float-right mb-1"
       id="editDatasetTooltip"
       data-cy="edit-dataset-button"
-      to={(location) =>
-        cleanModifyLocation(location, {
-          dataset,
-          files,
-          isFilesFetching,
-          filesFetchError,
-        })
-      }
+      to={cleanModifyLocation(location)}
+      state={{ dataset, files, isFilesFetching, filesFetchError }}
     >
       <Button
         className="btn-outline-rk-pink icon-button"
@@ -500,7 +497,10 @@ export default function DatasetView(props) {
       }
     >
       <Col>
-        <ErrorAfterCreation location={props.location} dataset={dataset} />
+        <ErrorAfterCreation
+          // location={props.location}
+          dataset={dataset}
+        />
         {props.insideProject ? null : (
           <Helmet>
             <title>{pageTitle}</title>

--- a/client/src/dataset/Dataset.present.jsx
+++ b/client/src/dataset/Dataset.present.jsx
@@ -21,7 +21,6 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { groupBy, isEmpty } from "lodash-es";
 import { useState } from "react";
 import { Helmet } from "react-helmet";
-// import { Link } from "react-router-dom";
 import { Link, useNavigate } from "react-router-dom-v5-compat";
 import {
   Button,
@@ -298,12 +297,10 @@ function ErrorAfterCreation(props) {
 }
 
 function AddToProjectButton({ insideKg, locked, logged, identifier }) {
-  // const history = useHistory();
   const navigate = useNavigate();
 
   const addDatasetUrl = `/datasets/${identifier}/add`;
   const goToAddToProject = () => {
-    // if (history) history.push(addDatasetUrl);
     navigate(addDatasetUrl);
   };
 
@@ -595,7 +592,6 @@ export default function DatasetView(props) {
             client={props.client}
             dataset={dataset}
             externalUrl={props.externalUrl}
-            // history={props.history}
             metadataVersion={props.metadataVersion}
             modalOpen={deleteDatasetModalOpen}
             projectPathWithNamespace={props.projectPathWithNamespace}

--- a/client/src/dataset/Dataset.present.jsx
+++ b/client/src/dataset/Dataset.present.jsx
@@ -18,10 +18,11 @@
 
 import { faPen, faPlus } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { isEmpty, groupBy } from "lodash-es";
+import { groupBy, isEmpty } from "lodash-es";
 import { useState } from "react";
 import { Helmet } from "react-helmet";
-import { Link, useHistory } from "react-router-dom";
+// import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom-v5-compat";
 import {
   Button,
   Card,
@@ -42,7 +43,9 @@ import { CoreErrorAlert } from "../components/errors/CoreErrorAlert";
 import { CoreError } from "../components/errors/CoreErrorHelpers";
 import LazyRenkuMarkdown from "../components/markdown/LazyRenkuMarkdown";
 import DeleteDataset from "../project/datasets/delete";
+import useLegacySelector from "../utils/customHooks/useLegacySelector.hook";
 import { toHumanDateTime } from "../utils/helpers/DateTimeUtils";
+import { getEntityImageUrl } from "../utils/helpers/HelperFunctions";
 import { Url } from "../utils/helpers/url";
 import { DatasetError } from "./DatasetError";
 import {
@@ -50,8 +53,6 @@ import {
   getDatasetAuthors,
   getUpdatedDatasetImage,
 } from "./DatasetFunctions";
-import { getEntityImageUrl } from "../utils/helpers/HelperFunctions";
-import useLegacySelector from "../utils/customHooks/useLegacySelector.hook";
 
 function DisplayFiles(props) {
   if (!props.files || !props.files?.hasPart) return null;
@@ -297,10 +298,13 @@ function ErrorAfterCreation(props) {
 }
 
 function AddToProjectButton({ insideKg, locked, logged, identifier }) {
-  const history = useHistory();
+  // const history = useHistory();
+  const navigate = useNavigate();
+
   const addDatasetUrl = `/datasets/${identifier}/add`;
   const goToAddToProject = () => {
-    if (history) history.push(addDatasetUrl);
+    // if (history) history.push(addDatasetUrl);
+    navigate(addDatasetUrl);
   };
 
   const tooltip =
@@ -591,7 +595,7 @@ export default function DatasetView(props) {
             client={props.client}
             dataset={dataset}
             externalUrl={props.externalUrl}
-            history={props.history}
+            // history={props.history}
             metadataVersion={props.metadataVersion}
             modalOpen={deleteDatasetModalOpen}
             projectPathWithNamespace={props.projectPathWithNamespace}

--- a/client/src/dataset/Dataset.present.jsx
+++ b/client/src/dataset/Dataset.present.jsx
@@ -497,10 +497,7 @@ export default function DatasetView(props) {
       }
     >
       <Col>
-        <ErrorAfterCreation
-          // location={props.location}
-          dataset={dataset}
-        />
+        <ErrorAfterCreation dataset={dataset} />
         {props.insideProject ? null : (
           <Helmet>
             <title>{pageTitle}</title>

--- a/client/src/dataset/DatasetFunctions.js
+++ b/client/src/dataset/DatasetFunctions.js
@@ -72,12 +72,12 @@ export { mapDataset, getDatasetAuthors, getUpdatedDatasetImage };
  * @param {*} location - current location object
  * @param {*} newState - any new state to set
  */
-export function cleanModifyLocation(location, newState) {
+export function cleanModifyLocation(location) {
   return {
     ...location,
     pathname: location.pathname.endsWith("/")
       ? location.pathname + "modify"
       : location.pathname + "/modify",
-    state: newState,
+    // state: newState,
   };
 }

--- a/client/src/dataset/DatasetFunctions.js
+++ b/client/src/dataset/DatasetFunctions.js
@@ -70,7 +70,6 @@ export { mapDataset, getDatasetAuthors, getUpdatedDatasetImage };
  * Prevents issues with the leading slash  on the dataset modify link.
  *
  * @param {*} location - current location object
- * @param {*} newState - any new state to set
  */
 export function cleanModifyLocation(location) {
   return {
@@ -78,6 +77,5 @@ export function cleanModifyLocation(location) {
     pathname: location.pathname.endsWith("/")
       ? location.pathname + "modify"
       : location.pathname + "/modify",
-    // state: newState,
   };
 }

--- a/client/src/features/project/dataset/DatasetModify.tsx
+++ b/client/src/features/project/dataset/DatasetModify.tsx
@@ -20,7 +20,6 @@ import cx from "classnames";
 import React from "react";
 import type { FieldErrors } from "react-hook-form";
 import { SubmitHandler, useForm } from "react-hook-form";
-// import { useHistory } from "react-router-dom";
 import {
   type NavigateFunction,
   useLocation,
@@ -75,7 +74,6 @@ export type PostSubmitProps = {
   datasetId: string;
   dispatch: AppDispatch;
   fetchDatasets: (forceRefetch: boolean, versionUrl: string) => Promise<void>;
-  // history: DatasetModifyProps["history"];
   navigate: NavigateFunction;
   projectPathWithNamespace: string;
   state?: unknown;
@@ -85,7 +83,6 @@ async function redirectAfterSubmit({
   datasetId,
   dispatch,
   fetchDatasets,
-  // history,
   navigate,
   projectPathWithNamespace,
   state,
@@ -96,10 +93,6 @@ async function redirectAfterSubmit({
   navigate(`/projects/${projectPathWithNamespace}/datasets/${datasetId}`, {
     state,
   });
-  // history.push({
-  //   pathname: `/projects/${projectPathWithNamespace}/datasets/${datasetId}`,
-  //   state,
-  // });
 }
 
 type DatasetCreateSubmitGroupProps = {
@@ -388,8 +381,6 @@ export default function DatasetModify(props: DatasetModifyProps) {
     defaultBranch,
     externalUrl,
     fetchDatasets,
-    // history,
-    // location,
     metadataVersion,
     overviewCommitsUrl,
     projectPathWithNamespace,
@@ -498,7 +489,6 @@ export default function DatasetModify(props: DatasetModifyProps) {
                 await redirectAfterSubmit({
                   datasetId: dataset?.slug ?? response.data.slug,
                   fetchDatasets,
-                  // history,
                   navigate,
                   projectPathWithNamespace,
                   state: undefined,
@@ -536,7 +526,6 @@ export default function DatasetModify(props: DatasetModifyProps) {
                     await redirectAfterSubmit({
                       datasetId: response.data.slug,
                       fetchDatasets,
-                      // history,
                       navigate,
                       projectPathWithNamespace,
                       state: { errorOnCreation: true },
@@ -554,7 +543,6 @@ export default function DatasetModify(props: DatasetModifyProps) {
                   await redirectAfterSubmit({
                     datasetId: dataset?.slug ?? response.data.slug,
                     fetchDatasets,
-                    // history,
                     navigate,
                     projectPathWithNamespace,
                     state: undefined,
@@ -613,7 +601,6 @@ export default function DatasetModify(props: DatasetModifyProps) {
       edit,
       externalUrl,
       fetchDatasets,
-      // history,
       navigate,
       metadataVersion,
       slug,

--- a/client/src/features/project/dataset/DatasetModify.tsx
+++ b/client/src/features/project/dataset/DatasetModify.tsx
@@ -20,7 +20,12 @@ import cx from "classnames";
 import React from "react";
 import type { FieldErrors } from "react-hook-form";
 import { SubmitHandler, useForm } from "react-hook-form";
-import { useHistory } from "react-router-dom";
+// import { useHistory } from "react-router-dom";
+import {
+  type NavigateFunction,
+  useLocation,
+  useNavigate,
+} from "react-router-dom-v5-compat";
 import { Button, FormGroup, UncontrolledAlert } from "reactstrap";
 
 import { ExternalLink } from "../../../components/ExternalLinks";
@@ -70,7 +75,8 @@ export type PostSubmitProps = {
   datasetId: string;
   dispatch: AppDispatch;
   fetchDatasets: (forceRefetch: boolean, versionUrl: string) => Promise<void>;
-  history: DatasetModifyProps["history"];
+  // history: DatasetModifyProps["history"];
+  navigate: NavigateFunction;
   projectPathWithNamespace: string;
   state?: unknown;
   versionUrl: string;
@@ -79,17 +85,21 @@ async function redirectAfterSubmit({
   datasetId,
   dispatch,
   fetchDatasets,
-  history,
+  // history,
+  navigate,
   projectPathWithNamespace,
   state,
   versionUrl,
 }: PostSubmitProps) {
   dispatch(reset());
   await fetchDatasets(true, versionUrl);
-  history.push({
-    pathname: `/projects/${projectPathWithNamespace}/datasets/${datasetId}`,
+  navigate(`/projects/${projectPathWithNamespace}/datasets/${datasetId}`, {
     state,
   });
+  // history.push({
+  //   pathname: `/projects/${projectPathWithNamespace}/datasets/${datasetId}`,
+  //   state,
+  // });
 }
 
 type DatasetCreateSubmitGroupProps = {
@@ -359,9 +369,7 @@ export interface DatasetModifyProps extends DatasetModifyDisplayProps {
   existingFiles: DatasetModifyFormProps["existingFiles"];
   externalUrl: string;
   fetchDatasets: PostSubmitProps["fetchDatasets"];
-  history: ReturnType<typeof useHistory>;
   initialized: boolean;
-  location: { pathname: string };
   metadataVersion: number | undefined;
   notifications: unknown;
   onCancel: () => void;
@@ -380,14 +388,17 @@ export default function DatasetModify(props: DatasetModifyProps) {
     defaultBranch,
     externalUrl,
     fetchDatasets,
-    history,
-    location,
+    // history,
+    // location,
     metadataVersion,
     overviewCommitsUrl,
     projectPathWithNamespace,
     setSubmitting,
     versionUrl,
   } = props;
+
+  const location = useLocation();
+  const navigate = useNavigate();
 
   const edit = dataset != null;
   const slug = dataset?.slug;
@@ -487,7 +498,8 @@ export default function DatasetModify(props: DatasetModifyProps) {
                 await redirectAfterSubmit({
                   datasetId: dataset?.slug ?? response.data.slug,
                   fetchDatasets,
-                  history,
+                  // history,
+                  navigate,
                   projectPathWithNamespace,
                   state: undefined,
                   dispatch,
@@ -524,7 +536,8 @@ export default function DatasetModify(props: DatasetModifyProps) {
                     await redirectAfterSubmit({
                       datasetId: response.data.slug,
                       fetchDatasets,
-                      history,
+                      // history,
+                      navigate,
                       projectPathWithNamespace,
                       state: { errorOnCreation: true },
                       dispatch,
@@ -541,7 +554,8 @@ export default function DatasetModify(props: DatasetModifyProps) {
                   await redirectAfterSubmit({
                     datasetId: dataset?.slug ?? response.data.slug,
                     fetchDatasets,
-                    history,
+                    // history,
+                    navigate,
                     projectPathWithNamespace,
                     state: undefined,
                     dispatch,
@@ -599,7 +613,8 @@ export default function DatasetModify(props: DatasetModifyProps) {
       edit,
       externalUrl,
       fetchDatasets,
-      history,
+      // history,
+      navigate,
       metadataVersion,
       slug,
       postDatasetMutation,

--- a/client/src/features/project/dataset/ProjectDatasetImport.tsx
+++ b/client/src/features/project/dataset/ProjectDatasetImport.tsx
@@ -6,8 +6,6 @@ import type { StateModelProject } from "../project.types";
 type ProjectDatasetImportProps = {
   client: DatasetImportProps["client"];
   fetchDatasets: DatasetImportProps["fetchDatasets"];
-  // history: DatasetImportProps["history"];
-  // location: DatasetImportProps["location"];
   model: unknown;
   notifications: unknown;
   params: unknown;
@@ -33,8 +31,6 @@ function ProjectDatasetImport(props: ProjectDatasetImportProps) {
       client={props.client}
       externalUrl={externalUrl}
       fetchDatasets={props.fetchDatasets}
-      // history={props.history}
-      // location={props.location}
       projectPathWithNamespace={projectPathWithNamespace}
       toggleNewDataset={props.toggleNewDataset}
     />

--- a/client/src/features/project/dataset/ProjectDatasetImport.tsx
+++ b/client/src/features/project/dataset/ProjectDatasetImport.tsx
@@ -6,8 +6,8 @@ import type { StateModelProject } from "../project.types";
 type ProjectDatasetImportProps = {
   client: DatasetImportProps["client"];
   fetchDatasets: DatasetImportProps["fetchDatasets"];
-  history: DatasetImportProps["history"];
-  location: DatasetImportProps["location"];
+  // history: DatasetImportProps["history"];
+  // location: DatasetImportProps["location"];
   model: unknown;
   notifications: unknown;
   params: unknown;
@@ -33,8 +33,8 @@ function ProjectDatasetImport(props: ProjectDatasetImportProps) {
       client={props.client}
       externalUrl={externalUrl}
       fetchDatasets={props.fetchDatasets}
-      history={props.history}
-      location={props.location}
+      // history={props.history}
+      // location={props.location}
       projectPathWithNamespace={projectPathWithNamespace}
       toggleNewDataset={props.toggleNewDataset}
     />

--- a/client/src/features/project/dataset/ProjectDatasetNewEdit.tsx
+++ b/client/src/features/project/dataset/ProjectDatasetNewEdit.tsx
@@ -178,8 +178,6 @@ function ProjectDatasetNewEdit(props: ProjectDatasetNewEditProps) {
       externalUrl={projectMetadata.externalUrl}
       fetchDatasets={props.fetchDatasets}
       initialized={true}
-      // history={props.history}
-      // location={props.location}
       metadataVersion={props.metadataVersion}
       notifications={props.notifications}
       onCancel={onCancel}
@@ -198,7 +196,6 @@ function ProjectDatasetNew(
   props: Omit<ChangeDatasetProps, "submitting" | "setSubmitting"> &
     ProjectDatasetNewOnlyProps
 ) {
-  // const location = props.location;
   const location = useLocation();
 
   const project = useLegacySelector<StateModelProject>(
@@ -232,8 +229,6 @@ function ProjectDatasetNew(
           apiVersion={props.apiVersion}
           client={props.client}
           fetchDatasets={props.fetchDatasets}
-          // history={props.history}
-          // location={props.location}
           metadataVersion={props.metadataVersion}
           model={props.model}
           notifications={props.notifications}
@@ -341,8 +336,6 @@ function ProjectDatasetEdit(props: ProjectDatasetEditProps) {
         datasetId={datasetId}
         fetchDatasets={props.fetchDatasets}
         files={props.files}
-        // history={props.history}
-        // location={props.location}
         metadataVersion={props.metadataVersion}
         model={props.model}
         notifications={props.notifications}

--- a/client/src/features/project/dataset/ProjectDatasetNewEdit.tsx
+++ b/client/src/features/project/dataset/ProjectDatasetNewEdit.tsx
@@ -21,7 +21,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { SerializedError } from "@reduxjs/toolkit";
 import { FetchBaseQueryError } from "@reduxjs/toolkit/dist/query";
 import React from "react";
-import { useHistory } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom-v5-compat";
 import { Alert, Button, Col } from "reactstrap";
 
 import { ACCESS_LEVELS } from "../../../api-client";
@@ -49,8 +49,6 @@ type ChangeDatasetProps = {
   apiVersion: string | undefined;
   client: DatasetPostClient;
   fetchDatasets: PostSubmitProps["fetchDatasets"];
-  history: ReturnType<typeof useHistory>;
-  location: { pathname: string };
   model: unknown;
   notifications: unknown;
   metadataVersion: number | undefined;
@@ -113,7 +111,9 @@ function ProjectDatasetNewEdit(props: ProjectDatasetNewEditProps) {
     projectUrlProps
   );
 
-  const { dataset, history, submitting, setSubmitting } = props;
+  const { dataset, submitting, setSubmitting } = props;
+
+  const navigate = useNavigate();
 
   const onCancel = React.useCallback(() => {
     const targetPath = { path: projectPathWithNamespace };
@@ -123,8 +123,8 @@ function ProjectDatasetNewEdit(props: ProjectDatasetNewEditProps) {
           dataset: dataset.slug,
         })
       : Url.get(Url.pages.project.datasets.base, { ...targetPath });
-    history.push({ pathname });
-  }, [dataset, history, projectPathWithNamespace]);
+    navigate(pathname);
+  }, [dataset, navigate, projectPathWithNamespace]);
 
   if (accessLevel < ACCESS_LEVELS.MAINTAINER) {
     return (
@@ -178,8 +178,8 @@ function ProjectDatasetNewEdit(props: ProjectDatasetNewEditProps) {
       externalUrl={projectMetadata.externalUrl}
       fetchDatasets={props.fetchDatasets}
       initialized={true}
-      history={props.history}
-      location={props.location}
+      // history={props.history}
+      // location={props.location}
       metadataVersion={props.metadataVersion}
       notifications={props.notifications}
       onCancel={onCancel}
@@ -198,7 +198,9 @@ function ProjectDatasetNew(
   props: Omit<ChangeDatasetProps, "submitting" | "setSubmitting"> &
     ProjectDatasetNewOnlyProps
 ) {
-  const location = props.location;
+  // const location = props.location;
+  const location = useLocation();
+
   const project = useLegacySelector<StateModelProject>(
     (state) => state.stateModel.project
   );
@@ -230,8 +232,8 @@ function ProjectDatasetNew(
           apiVersion={props.apiVersion}
           client={props.client}
           fetchDatasets={props.fetchDatasets}
-          history={props.history}
-          location={props.location}
+          // history={props.history}
+          // location={props.location}
           metadataVersion={props.metadataVersion}
           model={props.model}
           notifications={props.notifications}
@@ -253,7 +255,7 @@ function ProjectDatasetEditForm(
     DatasetModifyDisplayProps &
     ProjectDatasetEditOnlyProps
 ) {
-  const location = props.location;
+  const location = useLocation();
   const project = useLegacySelector<StateModelProject>(
     (state) => state.stateModel.project
   );
@@ -279,8 +281,6 @@ function ProjectDatasetEditForm(
       datasetId={props.datasetId}
       fetchDatasets={props.fetchDatasets}
       files={files}
-      history={props.history}
-      location={props.location}
       metadataVersion={props.metadataVersion}
       model={props.model}
       notifications={props.notifications}
@@ -341,8 +341,8 @@ function ProjectDatasetEdit(props: ProjectDatasetEditProps) {
         datasetId={datasetId}
         fetchDatasets={props.fetchDatasets}
         files={props.files}
-        history={props.history}
-        location={props.location}
+        // history={props.history}
+        // location={props.location}
         metadataVersion={props.metadataVersion}
         model={props.model}
         notifications={props.notifications}

--- a/client/src/features/project/dataset/ProjectDatasetShow.tsx
+++ b/client/src/features/project/dataset/ProjectDatasetShow.tsx
@@ -50,8 +50,6 @@ type ProjectDatasetShowProps = {
   datasetCoordinator: unknown;
   datasetId: string;
   graphStatus: boolean;
-  // history: unknown;
-  // location: unknown;
   model: unknown;
   projectInsideKg: boolean;
 };
@@ -63,10 +61,8 @@ type ProjectDatasetViewProps = {
   externalUrl: string;
   fileContentUrl: string;
   graphStatus: boolean;
-  // history: unknown;
   httpProjectUrl: string;
   lineagesUrl: string;
-  // location: unknown;
   lockStatus: unknown;
   logged: unknown;
   maintainer: boolean;
@@ -181,13 +177,11 @@ function ProjectDatasetView(props: ProjectDatasetViewProps) {
       fetchError={kgFetchError}
       fetchedKg={kgDataset != null}
       fileContentUrl={props.fileContentUrl}
-      // history={props.history}
       httpProjectUrl={props.httpProjectUrl}
       identifier={datasetId}
       insideProject={true}
       lineagesUrl={props.lineagesUrl}
       loadingDatasets={loadingDatasets}
-      // location={props.location}
       lockStatus={props.lockStatus}
       logged={props.logged}
       maintainer={props.maintainer}
@@ -238,10 +232,8 @@ function ProjectDatasetShow(props: ProjectDatasetShowProps) {
       externalUrl={projectMetadata.externalUrl}
       fileContentUrl={fileContentUrl}
       graphStatus={props.graphStatus}
-      // history={props.history}
       httpProjectUrl={httpProjectUrl}
       lineagesUrl={lineagesUrl}
-      // location={props.location}
       lockStatus={lockStatus}
       logged={user.logged}
       maintainer={maintainer}

--- a/client/src/features/project/dataset/ProjectDatasetShow.tsx
+++ b/client/src/features/project/dataset/ProjectDatasetShow.tsx
@@ -50,8 +50,8 @@ type ProjectDatasetShowProps = {
   datasetCoordinator: unknown;
   datasetId: string;
   graphStatus: boolean;
-  history: unknown;
-  location: unknown;
+  // history: unknown;
+  // location: unknown;
   model: unknown;
   projectInsideKg: boolean;
 };
@@ -63,10 +63,10 @@ type ProjectDatasetViewProps = {
   externalUrl: string;
   fileContentUrl: string;
   graphStatus: boolean;
-  history: unknown;
+  // history: unknown;
   httpProjectUrl: string;
   lineagesUrl: string;
-  location: unknown;
+  // location: unknown;
   lockStatus: unknown;
   logged: unknown;
   maintainer: boolean;
@@ -181,13 +181,13 @@ function ProjectDatasetView(props: ProjectDatasetViewProps) {
       fetchError={kgFetchError}
       fetchedKg={kgDataset != null}
       fileContentUrl={props.fileContentUrl}
-      history={props.history}
+      // history={props.history}
       httpProjectUrl={props.httpProjectUrl}
       identifier={datasetId}
       insideProject={true}
       lineagesUrl={props.lineagesUrl}
       loadingDatasets={loadingDatasets}
-      location={props.location}
+      // location={props.location}
       lockStatus={props.lockStatus}
       logged={props.logged}
       maintainer={props.maintainer}
@@ -238,10 +238,10 @@ function ProjectDatasetShow(props: ProjectDatasetShowProps) {
       externalUrl={projectMetadata.externalUrl}
       fileContentUrl={fileContentUrl}
       graphStatus={props.graphStatus}
-      history={props.history}
+      // history={props.history}
       httpProjectUrl={httpProjectUrl}
       lineagesUrl={lineagesUrl}
-      location={props.location}
+      // location={props.location}
       lockStatus={lockStatus}
       logged={user.logged}
       maintainer={maintainer}

--- a/client/src/features/project/dataset/ProjectDatasetsView.tsx
+++ b/client/src/features/project/dataset/ProjectDatasetsView.tsx
@@ -20,7 +20,6 @@ import { faInfoCircle, faUserClock } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { skipToken } from "@reduxjs/toolkit/query";
 import React, { useEffect } from "react";
-// import { Link, Route, Switch, useHistory, useParams } from "react-router-dom";
 import {
   Link,
   Route,
@@ -40,23 +39,13 @@ import { DatasetCoordinator } from "../../../dataset/Dataset.state";
 import { SpecialPropVal } from "../../../model/Model";
 import useLegacySelector from "../../../utils/customHooks/useLegacySelector.hook";
 import { Url } from "../../../utils/helpers/url";
-// import type { DatasetCore } from "../project.types";
 import { StateModelProject } from "../project.types";
 import { useGetProjectIndexingStatusQuery } from "../projectKg.api";
 import { useCoreSupport } from "../useProjectCoreSupport";
 import ProjectDatasetImport from "./ProjectDatasetImport";
-// import type { ProjectDatasetEditProps } from "./ProjectDatasetNewEdit";
 import { ProjectDatasetEdit, ProjectDatasetNew } from "./ProjectDatasetNewEdit";
 import ProjectDatasetShow from "./ProjectDatasetShow";
 import ProjectDatasetListView from "./ProjectDatasetsListView";
-
-// type LocationState = {
-//   dataset: DatasetCore;
-//   files: ProjectDatasetEditProps["files"];
-//   isFilesFetching: boolean;
-//   filesFetchError: ProjectDatasetEditProps["filesFetchError"];
-//   reload: boolean;
-// };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function ProjectDatasetLockAlert({ lockStatus }: any) {
@@ -134,8 +123,6 @@ function ProjectAddDataset(props: any) {
           apiVersion={props.apiVersion}
           client={props.client}
           fetchDatasets={props.fetchDatasets}
-          // history={props.history}
-          // location={props.location}
           metadataVersion={props.metadataVersion}
           model={props.model}
           notifications={props.notifications}
@@ -147,8 +134,6 @@ function ProjectAddDataset(props: any) {
         <ProjectDatasetImport
           client={props.client}
           fetchDatasets={props.fetchDatasets}
-          // history={props.history}
-          // location={props.location}
           model={props.model}
           notifications={props.notifications}
           params={props.params}
@@ -184,14 +169,9 @@ function EmptyDatasets({ locked, membership, newDatasetUrl }: any) {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function ProjectDatasetsView(props: any) {
-  const {
-    datasets,
-    fetchDatasets,
-    //  location
-  } = props;
+  const { datasets, fetchDatasets } = props;
   const location = useLocation();
   const navigate = useNavigate();
-  // const history = useHistory();
 
   const [datasetCoordinator, setDatasetCoordinator] =
     React.useState<unknown>(null);
@@ -243,7 +223,6 @@ function ProjectDatasetsView(props: any) {
       (location.state && location.state.reload)
     ) {
       fetchDatasets(location.state && location.state.reload, versionUrl);
-      // history.replace({ state: { reload: false } });
       navigate(location, { replace: true, state: { reload: false } });
     }
   }, [
@@ -462,8 +441,6 @@ function EditDatasetRoute({
   params,
   versionUrl,
 }: EditDatasetRouteProps) {
-  // const history = useHistory<Partial<LocationState>>();
-  // const location = history.location;
   const location = useLocation();
 
   const { datasetId } = useParams<{ datasetId: string }>();
@@ -484,9 +461,7 @@ function EditDatasetRoute({
         fetchDatasets={fetchDatasets}
         files={location.state.files ?? { hasPart: [] }}
         filesFetchError={location.state.filesFetchError}
-        // history={history}
         isFilesFetching={location.state.isFilesFetching ?? false}
-        // location={location}
         metadataVersion={metadataVersion}
         model={model}
         notifications={notifications}
@@ -512,8 +487,6 @@ function ShowDatasetRoute({
   pathWithNamespace,
   projectIndexingStatus,
 }: ShowDatasetRouteProps) {
-  // const history = useHistory();
-  // const location = history.location;
   const { datasetId } = useParams<{ datasetId: string }>();
 
   return (
@@ -529,8 +502,6 @@ function ShowDatasetRoute({
         datasetCoordinator={datasetCoordinator}
         datasetId={decodeURIComponent(datasetId ?? "")}
         graphStatus={projectIndexingStatus.data?.activated ?? false}
-        // history={history}
-        // location={location}
         model={model}
         projectInsideKg={projectIndexingStatus.data?.activated ?? false}
       />

--- a/client/src/features/project/dataset/ProjectDatasetsView.tsx
+++ b/client/src/features/project/dataset/ProjectDatasetsView.tsx
@@ -20,7 +20,15 @@ import { faInfoCircle, faUserClock } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { skipToken } from "@reduxjs/toolkit/query";
 import React, { useEffect } from "react";
-import { Link, Route, Switch, useHistory, useParams } from "react-router-dom";
+// import { Link, Route, Switch, useHistory, useParams } from "react-router-dom";
+import {
+  Link,
+  Route,
+  Routes,
+  useLocation,
+  useNavigate,
+  useParams,
+} from "react-router-dom-v5-compat";
 import { Alert, Button, Col } from "reactstrap";
 
 import { ACCESS_LEVELS } from "../../../api-client";
@@ -32,23 +40,23 @@ import { DatasetCoordinator } from "../../../dataset/Dataset.state";
 import { SpecialPropVal } from "../../../model/Model";
 import useLegacySelector from "../../../utils/customHooks/useLegacySelector.hook";
 import { Url } from "../../../utils/helpers/url";
-import type { DatasetCore } from "../project.types";
+// import type { DatasetCore } from "../project.types";
 import { StateModelProject } from "../project.types";
 import { useGetProjectIndexingStatusQuery } from "../projectKg.api";
 import { useCoreSupport } from "../useProjectCoreSupport";
 import ProjectDatasetImport from "./ProjectDatasetImport";
-import type { ProjectDatasetEditProps } from "./ProjectDatasetNewEdit";
+// import type { ProjectDatasetEditProps } from "./ProjectDatasetNewEdit";
 import { ProjectDatasetEdit, ProjectDatasetNew } from "./ProjectDatasetNewEdit";
 import ProjectDatasetShow from "./ProjectDatasetShow";
 import ProjectDatasetListView from "./ProjectDatasetsListView";
 
-type LocationState = {
-  dataset: DatasetCore;
-  files: ProjectDatasetEditProps["files"];
-  isFilesFetching: boolean;
-  filesFetchError: ProjectDatasetEditProps["filesFetchError"];
-  reload: boolean;
-};
+// type LocationState = {
+//   dataset: DatasetCore;
+//   files: ProjectDatasetEditProps["files"];
+//   isFilesFetching: boolean;
+//   filesFetchError: ProjectDatasetEditProps["filesFetchError"];
+//   reload: boolean;
+// };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function ProjectDatasetLockAlert({ lockStatus }: any) {
@@ -126,8 +134,8 @@ function ProjectAddDataset(props: any) {
           apiVersion={props.apiVersion}
           client={props.client}
           fetchDatasets={props.fetchDatasets}
-          history={props.history}
-          location={props.location}
+          // history={props.history}
+          // location={props.location}
           metadataVersion={props.metadataVersion}
           model={props.model}
           notifications={props.notifications}
@@ -139,8 +147,8 @@ function ProjectAddDataset(props: any) {
         <ProjectDatasetImport
           client={props.client}
           fetchDatasets={props.fetchDatasets}
-          history={props.history}
-          location={props.location}
+          // history={props.history}
+          // location={props.location}
           model={props.model}
           notifications={props.notifications}
           params={props.params}
@@ -176,8 +184,14 @@ function EmptyDatasets({ locked, membership, newDatasetUrl }: any) {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function ProjectDatasetsView(props: any) {
-  const { datasets, fetchDatasets, location } = props;
-  const history = useHistory();
+  const {
+    datasets,
+    fetchDatasets,
+    //  location
+  } = props;
+  const location = useLocation();
+  const navigate = useNavigate();
+  // const history = useHistory();
 
   const [datasetCoordinator, setDatasetCoordinator] =
     React.useState<unknown>(null);
@@ -229,15 +243,16 @@ function ProjectDatasetsView(props: any) {
       (location.state && location.state.reload)
     ) {
       fetchDatasets(location.state && location.state.reload, versionUrl);
-      history.replace({ state: { reload: false } });
+      // history.replace({ state: { reload: false } });
+      navigate(location, { replace: true, state: { reload: false } });
     }
   }, [
     backendAvailable,
     coreSupportComputed,
     datasets.core,
     fetchDatasets,
-    history,
-    location.state,
+    location,
+    navigate,
     versionUrl,
   ]);
 
@@ -350,7 +365,7 @@ function ProjectDatasetsView(props: any) {
   if (
     props.datasets.core.datasets != null &&
     props.datasets.core.datasets.length === 0 &&
-    props.location.pathname !== props.newDatasetUrl
+    location.pathname !== props.newDatasetUrl
   ) {
     return (
       <Col sm={12}>
@@ -369,48 +384,57 @@ function ProjectDatasetsView(props: any) {
     <Col sm={12}>
       {coreSupportMessage}
       <ProjectDatasetLockAlert lockStatus={props.lockStatus} />
-      <Switch>
-        <Route path={props.newDatasetUrl}>
-          <Col key="btn" md={12}>
-            <GoBackButton
-              data-cy="go-back-dataset"
-              label="Back to list"
-              url={props.datasetsUrl}
+      <Routes>
+        <Route
+          path="new"
+          element={
+            <>
+              <Col key="btn" md={12}>
+                <GoBackButton
+                  data-cy="go-back-dataset"
+                  label="Back to list"
+                  url={props.datasetsUrl}
+                />
+              </Col>
+              <ProjectAddDataset
+                {...props}
+                apiVersion={apiVersion}
+                metadataVersion={metadataVersion}
+                versionUrl={versionUrl}
+              />
+            </>
+          }
+        />
+        <Route
+          path=":datasetId/modify"
+          element={
+            <EditDatasetRoute
+              apiVersion={apiVersion}
+              client={props.client}
+              datasetsUrl={props.datasetsUrl}
+              fetchDatasets={props.fetchDatasets}
+              metadataVersion={metadataVersion}
+              model={props.model}
+              notifications={props.notifications}
+              params={props.params}
+              versionUrl={versionUrl}
             />
-          </Col>
-          <ProjectAddDataset
-            {...props}
-            apiVersion={apiVersion}
-            metadataVersion={metadataVersion}
-            versionUrl={versionUrl}
-          />
-        </Route>
-        <Route path={props.editDatasetUrl}>
-          <EditDatasetRoute
-            apiVersion={apiVersion}
-            client={props.client}
-            datasetsUrl={props.datasetsUrl}
-            fetchDatasets={props.fetchDatasets}
-            metadataVersion={metadataVersion}
-            model={props.model}
-            notifications={props.notifications}
-            params={props.params}
-            versionUrl={versionUrl}
-          />
-        </Route>
-        <Route path={props.datasetUrl}>
-          <ShowDatasetRoute
-            datasetCoordinator={datasetCoordinator}
-            datasetsUrl={props.datasetsUrl}
-            model={props.model}
-            pathWithNamespace={props.metadata.pathWithNamespace}
-            projectIndexingStatus={projectIndexingStatus}
-          />
-        </Route>
-        <Route exact path={props.datasetsUrl}>
-          <ProjectDatasetsNav {...props} />
-        </Route>
-      </Switch>
+          }
+        />
+        <Route
+          path=":datasetId"
+          element={
+            <ShowDatasetRoute
+              datasetCoordinator={datasetCoordinator}
+              datasetsUrl={props.datasetsUrl}
+              model={props.model}
+              pathWithNamespace={props.metadata.pathWithNamespace}
+              projectIndexingStatus={projectIndexingStatus}
+            />
+          }
+        />
+        <Route path="/" element={<ProjectDatasetsNav {...props} />} />
+      </Routes>
     </Col>
   );
 }
@@ -438,8 +462,9 @@ function EditDatasetRoute({
   params,
   versionUrl,
 }: EditDatasetRouteProps) {
-  const history = useHistory<Partial<LocationState>>();
-  const location = history.location;
+  // const history = useHistory<Partial<LocationState>>();
+  // const location = history.location;
+  const location = useLocation();
 
   const { datasetId } = useParams<{ datasetId: string }>();
 
@@ -455,13 +480,13 @@ function EditDatasetRoute({
         apiVersion={apiVersion}
         client={client}
         dataset={location.state.dataset}
-        datasetId={decodeURIComponent(datasetId)}
+        datasetId={decodeURIComponent(datasetId ?? "")}
         fetchDatasets={fetchDatasets}
         files={location.state.files ?? { hasPart: [] }}
         filesFetchError={location.state.filesFetchError}
-        history={history}
+        // history={history}
         isFilesFetching={location.state.isFilesFetching ?? false}
-        location={location}
+        // location={location}
         metadataVersion={metadataVersion}
         model={model}
         notifications={notifications}
@@ -487,9 +512,8 @@ function ShowDatasetRoute({
   pathWithNamespace,
   projectIndexingStatus,
 }: ShowDatasetRouteProps) {
-  const history = useHistory();
-  const location = history.location;
-
+  // const history = useHistory();
+  // const location = history.location;
   const { datasetId } = useParams<{ datasetId: string }>();
 
   return (
@@ -503,10 +527,10 @@ function ShowDatasetRoute({
       </Col>
       <ProjectDatasetShow
         datasetCoordinator={datasetCoordinator}
-        datasetId={decodeURIComponent(datasetId)}
+        datasetId={decodeURIComponent(datasetId ?? "")}
         graphStatus={projectIndexingStatus.data?.activated ?? false}
-        history={history}
-        location={location}
+        // history={history}
+        // location={location}
         model={model}
         projectInsideKg={projectIndexingStatus.data?.activated ?? false}
       />

--- a/client/src/project/Project.present.jsx
+++ b/client/src/project/Project.present.jsx
@@ -947,9 +947,9 @@ function ProjectView(props) {
           <Route path={props.filesUrl}>
             <ProjectViewFiles key="files" {...props} />
           </Route>
-          <Route path={props.datasetsUrl}>
+          <CompatRoute path={props.datasetsUrl}>
             <ProjectDatasetsView key="datasets" {...props} />
-          </Route>
+          </CompatRoute>
           <Route path={[props.workflowUrl, props.workflowsUrl]}>
             <ProjectViewWorkflows key="workflows" {...props} />
           </Route>

--- a/client/src/project/datasets/delete/DeleteDataset.tsx
+++ b/client/src/project/datasets/delete/DeleteDataset.tsx
@@ -17,27 +17,28 @@
  */
 
 import { useEffect, useState } from "react";
-import { useHistory } from "react-router";
+// import { useHistory } from "react-router";
+import { useNavigate } from "react-router-dom-v5-compat";
 import {
-  Row,
-  Col,
-  Modal,
-  ModalHeader,
-  ModalBody,
   Button,
+  Col,
   FormText,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  Row,
 } from "reactstrap";
 
 import { CoreErrorAlert } from "../../../components/errors/CoreErrorAlert";
 import { Loader } from "../../../components/Loader";
-import type { DatasetCore } from "../../../features/project/project.types";
 import { useDeleteDatasetMutation } from "../../../features/datasets/datasetsCore.api";
+import type { DatasetCore } from "../../../features/project/project.types";
+import { Url } from "../../../utils/helpers/url";
 import {
   CoreErrorContent,
   CoreErrorResponse,
   CoreVersionUrl,
 } from "../../../utils/types/coreService.types";
-import { Url } from "../../../utils/helpers/url";
 
 function ModalContent({
   closeModal,
@@ -108,7 +109,7 @@ type DatasetDeleteModalProps = {
   closeModal: () => void;
   dataset: DeleteDatasetProps["dataset"];
   deleteDataset: () => void;
-  history: DeleteDatasetProps["history"];
+  // history: DeleteDatasetProps["history"];
   modalOpen: DeleteDatasetProps["modalOpen"];
   serverErrors: CoreErrorContent | string | undefined;
   submitLoader: { isSubmitting: boolean; text: string | undefined };
@@ -141,7 +142,7 @@ export type DeleteDatasetSuccessResponse = {
 
 export interface DeleteDatasetProps extends CoreVersionUrl {
   dataset: DatasetCore;
-  history: ReturnType<typeof useHistory>;
+  // history: ReturnType<typeof useHistory>;
   externalUrl: string;
   onCancel: () => void;
   modalOpen: boolean;
@@ -151,6 +152,8 @@ export interface DeleteDatasetProps extends CoreVersionUrl {
 }
 
 function DeleteDataset(props: DeleteDatasetProps) {
+  const navigate = useNavigate();
+
   const [serverErrors, setServerErrors] = useState<
     CoreErrorContent | string | undefined
   >(undefined);
@@ -166,27 +169,33 @@ function DeleteDataset(props: DeleteDatasetProps) {
   });
 
   // handle deleting dataset
-  useEffect(() => {
-    if (deleteDatasetStatus.error && "data" in deleteDatasetStatus.error) {
-      const errorResponse = deleteDatasetStatus.error.data as CoreErrorResponse;
-      setSubmitting(false);
-      setServerErrors(errorResponse.error);
-    } else if (deleteDatasetStatus.error) {
-      // ? This cases is unlikely to happen with the current implementation of renku-core
-      setSubmitting(false);
-      const errorMessage =
-        "There was an unexpected problem deleting the dataset: " +
-        deleteDatasetStatus.error.toString();
-      setServerErrors(errorMessage);
-    } else if (deleteDatasetStatus.isSuccess) {
-      setSubmitting(false);
-      setSubmitLoaderText("Dataset deleted, you will be redirected soon...");
-      props.history.push({
-        pathname: projectDatasetsUrl,
-        state: { reload: true },
-      });
-    }
-  }, [deleteDatasetStatus, props.history, projectDatasetsUrl]);
+  useEffect(
+    () => {
+      if (deleteDatasetStatus.error && "data" in deleteDatasetStatus.error) {
+        const errorResponse = deleteDatasetStatus.error
+          .data as CoreErrorResponse;
+        setSubmitting(false);
+        setServerErrors(errorResponse.error);
+      } else if (deleteDatasetStatus.error) {
+        // ? This cases is unlikely to happen with the current implementation of renku-core
+        setSubmitting(false);
+        const errorMessage =
+          "There was an unexpected problem deleting the dataset: " +
+          deleteDatasetStatus.error.toString();
+        setServerErrors(errorMessage);
+      } else if (deleteDatasetStatus.isSuccess) {
+        setSubmitting(false);
+        setSubmitLoaderText("Dataset deleted, you will be redirected soon...");
+        // props.history.push({
+        //   pathname: projectDatasetsUrl,
+        //   state: { reload: true },
+        // });
+        navigate({ pathname: projectDatasetsUrl }, { state: { reload: true } });
+      }
+    },
+    [deleteDatasetStatus, navigate, projectDatasetsUrl]
+    // [deleteDatasetStatus, props.history, projectDatasetsUrl]
+  );
 
   const localDeleteDataset = () => {
     setSubmitting(true);
@@ -216,7 +225,7 @@ function DeleteDataset(props: DeleteDatasetProps) {
       deleteDataset={localDeleteDataset}
       serverErrors={serverErrors}
       submitLoader={{ isSubmitting, text: submitLoaderText }}
-      history={props.history}
+      // history={props.history}
     />
   );
 }

--- a/client/src/project/datasets/delete/DeleteDataset.tsx
+++ b/client/src/project/datasets/delete/DeleteDataset.tsx
@@ -17,7 +17,6 @@
  */
 
 import { useEffect, useState } from "react";
-// import { useHistory } from "react-router";
 import { useNavigate } from "react-router-dom-v5-compat";
 import {
   Button,
@@ -109,7 +108,6 @@ type DatasetDeleteModalProps = {
   closeModal: () => void;
   dataset: DeleteDatasetProps["dataset"];
   deleteDataset: () => void;
-  // history: DeleteDatasetProps["history"];
   modalOpen: DeleteDatasetProps["modalOpen"];
   serverErrors: CoreErrorContent | string | undefined;
   submitLoader: { isSubmitting: boolean; text: string | undefined };
@@ -142,7 +140,6 @@ export type DeleteDatasetSuccessResponse = {
 
 export interface DeleteDatasetProps extends CoreVersionUrl {
   dataset: DatasetCore;
-  // history: ReturnType<typeof useHistory>;
   externalUrl: string;
   onCancel: () => void;
   modalOpen: boolean;
@@ -169,33 +166,24 @@ function DeleteDataset(props: DeleteDatasetProps) {
   });
 
   // handle deleting dataset
-  useEffect(
-    () => {
-      if (deleteDatasetStatus.error && "data" in deleteDatasetStatus.error) {
-        const errorResponse = deleteDatasetStatus.error
-          .data as CoreErrorResponse;
-        setSubmitting(false);
-        setServerErrors(errorResponse.error);
-      } else if (deleteDatasetStatus.error) {
-        // ? This cases is unlikely to happen with the current implementation of renku-core
-        setSubmitting(false);
-        const errorMessage =
-          "There was an unexpected problem deleting the dataset: " +
-          deleteDatasetStatus.error.toString();
-        setServerErrors(errorMessage);
-      } else if (deleteDatasetStatus.isSuccess) {
-        setSubmitting(false);
-        setSubmitLoaderText("Dataset deleted, you will be redirected soon...");
-        // props.history.push({
-        //   pathname: projectDatasetsUrl,
-        //   state: { reload: true },
-        // });
-        navigate({ pathname: projectDatasetsUrl }, { state: { reload: true } });
-      }
-    },
-    [deleteDatasetStatus, navigate, projectDatasetsUrl]
-    // [deleteDatasetStatus, props.history, projectDatasetsUrl]
-  );
+  useEffect(() => {
+    if (deleteDatasetStatus.error && "data" in deleteDatasetStatus.error) {
+      const errorResponse = deleteDatasetStatus.error.data as CoreErrorResponse;
+      setSubmitting(false);
+      setServerErrors(errorResponse.error);
+    } else if (deleteDatasetStatus.error) {
+      // ? This cases is unlikely to happen with the current implementation of renku-core
+      setSubmitting(false);
+      const errorMessage =
+        "There was an unexpected problem deleting the dataset: " +
+        deleteDatasetStatus.error.toString();
+      setServerErrors(errorMessage);
+    } else if (deleteDatasetStatus.isSuccess) {
+      setSubmitting(false);
+      setSubmitLoaderText("Dataset deleted, you will be redirected soon...");
+      navigate({ pathname: projectDatasetsUrl }, { state: { reload: true } });
+    }
+  }, [deleteDatasetStatus, navigate, projectDatasetsUrl]);
 
   const localDeleteDataset = () => {
     setSubmitting(true);
@@ -225,7 +213,6 @@ function DeleteDataset(props: DeleteDatasetProps) {
       deleteDataset={localDeleteDataset}
       serverErrors={serverErrors}
       submitLoader={{ isSubmitting, text: submitLoaderText }}
-      // history={props.history}
     />
   );
 }

--- a/client/src/project/datasets/import/DatasetImport.tsx
+++ b/client/src/project/datasets/import/DatasetImport.tsx
@@ -27,7 +27,7 @@ import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React, { useState } from "react";
 import { SubmitHandler, useForm } from "react-hook-form";
-import { useHistory } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom-v5-compat";
 import { Alert, Button, Col, UncontrolledAlert } from "reactstrap";
 
 import { ACCESS_LEVELS } from "../../../api-client";
@@ -300,14 +300,13 @@ async function importDatasetAndWaitForResult({
 function DatasetImportContainer(
   props: DatasetImportProps & { branch: string; versionUrl: string }
 ) {
-  const {
-    externalUrl,
-    fetchDatasets,
-    history,
-    projectPathWithNamespace,
-    versionUrl,
-  } = props;
-  const formLocation = props.location.pathname + "/import";
+  const { externalUrl, fetchDatasets, projectPathWithNamespace, versionUrl } =
+    props;
+
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const formLocation = location.pathname + "/import";
   const [submitLoader, setSubmitLoader] = useState<
     DatasetImportFormProps["submitLoader"]
   >({ value: false, text: "Please wait..." });
@@ -315,19 +314,15 @@ function DatasetImportContainer(
   const [serverErrors, setServerErrors] = useState<string | undefined>();
 
   const onCancel = React.useCallback(() => {
-    history.push({
-      pathname: `/projects/${projectPathWithNamespace}/datasets`,
-    });
-  }, [history, projectPathWithNamespace]);
+    navigate(`/projects/${projectPathWithNamespace}/datasets`);
+  }, [navigate, projectPathWithNamespace]);
 
   const redirectUser = React.useCallback(() => {
     fetchDatasets(true, versionUrl);
-    history.push({
-      //we should do the redirect to the new dataset
-      //but for this we need the dataset name in the response of the dataset.import operation :(
-      pathname: `/projects/${projectPathWithNamespace}/datasets`,
-    });
-  }, [history, projectPathWithNamespace, fetchDatasets, versionUrl]);
+    //we should do the redirect to the new dataset
+    //but for this we need the dataset name in the response of the dataset.import operation :(
+    navigate(`/projects/${projectPathWithNamespace}/datasets`);
+  }, [fetchDatasets, navigate, projectPathWithNamespace, versionUrl]);
 
   const client = props.client;
   const submitCallback = React.useCallback(
@@ -402,9 +397,7 @@ type DatasetImportProps = {
   client: DatasetImportClient;
   externalUrl: string;
   fetchDatasets: (force: boolean, versionUrl: string) => void;
-  history: ReturnType<typeof useHistory>;
   projectPathWithNamespace: string;
-  location: { pathname: string };
   toggleNewDataset: DatasetImportFormProps["toggleNewDataset"];
 };
 function DatasetImport(props: DatasetImportProps) {


### PR DESCRIPTION
Setup CompatRoute for dataset routes.

* `/projects/<project>/datasets/*`

See:
* #3028
* #3041
* #3151

/deploy