### PR TITLE
feat: set styles for new routing

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -32,32 +32,26 @@ import { CompatRoute } from "react-router-dom-v5-compat";
 import { ToastContainer } from "react-toastify";
 
 import { LoginHelper } from "./authentication";
-import { DashboardBanner } from "./components/earlyAccessBanner/EarlyAccessBanner";
 import { Loader } from "./components/Loader";
 import LazyDatasetAddToProject from "./dataset/addtoproject/LazyDatasetAddToProject";
 import { DatasetCoordinator } from "./dataset/Dataset.state";
 import LazyShowDataset from "./dataset/LazyShowDataset";
 import LazyAdminPage from "./features/admin/LazyAdminPage";
-import LazyDashboard from "./features/dashboard/LazyDashboard";
+import LazyDashboardV2 from "./features/dashboardV2/LazyDashboardV2";
 import { Favicon } from "./features/favicon/Favicon";
-import LazyInactiveKGProjectsPage from "./features/inactiveKgProjects/LazyInactiveKGProjectsPage";
-import LazySearchPage from "./features/kgSearch/LazySearchPage";
 import { Unavailable } from "./features/maintenance/Maintenance";
+import LazyRootV1 from "./features/rootV1/LazyRootV1";
 import LazyRootV2 from "./features/rootV2/LazyRootV2";
-import LazySecrets from "./features/secrets/LazySecrets";
 import LazyAnonymousSessionsList from "./features/session/components/LazyAnonymousSessionsList";
 import { useGetUserQuery } from "./features/usersV2/api/users.api";
-import LazyHelp from "./help/LazyHelp";
 import LazyAnonymousHome from "./landing/LazyAnonymousHome";
 import { FooterNavbar, RenkuNavBar } from "./landing/NavBar";
 import LazyNotFound from "./not-found/LazyNotFound";
-import LazyNotificationsPage from "./notifications/LazyNotificationsPage";
 import NotificationsManager from "./notifications/NotificationsManager";
 import Cookie from "./privacy/Cookie";
 import LazyProjectView from "./project/LazyProjectView";
 import LazyProjectList from "./project/list/LazyProjectList";
 import LazyNewProject from "./project/new/LazyNewProject";
-import LazyStyleGuide from "./styleguide/LazyStyleGuide";
 import AppContext from "./utils/context/appContext";
 import useLegacySelector from "./utils/customHooks/useLegacySelector.hook";
 import { Url } from "./utils/helpers/url";
