### PR TITLE
feat: get build status and trigger builds

### DIFF
--- a/client/src/features/sessionsV2/SessionView/EnvironmentCard.tsx
+++ b/client/src/features/sessionsV2/SessionView/EnvironmentCard.tsx
@@ -257,7 +257,7 @@ function CustomBuildEnvironmentValues({
         value={frontend_variant || ""}
       />
 
-      {environment.container_image !== "image:unknown-at-the-moment" && (
+      {environment.container_image !== BUILDER_IMAGE_NOT_READY_VALUE && (
         <CustomImageEnvironmentValues launcher={launcher} />
       )}
     </>

--- a/client/src/features/sessionsV2/SessionView/EnvironmentCard.tsx
+++ b/client/src/features/sessionsV2/SessionView/EnvironmentCard.tsx
@@ -188,8 +188,7 @@ function CustomBuildEnvironmentValues({
       ? { environmentId: environment.id }
       : skipToken,
     {
-      // TODO: use 1 second once the backend has a k8s cache
-      pollingInterval: 30_000,
+      pollingInterval: 1_000,
     }
   );
 

--- a/client/src/features/sessionsV2/api/sessionLaunchersV2.api.ts
+++ b/client/src/features/sessionsV2/api/sessionLaunchersV2.api.ts
@@ -43,7 +43,7 @@ const withFixedEndpoints = sessionLaunchersV2GeneratedApi.injectEndpoints({
 });
 
 // Adds tag handling for cache management
-export const sessionLaunchersV2Api = withFixedEndpoints.enhanceEndpoints({
+const withTagHandling = withFixedEndpoints.enhanceEndpoints({
   addTagTypes: ["Environment", "Launcher", "Build"],
   endpoints: {
     getEnvironments: {
@@ -104,6 +104,16 @@ export const sessionLaunchersV2Api = withFixedEndpoints.enhanceEndpoints({
           : ["Build"],
     },
   },
+});
+
+// Adds tag invalidation endpoints
+export const sessionLaunchersV2Api = withTagHandling.injectEndpoints({
+  endpoints: (build) => ({
+    invalidateLaunchers: build.mutation<null, void>({
+      queryFn: () => ({ data: null }),
+      invalidatesTags: ["Launcher"],
+    }),
+  }),
 });
 
 export const {

--- a/client/src/features/sessionsV2/api/sessionLaunchersV2.api.ts
+++ b/client/src/features/sessionsV2/api/sessionLaunchersV2.api.ts
@@ -44,7 +44,7 @@ const withFixedEndpoints = sessionLaunchersV2GeneratedApi.injectEndpoints({
 
 // Adds tag handling for cache management
 export const sessionLaunchersV2Api = withFixedEndpoints.enhanceEndpoints({
-  addTagTypes: ["Environment", "Launcher"],
+  addTagTypes: ["Environment", "Launcher", "Build"],
   endpoints: {
     getEnvironments: {
       providesTags: (result) =>
@@ -83,6 +83,26 @@ export const sessionLaunchersV2Api = withFixedEndpoints.enhanceEndpoints({
             ]
           : ["Launcher"],
     },
+    getBuildsByBuildId: {
+      providesTags: (result) =>
+        result ? [{ id: result.id, type: "Build" }, "Build"] : ["Build"],
+    },
+    postEnvironmentsByEnvironmentIdBuilds: {
+      invalidatesTags: ["Build"],
+    },
+    patchBuildsByBuildId: {
+      invalidatesTags: (result) =>
+        result ? [{ id: result.id, type: "Build" }] : ["Build"],
+    },
+    getEnvironmentsByEnvironmentIdBuilds: {
+      providesTags: (result) =>
+        result
+          ? [
+              ...result.map(({ id }) => ({ id, type: "Build" as const })),
+              "Build",
+            ]
+          : ["Build"],
+    },
   },
 });
 
@@ -95,6 +115,11 @@ export const {
   usePatchSessionLaunchersByLauncherIdMutation,
   useDeleteSessionLaunchersByLauncherIdMutation,
   useGetProjectsByProjectIdSessionLaunchersQuery,
+  // "builds" hooks
+  useGetBuildsByBuildIdQuery,
+  usePostEnvironmentsByEnvironmentIdBuildsMutation,
+  usePatchBuildsByBuildIdMutation,
+  useGetEnvironmentsByEnvironmentIdBuildsQuery,
 } = sessionLaunchersV2Api;
 
 export type * from "./sessionLaunchersV2.generated-api";

--- a/client/src/features/sessionsV2/api/sessionLaunchersV2.generated-api.ts
+++ b/client/src/features/sessionsV2/api/sessionLaunchersV2.generated-api.ts
@@ -116,7 +116,10 @@ const injectedRtkApi = api.injectEndpoints({
       GetBuildsByBuildIdLogsApiResponse,
       GetBuildsByBuildIdLogsApiArg
     >({
-      query: (queryArg) => ({ url: `/builds/${queryArg.buildId}/logs` }),
+      query: (queryArg) => ({
+        url: `/builds/${queryArg.buildId}/logs`,
+        params: { max_lines: queryArg.maxLines },
+      }),
     }),
     getEnvironmentsByEnvironmentIdBuilds: build.query<
       GetEnvironmentsByEnvironmentIdBuildsApiResponse,
@@ -212,6 +215,8 @@ export type GetBuildsByBuildIdLogsApiResponse =
   /** status 200 The build logs */ BuildLogs;
 export type GetBuildsByBuildIdLogsApiArg = {
   buildId: Ulid;
+  /** The maximum number of most-recent lines to return for each container */
+  maxLines?: number;
 };
 export type GetEnvironmentsByEnvironmentIdBuildsApiResponse =
   /** status 200 List of container image builds */ BuildList;
@@ -400,10 +405,8 @@ export type BuildPatch = {
   status?: "cancelled";
 };
 export type BuildLogs = {
-  process_name?: string;
-  stdout?: string;
-  stderr?: string;
-}[];
+  [key: string]: string;
+};
 export type BuildList = Build[];
 export const {
   useGetEnvironmentsQuery,

--- a/client/src/features/sessionsV2/api/sessionLaunchersV2.generated-api.ts
+++ b/client/src/features/sessionsV2/api/sessionLaunchersV2.generated-api.ts
@@ -96,6 +96,45 @@ const injectedRtkApi = api.injectEndpoints({
         url: `/projects/${queryArg.projectId}/session_launchers`,
       }),
     }),
+    getBuildsByBuildId: build.query<
+      GetBuildsByBuildIdApiResponse,
+      GetBuildsByBuildIdApiArg
+    >({
+      query: (queryArg) => ({ url: `/builds/${queryArg.buildId}` }),
+    }),
+    patchBuildsByBuildId: build.mutation<
+      PatchBuildsByBuildIdApiResponse,
+      PatchBuildsByBuildIdApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/builds/${queryArg.buildId}`,
+        method: "PATCH",
+        body: queryArg.buildPatch,
+      }),
+    }),
+    getBuildsByBuildIdLogs: build.query<
+      GetBuildsByBuildIdLogsApiResponse,
+      GetBuildsByBuildIdLogsApiArg
+    >({
+      query: (queryArg) => ({ url: `/builds/${queryArg.buildId}/logs` }),
+    }),
+    getEnvironmentsByEnvironmentIdBuilds: build.query<
+      GetEnvironmentsByEnvironmentIdBuildsApiResponse,
+      GetEnvironmentsByEnvironmentIdBuildsApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/environments/${queryArg.environmentId}/builds`,
+      }),
+    }),
+    postEnvironmentsByEnvironmentIdBuilds: build.mutation<
+      PostEnvironmentsByEnvironmentIdBuildsApiResponse,
+      PostEnvironmentsByEnvironmentIdBuildsApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/environments/${queryArg.environmentId}/builds`,
+        method: "POST",
+      }),
+    }),
   }),
   overrideExisting: false,
 });
@@ -157,6 +196,32 @@ export type GetProjectsByProjectIdSessionLaunchersApiResponse =
   /** status 200 List of sessions launchers */ SessionLaunchersList;
 export type GetProjectsByProjectIdSessionLaunchersApiArg = {
   projectId: Ulid;
+};
+export type GetBuildsByBuildIdApiResponse =
+  /** status 200 The container image build */ Build;
+export type GetBuildsByBuildIdApiArg = {
+  buildId: Ulid;
+};
+export type PatchBuildsByBuildIdApiResponse =
+  /** status 200 The updated container image build */ Build;
+export type PatchBuildsByBuildIdApiArg = {
+  buildId: Ulid;
+  buildPatch: BuildPatch;
+};
+export type GetBuildsByBuildIdLogsApiResponse =
+  /** status 200 The build logs */ BuildLogs;
+export type GetBuildsByBuildIdLogsApiArg = {
+  buildId: Ulid;
+};
+export type GetEnvironmentsByEnvironmentIdBuildsApiResponse =
+  /** status 200 List of container image builds */ BuildList;
+export type GetEnvironmentsByEnvironmentIdBuildsApiArg = {
+  environmentId: Ulid;
+};
+export type PostEnvironmentsByEnvironmentIdBuildsApiResponse =
+  /** status 201 The build was created */ Build;
+export type PostEnvironmentsByEnvironmentIdBuildsApiArg = {
+  environmentId: Ulid;
 };
 export type Ulid = string;
 export type SessionName = string;
@@ -311,6 +376,35 @@ export type SessionLauncherPatch = {
   disk_storage?: DiskStoragePatch;
   environment?: EnvironmentPatchInLauncher | EnvironmentIdOnlyPatch;
 };
+export type BuildCommonPart = {
+  id: Ulid;
+  environment_id: Ulid;
+  created_at: CreationDate;
+};
+export type BuildNotCompletedPart = {
+  status: "in_progress" | "failed" | "cancelled";
+};
+export type BuildResult = {
+  image: ContainerImage;
+  completed_at: CreationDate;
+  repository_url: string;
+  repository_git_commit_sha: string;
+};
+export type BuildCompletedPart = {
+  status: "succeeded";
+  result: BuildResult;
+};
+export type Build = BuildCommonPart &
+  (BuildNotCompletedPart | BuildCompletedPart);
+export type BuildPatch = {
+  status?: "cancelled";
+};
+export type BuildLogs = {
+  process_name?: string;
+  stdout?: string;
+  stderr?: string;
+}[];
+export type BuildList = Build[];
 export const {
   useGetEnvironmentsQuery,
   usePostEnvironmentsMutation,
@@ -323,4 +417,9 @@ export const {
   usePatchSessionLaunchersByLauncherIdMutation,
   useDeleteSessionLaunchersByLauncherIdMutation,
   useGetProjectsByProjectIdSessionLaunchersQuery,
+  useGetBuildsByBuildIdQuery,
+  usePatchBuildsByBuildIdMutation,
+  useGetBuildsByBuildIdLogsQuery,
+  useGetEnvironmentsByEnvironmentIdBuildsQuery,
+  usePostEnvironmentsByEnvironmentIdBuildsMutation,
 } = injectedRtkApi;

--- a/client/src/features/sessionsV2/api/sessionLaunchersV2.openapi.json
+++ b/client/src/features/sessionsV2/api/sessionLaunchersV2.openapi.json
@@ -460,6 +460,18 @@
       ],
       "get": {
         "summary": "Get the logs of a container image build",
+        "parameters": [
+          {
+            "description": "The maximum number of most-recent lines to return for each container",
+            "in": "query",
+            "name": "max_lines",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 250
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "The build logs",
@@ -1263,21 +1275,13 @@
       },
       "BuildLogs": {
         "description": "The logs of a container image build",
-        "type": "array",
-        "items": {
-          "description": "The logs of build step",
-          "type": "object",
-          "properties": {
-            "process_name": {
-              "type": "string"
-            },
-            "stdout": {
-              "type": "string"
-            },
-            "stderr": {
-              "type": "string"
-            }
-          }
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        },
+        "example": {
+          "container-A": "Log line 1\nLog line 2",
+          "container-B": "Log line 1\nLog line 2"
         }
       },
       "BuildResult": {

--- a/client/src/features/sessionsV2/api/sessionLaunchersV2.openapi.json
+++ b/client/src/features/sessionsV2/api/sessionLaunchersV2.openapi.json
@@ -386,6 +386,147 @@
         },
         "tags": ["session_launchers"]
       }
+    },
+    "/builds/{build_id}": {
+      "parameters": [
+        {
+          "in": "path",
+          "name": "build_id",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Ulid"
+          }
+        }
+      ],
+      "get": {
+        "summary": "Get the details of a container image build",
+        "responses": {
+          "200": {
+            "description": "The container image build",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Build"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          }
+        },
+        "tags": ["builds"]
+      },
+      "patch": {
+        "summary": "Update a container image build",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BuildPatch"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The updated container image build",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Build"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          }
+        },
+        "tags": ["builds"]
+      }
+    },
+    "/builds/{build_id}/logs": {
+      "parameters": [
+        {
+          "in": "path",
+          "name": "build_id",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Ulid"
+          }
+        }
+      ],
+      "get": {
+        "summary": "Get the logs of a container image build",
+        "responses": {
+          "200": {
+            "description": "The build logs",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BuildLogs"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          }
+        },
+        "tags": ["builds"]
+      }
+    },
+    "/environments/{environment_id}/builds": {
+      "parameters": [
+        {
+          "in": "path",
+          "name": "environment_id",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Ulid"
+          }
+        }
+      ],
+      "get": {
+        "summary": "Get a session environment's list of builds",
+        "responses": {
+          "200": {
+            "description": "List of container image builds",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BuildList"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          }
+        },
+        "tags": ["builds"]
+      },
+      "post": {
+        "summary": "Create a new container image build",
+        "responses": {
+          "201": {
+            "description": "The build was created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Build"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          }
+        },
+        "tags": ["builds"]
+      }
     }
   },
   "components": {
@@ -1039,6 +1180,136 @@
         "type": "boolean",
         "description": "Whether this environment is archived and not for use in new projects or not",
         "default": false
+      },
+      "Build": {
+        "description": "A container image build",
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BuildCommonPart"
+          },
+          {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/BuildNotCompletedPart"
+              },
+              {
+                "$ref": "#/components/schemas/BuildCompletedPart"
+              }
+            ]
+          }
+        ]
+      },
+      "BuildCommonPart": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/Ulid"
+          },
+          "environment_id": {
+            "$ref": "#/components/schemas/Ulid"
+          },
+          "created_at": {
+            "$ref": "#/components/schemas/CreationDate"
+          }
+        },
+        "required": ["id", "environment_id", "created_at"],
+        "additionalProperties": false
+      },
+      "BuildNotCompletedPart": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": ["in_progress", "failed", "cancelled"],
+            "example": "in_progress"
+          }
+        },
+        "required": ["status"],
+        "additionalProperties": false
+      },
+      "BuildCompletedPart": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": ["succeeded"],
+            "example": "succeeded"
+          },
+          "result": {
+            "$ref": "#/components/schemas/BuildResult"
+          }
+        },
+        "required": ["status", "result"],
+        "additionalProperties": false
+      },
+      "BuildList": {
+        "description": "A list of container image builds",
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/Build"
+        }
+      },
+      "BuildPatch": {
+        "description": "The requested update of a container image build",
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": ["cancelled"]
+          }
+        },
+        "additionalProperties": false
+      },
+      "BuildLogs": {
+        "description": "The logs of a container image build",
+        "type": "array",
+        "items": {
+          "description": "The logs of build step",
+          "type": "object",
+          "properties": {
+            "process_name": {
+              "type": "string"
+            },
+            "stdout": {
+              "type": "string"
+            },
+            "stderr": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "BuildResult": {
+        "description": "The result of a container image build",
+        "type": "object",
+        "properties": {
+          "image": {
+            "$ref": "#/components/schemas/ContainerImage"
+          },
+          "completed_at": {
+            "$ref": "#/components/schemas/CreationDate"
+          },
+          "repository_url": {
+            "type": "string"
+          },
+          "repository_git_commit_sha": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "image",
+          "completed_at",
+          "repository_url",
+          "repository_git_commit_sha"
+        ],
+        "additionalProperties": false
+      },
+      "BuildStatus": {
+        "description": "The status of a container image build",
+        "type": "string",
+        "enum": ["in_progress", "succeeded", "failed", "cancelled"],
+        "example": "succeeded"
       },
       "ErrorResponse": {
         "type": "object",


### PR DESCRIPTION
PR stack:
* (this) #3529
  * #3534
    * #3536
      * #3511

Update the UI for session environments created from code repositories.

* Get the build status and show it in the session offcanvas
* Allow users with edit permissions on the project to trigger builds and to cancel in-progress builds.

![image](https://github.com/user-attachments/assets/7b838382-f628-41d9-a868-3de21381194c)

/deploy #notest renku=build/session-env-builders renku-data-services=kpack-resources renku-notebooks=leafty/shipwright-buildrun-cache extra-values=dataService.imageBuilders.enabled=true,dataService.imageBuilders.pushSecretName=flora-docker-secret,dataService.imageBuilders.buildRunRetentionAfterFailedSeconds=86400,dataService.imageBuilders.outputImagePrefix=harbor.dev.renku.ch/flora-dev/