### PR TITLE
dev: auto-detect telepresence context

### DIFF
--- a/client/run-telepresence.sh
+++ b/client/run-telepresence.sh
@@ -99,6 +99,15 @@ then
   done
 fi
 
+# Try to guess the namespace using the GitHub CLI
+GH_CLI="${GH_CLI:-gh}"
+PR_NUMBER=$($GH_CLI pr view --json number --jq .number || true)
+if [[ $PR_NUMBER ]]
+then
+  echo "Detected current PR: ${PR_NUMBER}"
+  NAMESPACE=$PR_NUMBER
+fi
+
 # Get the namespaces when not set
 if [[ ! $NAMESPACE ]]
 then

--- a/client/run-telepresence.sh
+++ b/client/run-telepresence.sh
@@ -99,20 +99,20 @@ then
   done
 fi
 
-# Try to guess the namespace using the GitHub CLI
-GH_CLI="${GH_CLI:-gh}"
-PR_NUMBER=$($GH_CLI pr view --json number --jq .number || true)
-if [[ $PR_NUMBER ]]
-then
-  echo "Detected current PR: ${PR_NUMBER}"
-  NAMESPACE=$PR_NUMBER
-fi
-
 # Get the namespaces when not set
 if [[ ! $NAMESPACE ]]
 then
   if [[ ! $DEV_NAMESPACE ]]
   then
+    # Try to guess the namespace using the GitHub CLI
+    GH_CLI="${GH_CLI:-gh}"
+    PR_NUMBER=$($GH_CLI pr view --json number --jq .number || true)
+    if [[ $PR_NUMBER ]]
+    then
+      echo "Detected current PR: ${PR_NUMBER}"
+      NAMESPACE=$PR_NUMBER
+    fi
+
     while [[ ! $NAMESPACE ]]; do
       read -p "Enter your k8s namespace. Numbers-only will be converted to the renku-ui PR deployment: "
       NAMESPACE=$REPLY

--- a/server/run-telepresence.sh
+++ b/server/run-telepresence.sh
@@ -20,6 +20,21 @@ set -e
 
 CURRENT_CONTEXT=`kubectl config current-context`
 
+# Try to guess the namespace using the GitHub CLI
+if [[ ! $DEV_NAMESPACE ]]
+then
+  if [[ ! $PR ]]
+  then
+    GH_CLI="${GH_CLI:-gh}"
+    PR_NUMBER=$($GH_CLI pr view --json number --jq .number || true)
+    if [[ $PR_NUMBER ]]
+    then
+      echo "Detected current PR: ${PR_NUMBER}"
+      PR=$PR_NUMBER
+    fi
+  fi
+fi
+
 if [[ -n $PR ]]
 then
   DEV_NAMESPACE=renku-ci-ui-${PR}


### PR DESCRIPTION
In `client/`, you can now do:

```bash
$ ./run-telepresence.sh

Detected current PR: 3491
Exchanging k8s deployments for the following context/namespace: 
renku-dev/renku-ci-ui-3491
The deployment URL is expected to be: 
https://renku-ci-ui-3491.dev.renku.ch
[...]
```

The script assumes that the GitHub CLI is available as `gh`, but this can be overriden with `GH_CLI="github" ./run-telepresence.sh`.
Also, the script does not crash if the CLI is not available or if the current branch does not correspond to a PR.