### PR TITLE
fix: correct alert test in maintenance.spec.ts

### DIFF
--- a/tests/cypress/e2e/maintenance.spec.ts
+++ b/tests/cypress/e2e/maintenance.spec.ts
@@ -74,7 +74,7 @@ describe("display the status page", () => {
     fixtures.config().versions().userNone().getStatuspageInfo();
     cy.visit("/");
     cy.wait("@getStatuspageInfo");
-    cy.get(".alert").should("not.exist");
+    cy.get(".alert").contains("Ongoing incident").should("not.exist");
   });
 
   it("Shows the banner on the dashboard if there is an incident", () => {


### PR DESCRIPTION
Fixes a flakey test in `maintenance.spec.ts` introduced by the "Early access" banner.