### PR TITLE
feat: create data connector in project

### DIFF
--- a/client/src/features/dataConnectorsV2/components/DataConnectorModal/DataConnectorModalBody.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorModal/DataConnectorModalBody.tsx
@@ -47,15 +47,18 @@ import dataConnectorFormSlice from "../../state/dataConnectors.slice";
 
 import DataConnectorModalResult from "./DataConnectorModalResult";
 import DataConnectorSaveCredentialsInfo from "./DataConnectorSaveCredentialsInfo";
+import type { Project } from "../../../projectsV2/api/projectV2.api";
 
 interface AddOrEditDataConnectorProps {
   storageSecrets: DataConnectorSecret[];
+  project?: Project;
 }
 
 type DataConnectorModalBodyProps = AddOrEditDataConnectorProps;
 
 export default function DataConnectorModalBody({
   storageSecrets,
+  project,
 }: DataConnectorModalBodyProps) {
   const { flatDataConnector, schemata, success } = useAppSelector(
     (state) => state.dataConnectorFormSlice
@@ -76,13 +79,17 @@ export default function DataConnectorModalBody({
           Or, connect to cloud storage to read and write custom data.
         </p>
       )}
-      <AddOrEditDataConnector storageSecrets={storageSecrets} />
+      <AddOrEditDataConnector
+        storageSecrets={storageSecrets}
+        project={project}
+      />
     </>
   );
 }
 
 function AddOrEditDataConnector({
   storageSecrets,
+  project,
 }: AddOrEditDataConnectorProps) {
   const { cloudStorageState, flatDataConnector, schemata, validationResult } =
     useAppSelector((state) => state.dataConnectorFormSlice);
@@ -150,7 +157,10 @@ function AddOrEditDataConnector({
             setState={setState}
           />
         </div>
-        <DataConnectorContentByStep storageSecrets={storageSecrets} />
+        <DataConnectorContentByStep
+          storageSecrets={storageSecrets}
+          project={project}
+        />
       </>
     );
   return <p>Error - not implemented yet</p>;
@@ -173,7 +183,7 @@ type DataConnectorMountFormFields =
   | "mountPoint"
   | "readOnly"
   | "saveCredentials";
-export function DataConnectorMount() {
+export function DataConnectorMount({ project }: AddOrEditDataConnectorProps) {
   const dispatch = useAppDispatch();
   const { cloudStorageState, flatDataConnector, schemata } = useAppSelector(
     (state) => state.dataConnectorFormSlice
@@ -305,6 +315,18 @@ export function DataConnectorMount() {
             const fields: Partial<typeof field> = { ...field };
             delete fields?.ref;
             return (
+              //<DataConnectorNamespaceControl
+              //  {...fields}
+              //  projectId={projectId || ""}
+              //  className={cx(errors.namespace && "is-invalid")}
+              //  data-cy={"data-controller-namespace-input"}
+              //  id="namespace"
+              //  inputId="namespace-input"
+              //  onChange={(e) => {
+              //    field.onChange(e);
+              //    onFieldValueChange("namespace", e?.value || "");
+              //  }}
+              ///>
               <ProjectNamespaceControl
                 {...fields}
                 className={cx(errors.namespace && "is-invalid")}
@@ -315,6 +337,10 @@ export function DataConnectorMount() {
                   field.onChange(e);
                   onFieldValueChange("namespace", e?.slug ?? "");
                 }}
+                project={project}
+                value={
+                  project ? `${project.namespace}/${project.slug}` : undefined
+                }
               />
             );
           }}

--- a/client/src/features/dataConnectorsV2/components/DataConnectorModal/DataConnectorModalBody.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorModal/DataConnectorModalBody.tsx
@@ -315,18 +315,6 @@ export function DataConnectorMount({ project }: AddOrEditDataConnectorProps) {
             const fields: Partial<typeof field> = { ...field };
             delete fields?.ref;
             return (
-              //<DataConnectorNamespaceControl
-              //  {...fields}
-              //  projectId={projectId || ""}
-              //  className={cx(errors.namespace && "is-invalid")}
-              //  data-cy={"data-controller-namespace-input"}
-              //  id="namespace"
-              //  inputId="namespace-input"
-              //  onChange={(e) => {
-              //    field.onChange(e);
-              //    onFieldValueChange("namespace", e?.value || "");
-              //  }}
-              ///>
               <ProjectNamespaceControl
                 {...fields}
                 className={cx(errors.namespace && "is-invalid")}
@@ -338,9 +326,6 @@ export function DataConnectorMount({ project }: AddOrEditDataConnectorProps) {
                   onFieldValueChange("namespace", e?.slug ?? "");
                 }}
                 project={project}
-                value={
-                  project ? `${project.namespace}/${project.slug}` : undefined
-                }
               />
             );
           }}

--- a/client/src/features/dataConnectorsV2/components/DataConnectorModal/index.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorModal/index.tsx
@@ -102,7 +102,10 @@ export function DataConnectorModalBodyAndFooter({
         ) : schemaQueryResult.error ? (
           <RtkOrNotebooksError error={schemaQueryResult.error} />
         ) : (
-          <DataConnectorModalBody storageSecrets={connectorSecrets ?? []} />
+          <DataConnectorModalBody
+            storageSecrets={connectorSecrets ?? []}
+            project={project}
+          />
         )}
       </ModalBody>
 

--- a/client/src/features/dataConnectorsV2/components/DataConnectorModal/index.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorModal/index.tsx
@@ -72,7 +72,7 @@ export function DataConnectorModalBodyAndFooter({
     if (dataConnector == null) {
       flattened = {
         ...flattened,
-        namespace,
+        namespace: project ? `${project.namespace}/${project.slug}` : namespace,
         visibility: project?.visibility ?? "private",
       };
     }
@@ -91,7 +91,7 @@ export function DataConnectorModalBodyAndFooter({
         schemata: schemata ?? [],
       })
     );
-  }, [dataConnector, dispatch, namespace, project?.visibility, schemata]);
+  }, [dataConnector, dispatch, namespace, project, schemata]);
 
   // Visual elements
   return (

--- a/client/src/features/dataConnectorsV2/components/DataConnectorsBox.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorsBox.tsx
@@ -34,7 +34,7 @@ import Pagination from "../../../components/Pagination";
 import { RtkOrNotebooksError } from "../../../components/errors/RtkErrorAlert";
 import useGroupPermissions from "../../groupsV2/utils/useGroupPermissions.hook";
 import PermissionsGuard from "../../permissionsV2/PermissionsGuard";
-import type { NamespaceKind } from "../../projectsV2/api/namespace.api";
+import type { NamespaceKind } from "../../projectsV2/api/namespace.enhanced-api";
 import { useGetUserQuery } from "../../usersV2/api/users.api";
 import {
   useGetDataConnectorsQuery,

--- a/client/src/features/project/components/cloudStorage/AddOrEditCloudStorage.tsx
+++ b/client/src/features/project/components/cloudStorage/AddOrEditCloudStorage.tsx
@@ -1039,7 +1039,6 @@ export function AddStorageMount({
   storage,
   state,
   validationSucceeded,
-  projectId,
 }: AddStorageStepProps) {
   const {
     control,

--- a/client/src/features/project/components/cloudStorage/AddOrEditCloudStorage.tsx
+++ b/client/src/features/project/components/cloudStorage/AddOrEditCloudStorage.tsx
@@ -80,6 +80,7 @@ interface AddOrEditCloudStorageProps {
   state: AddCloudStorageState;
   storage: CloudStorageDetails;
   storageSecrets: CloudStorageSecretGet[];
+  projectId?: string;
 }
 
 export default function AddOrEditCloudStorage({
@@ -88,6 +89,7 @@ export default function AddOrEditCloudStorage({
   setState,
   state,
   storage,
+  projectId,
 }: AddOrEditCloudStorageProps) {
   const ContentByStep =
     state.step >= 0 && state.step <= CLOUD_STORAGE_TOTAL_STEPS
@@ -107,6 +109,7 @@ export default function AddOrEditCloudStorage({
           setStorage={setStorage}
           storageSecrets={[]}
           validationSucceeded={false}
+          projectId={projectId}
         />
       </>
     );
@@ -171,6 +174,7 @@ export interface AddStorageStepProps {
   storageSecrets: CloudStorageSecretGet[];
   isV2?: boolean;
   validationSucceeded: boolean;
+  projectId?: string;
 }
 
 const mapStepToElement: {
@@ -1035,6 +1039,7 @@ export function AddStorageMount({
   storage,
   state,
   validationSucceeded,
+  projectId,
 }: AddStorageStepProps) {
   const {
     control,

--- a/client/src/features/project/components/cloudStorage/CloudStorageModal.tsx
+++ b/client/src/features/project/components/cloudStorage/CloudStorageModal.tsx
@@ -403,6 +403,7 @@ export default function CloudStorageModal({
           storageId={storageId}
           success={success}
           validationSucceeded={validationSucceeded}
+          projectId={projectId}
         />
       </ModalBody>
 

--- a/client/src/features/project/components/cloudStorage/cloudStorageModalComponents.tsx
+++ b/client/src/features/project/components/cloudStorage/cloudStorageModalComponents.tsx
@@ -107,6 +107,7 @@ export interface AddCloudStorageBodyContentProps
   storageDetails: CloudStorageDetails;
   success: boolean;
   validationSucceeded: boolean;
+  projectId?: string;
 }
 export function AddCloudStorageBodyContent({
   addResultStorageName,
@@ -121,6 +122,7 @@ export function AddCloudStorageBodyContent({
   storageDetails,
   storageId,
   success,
+  projectId,
 }: AddCloudStorageBodyContentProps) {
   if (redraw) return <Loader />;
   if (success) {
@@ -140,6 +142,7 @@ export function AddCloudStorageBodyContent({
       state={state}
       storage={storageDetails}
       storageSecrets={[]}
+      projectId={projectId}
     />
   );
 }

--- a/client/src/features/projectsV2/api/namespace.enhanced-api.ts
+++ b/client/src/features/projectsV2/api/namespace.enhanced-api.ts
@@ -1,0 +1,12 @@
+import {
+  NamespaceKind as NamespaceKindOrig,
+  NamespaceResponse as NamespaceResponseOrig,
+} from "./namespace.api.ts";
+
+export type NamespaceKind = NamespaceKindOrig | "project";
+export interface NamespaceResponse
+  extends Omit<NamespaceResponseOrig, "namespace_kind"> {
+  namespace_kind: NamespaceKind;
+}
+export type NamespaceResponseList = NamespaceResponse[];
+export type GetNamespacesApiResponse = NamespaceResponseList;

--- a/client/src/features/projectsV2/api/projectV2.enhanced-api.ts
+++ b/client/src/features/projectsV2/api/projectV2.enhanced-api.ts
@@ -17,10 +17,12 @@ import type {
   GetGroupsApiArg,
   GetGroupsApiResponse as GetGroupsApiResponseOrig,
   GetNamespacesApiArg,
-  GetNamespacesApiResponse as GetNamespacesApiResponseOrig,
   GroupResponseList,
-  NamespaceResponseList,
 } from "./namespace.api";
+import type {
+  GetNamespacesApiResponse as GetNamespacesApiResponseOrig,
+  NamespaceResponseList,
+} from "./namespace.enhanced-api";
 
 export interface GetGroupsApiResponse extends AbstractKgPaginatedResponse {
   groups: GetGroupsApiResponseOrig;

--- a/client/src/features/projectsV2/fields/ProjectNamespaceFormField.tsx
+++ b/client/src/features/projectsV2/fields/ProjectNamespaceFormField.tsx
@@ -251,7 +251,6 @@ export default function ProjectNamespaceFormField<T extends FieldValues>({
               id={`${entityName}-namespace`}
               inputId={`${entityName}-namespace-input`}
               onChange={(newValue) => field.onChange(newValue?.slug)}
-              project={undefined}
             />
           );
         }}

--- a/client/src/features/projectsV2/fields/ProjectNamespaceFormField.tsx
+++ b/client/src/features/projectsV2/fields/ProjectNamespaceFormField.tsx
@@ -38,6 +38,8 @@ import { ErrorAlert } from "../../../components/Alert";
 import { Loader } from "../../../components/Loader";
 import type { PaginatedState } from "../../session/components/options/fetchMore.types";
 import type { GetNamespacesApiResponse } from "../api/projectV2.enhanced-api";
+import type { Project } from "../api/projectV2.api";
+import type { NamespaceResponse } from "../api/namespace.enhanced-api";
 import {
   useGetNamespacesByNamespaceSlugQuery,
   useGetNamespacesQuery,
@@ -136,6 +138,7 @@ interface NamespaceSelectorProps {
   namespaces: ResponseNamespaces;
   onChange?: (newValue: SingleValue<ResponseNamespace>) => void;
   onFetchMore?: () => void;
+  project?: Project;
 }
 
 function NamespaceSelector({
@@ -146,10 +149,27 @@ function NamespaceSelector({
   namespaces,
   onChange,
   onFetchMore,
+  project,
 }: NamespaceSelectorProps) {
+  const namespaceOptions = useMemo(() => {
+    if (!project) {
+      return namespaces;
+    }
+    return [
+      {
+        id: project.id,
+        name: project.name,
+        slug: `${project.namespace}/${project.slug}`,
+        created_by: project.created_by,
+        creation_date: project.creation_date,
+        namespace_kind: "project",
+      } as NamespaceResponse,
+      ...namespaces,
+    ];
+  }, [namespaces, project]);
   const currentValue = useMemo(
-    () => namespaces.find(({ slug }) => slug === currentNamespace),
-    [namespaces, currentNamespace]
+    () => namespaceOptions.find(({ slug }) => slug === currentNamespace),
+    [namespaceOptions, currentNamespace]
   );
 
   const components = useMemo(
@@ -163,7 +183,7 @@ function NamespaceSelector({
   return (
     <Select
       inputId={inputId}
-      options={namespaces}
+      options={namespaceOptions}
       value={currentValue}
       unstyled
       getOptionValue={(option) => option.id}
@@ -249,6 +269,7 @@ export default function ProjectNamespaceFormField<T extends FieldValues>({
               id={`${entityName}-namespace`}
               inputId={`${entityName}-namespace-input`}
               onChange={(newValue) => field.onChange(newValue?.slug)}
+              project={undefined}
             />
           );
         }}
@@ -273,6 +294,7 @@ interface ProjectNamespaceControlProps {
   inputId: string;
   onChange: (newValue: SingleValue<ResponseNamespace>) => void;
   value?: string;
+  project?: Project;
 }
 
 export function ProjectNamespaceControl({
@@ -283,6 +305,7 @@ export function ProjectNamespaceControl({
   onChange,
   value,
   "data-cy": dataCy,
+  project,
 }: ProjectNamespaceControlProps) {
   const {
     data: namespacesFirstPage,
@@ -421,6 +444,7 @@ export function ProjectNamespaceControl({
         namespaces={allNamespaces}
         onChange={onChange}
         onFetchMore={onFetchMore}
+        project={project}
       />
     </div>
   );

--- a/client/src/features/projectsV2/fields/ProjectNamespaceFormField.tsx
+++ b/client/src/features/projectsV2/fields/ProjectNamespaceFormField.tsx
@@ -138,7 +138,6 @@ interface NamespaceSelectorProps {
   namespaces: ResponseNamespaces;
   onChange?: (newValue: SingleValue<ResponseNamespace>) => void;
   onFetchMore?: () => void;
-  project?: Project;
 }
 
 function NamespaceSelector({
@@ -149,27 +148,10 @@ function NamespaceSelector({
   namespaces,
   onChange,
   onFetchMore,
-  project,
 }: NamespaceSelectorProps) {
-  const namespaceOptions = useMemo(() => {
-    if (!project) {
-      return namespaces;
-    }
-    return [
-      {
-        id: project.id,
-        name: project.name,
-        slug: `${project.namespace}/${project.slug}`,
-        created_by: project.created_by,
-        creation_date: project.creation_date,
-        namespace_kind: "project",
-      } as NamespaceResponse,
-      ...namespaces,
-    ];
-  }, [namespaces, project]);
   const currentValue = useMemo(
-    () => namespaceOptions.find(({ slug }) => slug === currentNamespace),
-    [namespaceOptions, currentNamespace]
+    () => namespaces.find(({ slug }) => slug === currentNamespace),
+    [namespaces, currentNamespace]
   );
 
   const components = useMemo(
@@ -183,7 +165,7 @@ function NamespaceSelector({
   return (
     <Select
       inputId={inputId}
-      options={namespaceOptions}
+      options={namespaces}
       value={currentValue}
       unstyled
       getOptionValue={(option) => option.id}
@@ -415,6 +397,23 @@ export function ProjectNamespaceControl({
     });
   }, [allNamespaces, specificNamespace, specificNamespaceRequestId]);
 
+  const allNamespacesWithProject = useMemo(() => {
+    if (!project) {
+      return allNamespaces || [];
+    }
+    return [
+      {
+        id: project.id,
+        slug: `${project.namespace}/${project.slug}`,
+        creation_date: project.creation_date,
+        created_by: project.created_by,
+        namespace_kind: "project",
+        name: `${project.namespace}/${project.slug}`,
+      } as NamespaceResponse,
+      ...(allNamespaces || []),
+    ];
+  }, [allNamespaces, project]);
+
   if (isFetching) {
     return (
       <div className={cx(className, "form-control")} id={id}>
@@ -441,10 +440,9 @@ export function ProjectNamespaceControl({
         hasMore={hasMore}
         inputId={inputId}
         isFetchingMore={namespacesPageResult.isFetching}
-        namespaces={allNamespaces}
+        namespaces={allNamespacesWithProject}
         onChange={onChange}
         onFetchMore={onFetchMore}
-        project={project}
       />
     </div>
   );

--- a/client/src/features/projectsV2/list/ProjectV2ListDisplay.tsx
+++ b/client/src/features/projectsV2/list/ProjectV2ListDisplay.tsx
@@ -28,7 +28,7 @@ import { RtkOrNotebooksError } from "../../../components/errors/RtkErrorAlert";
 import useGroupPermissions from "../../groupsV2/utils/useGroupPermissions.hook";
 import PermissionsGuard from "../../permissionsV2/PermissionsGuard";
 import { useGetUserQuery } from "../../usersV2/api/users.api";
-import { NamespaceKind } from "../api/namespace.api";
+import { NamespaceKind } from "../api/namespace.enhanced-api";
 import { useGetProjectsQuery } from "../api/projectV2.enhanced-api";
 import ProjectShortHandDisplay from "../show/ProjectShortHandDisplay";
 

--- a/tests/cypress/e2e/projectV2DataConnectorCredentials.spec.ts
+++ b/tests/cypress/e2e/projectV2DataConnectorCredentials.spec.ts
@@ -45,7 +45,10 @@ describe("Set up data connectors with credentials", () => {
   it("set up data connector with failed connection test", () => {
     fixtures
       .testCloudStorage({ success: false })
-      .postDataConnector({ namespace: "user1-uuid", visibility: "public" })
+      .postDataConnector({
+        namespace: "user1-uuid/test-2-v2-project",
+        visibility: "public",
+      })
       .postDataConnectorProjectLink({
         dataConnectorId: "ULID-5",
       })
@@ -85,7 +88,7 @@ describe("Set up data connectors with credentials", () => {
     cy.wait("@postDataConnector");
     cy.getDataCy("data-connector-edit-body").should(
       "contain.text",
-      "The data connector user1-uuid/example-storage-without-credentials has been successfully added"
+      "The data connector user1-uuid/test-2-v2-project/example-storage-without-credentials has been successfully added"
     );
     cy.getDataCy("data-connector-edit-body").should(
       "contain.text",
@@ -109,7 +112,10 @@ describe("Set up data connectors with credentials", () => {
   it("set up data connector with credentials", () => {
     fixtures
       .testCloudStorage({ success: true })
-      .postDataConnector({ namespace: "user1-uuid", visibility: "public" })
+      .postDataConnector({
+        namespace: "user1-uuid/test-2-v2-project",
+        visibility: "public",
+      })
       .postDataConnectorProjectLink({ dataConnectorId: "ULID-5" })
       .patchDataConnectorSecrets({
         dataConnectorId: "ULID-5",
@@ -161,7 +167,7 @@ describe("Set up data connectors with credentials", () => {
     cy.wait("@patchDataConnectorSecrets");
     cy.getDataCy("data-connector-edit-body").should(
       "contain.text",
-      "The data connector user1-uuid/example-storage-with-credentials has been successfully added"
+      "The data connector user1-uuid/test-2-v2-project/example-storage-with-credentials has been successfully added"
     );
     cy.getDataCy("data-connector-edit-body").should(
       "contain.text",

--- a/tests/cypress/e2e/projectV2setup.spec.ts
+++ b/tests/cypress/e2e/projectV2setup.spec.ts
@@ -191,7 +191,10 @@ describe("Set up data connectors", () => {
       .getDataConnector()
       .getStorageSchema({ fixture: "cloudStorage/storage-schema-s3.json" })
       .testCloudStorage({ success: false })
-      .postDataConnector({ namespace: "user1-uuid", visibility: "public" })
+      .postDataConnector({
+        namespace: "user1-uuid/test-2-v2-project",
+        visibility: "public",
+      })
       .postDataConnectorProjectLink({ dataConnectorId: "ULID-5" });
     cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
     cy.wait("@readProjectV2");
@@ -239,7 +242,7 @@ describe("Set up data connectors", () => {
     cy.wait("@postDataConnector");
     cy.getDataCy("data-connector-edit-body").should(
       "contain.text",
-      "The data connector user1-uuid/example-storage-without-credentials has been successfully added"
+      "The data connector user1-uuid/test-2-v2-project/example-storage-without-credentials has been successfully added"
     );
     cy.getDataCy("data-connector-edit-body").should(
       "contain.text",
@@ -342,7 +345,10 @@ describe("Set up data connectors", () => {
       .getDataConnector()
       .getStorageSchema({ fixture: "cloudStorage/storage-schema-s3.json" })
       .testCloudStorage({ success: false })
-      .postDataConnector({ namespace: "user1-uuid", visibility: "public" })
+      .postDataConnector({
+        namespace: "user1-uuid/test-2-v2-project",
+        visibility: "public",
+      })
       .postDataConnectorProjectLink({ dataConnectorId: "ULID-5" });
     cy.visit("/v2/projects/user1-uuid/test-2-v2-project");
     cy.wait("@readProjectV2");
@@ -375,7 +381,7 @@ describe("Set up data connectors", () => {
     cy.wait("@postDataConnector");
     cy.getDataCy("data-connector-edit-body").should(
       "contain.text",
-      "The data connector user1-uuid/example-storage-without-credentials has been successfully added"
+      "The data connector user1-uuid/test-2-v2-project/example-storage-without-credentials has been successfully added"
     );
     cy.getDataCy("data-connector-edit-body").should(
       "contain.text",


### PR DESCRIPTION
This is the initial implementation.

Things that are missing:
- no tests
- the way that data connectors in projects are displayed is not right
- the backend is still a bit wonky and will not support everything (i.e. launching sessions fails)

/deploy renku-data-services=feat-add-project-as-dc-owner-pt2