@@ -74,142 +68,96 @@ export const ContainerWrap = ({ children, fullSize = false }) => {
 };
 
 function CentralContentContainer(props) {
-  const { coreApiVersionedUrlConfig, notifications, socket, user } = props;
+  const { notifications, socket, user } = props;
 
   const { data: userInfo } = useGetUserQuery(
     props.user.logged ? undefined : skipToken
   );
-
-  const appContext = {
-    client: props.client,
-    coreApiVersionedUrlConfig,
-    location: props.location,
-    model: props.model,
-    notifications,
-    params: props.params,
-    webSocket: socket,
-  };
 
   // check anonymous sessions settings
   const blockAnonymous = !user.logged && !props.params["ANONYMOUS_SESSIONS"];
 
   return (
     <div className="d-flex flex-grow-1">
-      <AppContext.Provider value={appContext}>
-        <Helmet>
-          <title>Reproducible Data Science | Open Research | Renku</title>
-        </Helmet>
-        <Switch>
-          <CompatRoute exact path="/">
-            {props.user.logged ? (
-              <ContainerWrap>
-                <LazyDashboard />
-              </ContainerWrap>
-            ) : (
-              <div className="w-100">
-                <LazyAnonymousHome />
-              </div>
-            )}
-          </CompatRoute>
-          <CompatRoute path="/help">
-            <ContainerWrap>
-              <LazyHelp />
+      <Helmet>
+        <title>Reproducible Data Science | Open Research | Renku</title>
+      </Helmet>
+      <Switch>
+        <CompatRoute exact path="/">
+          {props.user.logged ? (
+            <ContainerWrap fullSize={true}>
+              <LazyDashboardV2 />
             </ContainerWrap>
-          </CompatRoute>
-          <CompatRoute path="/search">
-            <ContainerWrap>
-              <LazySearchPage />
-            </ContainerWrap>
-          </CompatRoute>
-          <CompatRoute path="/inactive-kg-projects">
-            {props.user.logged ? (
-              <ContainerWrap>
-                <LazyInactiveKGProjectsPage />
-              </ContainerWrap>
-            ) : (
-              <LazyNotFound />
-            )}
-          </CompatRoute>
-          {["/projects", "/projects/starred", "/projects/all"].map((path) => (
-            <CompatRoute key={path} exact path={path}>
-              <ContainerWrap>
-                <LazyProjectList />
-              </ContainerWrap>
-            </CompatRoute>
-          ))}
-          <CompatRoute exact path="/projects/new">
-            <ContainerWrap>
-              <LazyNewProject />
-            </ContainerWrap>
-          </CompatRoute>
-          <Route path="/projects/:subUrl+">
-            <LazyProjectView
-              client={props.client}
-              params={props.params}
-              model={props.model}
-              user={props.user}
-              blockAnonymous={blockAnonymous}
-              notifications={notifications}
-              socket={socket}
-            />
-          </Route>
-          <Route exact path={Url.get(Url.pages.sessions)}>
-            {!user.logged ? <LazyAnonymousSessionsList /> : <Redirect to="/" />}
-          </Route>
-          <Route path="/datasets/:identifier/add">
-            <LazyDatasetAddToProject
-              insideProject={false}
-              model={props.model}
-            />
-          </Route>
-          <CompatRoute path="/datasets/:identifier">
-            <LazyShowDataset
-              insideProject={false}
-              client={props.client}
-              projectsUrl="/projects"
-              datasetCoordinator={
-                new DatasetCoordinator(
-                  props.client,
-                  props.model.subModel("dataset")
-                )
-              }
-              logged={props.user.logged}
-              model={props.model}
-            />
-          </CompatRoute>
-          <CompatRoute path="/datasets">
-            <Redirect to="/search?type=dataset" />
-          </CompatRoute>
-          <CompatRoute path="/notifications">
-            <ContainerWrap>
-              <LazyNotificationsPage />
-            </ContainerWrap>
-          </CompatRoute>
-          <CompatRoute path="/v2">
-            <LazyRootV2 />
-          </CompatRoute>
-          <CompatRoute path="/style-guide">
-            <ContainerWrap>
-              <LazyStyleGuide />
-            </ContainerWrap>
-          </CompatRoute>
-          {userInfo?.isLoggedIn && userInfo.is_admin && (
-            <CompatRoute path="/admin">
-              <ContainerWrap>
-                <LazyAdminPage />
-              </ContainerWrap>
-            </CompatRoute>
+          ) : (
+            <div className="w-100">
+              <LazyAnonymousHome />
+            </div>
           )}
-          <CompatRoute path="/secrets">
+        </CompatRoute>
+        {["/projects", "/projects/starred", "/projects/all"].map((path) => (
+          <CompatRoute key={path} exact path={path}>
             <ContainerWrap>
-              <LazySecrets />
+              <LazyProjectList />
             </ContainerWrap>
           </CompatRoute>
-          <Route path="/*">
-            <LazyNotFound />
-          </Route>
-        </Switch>
-      </AppContext.Provider>
+        ))}
+        <CompatRoute exact path="/projects/new">
+          <ContainerWrap>
+            <LazyNewProject />
+          </ContainerWrap>
+        </CompatRoute>
+        <Route path="/projects/:subUrl+">
+          <LazyProjectView
+            client={props.client}
+            params={props.params}
+            model={props.model}
+            user={props.user}
+            blockAnonymous={blockAnonymous}
+            notifications={notifications}
+            socket={socket}
+          />
+        </Route>
+        <Route exact path={Url.get(Url.pages.sessions)}>
+          {!user.logged ? <LazyAnonymousSessionsList /> : <Redirect to="/" />}
+        </Route>
+        <Route path="/datasets/:identifier/add">
+          <LazyDatasetAddToProject insideProject={false} model={props.model} />
+        </Route>
+        <CompatRoute path="/datasets/:identifier">
+          <LazyShowDataset
+            insideProject={false}
+            client={props.client}
+            projectsUrl="/projects"
+            datasetCoordinator={
+              new DatasetCoordinator(
+                props.client,
+                props.model.subModel("dataset")
+              )
+            }
+            logged={props.user.logged}
+            model={props.model}
+          />
+        </CompatRoute>
+        <CompatRoute path="/datasets">
+          <Redirect to="/search?type=dataset" />
+        </CompatRoute>
+        <CompatRoute path="/v1">
+          <LazyRootV1 {...props} />
+        </CompatRoute>
+        <CompatRoute path="/v2">
+          <LazyRootV2 />
+        </CompatRoute>
+        {userInfo?.isLoggedIn && userInfo.is_admin && (
+          <CompatRoute path="/admin">
+            <ContainerWrap>
+              <LazyAdminPage />
+            </ContainerWrap>
+          </CompatRoute>
+        )}
+        <Route path="/*">
+          <LazyNotFound />
+        </Route>
+      </Switch>
     </div>
   );
 }
@@ -263,18 +211,29 @@ function App(props) {
       <Unavailable model={props.model} statuspageId={props.statuspageId} />
     );
   }
+  const { coreApiVersionedUrlConfig, socket } = props;
+  const appContext = {
+    client: props.client,
+    coreApiVersionedUrlConfig,
+    location: props.location,
+    model: props.model,
+    notifications,
+    params: props.params,
+    webSocket: socket,
+  };
 
   return (
     <Fragment>
       <Favicon />
-      <RenkuNavBar {...props} notifications={notifications} />
-      <DashboardBanner user={props.user} />
-      <CentralContentContainer
-        notifications={notifications}
-        socket={webSocket}
-        location={location}
-        {...props}
-      />
+      <AppContext.Provider value={appContext}>
+        <RenkuNavBar {...props} notifications={notifications} />
+        <CentralContentContainer
+          notifications={notifications}
+          socket={webSocket}
+          location={location}
+          {...props}
+        />
+      </AppContext.Provider>
       <FooterNavbar params={props.params} />
       <Cookie />
       <ToastContainer />

--- a/client/src/components/navbar/AnonymousNavBar.tsx
+++ b/client/src/components/navbar/AnonymousNavBar.tsx
@@ -55,10 +55,23 @@ export default function AnonymousNavBar({
 
   return (
     <>
-      <header className="navbar navbar-expand-lg navbar-dark rk-navbar p-0">
+      <header
+        className={cx(
+          "navbar",
+          "navbar-expand-lg",
+          "bg-navy",
+          "rk-navbar",
+          "p-0"
+        )}
+      >
         <Navbar
           color="primary"
-          className="container-fluid flex-wrap flex-lg-nowrap renku-container"
+          className={cx(
+            "container",
+            "flex-wrap",
+            "flex-lg-nowrap",
+            "renku-container"
+          )}
         >
           <Link
             id="link-home"

--- a/client/src/components/navbar/AnonymousNavBar.tsx
+++ b/client/src/components/navbar/AnonymousNavBar.tsx
@@ -17,14 +17,15 @@
  */
 
 import cx from "classnames";
-import { useCallback, useState } from "react";
+import { useCallback, useContext, useState } from "react";
 import { List, Search } from "react-bootstrap-icons";
 import { Link } from "react-router-dom";
 import { Collapse, Nav, NavItem, Navbar, NavbarToggler } from "reactstrap";
 
 import StatusBanner from "../../features/platform/components/StatusBanner";
 import { NavBarWarnings } from "../../landing/NavBarWarnings";
-import type { AppParams } from "../../utils/context/appParams.types";
+import { ABSOLUTE_ROUTES } from "../../routing/routes.constants";
+import AppContext from "../../utils/context/appContext";
 import { Url } from "../../utils/helpers/url";
 import { RenkuNavLink } from "../RenkuNavLink";
 import {
@@ -34,18 +35,9 @@ import {
 } from "./NavBarItems";
 import { RENKU_LOGO } from "./navbar.constans";
 
-interface AnonymousNavBarProps {
-  model: unknown;
-  notifications: unknown;
-  params: AppParams;
-}
-
-export default function AnonymousNavBar({
-  model,
-  notifications,
-  params,
-}: AnonymousNavBarProps) {
-  const uiShortSha = params.UI_SHORT_SHA;
+export default function AnonymousNavBar() {
+  const { params, model, notifications } = useContext(AppContext);
+  const uiShortSha = params?.UI_SHORT_SHA;
 
   const [isOpen, setIsOpen] = useState(false);
 
@@ -96,7 +88,7 @@ export default function AnonymousNavBar({
             >
               <NavItem className="nav-item col-12 col-sm-4 col-lg-auto pe-lg-4">
                 <RenkuNavLink
-                  to={Url.get(Url.pages.search)}
+                  to={ABSOLUTE_ROUTES.v1.search}
                   title="Search"
                   id="link-search"
                   icon={<Search />}
@@ -105,7 +97,7 @@ export default function AnonymousNavBar({
               </NavItem>
               <NavItem className="nav-item col-12 col-sm-4 col-lg-auto pe-lg-4">
                 <RenkuNavLink
-                  to={Url.get(Url.pages.sessions)}
+                  to={ABSOLUTE_ROUTES.v1.sessions}
                   title="Sessions"
                   id="link-sessions"
                 />

--- a/client/src/components/navbar/LoggedInNavBar.tsx
+++ b/client/src/components/navbar/LoggedInNavBar.tsx
@@ -17,15 +17,14 @@
  */
 
 import cx from "classnames";
-import { useCallback, useState } from "react";
+import { useCallback, useContext, useState } from "react";
 import { List, Search } from "react-bootstrap-icons";
 import { Link } from "react-router-dom";
 import { Collapse, Nav, NavItem, Navbar, NavbarToggler } from "reactstrap";
 import StatusBanner from "../../features/platform/components/StatusBanner";
 import { NavBarWarnings } from "../../landing/NavBarWarnings";
-import { ABSOLUTE_ROUTES } from "../../routing/routes.constants.ts";
-import { AppParams } from "../../utils/context/appParams.types";
-import { Url } from "../../utils/helpers/url";
+import { ABSOLUTE_ROUTES } from "../../routing/routes.constants";
+import AppContext from "../../utils/context/appContext";
 import { RenkuNavLink } from "../RenkuNavLink";
 import {
   RenkuToolbarGitLabMenu,
@@ -36,24 +35,14 @@ import {
 } from "./NavBarItems";
 import { RENKU_LOGO } from "./navbar.constans";
 
-interface LoggedInNavBarProps {
-  model: unknown;
-  notifications: unknown;
-  params: AppParams;
-}
-
-export default function LoggedInNavBar({
-  model,
-  notifications,
-  params,
-}: LoggedInNavBarProps) {
-  const uiShortSha = params.UI_SHORT_SHA;
-
+export default function LoggedInNavBar() {
+  const { params, model, notifications } = useContext(AppContext);
   const [isOpen, setIsOpen] = useState(false);
-
   const onToggle = useCallback(() => {
     setIsOpen((isOpen) => !isOpen);
   }, []);
+  if (!params) return null;
+  const uiShortSha = params?.UI_SHORT_SHA;
 
   return (
     <>
@@ -65,7 +54,7 @@ export default function LoggedInNavBar({
           <Link
             id="link-home"
             data-cy="link-home"
-            to={Url.get(Url.pages.landing)}
+            to={ABSOLUTE_ROUTES.v1.root}
             className="navbar-brand me-2 pb-0 pt-0"
           >
             <img src={RENKU_LOGO} alt="Renku" height="50" className="d-block" />
@@ -86,7 +75,7 @@ export default function LoggedInNavBar({
             >
               <NavItem className="nav-item col-12 col-sm-4 col-lg-auto pe-lg-4">
                 <RenkuNavLink
-                  to={Url.get(ABSOLUTE_ROUTES.v1.search)}
+                  to={ABSOLUTE_ROUTES.v1.search}
                   title="Search"
                   id="link-search"
                   icon={<Search />}
@@ -99,7 +88,7 @@ export default function LoggedInNavBar({
                 className="nav-item col-12 col-sm-4 col-lg-auto pe-lg-4"
               >
                 <RenkuNavLink
-                  to={Url.get(ABSOLUTE_ROUTES.v1.root)}
+                  to={ABSOLUTE_ROUTES.v1.root}
                   title="Dashboard"
                   id="link-dashboard"
                 />

--- a/client/src/components/navbar/LoggedInNavBar.tsx
+++ b/client/src/components/navbar/LoggedInNavBar.tsx
@@ -23,6 +23,7 @@ import { Link } from "react-router-dom";
 import { Collapse, Nav, NavItem, Navbar, NavbarToggler } from "reactstrap";
 import StatusBanner from "../../features/platform/components/StatusBanner";
 import { NavBarWarnings } from "../../landing/NavBarWarnings";
+import { ABSOLUTE_ROUTES } from "../../routing/routes.constants.ts";
 import { AppParams } from "../../utils/context/appParams.types";
 import { Url } from "../../utils/helpers/url";
 import { RenkuNavLink } from "../RenkuNavLink";
@@ -85,7 +86,7 @@ export default function LoggedInNavBar({
             >
               <NavItem className="nav-item col-12 col-sm-4 col-lg-auto pe-lg-4">
                 <RenkuNavLink
-                  to={Url.get(Url.pages.search)}
+                  to={Url.get(ABSOLUTE_ROUTES.v1.search)}
                   title="Search"
                   id="link-search"
                   icon={<Search />}
@@ -98,7 +99,7 @@ export default function LoggedInNavBar({
                 className="nav-item col-12 col-sm-4 col-lg-auto pe-lg-4"
               >
                 <RenkuNavLink
-                  to={Url.get(Url.pages.landing)}
+                  to={Url.get(ABSOLUTE_ROUTES.v1.root)}
                   title="Dashboard"
                   id="link-dashboard"
                 />

--- a/client/src/components/navbar/NavBarItems.tsx
+++ b/client/src/components/navbar/NavBarItems.tsx
@@ -44,7 +44,6 @@ import {
   getActiveProjectPathWithNamespace,
   gitLabUrlFromProfileUrl,
 } from "../../utils/helpers/HelperFunctions";
-import { Url } from "../../utils/helpers/url";
 import { ExternalDocsLink, ExternalLink } from "../ExternalLinks";
 import { Loader } from "../Loader";
 import BootstrapGitLabIcon from "../icons/BootstrapGitLabIcon";
@@ -213,7 +212,7 @@ export function RenkuToolbarHelpMenu({ firstItem }: RenkuToolbarHelpMenuProps) {
         aria-labelledby="help-menu"
       >
         <DropdownItem className="p-0">
-          <Link className="dropdown-item" to={Url.get(ABSOLUTE_ROUTES.v1.help)}>
+          <Link className="dropdown-item" to={ABSOLUTE_ROUTES.v1.help}>
             Help
           </Link>
         </DropdownItem>

--- a/client/src/components/navbar/NavBarItems.tsx
+++ b/client/src/components/navbar/NavBarItems.tsx
@@ -212,7 +212,7 @@ export function RenkuToolbarHelpMenu({ firstItem }: RenkuToolbarHelpMenuProps) {
         aria-labelledby="help-menu"
       >
         <DropdownItem className="p-0">
-          <Link className="dropdown-item" to={ABSOLUTE_ROUTES.v1.help}>
+          <Link className="dropdown-item" to={ABSOLUTE_ROUTES.v1.help.root}>
             Help
           </Link>
         </DropdownItem>

--- a/client/src/components/navbar/NavBarItems.tsx
+++ b/client/src/components/navbar/NavBarItems.tsx
@@ -44,6 +44,7 @@ import {
   getActiveProjectPathWithNamespace,
   gitLabUrlFromProfileUrl,
 } from "../../utils/helpers/HelperFunctions";
+import { Url } from "../../utils/helpers/url";
 import { ExternalDocsLink, ExternalLink } from "../ExternalLinks";
 import { Loader } from "../Loader";
 import BootstrapGitLabIcon from "../icons/BootstrapGitLabIcon";
@@ -212,7 +213,7 @@ export function RenkuToolbarHelpMenu({ firstItem }: RenkuToolbarHelpMenuProps) {
         aria-labelledby="help-menu"
       >
         <DropdownItem className="p-0">
-          <Link className="dropdown-item" to="/help">
+          <Link className="dropdown-item" to={Url.get(ABSOLUTE_ROUTES.v1.help)}>
             Help
           </Link>
         </DropdownItem>
@@ -306,7 +307,9 @@ export function RenkuToolbarItemUser({
     );
   }
 
-  const userSecretsUrl = isV2 ? ABSOLUTE_ROUTES.v2.secrets : "/secrets";
+  const userSecretsUrl = isV2
+    ? ABSOLUTE_ROUTES.v2.secrets
+    : ABSOLUTE_ROUTES.v1.secrets;
 
   return (
     <UncontrolledDropdown className={cx("nav-item", "dropdown")}>
@@ -349,7 +352,7 @@ export function RenkuToolbarItemUser({
               Integrations
             </Link>
             <DropdownItem divider />
-            <Link to={ABSOLUTE_ROUTES.root} className="dropdown-item">
+            <Link to={ABSOLUTE_ROUTES.v1.root} className="dropdown-item">
               Back to <span className="fw-bold">Renku 1.0</span>
             </Link>
           </>
@@ -358,7 +361,7 @@ export function RenkuToolbarItemUser({
         {!isV2 && (
           <>
             <DropdownItem divider />
-            <Link to={ABSOLUTE_ROUTES.v2.root} className="dropdown-item">
+            <Link to={ABSOLUTE_ROUTES.root} className="dropdown-item">
               <span className="fw-bold">Renku 2.0</span> Early access
             </Link>
           </>

--- a/client/src/features/rootV1/LazyRootV1.tsx
+++ b/client/src/features/rootV1/LazyRootV1.tsx
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * Copyright 2025 - Swiss Data Science Center (SDSC)
  * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
  * Eidgenössische Technische Hochschule Zürich (ETHZ).
  *
@@ -16,29 +16,26 @@
  * limitations under the License
  */
 
-import cx from "classnames";
-import { BoxArrowInLeft } from "react-bootstrap-icons";
-import { Link } from "react-router-dom-v5-compat";
+import { Suspense, lazy } from "react";
 
-interface BackToV1ButtonProps {
-  outline?: boolean;
-  color?: string;
-}
-export default function BackToV1Button({
-  outline = false,
-  color = "light",
-}: BackToV1ButtonProps) {
+import PageLoader from "../../components/PageLoader";
+import { StateModel } from "../../model";
+import { NotificationsManager } from "../../notifications/notifications.types.ts";
+import { AppParams } from "../../utils/context/appParams.types.ts";
+
+const RootV1 = lazy(() => import("./RootV1"));
+
+export default function LazyRootV1(props: {
+  model: StateModel;
+  notifications: NotificationsManager;
+  params: AppParams;
+  user: {
+    logged: boolean;
+  };
+}) {
   return (
-    <Link
-      className={cx(
-        "btn",
-        "btn-sm",
-        outline ? `btn-outline-${color}` : `btn-${color}`,
-        "text-decoration-none"
-      )}
-      to="/v1"
-    >
-      <BoxArrowInLeft className="bi" /> Back to <b>Renku 1.0</b>
-    </Link>
+    <Suspense fallback={<PageLoader />}>
+      <RootV1 {...props} />
+    </Suspense>
   );
 }

--- a/client/src/features/rootV1/RootV1.tsx
+++ b/client/src/features/rootV1/RootV1.tsx
@@ -1,0 +1,129 @@
+/*!
+ * Copyright 2025 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+import cx from "classnames";
+import { Route, Routes } from "react-router-dom-v5-compat";
+import ContainerWrap from "../../components/container/ContainerWrap.tsx";
+import LoggedInNavBar from "../../components/navbar/LoggedInNavBar.tsx";
+import LazyHelp from "../../help/LazyHelp.tsx";
+import LazyAnonymousHome from "../../landing/LazyAnonymousHome.tsx";
+import { StateModel } from "../../model";
+import LazyNotFound from "../../not-found/LazyNotFound.tsx";
+import LazyNotificationsPage from "../../notifications/LazyNotificationsPage.tsx";
+import { NotificationsManager } from "../../notifications/notifications.types.ts";
+import LazyStyleGuide from "../../styleguide/LazyStyleGuide.tsx";
+import { AppParams } from "../../utils/context/appParams.types.ts";
+import LazyDashboard from "../dashboard/LazyDashboard.tsx";
+import LazyInactiveKGProjectsPage from "../inactiveKgProjects/LazyInactiveKGProjectsPage.tsx";
+import LazySearchPage from "../kgSearch/LazySearchPage.tsx";
+import LazySecrets from "../secrets/LazySecrets.tsx";
+
+export default function RootV1(props: {
+  model: StateModel;
+  notifications: NotificationsManager;
+  params: AppParams;
+  user: {
+    logged: boolean;
+  };
+}) {
+  if (!props.user.logged)
+    return (
+      <div className="w-100">
+        <LazyAnonymousHome />
+      </div>
+    );
+
+  return (
+    <div className="w-100">
+      <LoggedInNavBar
+        model={props.model}
+        notifications={props.notifications}
+        params={props.params}
+      />
+
+      <div className={cx("d-flex", "flex-grow-1")}>
+        <Routes>
+          <Route
+            index
+            element={
+              <ContainerWrap>
+                <LazyDashboard />
+              </ContainerWrap>
+            }
+          />
+          <Route
+            path="help/*"
+            element={
+              <ContainerWrap>
+                <LazyHelp />
+              </ContainerWrap>
+            }
+          />
+          <Route
+            path="search/*"
+            element={
+              <ContainerWrap>
+                <LazySearchPage />
+              </ContainerWrap>
+            }
+          />
+          <Route
+            path="/notifications"
+            element={
+              <ContainerWrap>
+                <LazyNotificationsPage />
+              </ContainerWrap>
+            }
+          />
+          <Route
+            path="/style-guide"
+            element={
+              <ContainerWrap>
+                <LazyStyleGuide />
+              </ContainerWrap>
+            }
+          />
+          <Route
+            path="/secrets"
+            element={
+              <ContainerWrap>
+                <LazySecrets />
+              </ContainerWrap>
+            }
+          />
+          <Route
+            path="/inactive-kg-projects"
+            element={
+              <ContainerWrap>
+                <LazyInactiveKGProjectsPage />
+              </ContainerWrap>
+            }
+          />
+          <Route
+            path="*"
+            element={
+              <ContainerWrap fullSize>
+                <LazyNotFound />
+              </ContainerWrap>
+            }
+          />
+        </Routes>
+      </div>
+    </div>
+  );
+}

--- a/client/src/features/rootV1/RootV1.tsx
+++ b/client/src/features/rootV1/RootV1.tsx
@@ -17,45 +17,32 @@
  */
 
 import cx from "classnames";
+import { Redirect } from "react-router";
 import { Route, Routes } from "react-router-dom-v5-compat";
-import ContainerWrap from "../../components/container/ContainerWrap.tsx";
-import LoggedInNavBar from "../../components/navbar/LoggedInNavBar.tsx";
-import LazyHelp from "../../help/LazyHelp.tsx";
-import LazyAnonymousHome from "../../landing/LazyAnonymousHome.tsx";
-import { StateModel } from "../../model";
-import LazyNotFound from "../../not-found/LazyNotFound.tsx";
-import LazyNotificationsPage from "../../notifications/LazyNotificationsPage.tsx";
-import { NotificationsManager } from "../../notifications/notifications.types.ts";
-import LazyStyleGuide from "../../styleguide/LazyStyleGuide.tsx";
-import { AppParams } from "../../utils/context/appParams.types.ts";
-import LazyDashboard from "../dashboard/LazyDashboard.tsx";
-import LazyInactiveKGProjectsPage from "../inactiveKgProjects/LazyInactiveKGProjectsPage.tsx";
-import LazySearchPage from "../kgSearch/LazySearchPage.tsx";
-import LazySecrets from "../secrets/LazySecrets.tsx";
+import ContainerWrap from "../../components/container/ContainerWrap";
+import AnonymousNavBar from "../../components/navbar/AnonymousNavBar";
+import LoggedInNavBar from "../../components/navbar/LoggedInNavBar";
+import LazyHelp from "../../help/LazyHelp";
+import LazyNotFound from "../../not-found/LazyNotFound";
+import LazyNotificationsPage from "../../notifications/LazyNotificationsPage";
+import { RELATIVE_ROUTES } from "../../routing/routes.constants";
+import LazyStyleGuide from "../../styleguide/LazyStyleGuide";
+import LazyDashboard from "../dashboard/LazyDashboard";
+import LazyInactiveKGProjectsPage from "../inactiveKgProjects/LazyInactiveKGProjectsPage";
+import LazySearchPage from "../kgSearch/LazySearchPage";
+import LazySecrets from "../secrets/LazySecrets";
+import LazyAnonymousSessionsList from "../session/components/LazyAnonymousSessionsList";
 
-export default function RootV1(props: {
-  model: StateModel;
-  notifications: NotificationsManager;
-  params: AppParams;
+export default function RootV1({
+  user,
+}: {
   user: {
     logged: boolean;
   };
 }) {
-  if (!props.user.logged)
-    return (
-      <div className="w-100">
-        <LazyAnonymousHome />
-      </div>
-    );
-
   return (
     <div className="w-100">
-      <LoggedInNavBar
-        model={props.model}
-        notifications={props.notifications}
-        params={props.params}
-      />
-
+      {!user.logged ? <AnonymousNavBar /> : <LoggedInNavBar />}
       <div className={cx("d-flex", "flex-grow-1")}>
         <Routes>
           <Route
@@ -67,7 +54,7 @@ export default function RootV1(props: {
             }
           />
           <Route
-            path="help/*"
+            path={RELATIVE_ROUTES.v1.help}
             element={
               <ContainerWrap>
                 <LazyHelp />
@@ -75,7 +62,7 @@ export default function RootV1(props: {
             }
           />
           <Route
-            path="search/*"
+            path={RELATIVE_ROUTES.v1.search}
             element={
               <ContainerWrap>
                 <LazySearchPage />
@@ -83,7 +70,7 @@ export default function RootV1(props: {
             }
           />
           <Route
-            path="/notifications"
+            path={RELATIVE_ROUTES.v1.notifications}
             element={
               <ContainerWrap>
                 <LazyNotificationsPage />
@@ -91,7 +78,7 @@ export default function RootV1(props: {
             }
           />
           <Route
-            path="/style-guide"
+            path={RELATIVE_ROUTES.v1.styleGuide}
             element={
               <ContainerWrap>
                 <LazyStyleGuide />
@@ -99,7 +86,7 @@ export default function RootV1(props: {
             }
           />
           <Route
-            path="/secrets"
+            path={RELATIVE_ROUTES.v1.secrets}
             element={
               <ContainerWrap>
                 <LazySecrets />
@@ -107,11 +94,21 @@ export default function RootV1(props: {
             }
           />
           <Route
-            path="/inactive-kg-projects"
+            path={RELATIVE_ROUTES.v1.inactiveKGProjects}
             element={
               <ContainerWrap>
                 <LazyInactiveKGProjectsPage />
               </ContainerWrap>
+            }
+          />
+          <Route
+            path={RELATIVE_ROUTES.v1.sessions}
+            element={
+              !user.logged ? (
+                <LazyAnonymousSessionsList />
+              ) : (
+                <Redirect to="/v1" />
+              )
             }
           />
           <Route

--- a/client/src/features/rootV2/RootV2.tsx
+++ b/client/src/features/rootV2/RootV2.tsx
@@ -111,7 +111,7 @@ export default function RootV2() {
             element={<ProjectsV2Routes />}
           />
           <Route
-            path="help/*"
+            path={RELATIVE_ROUTES.v2.help.root}
             element={
               <ContainerWrap>
                 <HelpV2Routes />
@@ -119,7 +119,7 @@ export default function RootV2() {
             }
           />
           <Route
-            path="search/*"
+            path={RELATIVE_ROUTES.v2.search}
             element={
               <ContainerWrap>
                 <LazySearchV2 />

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -5,6 +5,7 @@ import { connect, Provider } from "react-redux";
 import { Route, Switch, useHistory } from "react-router-dom";
 
 import "bootstrap";
+import { RELATIVE_ROUTES } from "./routing/routes.constants";
 
 // Use our version of bootstrap, not the one in import 'bootstrap/dist/css/bootstrap.css';
 import v1Styles from "./styles/index.scss?inline";
@@ -140,27 +141,17 @@ function FeatureFlagHandler() {
 export function StyleHandler() {
   return (
     <Switch>
-      <Route path="/projects">
+      <Route path={RELATIVE_ROUTES.projects}>
         <Helmet>
           <style type="text/css">{v1Styles}</style>
         </Helmet>
       </Route>
-      <Route path="/datasets">
+      <Route path={RELATIVE_ROUTES.datasets}>
         <Helmet>
           <style type="text/css">{v1Styles}</style>
         </Helmet>
       </Route>
-      <Route path="/notifications">
-        <Helmet>
-          <style type="text/css">{v1Styles}</style>
-        </Helmet>
-      </Route>
-      <Route path="/style-guide">
-        <Helmet>
-          <style type="text/css">{v1Styles}</style>
-        </Helmet>
-      </Route>
-      <Route path="/v1">
+      <Route path={RELATIVE_ROUTES.v1.root}>
         <Helmet>
           <style type="text/css">{v1Styles}</style>
         </Helmet>

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -2,10 +2,10 @@ import { useEffect } from "react";
 import { createRoot } from "react-dom/client";
 import { Helmet } from "react-helmet";
 import { connect, Provider } from "react-redux";
-import { Route, Switch, useHistory } from "react-router-dom";
+import { useHistory } from "react-router-dom";
 
 import "bootstrap";
-import { RELATIVE_ROUTES } from "./routing/routes.constants";
+import { useLocation } from "react-router-dom-v5-compat";
 
 // Use our version of bootstrap, not the one in import 'bootstrap/dist/css/bootstrap.css';
 import v1Styles from "./styles/index.scss?inline";
@@ -24,6 +24,7 @@ import { pollStatuspage } from "./statuspage";
 import { UserCoordinator } from "./user";
 import { validatedAppParams } from "./utils/context/appParams.utils";
 import useFeatureFlagSync from "./utils/feature-flags/useFeatureFlagSync.hook";
+import { isRenkuLegacy } from "./utils/helpers/HelperFunctionsV2";
 import { Sentry } from "./utils/helpers/sentry";
 import { createCoreApiVersionedUrlConfig, Url } from "./utils/helpers/url";
 
@@ -139,28 +140,12 @@ function FeatureFlagHandler() {
 }
 
 export function StyleHandler() {
+  const location = useLocation();
   return (
-    <Switch>
-      <Route path={RELATIVE_ROUTES.projects}>
-        <Helmet>
-          <style type="text/css">{v1Styles}</style>
-        </Helmet>
-      </Route>
-      <Route path={RELATIVE_ROUTES.datasets}>
-        <Helmet>
-          <style type="text/css">{v1Styles}</style>
-        </Helmet>
-      </Route>
-      <Route path={RELATIVE_ROUTES.v1.root}>
-        <Helmet>
-          <style type="text/css">{v1Styles}</style>
-        </Helmet>
-      </Route>
-      <Route path="*">
-        <Helmet>
-          <style type="text/css">{v2Styles}</style>
-        </Helmet>
-      </Route>
-    </Switch>
+    <Helmet>
+      <style type="text/css">
+        {isRenkuLegacy(location.pathname) ? v1Styles : v2Styles}
+      </style>
+    </Helmet>
   );
 }

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -3,7 +3,6 @@ import { createRoot } from "react-dom/client";
 import { Helmet } from "react-helmet";
 import { connect, Provider } from "react-redux";
 import { Route, Switch, useHistory } from "react-router-dom";
-import { CompatRoute } from "react-router-dom-v5-compat";
 
 import "bootstrap";
 
@@ -141,14 +140,34 @@ function FeatureFlagHandler() {
 export function StyleHandler() {
   return (
     <Switch>
-      <CompatRoute path="/v2">
-        <Helmet>
-          <style type="text/css">{v2Styles}</style>
-        </Helmet>
-      </CompatRoute>
-      <Route path="*">
+      <Route path="/projects">
         <Helmet>
           <style type="text/css">{v1Styles}</style>
+        </Helmet>
+      </Route>
+      <Route path="/datasets">
+        <Helmet>
+          <style type="text/css">{v1Styles}</style>
+        </Helmet>
+      </Route>
+      <Route path="/notifications">
+        <Helmet>
+          <style type="text/css">{v1Styles}</style>
+        </Helmet>
+      </Route>
+      <Route path="/style-guide">
+        <Helmet>
+          <style type="text/css">{v1Styles}</style>
+        </Helmet>
+      </Route>
+      <Route path="/v1">
+        <Helmet>
+          <style type="text/css">{v1Styles}</style>
+        </Helmet>
+      </Route>
+      <Route path="*">
+        <Helmet>
+          <style type="text/css">{v2Styles}</style>
         </Helmet>
       </Route>
     </Switch>

--- a/client/src/landing/GetSarted/GetStarted.tsx
+++ b/client/src/landing/GetSarted/GetStarted.tsx
@@ -58,7 +58,7 @@ export default function GetStarted(props: GetStartedProps) {
   const installRenku = "pipx install renku";
   return (
     <div id="rk-anon-home-get-started" ref={sectionRef}>
-      <div className="rk-anon-home-section-content">
+      <div className="container">
         <div id={styles.getStartedContainer}>
           <div className={styles.getStartedTitle}>
             <h2 className="text-rk-green">

--- a/client/src/landing/HeroLanding/HeroLanding.tsx
+++ b/client/src/landing/HeroLanding/HeroLanding.tsx
@@ -17,9 +17,9 @@ export default function HeroLanding(props: HeroLandingProps) {
   const loginUrl = useLoginUrl();
 
   return (
-    <div id="rk-anon-home-hero" className="rk-bg-shaded-dark">
+    <div id="rk-anon-home-hero" className="bg-navy">
       <HomeHeader {...props} />
-      <div className="rk-anon-home-section-content">
+      <div className="container">
         <div id={styles.heroContainer}>
           <div className={styles.heroTitle}>
             <h1 className="text-white">Connecting the research ecosystem</h1>
@@ -47,7 +47,8 @@ export default function HeroLanding(props: HeroLandingProps) {
               )}
             >
               <Button
-                className={cx("btn", "btn-rk-green", styles.heroBtn)}
+                className={cx("btn", styles.heroBtn)}
+                color="primary"
                 role="button"
                 id="link-try-it-out"
                 onClick={scrollToGetStarted}
@@ -55,7 +56,7 @@ export default function HeroLanding(props: HeroLandingProps) {
                 Try it out
               </Button>
               <a
-                className={cx("btn", "btn-outline-secondary", styles.heroBtn)}
+                className={cx("btn", "btn-outline-primary", styles.heroBtn)}
                 id="hero_link-sign_up"
                 href={loginUrl.href}
               >

--- a/client/src/landing/NavBar.jsx
+++ b/client/src/landing/NavBar.jsx
@@ -153,11 +153,11 @@ function FooterNavbarInner({ location }) {
       ? `${taggedVersion} (dev)`
       : taggedVersion;
 
-  const releaseLocation = location.pathname.startsWith("/v2")
-    ? ABSOLUTE_ROUTES.v2.help.release
-    : Url.pages.help.release;
-
   const isRenkuV1 = isRenkuLegacy(location.pathname);
+  const releaseLocation = isRenkuV1
+    ? ABSOLUTE_ROUTES.v1.help.release
+    : ABSOLUTE_ROUTES.v2.help.release;
+
   const footer = (
     <footer className={cx("text-body", "bg-body")} data-bs-theme="navy">
       <div

--- a/client/src/landing/NavBar.jsx
+++ b/client/src/landing/NavBar.jsx
@@ -28,14 +28,15 @@ import { Link, Route, Switch, useLocation } from "react-router-dom";
 
 import { ExternalDocsLink } from "../components/ExternalLinks";
 import { RenkuNavLink } from "../components/RenkuNavLink";
-import AnonymousNavBar from "../components/navbar/AnonymousNavBar";
 import LoggedInNavBar from "../components/navbar/LoggedInNavBar";
 import { RENKU_LOGO } from "../components/navbar/navbar.constans";
+import NavbarV2 from "../features/rootV2/NavbarV2";
 import { parseChartVersion } from "../help/release.utils";
+import { ABSOLUTE_ROUTES } from "../routing/routes.constants";
 import { Links } from "../utils/constants/Docs";
 import useLegacySelector from "../utils/customHooks/useLegacySelector.hook";
+import { isRenkuLegacy } from "../utils/helpers/HelperFunctions";
 import { Url } from "../utils/helpers/url";
-import { ABSOLUTE_ROUTES } from "../routing/routes.constants";
 
 import "./NavBar.css";
 
@@ -51,7 +52,6 @@ function RenkuNavBar(props) {
 }
 
 function RenkuNavBarInner(props) {
-  const { user } = props;
   const projectMetadata = useLegacySelector(
     (state) => state.stateModel.project?.metadata
   );
@@ -65,20 +65,23 @@ function RenkuNavBarInner(props) {
     <Switch key="mainNav">
       <Route path={sessionShowUrl} />
       <Route path="/v2/" />
+      <Route path="/v1/" />
+      <Route path="/projects/">
+        <LoggedInNavBar
+          model={props.model}
+          notifications={props.notifications}
+          params={props.params}
+        />
+      </Route>
+      <Route path="/datasets/">
+        <LoggedInNavBar
+          model={props.model}
+          notifications={props.notifications}
+          params={props.params}
+        />
+      </Route>
       <Route>
-        {user.logged ? (
-          <LoggedInNavBar
-            model={props.model}
-            notifications={props.notifications}
-            params={props.params}
-          />
-        ) : (
-          <AnonymousNavBar
-            model={props.model}
-            notifications={props.notifications}
-            params={props.params}
-          />
-        )}
+        <NavbarV2 />
       </Route>
     </Switch>
   );
@@ -159,6 +162,7 @@ function FooterNavbarInner({ location, params }) {
     ? ABSOLUTE_ROUTES.v2.help.release
     : Url.pages.help.release;
 
+  const isRenkuV1 = isRenkuLegacy(location.pathname);
   const footer = (
     <footer className={cx("text-body", "bg-body")} data-bs-theme="navy">
       <div
@@ -168,7 +172,7 @@ function FooterNavbarInner({ location, params }) {
           "px-2",
           "px-sm-3",
           "py-2",
-          !location.pathname.startsWith("/v2") && "bg-primary"
+          isRenkuV1 && "bg-primary"
         )}
       >
         <div className="navbar-nav">

--- a/client/src/landing/NavBar.jsx
+++ b/client/src/landing/NavBar.jsx
@@ -24,34 +24,36 @@
  */
 
 import cx from "classnames";
+import { useContext } from "react";
 import { Link, Route, Switch, useLocation } from "react-router-dom";
 
 import { ExternalDocsLink } from "../components/ExternalLinks";
-import { RenkuNavLink } from "../components/RenkuNavLink";
+import AnonymousNavBar from "../components/navbar/AnonymousNavBar";
 import LoggedInNavBar from "../components/navbar/LoggedInNavBar";
 import { RENKU_LOGO } from "../components/navbar/navbar.constans";
+import { RenkuNavLink } from "../components/RenkuNavLink";
 import NavbarV2 from "../features/rootV2/NavbarV2";
 import { parseChartVersion } from "../help/release.utils";
 import { ABSOLUTE_ROUTES } from "../routing/routes.constants";
 import { Links } from "../utils/constants/Docs";
+import AppContext from "../utils/context/appContext";
 import useLegacySelector from "../utils/customHooks/useLegacySelector.hook";
-import { isRenkuLegacy } from "../utils/helpers/HelperFunctions";
+import { isRenkuLegacy } from "../utils/helpers/HelperFunctionsV2";
 import { Url } from "../utils/helpers/url";
 
 import "./NavBar.css";
 
-function RenkuNavBar(props) {
-  const { user } = props;
+function RenkuNavBar({ user }) {
   const location = useLocation();
 
   if (!user.logged && location.pathname === Url.get(Url.pages.landing)) {
     return null;
   }
 
-  return <RenkuNavBarInner {...props} />;
+  return <RenkuNavBarInner user={user} />;
 }
 
-function RenkuNavBarInner(props) {
+function RenkuNavBarInner({ user }) {
   const projectMetadata = useLegacySelector(
     (state) => state.stateModel.project?.metadata
   );
@@ -67,18 +69,10 @@ function RenkuNavBarInner(props) {
       <Route path="/v2/" />
       <Route path="/v1/" />
       <Route path="/projects/">
-        <LoggedInNavBar
-          model={props.model}
-          notifications={props.notifications}
-          params={props.params}
-        />
+        {!user.logged ? <AnonymousNavBar /> : <LoggedInNavBar />}
       </Route>
       <Route path="/datasets/">
-        <LoggedInNavBar
-          model={props.model}
-          notifications={props.notifications}
-          params={props.params}
-        />
+        {!user.logged ? <AnonymousNavBar /> : <LoggedInNavBar />}
       </Route>
       <Route>
         <NavbarV2 />
@@ -126,13 +120,13 @@ function FooterNavbarLoggedInLinks({ privacyLink }) {
   );
 }
 
-function FooterNavbar(props) {
+function FooterNavbar() {
   const location = useLocation();
 
-  return <FooterNavbarInner {...props} location={location} />;
+  return <FooterNavbarInner location={location} />;
 }
 
-function FooterNavbarInner({ location, params }) {
+function FooterNavbarInner({ location }) {
   const projectMetadata = useLegacySelector(
     (state) => state.stateModel.project?.metadata
   );
@@ -142,6 +136,7 @@ function FooterNavbarInner({ location, params }) {
     path: projectMetadata["path"],
     server: ":server",
   });
+  const { params } = useContext(AppContext);
 
   const privacyLink =
     params && params["PRIVACY_STATEMENT"] ? (

--- a/client/src/landing/SectionShowcase.tsx
+++ b/client/src/landing/SectionShowcase.tsx
@@ -205,9 +205,7 @@ export default function SectionShowcase({
 
   return (
     <div id="rk-anon-home-section-showcase" data-cy="section-showcase">
-      <div
-        className={cx("rk-anon-home-section-content", styles.sectionShowcase)}
-      >
+      <div className={cx("container", styles.sectionShowcase)}>
         <Row className="rk-pt-m">
           <Col className={styles.sectionShowcaseHeader} md={10}>
             <h3 className="text-rk-green">{title}</h3>

--- a/client/src/landing/Teaching/Teaching.tsx
+++ b/client/src/landing/Teaching/Teaching.tsx
@@ -26,7 +26,7 @@ import styles from "../Teaching/Teaching.module.scss";
 export default function Teaching() {
   return (
     <div id="rk-anon-home-teaching">
-      <div className="rk-anon-home-section-content">
+      <div className="container">
         <div id={styles.teachingContainer}>
           <div className={styles.teachingTitle}>
             <h2>Computing courses without the hassle</h2>
@@ -57,7 +57,7 @@ export default function Teaching() {
                   "align-self-lg-center",
                   "gap-2"
                 )}
-                color="rk-green"
+                color="primary"
                 role="button"
                 id="learnMoreTeachingBtn"
                 url={Docs.rtdTopicGuide(

--- a/client/src/landing/WhatIsRenku/WhatIsRenku.tsx
+++ b/client/src/landing/WhatIsRenku/WhatIsRenku.tsx
@@ -430,7 +430,7 @@ export default function WhatIsRenku({
 }: WhatIsRenkuProps) {
   return (
     <div id="rk-anon-home-what-is-renku">
-      <div id={styles.featContainer} className="rk-anon-home-section-content">
+      <div id={styles.featContainer} className="container">
         <ShareFeatSection projectPath={projectPath} />
         <EnvFeatSection projectPath={projectPath} />
         <ComputeFeatSection projectPath={projectPath} />

--- a/client/src/landing/WhoWeAre/WhoWeAre.tsx
+++ b/client/src/landing/WhoWeAre/WhoWeAre.tsx
@@ -29,7 +29,7 @@ export default function WhoWeAre() {
   const contactEmail = RenkuContactEmail || "";
   return (
     <div id="rk-anon-home-who-we-are">
-      <div className="rk-anon-home-section-content">
+      <div className="container">
         <div id={styles.whoWeAreContainer}>
           <div className={styles.whoWeAreTitle}>
             <h2 className="text-rk-green">
@@ -54,7 +54,7 @@ export default function WhoWeAre() {
                 they need to work, collaborate and share their research.
               </p>
               <p>
-                Developed with <HeartFill className="text-rk-green" /> at ETH
+                Developed with <HeartFill className="text-primary" /> at ETH
                 Zurich and EPFL with contributions from our fantastic community.
               </p>
               <div className={styles.whoWeAreLinks}>
@@ -66,7 +66,7 @@ export default function WhoWeAre() {
                       "align-self-lg-center",
                       "gap-2"
                     )}
-                    color="rk-green"
+                    color="primary"
                     role="button"
                     id="Contact_us_btn"
                     url={`mailto:${contactEmail}`}

--- a/client/src/landing/anonymousHomeNav.tsx
+++ b/client/src/landing/anonymousHomeNav.tsx
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+import cx from "classnames";
 import type { CSSProperties } from "react";
 import React from "react";
 import { List } from "react-bootstrap-icons";
@@ -85,8 +86,8 @@ function BottomNavSection(props: BottomNavSectionProps) {
 function BottomNav(props: AnonymousHomeConfig) {
   const tutorialLink = props.homeCustomized.tutorialLink;
   return (
-    <div id="rk-anon-home-bottom-nav">
-      <div className="rk-anon-home-section-content rk-pt-m">
+    <div id="rk-anon-home-bottom-nav" className={cx("bg-navy")}>
+      <div className={cx("container", "py-5", "text-white")}>
         <Row>
           <Col md={3}>
             <BottomNavSection sectionTitle="Learn">
@@ -150,7 +151,7 @@ function TopNavExternalLink({ title, url }: BottomNavExternalLinkProps) {
 
 function TopNavLink({ title, to }: BottomNavLinkProps) {
   return (
-    <Link className="rk-anon-home-nav-link text-white" to={to}>
+    <Link className={cx("text-decoration-none", "text-white")} to={to}>
       {title}
     </Link>
   );
@@ -164,22 +165,26 @@ function TopNav() {
 
   return (
     <>
-      <header className="pt-2 pb-4 d-flex rk-anon-home">
-        <div className="align-self-center flex-grow-1">
+      <header className={cx("pt-2", "pb-4", "d-flex", "container")}>
+        <div className={cx("align-self-center", "flex-grow-1")}>
           <img src={logo} alt="Renku" height="68" className="d-block my-1" />
         </div>
         <div
-          className="px-2 mt-3 d-flex justify-content-center icons-menu
-        align-items-center bg-primary gap-3"
+          className={cx(
+            "px-2",
+            "mt-3",
+            "d-flex",
+            "justify-content-center",
+            "icons-menu",
+            "align-items-center",
+            "gap-3"
+          )}
         >
-          <div className="d-none d-md-inline-block">
-            <TopNavLink title="Sessions" to={Url.get(Url.pages.sessions)} />
-          </div>
           <div className="d-none d-md-inline-block">
             <TopNavLink title="Help" to={Url.get(Url.pages.help)} />
           </div>
           <a
-            className="btn btn-outline-secondary"
+            className={cx("btn", "btn-outline-primary")}
             id="login-button"
             href={loginUrl.href}
           >
@@ -188,7 +193,7 @@ function TopNav() {
           <Button
             onClick={toggleOpen}
             id="nav-hamburger"
-            className="border-0"
+            className={cx("border-0", "bg-transparent", "shadow-none")}
             title="Navigation Toggle"
           >
             <List className="m-0 bi" />
@@ -197,7 +202,7 @@ function TopNav() {
       </header>
       <div className="rk-navbar-home">
         <Collapse isOpen={isOpen}>
-          <Navbar className="navbar rk-anon-home px-0">
+          <Navbar className={cx("navbar", "container", "px-0")}>
             <Nav
               className="ms-auto flex-column rk-bg-shaded-dark text-end"
               style={{ "--rk-bg-opacity": 0.9, zIndex: 100 } as CSSProperties}
@@ -225,9 +230,6 @@ function TopNav() {
               </NavItem>
               <NavItem className="nav-item mb-2">
                 <TopNavExternalLink title="GitHub" url={Links.GITHUB} />
-              </NavItem>
-              <NavItem className="d-block d-md-none nav-item mb-2">
-                <TopNavLink title="Sessions" to={Url.get(Url.pages.sessions)} />
               </NavItem>
               <NavItem className="d-block d-md-none nav-item">
                 <TopNavLink title="Help" to={Url.get(Url.pages.help)} />

--- a/client/src/not-found/NotFound.tsx
+++ b/client/src/not-found/NotFound.tsx
@@ -30,7 +30,7 @@ import { ArrowLeft } from "react-bootstrap-icons";
 import ContainerWrap from "../components/container/ContainerWrap";
 import rkNotFoundImg from "../styles/assets/not-found.svg";
 import rkNotFoundImgV2 from "../styles/assets/not-foundV2.svg";
-import { isRenkuLegacy } from "../utils/helpers/HelperFunctions.js";
+import { isRenkuLegacy } from "../utils/helpers/HelperFunctionsV2";
 import "./NotFound.css";
 
 interface NotFoundProps {

--- a/client/src/not-found/NotFound.tsx
+++ b/client/src/not-found/NotFound.tsx
@@ -30,6 +30,7 @@ import { ArrowLeft } from "react-bootstrap-icons";
 import ContainerWrap from "../components/container/ContainerWrap";
 import rkNotFoundImg from "../styles/assets/not-found.svg";
 import rkNotFoundImgV2 from "../styles/assets/not-foundV2.svg";
+import { isRenkuLegacy } from "../utils/helpers/HelperFunctions.js";
 import "./NotFound.css";
 
 interface NotFoundProps {
@@ -43,7 +44,7 @@ export default function NotFound({
   description: description_,
   children,
 }: NotFoundProps) {
-  const isV2 = location.pathname?.startsWith("/v2");
+  const isV2 = !isRenkuLegacy(location.pathname);
   const title = title_ ?? "Page not found";
   const description =
     description_ ??

--- a/client/src/notifications/Notifications.present.jsx
+++ b/client/src/notifications/Notifications.present.jsx
@@ -51,7 +51,6 @@ import {
 import { ExternalLink } from "../components/ExternalLinks";
 import { TimeCaption } from "../components/TimeCaption";
 import { ABSOLUTE_ROUTES } from "../routing/routes.constants";
-import { Url } from "../utils/helpers/url";
 import { NotificationsInfo } from "./Notifications.state";
 
 import "./Notifications.css";
@@ -325,7 +324,7 @@ class NotificationsMenuList extends Component {
 
     return (
       <Fragment>
-        <Link to={Url.get(ABSOLUTE_ROUTES.v1.notifications)}>
+        <Link to={ABSOLUTE_ROUTES.v1.notifications}>
           <DropdownItem>
             Notifications ({renderedNotifications.length})
           </DropdownItem>

--- a/client/src/notifications/Notifications.present.jsx
+++ b/client/src/notifications/Notifications.present.jsx
@@ -50,6 +50,8 @@ import {
 
 import { ExternalLink } from "../components/ExternalLinks";
 import { TimeCaption } from "../components/TimeCaption";
+import { ABSOLUTE_ROUTES } from "../routing/routes.constants";
+import { Url } from "../utils/helpers/url";
 import { NotificationsInfo } from "./Notifications.state";
 
 import "./Notifications.css";
@@ -323,7 +325,7 @@ class NotificationsMenuList extends Component {
 
     return (
       <Fragment>
-        <Link to="/notifications">
+        <Link to={Url.get(ABSOLUTE_ROUTES.v1.notifications)}>
           <DropdownItem>
             Notifications ({renderedNotifications.length})
           </DropdownItem>
@@ -561,7 +563,7 @@ export {
   CloseToast,
   NotificationDropdownItem,
   NotificationPageItem,
-  NotificationToast,
   Notifications,
   NotificationsMenu,
+  NotificationToast,
 };

--- a/client/src/routing/routes.constants.ts
+++ b/client/src/routing/routes.constants.ts
@@ -56,10 +56,23 @@ export const ABSOLUTE_ROUTES = {
     connectedServices: "/v2/connected-services",
     secrets: "/v2/secrets",
   },
+  v1: {
+    root: "/v1",
+    search: "/v1/search",
+    help: "/v1/help",
+    notifications: "/v1/notifications",
+    styleGuide: "/v1/style-guide",
+    secrets: "/v1/secrets",
+  },
 } as const;
 
 export const RELATIVE_ROUTES = {
   root: "/",
+  v1: {
+    root: "v1/*",
+    search: "search",
+    help: "help",
+  },
   v2: {
     root: "v2/*",
     user: "user",

--- a/client/src/routing/routes.constants.ts
+++ b/client/src/routing/routes.constants.ts
@@ -63,15 +63,23 @@ export const ABSOLUTE_ROUTES = {
     notifications: "/v1/notifications",
     styleGuide: "/v1/style-guide",
     secrets: "/v1/secrets",
+    sessions: "/v1/sessions",
   },
 } as const;
 
 export const RELATIVE_ROUTES = {
   root: "/",
+  datasets: "/datasets",
+  projects: "/projects",
   v1: {
-    root: "v1/*",
+    root: "/v1",
     search: "search",
-    help: "help",
+    help: "help/*",
+    sessions: "sessions",
+    notifications: "notifications",
+    secrets: "secrets",
+    styleGuide: "style-guide",
+    inactiveKGProjects: "inactive-kg-projects",
   },
   v2: {
     root: "v2/*",

--- a/client/src/routing/routes.constants.ts
+++ b/client/src/routing/routes.constants.ts
@@ -59,7 +59,14 @@ export const ABSOLUTE_ROUTES = {
   v1: {
     root: "/v1",
     search: "/v1/search",
-    help: "/v1/help",
+    help: {
+      root: "/v1/help",
+      contact: "/v1/help/contact",
+      status: "/v1/help/status",
+      release: "/v1/help/release",
+      tos: "/v1/help/tos",
+      privacy: "/v1/help/privacy",
+    },
     notifications: "/v1/notifications",
     styleGuide: "/v1/style-guide",
     secrets: "/v1/secrets",

--- a/client/src/utils/helpers/HelperFunctions.js
+++ b/client/src/utils/helpers/HelperFunctions.js
@@ -364,14 +364,6 @@ function getEntityImageUrl(images) {
   }
 }
 
-export function isRenkuLegacy(pathname) {
-  return (
-    pathname.startsWith("/v1") ||
-    pathname.startsWith("/projects") ||
-    pathname.startsWith("/datasets")
-  );
-}
-
 export {
   capitalizeFirstLetter,
   generateZip,

--- a/client/src/utils/helpers/HelperFunctions.js
+++ b/client/src/utils/helpers/HelperFunctions.js
@@ -364,6 +364,14 @@ function getEntityImageUrl(images) {
   }
 }
 
+export function isRenkuLegacy(pathname) {
+  return (
+    pathname.startsWith("/v1") ||
+    pathname.startsWith("/projects") ||
+    pathname.startsWith("/datasets")
+  );
+}
+
 export {
   capitalizeFirstLetter,
   generateZip,

--- a/client/src/utils/helpers/HelperFunctionsV2.ts
+++ b/client/src/utils/helpers/HelperFunctionsV2.ts
@@ -16,10 +16,11 @@
  * limitations under the License.
  */
 
-export function isRenkuLegacy(pathname: string) {
+export function isRenkuLegacy(pathname: string | undefined) {
   return (
-    pathname.startsWith("/v1") ||
-    pathname.startsWith("/projects") ||
-    pathname.startsWith("/datasets")
+    typeof pathname === "string" &&
+    (pathname.startsWith("/v1") ||
+      pathname.startsWith("/projects") ||
+      pathname.startsWith("/datasets"))
   );
 }

--- a/client/src/utils/helpers/HelperFunctionsV2.ts
+++ b/client/src/utils/helpers/HelperFunctionsV2.ts
@@ -13,25 +13,13 @@
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License
+ * limitations under the License.
  */
 
-import { Suspense, lazy } from "react";
-
-import PageLoader from "../../components/PageLoader";
-
-const RootV1 = lazy(() => import("./RootV1"));
-
-export default function LazyRootV1({
-  user,
-}: {
-  user: {
-    logged: boolean;
-  };
-}) {
+export function isRenkuLegacy(pathname: string) {
   return (
-    <Suspense fallback={<PageLoader />}>
-      <RootV1 user={user} />
-    </Suspense>
+    pathname.startsWith("/v1") ||
+    pathname.startsWith("/projects") ||
+    pathname.startsWith("/datasets")
   );
 }

--- a/tests/cypress/e2e/dashboard.spec.ts
+++ b/tests/cypress/e2e/dashboard.spec.ts
@@ -43,7 +43,7 @@ describe("dashboard", () => {
       .noActiveProjects()
       .sessionServersEmpty();
 
-    cy.visit("/");
+    cy.visit("/v1");
     cy.wait("@getUser");
     cy.wait("@getDataServiceUser");
     cy.wait("@getEntities");
@@ -88,7 +88,7 @@ describe("dashboard", () => {
       });
     }
 
-    cy.visit("/");
+    cy.visit("/v1");
     let projects;
     cy.wait("@getUser");
     cy.wait("@getDataServiceUser");
@@ -138,7 +138,7 @@ describe("dashboard", () => {
       });
     }
 
-    cy.visit("/");
+    cy.visit("/v1");
     let projects;
     cy.wait("@getUser");
     cy.wait("@getDataServiceUser");
@@ -248,7 +248,7 @@ describe("dashboard message", () => {
   });
 
   const visitDashboardPage = () => {
-    cy.visit("/");
+    cy.visit("/v1");
     cy.wait("@getUser");
     cy.wait("@getDataServiceUser");
     cy.wait("@getEntities");
@@ -357,7 +357,7 @@ describe("Dashboard pins", () => {
       })
       .sessionServersEmpty()
       .userPreferences();
-    cy.visit("/");
+    cy.visit("/v1");
     cy.wait("@getUserPreferences");
 
     cy.getDataCy("projects-container").should("be.visible");
@@ -391,7 +391,7 @@ describe("Dashboard pins", () => {
       });
     }
 
-    cy.visit("/");
+    cy.visit("/v1");
     cy.wait("@getUserPreferences");
     cy.wait(Object.keys(files).map((filesKey) => `@getProject-${filesKey}`));
 
@@ -454,7 +454,7 @@ describe("Dashboard pins", () => {
       });
     }
 
-    cy.visit("/");
+    cy.visit("/v1");
     cy.wait("@getUserPreferences");
     cy.wait(Object.keys(files).map((filesKey) => `@getProject-${filesKey}`));
 
@@ -525,7 +525,7 @@ describe("Dashboard pins", () => {
       });
     }
 
-    cy.visit("/");
+    cy.visit("/v1");
     cy.wait("@getUserPreferences");
     cy.wait(Object.keys(files).map((filesKey) => `@getProject-${filesKey}`));
 

--- a/tests/cypress/e2e/datasets.spec.ts
+++ b/tests/cypress/e2e/datasets.spec.ts
@@ -23,7 +23,7 @@ describe("display a dataset", () => {
     fixtures.config().versions().userTest();
     fixtures.projects().landingUserProjects();
     fixtures.entitySearch().getLastSearch();
-    cy.visit("datasets");
+    cy.visit("/v1/search?type=dataset");
   });
 
   it("displays the dataset list", () => {

--- a/tests/cypress/e2e/home.spec.ts
+++ b/tests/cypress/e2e/home.spec.ts
@@ -61,7 +61,7 @@ describe("display the home page even when APIs return strange responses", () => 
 describe("display version information", () => {
   beforeEach(() => {
     fixtures.config().versions().userNone();
-    cy.visit("/");
+    cy.visit("/v1");
   });
 
   it("shows release and component versions", () => {
@@ -145,7 +145,7 @@ describe("shows terms of use", () => {
 
   it("Default terms are visible visible", () => {
     fixtures.config();
-    cy.visit("/help/tos");
+    cy.visit("/v1/help/tos");
     cy.contains("No terms of use have been configured.").should("be.visible");
     cy.get("a").contains("Terms of Use").should("not.exist");
   });
@@ -154,7 +154,7 @@ describe("shows terms of use", () => {
     fixtures
       .config({ overrides: { TERMS_PAGES_ENABLED: true } })
       .overrideTermsOfUse();
-    cy.visit("/help/tos");
+    cy.visit("/v1/help/tos");
     cy.wait("@getOverrideTermsOfUse");
     cy.get("h1").contains("Override terms of use").should("be.visible");
     cy.get("a").contains("Terms of Use").should("exist").should("be.visible");
@@ -168,7 +168,7 @@ describe("shows privacy policy", () => {
 
   it("Default privacy policy is visible", () => {
     fixtures.config();
-    cy.visit("/help/privacy");
+    cy.visit("/v1/help/privacy");
     cy.contains("No privacy policy has been configured.").should("be.visible");
     cy.get("a").contains("Privacy Policy").should("not.exist");
   });
@@ -177,7 +177,7 @@ describe("shows privacy policy", () => {
     fixtures
       .config({ overrides: { TERMS_PAGES_ENABLED: true } })
       .overridePrivacyPolicy();
-    cy.visit("/help/privacy");
+    cy.visit("/v1/help/privacy");
     cy.wait("@getOverridePrivacyPolicy");
     cy.get("h1").contains("Override privacy policy").should("be.visible");
     cy.get("a").contains("Privacy Policy").should("exist").should("be.visible");

--- a/tests/cypress/e2e/kgSearch.spec.ts
+++ b/tests/cypress/e2e/kgSearch.spec.ts
@@ -24,7 +24,7 @@ describe("display kg search", () => {
     fixtures.entitySearch().getLastSearch();
     fixtures.projects().landingUserProjects().projectTest();
     fixtures.projectLockStatus().projectMigrationUpToDate();
-    cy.visit("/search");
+    cy.visit("/v1/search");
   });
 
   it("displays the filters", () => {

--- a/tests/cypress/e2e/secrets.spec.ts
+++ b/tests/cypress/e2e/secrets.spec.ts
@@ -28,7 +28,7 @@ describe("Secrets", () => {
       .userTest()
       .listSecrets({ secretsKind: "general" })
       .listSecrets({ secretsKind: "storage" });
-    cy.visit("/secrets");
+    cy.visit("/v1/secrets");
 
     cy.get("#new-secret-button").should("be.visible");
     cy.getDataCy("secrets-list").should("not.exist");
@@ -39,7 +39,7 @@ describe("Secrets", () => {
       .userNone()
       .listSecrets({ secretsKind: "general" })
       .listSecrets({ secretsKind: "storage" });
-    cy.visit("/secrets");
+    cy.visit("/v1/secrets");
 
     cy.getDataCy("secrets-list").should("not.exist");
     cy.getDataCy("secrets-page")
@@ -54,7 +54,7 @@ describe("Secrets", () => {
       .listSecrets({ numberOfSecrets: 0, secretsKind: "storage" })
       .listSecrets({ numberOfSecrets: 5, secretsKind: "general" })
       .newSecret();
-    cy.visit("/secrets");
+    cy.visit("/v1/secrets");
 
     cy.get("#new-secret-button").should("be.visible");
     cy.getDataCy("secrets-list").should("exist");
@@ -99,7 +99,7 @@ describe("Secrets", () => {
       .listSecrets({ secretsKind: "storage" })
       .listSecrets({ numberOfSecrets: 2, secretsKind: "general" })
       .editSecret();
-    cy.visit("/secrets");
+    cy.visit("/v1/secrets");
 
     cy.getDataCy("secrets-list").first().contains("secret_0").click();
     cy.getDataCy("secrets-list")
@@ -122,7 +122,7 @@ describe("Secrets", () => {
       .listSecrets({ secretsKind: "storage" })
       .listSecrets({ numberOfSecrets: 2, secretsKind: "general" })
       .deleteSecret();
-    cy.visit("/secrets");
+    cy.visit("/v1/secrets");
 
     cy.getDataCy("secrets-list").first().contains("secret_0").click();
     cy.getDataCy("secrets-list")


### PR DESCRIPTION
PR to handle atyles for new routing

fix #3499 


Tests will be handled in [#3503](https://github.com/SwissDataScienceCenter/renku-ui/issues/3503).
Functionalities such as creating a new v2 project or v2 group will be addressed in [#3501](https://github.com/SwissDataScienceCenter/renku-ui/issues/3501).

### Summary of Changes
#### Included in the Update:
* Landing Page: Now loads with styles v2 
* Renku 1.0 Compatibility:
    *` /v1` now loads the Renku 1.0 dashboard when the user is authenticated.
    * Routes under `/v1/*` load the corresponding Renku 1.0 pages:
        * `/v1/search`
        * `/v1/help`
        * `/v1/notifications`
        * `/v1/secrets`
* Projects and Datasets:
    * Routes under `/projects/*` now load Renku 1.0 project pages.
    * Similarly, `/datasets/*` routes load the appropriate content from Renku 1.0. 
    
#### Pending Fixes to solve in  ([#3501](https://github.com/SwissDataScienceCenter/renku-ui/issues/3501)):
* Style Guide: The style guide is currently broken and will be deprecated in this context.
* Route Adjustments for `/v2`:
    * `/secrets`, `/search`, and `/help` should load the content currently served under  `/v2/secrets`, `/v2/search`, and `/v2/help`.
    * `/notifications` should load what is in `/v1/notifications`??? pending to decide since `/v2/notifications` doesn’t exist
* Project and Group Creation Redirects:
    * Issues with creating projects or groups in v2 need to be resolved.
    * The new redirect from `/v2` to `/r` should address these inconsistencies.

/deploy