### PR TITLE
fix: add allowed hosts to vite config

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -9,6 +9,9 @@ export default defineConfig({
     outDir: "build",
     sourcemap: true,
   },
+  server: {
+    allowedHosts: [".dev.renku.ch"],
+  },
   plugins: [react({ include: "/index.html" }), eslintPlugin()],
   resolve: {
     alias: {


### PR DESCRIPTION
See:
* https://github.com/vitejs/vite/security/advisories/GHSA-vg6x-rcgg-rjx6
* https://vite.dev/config/server-options.html#server-allowedhosts