### PR TITLE
Add data-cy attributes wherever convenient for Renku 2.0 Cypress acceptance tests

### DIFF
--- a/client/src/features/ProjectPageV2/ProjectPageContent/Settings/ProjectDelete.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/Settings/ProjectDelete.tsx
@@ -70,14 +70,14 @@ export default function ProjectPageDelete({ project }: ProjectDeleteProps) {
   );
 
   return (
-    <Card id="delete">
-      <CardHeader>
+    <Card data-cy="project-delete">
+      <CardHeader data-cy="project-delete-header">
         <h4 className="mb-0">
           <Trash className={cx("me-1", "bi")} />
           Delete project
         </h4>
       </CardHeader>
-      <CardBody>
+      <CardBody data-cy="project-delete-body">
         <p className="fw-bold">Are you sure you want to delete this project?</p>
         <div className="mb-3">
           <p className="mb-2">
@@ -94,6 +94,7 @@ export default function ProjectPageDelete({ project }: ProjectDeleteProps) {
         <div className="text-end">
           <Button
             color="danger"
+            data-cy="project-delete-button"
             disabled={typedName !== project.slug?.trim() || result.isLoading}
             onClick={onDelete}
           >

--- a/client/src/features/ProjectPageV2/ProjectPageNav/ProjectPageNav.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageNav/ProjectPageNav.tsx
@@ -42,13 +42,23 @@ export default function ProjectPageNav({ project }: { project: Project }) {
     <>
       <Nav tabs>
         <NavItem>
-          <RenkuNavLinkV2 end to={projectUrl} title="Overview">
+          <RenkuNavLinkV2
+            data-cy="project-overview-link"
+            end
+            to={projectUrl}
+            title="Overview"
+          >
             <Eye className={cx("bi", "me-1")} />
             Overview
           </RenkuNavLinkV2>
         </NavItem>
         <NavItem>
-          <RenkuNavLinkV2 end to={projectSettingsUrl} title="Settings">
+          <RenkuNavLinkV2
+            data-cy="project-settings-link"
+            end
+            to={projectSettingsUrl}
+            title="Settings"
+          >
             <Sliders className={cx("bi", "me-1")} />
             Settings
           </RenkuNavLinkV2>


### PR DESCRIPTION
This PR adds `data-cy` attributes in places where it's convenient to abstract specific HTML elements when testing the UI through Cypress.

Reference issue: https://github.com/SwissDataScienceCenter/renku/issues/3874