### PR TITLE
feat: show last build's logs

### DIFF
--- a/client/src/features/sessionsV2/SessionView/EnvironmentCard.tsx
+++ b/client/src/features/sessionsV2/SessionView/EnvironmentCard.tsx
@@ -516,7 +516,7 @@ function BuildActions({ launcher }: BuildActionsProps) {
           onClick={toggleLogs}
         >
           <FileEarmarkText className={cx("bi", "me-1")} />
-          Show logs from {hasInProgressBuild ? "current" : "last"} build
+          Show logs
         </DropdownItem>
       </ButtonWithMenuV2>
     ) : (
@@ -596,6 +596,11 @@ interface BuildLogsModalProps {
 function BuildLogsModal({ builds, isOpen, toggle }: BuildLogsModalProps) {
   const lastBuild = builds?.at(0);
   const name = lastBuild?.id ?? "build_logs";
+  const inProgressBuild = useMemo(
+    () => builds?.find(({ status }) => status === "in_progress"),
+    [builds]
+  );
+  const hasInProgressBuild = !!inProgressBuild;
 
   const [logs, setLogs] = useState<ILogs>({
     data: {},
@@ -649,7 +654,7 @@ function BuildLogsModal({ builds, isOpen, toggle }: BuildLogsModalProps) {
       toggleLogs={toggle}
       logs={logs}
       name={name}
-      title="Logs"
+      title={`${hasInProgressBuild ? "Current" : "Last"} build logs`}
     />
   );
 }

--- a/client/src/features/sessionsV2/SessionsV2.tsx
+++ b/client/src/features/sessionsV2/SessionsV2.tsx
@@ -20,7 +20,14 @@ import { SerializedError } from "@reduxjs/toolkit";
 import { FetchBaseQueryError, skipToken } from "@reduxjs/toolkit/query";
 import cx from "classnames";
 import { useCallback, useMemo, useState } from "react";
-import { Bricks, Pencil, PlayCircle, Trash, XLg } from "react-bootstrap-icons";
+import {
+  Bricks,
+  FileEarmarkText,
+  Pencil,
+  PlayCircle,
+  Trash,
+  XLg,
+} from "react-bootstrap-icons";
 import { generatePath } from "react-router-dom-v5-compat";
 import {
   Badge,
@@ -246,6 +253,15 @@ export function SessionV2Actions({
       </DropdownItem>
     );
 
+  const showLastBuildLogsAction = launcher.environment.environment_kind ===
+    "CUSTOM" &&
+    launcher.environment.environment_image_source === "build" && (
+      <DropdownItem data-cy="session-view-menu-show-last-build-logs" disabled>
+        <FileEarmarkText className={cx("bi", "me-1")} />
+        Show logs from last build
+      </DropdownItem>
+    );
+
   return (
     <>
       <PermissionsGuard
@@ -266,6 +282,7 @@ export function SessionV2Actions({
                 Delete
               </DropdownItem>
               {rebuildAction}
+              {showLastBuildLogsAction}
             </ButtonWithMenuV2>
             <UpdateSessionLauncherModal
               isOpen={isUpdateOpen}

--- a/client/src/features/sessionsV2/api/sessionLaunchersV2.api.ts
+++ b/client/src/features/sessionsV2/api/sessionLaunchersV2.api.ts
@@ -44,7 +44,7 @@ const withFixedEndpoints = sessionLaunchersV2GeneratedApi.injectEndpoints({
 
 // Adds tag handling for cache management
 const withTagHandling = withFixedEndpoints.enhanceEndpoints({
-  addTagTypes: ["Environment", "Launcher", "Build"],
+  addTagTypes: ["Environment", "Launcher", "Build", "BuildLogs"],
   endpoints: {
     getEnvironments: {
       providesTags: (result) =>
@@ -103,6 +103,12 @@ const withTagHandling = withFixedEndpoints.enhanceEndpoints({
             ]
           : ["Build"],
     },
+    getBuildsByBuildIdLogs: {
+      providesTags: (result, _error, args) =>
+        result
+          ? [{ id: args.buildId, type: "BuildLogs" }, "BuildLogs"]
+          : ["BuildLogs"],
+    },
   },
 });
 
@@ -130,6 +136,7 @@ export const {
   usePostEnvironmentsByEnvironmentIdBuildsMutation,
   usePatchBuildsByBuildIdMutation,
   useGetEnvironmentsByEnvironmentIdBuildsQuery,
+  useGetBuildsByBuildIdLogsQuery,
 } = sessionLaunchersV2Api;
 
 export type * from "./sessionLaunchersV2.generated-api";

--- a/client/src/features/sessionsV2/components/SessionForm/EnvironmentKindField.tsx
+++ b/client/src/features/sessionsV2/components/SessionForm/EnvironmentKindField.tsx
@@ -84,7 +84,7 @@ export default function EnvironmentKindField({
               data-cy="environment-kind-builder"
               htmlFor="environment-kind-builder-radio"
             >
-              Create from a repository
+              Create from code
             </label>
           </ButtonGroup>
         </div>


### PR DESCRIPTION
PR stack:
* #3529
  * (this) #3534
    * #3536
      * #3511

Add an action to retrieve the logs from the last build (or the current build if a build is in progress).

Also, improve the build actions logic.

![Screenshot From 2025-02-24 15-05-23](https://github.com/user-attachments/assets/7cb66823-06e9-4934-a9cd-1a60dbf8813c)
![Screenshot From 2025-02-24 15-06-01](https://github.com/user-attachments/assets/ff658389-f861-415c-a2be-fc3354a8f272)


/deploy #notest renku=build/session-env-builders renku-data-services=kpack-resources renku-notebooks=leafty/shipwright-buildrun-cache extra-values=dataService.imageBuilders.enabled=true,dataService.imageBuilders.pushSecretName=flora-docker-secret,dataService.imageBuilders.buildRunRetentionAfterFailedSeconds=86400,dataService.imageBuilders.outputImagePrefix=harbor.dev.renku.ch/flora-dev/