### PR TITLE
fix: cleanup the project and group settings pages

### DIFF
--- a/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/ProjectSessionSecrets.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/ProjectSessionSecrets.tsx
@@ -123,15 +123,10 @@ export default function ProjectSessionSecrets() {
             />
           </div>
         </div>
-        <p className="mb-1">
+        <p className="mb-0">
           Use session secrets to connect to resources from inside a session that
           require a password or credential.
         </p>
-        <p className="mb-0">
-          Session secrets will be mounted at the following location:
-        </p>
-        <SecretsMountDirectoryComponent />
-
         {!userLogged && (
           <InfoAlert
             className={cx("mt-3", "mb-0")}
@@ -144,7 +139,14 @@ export default function ProjectSessionSecrets() {
           </InfoAlert>
         )}
       </CardHeader>
-      <CardBody className={cx(sessionSecretSlots?.length == 0 && "pb-0")}>
+      <CardBody>
+        <div className={cx(sessionSecretSlots?.length !== 0 && "mb-3")}>
+          <p className="mb-1">
+            Session secrets will be mounted at the following location:
+          </p>
+          <SecretsMountDirectoryComponent />
+        </div>
+
         {content}
       </CardBody>
     </Card>

--- a/client/src/features/ProjectPageV2/ProjectPageContent/Settings/ProjectDelete.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/Settings/ProjectDelete.tsx
@@ -72,13 +72,10 @@ export default function ProjectPageDelete({ project }: ProjectDeleteProps) {
   return (
     <Card id="delete">
       <CardHeader>
-        <h4>
+        <h4 className="mb-0">
           <Trash className={cx("me-1", "bi")} />
           Delete project
         </h4>
-        <p className="m-0">
-          Deleting the project will remove its repository and session launchers.
-        </p>
       </CardHeader>
       <CardBody>
         <p className="fw-bold">Are you sure you want to delete this project?</p>

--- a/client/src/features/ProjectPageV2/ProjectPageContent/Settings/ProjectDelete.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/Settings/ProjectDelete.tsx
@@ -82,11 +82,12 @@ export default function ProjectPageDelete({ project }: ProjectDeleteProps) {
       </CardHeader>
       <CardBody>
         <p className="fw-bold">Are you sure you want to delete this project?</p>
-        <p>
-          Deleted projects cannot be restored. Please type{" "}
-          <strong>{project.slug}</strong>, the slug of the project, to confirm.
-        </p>
         <div className="mb-3">
+          <p className="mb-2">
+            Deleted projects cannot be restored. Please type{" "}
+            <strong>{project.slug}</strong>, the slug of the project, to
+            confirm.
+          </p>
           <Input
             data-cy="delete-confirmation-input"
             value={typedName}

--- a/client/src/features/ProjectPageV2/ProjectPageContent/Settings/ProjectSettings.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/Settings/ProjectSettings.tsx
@@ -439,33 +439,13 @@ function ProjectSettingsForm({ project }: ProjectPageSettingsProps) {
 }
 
 function ProjectSettingsMetadata({ project }: ProjectPageSettingsProps) {
-  const permissions = useProjectPermissions({ projectId: project.id });
-
   return (
     <Card id="general">
       <CardHeader>
-        <PermissionsGuard
-          disabled={
-            <h4 className="m-0">
-              <Sliders className={cx("me-1", "bi")} />
-              General settings
-            </h4>
-          }
-          enabled={
-            <>
-              <h4>
-                <Sliders className={cx("me-1", "bi")} />
-                General settings
-              </h4>
-              <p className="m-0">
-                Update your project title, description, visibility and
-                namespace.
-              </p>
-            </>
-          }
-          requestedPermission="delete"
-          userPermissions={permissions}
-        />
+        <h4 className="m-0">
+          <Sliders className={cx("me-1", "bi")} />
+          General settings
+        </h4>
       </CardHeader>
       <CardBody>
         <ProjectSettingsForm project={project} />

--- a/client/src/features/ProjectPageV2/ProjectPageContent/Settings/ProjectSettings.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/Settings/ProjectSettings.tsx
@@ -73,11 +73,29 @@ function notificationProjectUpdated(
   );
 }
 
+function ProjectReadOnlyNameField({ name }: { name: string }) {
+  return (
+    <div>
+      <Label className="form-label" for="project-name">
+        Name
+      </Label>
+      <Input
+        className="form-control"
+        id="project-name"
+        type="text"
+        value={name}
+        disabled={true}
+        readOnly
+      />
+    </div>
+  );
+}
+
 function ProjectReadOnlyNamespaceField({ namespace }: { namespace: string }) {
   return (
     <div>
       <Label className="form-label" for="project-namespace">
-        Namespace
+        Owner
       </Label>
       <Input
         className="form-control"
@@ -113,7 +131,55 @@ function ProjectReadOnlyVisibilityField({
   );
 }
 
-function ProjectSettingsEditForm({ project }: ProjectPageSettingsProps) {
+function ProjectReadOnlyDescriptionFiled({
+  description,
+}: {
+  description: string;
+}) {
+  return (
+    <div>
+      <Label className="form-label" for="project-description">
+        Description
+      </Label>
+      <Input
+        className="form-control"
+        id="project-description"
+        type="textarea"
+        value={description}
+        disabled={true}
+        readOnly
+      />
+    </div>
+  );
+}
+
+function ProjectReadOnlyTemplateField({ isTemplate }: { isTemplate: boolean }) {
+  return (
+    <div>
+      <Label className="form-label" for="project-template">
+        Template
+      </Label>
+      <div className={cx("d-flex", "flex-row gap-4")}>
+        <FormGroup switch>
+          <Input
+            className="form-control"
+            type="checkbox"
+            role="switch"
+            id="project-template"
+            disabled={true}
+            checked={isTemplate}
+          />
+          <Label for="project-template" check>
+            <Diagram3Fill className={cx("bi", "me-1")} />
+            Template Project
+          </Label>
+        </FormGroup>
+      </div>
+    </div>
+  );
+}
+
+function ProjectSettingsForm({ project }: ProjectPageSettingsProps) {
   const permissions = useProjectPermissions({ projectId: project.id });
   const {
     control,
@@ -204,7 +270,18 @@ function ProjectSettingsEditForm({ project }: ProjectPageSettingsProps) {
         noValidate
         onSubmit={handleSubmit(onSubmit)}
       >
-        <ProjectNameFormField name="name" control={control} errors={errors} />
+        <PermissionsGuard
+          disabled={<ProjectReadOnlyNameField name={project.name} />}
+          enabled={
+            <ProjectNameFormField
+              name="name"
+              control={control}
+              errors={errors}
+            />
+          }
+          requestedPermission="write"
+          userPermissions={permissions}
+        />
 
         <PermissionsGuard
           disabled={
@@ -219,7 +296,7 @@ function ProjectSettingsEditForm({ project }: ProjectPageSettingsProps) {
               errors={errors}
             />
           }
-          requestedPermission="delete"
+          requestedPermission="write"
           userPermissions={permissions}
         />
         {currentNamespace !== project.namespace && (
@@ -245,138 +322,117 @@ function ProjectSettingsEditForm({ project }: ProjectPageSettingsProps) {
               errors={errors}
             />
           }
-          requestedPermission="delete"
+          requestedPermission="write"
           userPermissions={permissions}
         />
 
-        <ProjectDescriptionFormField
-          name="description"
-          control={control}
-          errors={errors}
+        <PermissionsGuard
+          disabled={
+            <ProjectReadOnlyDescriptionFiled
+              description={project.description ?? ""}
+            />
+          }
+          enabled={
+            <ProjectDescriptionFormField
+              name="description"
+              control={control}
+              errors={errors}
+            />
+          }
+          requestedPermission="write"
+          userPermissions={permissions}
         />
 
-        <KeywordsInput
-          hasError={errors.keywords != null}
-          help="Keywords are used to describe the project. To add one, type a keyword and press enter."
-          label="Keywords"
-          name="keywords"
-          register={register("keywords", {
-            validate: () => !areKeywordsDirty,
-          })}
-          setDirty={setKeywordsDirty}
-          value={project.keywords as string[]}
-        />
-        <div className="mb-3">
-          <div className="form-label">Template</div>
-          <Controller
-            aria-describedby="projectTemplateHelp"
-            control={control}
-            name={"is_template"}
-            render={({ field }) => {
-              const { value, ...props } = field;
-              return (
-                <div className={cx("d-flex", "flex-row gap-4")}>
-                  <FormGroup switch>
-                    <Input
-                      type="checkbox"
-                      role="switch"
-                      className={cx(errors.is_template && "is-invalid")}
-                      data-cy="project-template"
-                      id="project-template"
-                      {...props}
-                      checked={value}
-                    />
-                    <Label
-                      for="project-template"
-                      className="cursor-pointer"
-                      check
-                    >
-                      <Diagram3Fill className={cx("bi", "me-1")} />
-                      Mark this project as a template
-                    </Label>
-                  </FormGroup>
-                </div>
-              );
-            }}
-          />
-          <FormText id="projectTemplateHelp" className="input-hint">
-            Make this a template project to indicate to viewers that this
-            project should be copied before being used.
-          </FormText>
-        </div>
-
-        <div className={cx("d-flex", "justify-content-end")}>
-          <Button
-            color="primary"
-            disabled={isUpdating || !isDirty}
-            type="submit"
-          >
-            {isUpdating ? (
-              <Loader className="me-1" inline size={16} />
-            ) : (
-              <Pencil className={cx("bi", "me-1")} />
-            )}
-            Update project
-          </Button>
-        </div>
-      </Form>
-    </div>
-  );
-}
-
-function ProjectSettingsDisplay({ project }: ProjectPageSettingsProps) {
-  const onSubmit = () => {};
-
-  return (
-    <div>
-      <Form className="form-rk-green" noValidate onSubmit={onSubmit}>
-        <div className="mb-3">
-          <Label className="form-label" for="project-name">
-            Name
-          </Label>
-          <Input
-            className="form-control"
-            id="project-name"
-            type="text"
-            value={project.name}
-            disabled={true}
-            readOnly
-          />
-        </div>
-        <ProjectReadOnlyNamespaceField namespace={project.namespace} />
-        <div className="mb-3">
-          <Label className="form-label" for="project-description">
-            Description
-          </Label>
-          <Input
-            className="form-control"
-            id="project-description"
-            type="textarea"
-            value={project.description}
-            disabled={true}
-            readOnly
-          />
-        </div>
-        <ProjectReadOnlyVisibilityField visibility={project.visibility} />
-        <div className="mb-3">
-          <div className="form-label">Template</div>
-          <div className={cx("d-flex", "flex-row gap-4")}>
-            <FormGroup switch>
-              <Input
-                className="form-control"
-                type="checkbox"
-                role="switch"
-                id="project-template"
-                disabled={true}
-                checked={project.is_template}
+        <PermissionsGuard
+          disabled={
+            <ProjectReadOnlyTemplateField
+              isTemplate={project.is_template ?? false}
+            />
+          }
+          enabled={
+            <div>
+              <div className="form-label">Template</div>
+              <Controller
+                aria-describedby="projectTemplateHelp"
+                control={control}
+                name={"is_template"}
+                render={({ field }) => {
+                  const { value, ...props } = field;
+                  return (
+                    <div className={cx("d-flex", "flex-row gap-4")}>
+                      <FormGroup switch>
+                        <Input
+                          type="checkbox"
+                          role="switch"
+                          className={cx(errors.is_template && "is-invalid")}
+                          data-cy="project-template"
+                          id="project-template"
+                          {...props}
+                          checked={value}
+                        />
+                        <Label
+                          for="project-template"
+                          className="cursor-pointer"
+                          check
+                        >
+                          <Diagram3Fill className={cx("bi", "me-1")} />
+                          Mark this project as a template
+                        </Label>
+                      </FormGroup>
+                    </div>
+                  );
+                }}
               />
-              <Label for="project-template" check>
-                <Diagram3Fill className={cx("bi", "me-1")} />
-                Template Project
-              </Label>
-            </FormGroup>
-          </div>
-        </div>
+              <FormText id="projectTemplateHelp" className="input-hint">
+                Make this a template project to indicate to viewers that this
+                project should be copied before being used.
+              </FormText>
+            </div>
+          }
+          requestedPermission="write"
+          userPermissions={permissions}
+        />
+
+        <PermissionsGuard
+          disabled={null}
+          enabled={
+            <KeywordsInput
+              hasError={errors.keywords != null}
+              help="Keywords are used to describe the project. To add one, type a keyword and press enter."
+              label="Keywords"
+              name="keywords"
+              register={register("keywords", {
+                validate: () => !areKeywordsDirty,
+              })}
+              setDirty={setKeywordsDirty}
+              value={project.keywords as string[]}
+            />
+          }
+          requestedPermission="write"
+          userPermissions={permissions}
+        />
+
+        <PermissionsGuard
+          disabled={null}
+          enabled={
+            <div className={cx("d-flex", "justify-content-end")}>
+              <Button
+                color="primary"
+                disabled={isUpdating || !isDirty}
+                type="submit"
+              >
+                {isUpdating ? (
+                  <Loader className="me-1" inline size={16} />
+                ) : (
+                  <Pencil className={cx("bi", "me-1")} />
+                )}
+                Update project
+              </Button>
+            </div>
+          }
+          requestedPermission="write"
+          userPermissions={permissions}
+        />
       </Form>
     </div>
   );
@@ -412,12 +468,7 @@ function ProjectSettingsMetadata({ project }: ProjectPageSettingsProps) {
         />
       </CardHeader>
       <CardBody>
-        <PermissionsGuard
-          disabled={<ProjectSettingsDisplay project={project} />}
-          enabled={<ProjectSettingsEditForm project={project} />}
-          requestedPermission="write"
-          userPermissions={permissions}
-        />
+        <ProjectSettingsForm project={project} />
       </CardBody>
     </Card>
   );

--- a/client/src/features/ProjectPageV2/ProjectPageContent/Settings/ProjectSettingsMembers.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/Settings/ProjectSettingsMembers.tsx
@@ -328,7 +328,7 @@ export default function ProjectPageSettingsMembers({
             enabled={
               <Button
                 color="outline-primary"
-                data-cy="group-add-member"
+                data-cy="project-add-member"
                 onClick={toggleAddMemberModalOpen}
                 size="sm"
               >

--- a/client/src/features/groupsV2/settings/GroupSettingsMembers.tsx
+++ b/client/src/features/groupsV2/settings/GroupSettingsMembers.tsx
@@ -87,7 +87,7 @@ export default function GroupSettingsMembers({
   return (
     <>
       <CardHeader>
-        <div className={cx("d-flex", "gap-2", "mb-3")}>
+        <div className={cx("d-flex", "gap-2")}>
           <h4>
             <PersonGear className={cx("me-1", "bi")} />
             Group Members

--- a/client/src/features/groupsV2/settings/GroupSettingsMetadata.tsx
+++ b/client/src/features/groupsV2/settings/GroupSettingsMetadata.tsx
@@ -183,7 +183,11 @@ export default function GroupMetadataForm({ group }: GroupMetadataFormProps) {
         <RtkOrNotebooksError error={updateGroupResult.error} />
       )}
       <GroupDeleteConfirmation isOpen={isOpen} group={group} toggle={toggle} />
-      <Form noValidate onSubmit={handleSubmit(onSubmit)}>
+      <Form
+        className={cx("d-flex", "flex-column", "gap-3")}
+        noValidate
+        onSubmit={handleSubmit(onSubmit)}
+      >
         <PermissionsGuard
           disabled={<GroupReadOnlyField title="Name" value={group.name} />}
           enabled={
@@ -294,7 +298,7 @@ function GroupReadOnlyField({
   value: string;
 }) {
   return (
-    <div className="mb-3">
+    <div>
       <Label className="form-label" for={`group-${title}`}>
         {title}
       </Label>

--- a/tests/cypress/e2e/projectV2.spec.ts
+++ b/tests/cypress/e2e/projectV2.spec.ts
@@ -370,11 +370,11 @@ describe("Edit v2 project", () => {
       .readProjectV2()
       .patchProjectV2Member({ memberId: projectMemberToEdit });
     cy.visit("/v2/projects/user1-uuid/test-2-v2-project/settings#members");
-    cy.contains("Members of the project").should("be.visible");
+    cy.contains("Project Members").should("be.visible");
     cy.wait("@readProjectV2");
     cy.getDataCy("project-member-edit-0").should("be.enabled");
     cy.getDataCy("project-member-edit-1").should("be.enabled");
-    cy.getDataCy("project-member-edit-1").should("be.visible").click();
+    cy.getDataCy("project-member-edit-0").should("be.visible").click();
     cy.getDataCy("member-role").select("Viewer");
     fixtures.listProjectV2Members({
       fixture: "projectV2/list-projectV2-members-many.json",

--- a/tests/cypress/e2e/projectV2.spec.ts
+++ b/tests/cypress/e2e/projectV2.spec.ts
@@ -266,7 +266,7 @@ describe("Edit v2 project", () => {
     const projectMemberToRemove = "user3-uuid";
     fixtures.listProjectV2Members().readProjectV2();
     cy.visit("/v2/projects/user1-uuid/test-2-v2-project/settings#members");
-    cy.contains("Members of the project").should("be.visible");
+    cy.contains("Project Members").should("be.visible");
     cy.wait("@readProjectV2");
     cy.contains("@user3").should("be.visible");
     fixtures
@@ -278,7 +278,6 @@ describe("Edit v2 project", () => {
     cy.getDataCy("project-member-actions-1").contains("Remove").click();
     cy.getDataCy("remove-member-form").should("be.visible");
     cy.contains("Remove member").should("be.visible").click();
-    cy.getDataCy("remove-member-form").should("not.be.visible");
     cy.contains("@user3").should("not.exist");
   });
 
@@ -288,7 +287,7 @@ describe("Edit v2 project", () => {
       .searchV2ListProjects({ numberOfProjects: 0, numberOfUsers: 5 })
       .readProjectV2();
     cy.visit("/v2/projects/user1-uuid/test-2-v2-project/settings#members");
-    cy.contains("Members of the project").should("be.visible");
+    cy.contains("Project Members").should("be.visible");
     cy.wait("@readProjectV2");
     cy.contains("user 1").should("be.visible");
 
@@ -314,7 +313,7 @@ describe("Edit v2 project", () => {
       .searchV2ListProjects({ numberOfProjects: 0, numberOfUsers: 5 })
       .readProjectV2();
     cy.visit("/v2/projects/user1-uuid/test-2-v2-project/settings#members");
-    cy.contains("Members of the project").should("be.visible");
+    cy.contains("Project Members").should("be.visible");
     cy.wait("@readProjectV2");
     cy.contains("user1").should("be.visible");
 
@@ -331,10 +330,10 @@ describe("Edit v2 project", () => {
       .readProjectV2()
       .patchProjectV2Member({ memberId: projectMemberToEdit });
     cy.visit("/v2/projects/user1-uuid/test-2-v2-project/settings#members");
-    cy.contains("Members of the project").should("be.visible");
+    cy.contains("Project Members").should("be.visible");
     cy.wait("@readProjectV2");
     cy.contains("@user3").should("be.visible");
-    cy.getDataCy("project-member-edit-1").should("be.visible").click();
+    cy.getDataCy("project-member-edit-2").should("be.visible").click();
     cy.getDataCy("member-role").select("Viewer");
     fixtures.listProjectV2Members({
       removeMemberId: projectMemberToEdit,
@@ -356,7 +355,7 @@ describe("Edit v2 project", () => {
       .readProjectV2()
       .patchProjectV2Member({ memberId: projectMemberToEdit });
     cy.visit("/v2/projects/user1-uuid/test-2-v2-project/settings#members");
-    cy.contains("Members of the project").should("be.visible");
+    cy.contains("Project Members").should("be.visible");
     cy.wait("@readProjectV2");
     cy.contains("user 1").should("be.visible");
     cy.getDataCy("project-member-edit-0").should("be.disabled");
@@ -465,7 +464,7 @@ describe("Editor cannot maintain members", () => {
     cy.get("a[title='Settings']").click();
     cy.getDataCy("project-member-edit-2").should("not.exist");
     // TODO: can edit self
-    cy.getDataCy("project-member-remove-1").should("be.enabled");
+    cy.getDataCy("project-member-remove-2").should("be.enabled");
   });
 });
 


### PR DESCRIPTION
There were a few glitches and inconsistencies on those pages found while addressing https://github.com/SwissDataScienceCenter/renku-ui/issues/3460. I decided to separate them into this PR to simplify the review process.

This cleanup includes:

- Adjusting spacing and visualizations.
- Update the visualization for users without permissions and remove redundant PermissionsGuard elements.
  - ![Screenshot_20250107_163913](https://github.com/user-attachments/assets/fa299980-7a8c-4393-8f0b-22dfbb1201bc)

- Remove card's subtitles and reuse the same solution for members to keep consistency across the pages.
  - ![image](https://github.com/user-attachments/assets/dc3a7846-d6b5-4e0e-b5c0-5b51229156a9)
  - ![image](https://github.com/user-attachments/assets/3ab00254-2e10-4501-a8d4-851e194df9ec)

/deploy
