### PR TITLE
test: use port 3001 instead of 3000 for Cypress

### DIFF
--- a/.github/workflows/test-and-ci.yml
+++ b/.github/workflows/test-and-ci.yml
@@ -123,7 +123,7 @@ jobs:
         with:
           browser: chrome
           start: npm run client:preview
-          wait-on: http://localhost:3000/
+          wait-on: http://localhost:3001/
           wait-on-timeout: 300
           working-directory: tests
       - uses: actions/upload-artifact@v4

--- a/tests/cypress.config.ts
+++ b/tests/cypress.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "cypress";
 
 export default defineConfig({
   e2e: {
-    baseUrl: "http://localhost:3000",
+    baseUrl: "http://localhost:3001",
     specPattern: "cypress/e2e/**/*.{js,jsx,ts,tsx}",
   },
   retries: {

--- a/tests/package.json
+++ b/tests/package.json
@@ -6,17 +6,17 @@
   "scripts": {
     "cypress": "cypress open --e2e --browser=chrome --config-file cypress.config.ts",
     "cypress:headless": "cypress run --e2e --browser=chrome --headless --config-file cypress.config.ts --spec '**/*'",
-    "e2e": "start-server-and-test start http://localhost:3000 cypress",
-    "e2e:headless": "start-server-and-test start http://localhost:3000 cypress:headless",
+    "e2e": "start-server-and-test start http://localhost:3001 cypress",
+    "e2e:headless": "start-server-and-test start http://localhost:3001 cypress:headless",
     "lint": "eslint --max-warnings=0 cypress/",
     "format": "prettier -w .",
     "format-check": "prettier -c .",
     "format-changed": "pretty-quick --pattern \"tests/**/*.*\"",
     "format-commit": "pretty-quick --staged --pattern \"tests/**/*.*\"",
-    "start": "npm --prefix ../client run start:strict-port",
+    "start": "npm --prefix ../client run start:strict-port -- --port=3001",
     "client:install": "npm --prefix ../client clean-install",
     "client:build": "npm --prefix ../client run build",
-    "client:preview": "npm --prefix ../client run preview"
+    "client:preview": "npm --prefix ../client run preview -- --port=3001"
   },
   "author": "Swiss Data Science Center",
   "devDependencies": {


### PR DESCRIPTION
Currently, we use the same default port for both Cypress and telepresence. There is nothing wrong with that, but it makes running both at the same time a little more tricky.

This PR switches to using a different port for Cypress (3001 instead of 3000)

/deploy
