### PR TITLE
refine: improve the selector fields for repo-based environments

### DIFF
--- a/client/src/features/sessionsV2/SessionView/EnvironmentCard.tsx
+++ b/client/src/features/sessionsV2/SessionView/EnvironmentCard.tsx
@@ -516,7 +516,7 @@ function BuildActions({ launcher }: BuildActionsProps) {
           onClick={toggleLogs}
         >
           <FileEarmarkText className={cx("bi", "me-1")} />
-          Show logs from {hasInProgressBuild ? "current" : "last"} build
+          Show logs
         </DropdownItem>
       </ButtonWithMenuV2>
     ) : (
@@ -596,6 +596,11 @@ interface BuildLogsModalProps {
 function BuildLogsModal({ builds, isOpen, toggle }: BuildLogsModalProps) {
   const lastBuild = builds?.at(0);
   const name = lastBuild?.id ?? "build_logs";
+  const inProgressBuild = useMemo(
+    () => builds?.find(({ status }) => status === "in_progress"),
+    [builds]
+  );
+  const hasInProgressBuild = !!inProgressBuild;
 
   const [logs, setLogs] = useState<ILogs>({
     data: {},
@@ -649,7 +654,7 @@ function BuildLogsModal({ builds, isOpen, toggle }: BuildLogsModalProps) {
       toggleLogs={toggle}
       logs={logs}
       name={name}
-      title="Logs"
+      title={`${hasInProgressBuild ? "Current" : "Last"} build logs`}
     />
   );
 }

--- a/client/src/features/sessionsV2/SessionsV2.tsx
+++ b/client/src/features/sessionsV2/SessionsV2.tsx
@@ -20,7 +20,14 @@ import { SerializedError } from "@reduxjs/toolkit";
 import { FetchBaseQueryError, skipToken } from "@reduxjs/toolkit/query";
 import cx from "classnames";
 import { useCallback, useMemo, useState } from "react";
-import { Bricks, Pencil, PlayCircle, Trash, XLg } from "react-bootstrap-icons";
+import {
+  Bricks,
+  FileEarmarkText,
+  Pencil,
+  PlayCircle,
+  Trash,
+  XLg,
+} from "react-bootstrap-icons";
 import { generatePath } from "react-router-dom-v5-compat";
 import {
   Badge,
@@ -246,6 +253,15 @@ export function SessionV2Actions({
       </DropdownItem>
     );
 
+  const showLastBuildLogsAction = launcher.environment.environment_kind ===
+    "CUSTOM" &&
+    launcher.environment.environment_image_source === "build" && (
+      <DropdownItem data-cy="session-view-menu-show-last-build-logs" disabled>
+        <FileEarmarkText className={cx("bi", "me-1")} />
+        Show logs from last build
+      </DropdownItem>
+    );
+
   return (
     <>
       <PermissionsGuard
@@ -266,6 +282,7 @@ export function SessionV2Actions({
                 Delete
               </DropdownItem>
               {rebuildAction}
+              {showLastBuildLogsAction}
             </ButtonWithMenuV2>
             <UpdateSessionLauncherModal
               isOpen={isUpdateOpen}

--- a/client/src/features/sessionsV2/api/sessionLaunchersV2.api.ts
+++ b/client/src/features/sessionsV2/api/sessionLaunchersV2.api.ts
@@ -44,7 +44,7 @@ const withFixedEndpoints = sessionLaunchersV2GeneratedApi.injectEndpoints({
 
 // Adds tag handling for cache management
 const withTagHandling = withFixedEndpoints.enhanceEndpoints({
-  addTagTypes: ["Environment", "Launcher", "Build"],
+  addTagTypes: ["Environment", "Launcher", "Build", "BuildLogs"],
   endpoints: {
     getEnvironments: {
       providesTags: (result) =>
@@ -103,6 +103,12 @@ const withTagHandling = withFixedEndpoints.enhanceEndpoints({
             ]
           : ["Build"],
     },
+    getBuildsByBuildIdLogs: {
+      providesTags: (result, _error, args) =>
+        result
+          ? [{ id: args.buildId, type: "BuildLogs" }, "BuildLogs"]
+          : ["BuildLogs"],
+    },
   },
 });
 
@@ -130,6 +136,7 @@ export const {
   usePostEnvironmentsByEnvironmentIdBuildsMutation,
   usePatchBuildsByBuildIdMutation,
   useGetEnvironmentsByEnvironmentIdBuildsQuery,
+  useGetBuildsByBuildIdLogsQuery,
 } = sessionLaunchersV2Api;
 
 export type * from "./sessionLaunchersV2.generated-api";

--- a/client/src/features/sessionsV2/components/SessionForm/BuilderEnvironmentFields.tsx
+++ b/client/src/features/sessionsV2/components/SessionForm/BuilderEnvironmentFields.tsx
@@ -30,6 +30,7 @@ import type { SessionLauncherForm } from "../../sessionsV2.types";
 import BuilderFrontendSelector from "./BuilderFrontendSelector";
 import BuilderTypeSelector from "./BuilderTypeSelector";
 import CodeRepositorySelector from "./CodeRepositorySelector";
+import WipBadge from "../../../projectsV2/shared/WipBadge";
 
 interface BuilderEnvironmentFieldsProps {
   control: Control<SessionLauncherForm>;
@@ -90,6 +91,11 @@ export default function BuilderEnvironmentFields({
 
   return (
     <div className={cx("d-flex", "flex-column", "gap-3")}>
+      <div>
+        <WipBadge tooltip="This is an experimental feature. Use at your own risk.">
+          Experimental
+        </WipBadge>
+      </div>
       {!isEdit && (
         <p className={cx("mb-0")}>
           Let RenkuLab create a customized environment from a code repository. A

--- a/client/src/features/sessionsV2/components/SessionForm/BuilderFrontendSelector.tsx
+++ b/client/src/features/sessionsV2/components/SessionForm/BuilderFrontendSelector.tsx
@@ -17,8 +17,7 @@
  */
 
 import cx from "classnames";
-import { useCallback, useMemo } from "react";
-import { ChevronDown } from "react-bootstrap-icons";
+import { useMemo } from "react";
 import {
   Controller,
   type FieldValues,
@@ -26,20 +25,9 @@ import {
   type PathValue,
   type UseControllerProps,
 } from "react-hook-form";
-import Select, {
-  components,
-  type ClassNamesConfig,
-  type GroupBase,
-  type SelectComponentsConfig,
-  type SingleValue,
-} from "react-select";
 import { Label } from "reactstrap";
-
-import styles from "./Select.module.scss";
-
-/* eslint-disable spellcheck/spell-checker */
-const BUILDER_FRONTENDS = ["vscodium"] as const;
-/* eslint-enable spellcheck/spell-checker */
+import { BUILDER_FRONTENDS } from "../../session.constants";
+import BuilderSelectorCommon from "./BuilderSelectorCommon";
 
 interface BuilderFrontendSelectorProps<T extends FieldValues>
   extends UseControllerProps<T> {}
@@ -71,7 +59,7 @@ export default function BuilderFrontendSelector<T extends FieldValues>({
               className={cx(error && "is-invalid")}
               data-cy="environment-type-select"
             >
-              <BuilderFrontendSelect
+              <BuilderSelectorCommon
                 name={controllerProps.name}
                 defaultValue={defaultValue}
                 options={BUILDER_FRONTENDS}
@@ -100,90 +88,3 @@ export default function BuilderFrontendSelector<T extends FieldValues>({
     </div>
   );
 }
-
-interface BuilderFrontendSelectProps {
-  name: string;
-
-  defaultValue?: string;
-
-  options: readonly string[];
-
-  onChange?: (newValue?: string) => void;
-  onBlur?: () => void;
-  value: string;
-  disabled?: boolean;
-}
-
-function BuilderFrontendSelect({
-  name,
-  options,
-  defaultValue,
-  onBlur,
-  onChange: onChange_,
-  disabled,
-  value,
-}: BuilderFrontendSelectProps) {
-  const onChange = useCallback(
-    (newValue: SingleValue<{ value: string }>) => {
-      onChange_?.(newValue?.value);
-    },
-    [onChange_]
-  );
-
-  return (
-    <Select
-      id="builder-environment-frontend-select"
-      inputId="builder-environment-frontend-select-input"
-      name={name}
-      isClearable={false}
-      isSearchable
-      options={options.map((value) => ({ value }))}
-      getOptionLabel={({ value }) => value}
-      getOptionValue={({ value }) => value}
-      unstyled
-      onChange={onChange}
-      onBlur={onBlur}
-      value={{ value }}
-      isDisabled={disabled}
-      defaultValue={defaultValue ? { value: defaultValue } : undefined}
-      classNames={selectClassNames}
-      components={selectComponents}
-    />
-  );
-}
-
-const selectClassNames: ClassNamesConfig<{ value: string }, false> = {
-  control: ({ menuIsOpen }) =>
-    cx(menuIsOpen ? "rounded-top" : "rounded", "border", styles.control),
-  dropdownIndicator: () => cx("pe-3"),
-  input: () => cx("px-3"),
-  menu: () => cx("bg-white", "rounded-bottom", "border"),
-  menuList: () => cx("d-grid"),
-  option: ({ isFocused, isSelected, isDisabled }) =>
-    cx(
-      "px-3",
-      "py-2",
-      isDisabled && "text-secondary",
-      styles.option,
-      isDisabled && styles.optionIsDisabled,
-      isFocused && !isDisabled && styles.optionIsFocused,
-      !isFocused && isSelected && !isDisabled && styles.optionIsSelected
-    ),
-  placeholder: () => cx("px-3"),
-  loadingMessage: () => cx("p-3"),
-  singleValue: () => cx("px-3"),
-};
-
-const selectComponents: SelectComponentsConfig<
-  { value: string },
-  false,
-  GroupBase<{ value: string }>
-> = {
-  DropdownIndicator: (props) => {
-    return (
-      <components.DropdownIndicator {...props}>
-        <ChevronDown className="bi" />
-      </components.DropdownIndicator>
-    );
-  },
-};

--- a/client/src/features/sessionsV2/components/SessionForm/BuilderFrontendSelector.tsx
+++ b/client/src/features/sessionsV2/components/SessionForm/BuilderFrontendSelector.tsx
@@ -60,13 +60,15 @@ export default function BuilderFrontendSelector<T extends FieldValues>({
               data-cy="environment-type-select"
             >
               <BuilderSelectorCommon
-                name={controllerProps.name}
                 defaultValue={defaultValue}
-                options={BUILDER_FRONTENDS}
+                disabled={disabled}
+                id="builder-environment-frontend-select"
+                inputId="builder-environment-frontend-select-input"
+                name={controllerProps.name}
                 onBlur={onBlur}
                 onChange={onChange}
+                options={BUILDER_FRONTENDS}
                 value={value ?? ""}
-                disabled={disabled}
               />
             </div>
             <div className="invalid-feedback">

--- a/client/src/features/sessionsV2/components/SessionForm/BuilderFrontendSelector.tsx
+++ b/client/src/features/sessionsV2/components/SessionForm/BuilderFrontendSelector.tsx
@@ -21,11 +21,10 @@ import { useMemo } from "react";
 import {
   Controller,
   type FieldValues,
-  type Path,
-  type PathValue,
   type UseControllerProps,
 } from "react-hook-form";
 import { Label } from "reactstrap";
+
 import { BUILDER_FRONTENDS } from "../../session.constants";
 import BuilderSelectorCommon from "./BuilderSelectorCommon";
 
@@ -85,7 +84,6 @@ export default function BuilderFrontendSelector<T extends FieldValues>({
             required: "Please select an environment type.",
           }
         }
-        defaultValue={defaultValue as PathValue<T, Path<T>>}
       />
     </div>
   );

--- a/client/src/features/sessionsV2/components/SessionForm/BuilderSelectorCommon.tsx
+++ b/client/src/features/sessionsV2/components/SessionForm/BuilderSelectorCommon.tsx
@@ -1,0 +1,144 @@
+/*!
+ * Copyright 2025 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import cx from "classnames";
+import { useCallback, useEffect, useMemo } from "react";
+import { ChevronDown } from "react-bootstrap-icons";
+import Select, {
+  components,
+  type ClassNamesConfig,
+  type GroupBase,
+  type OptionProps,
+  type SelectComponentsConfig,
+  type SingleValue,
+} from "react-select";
+import { BUILDER_TYPES } from "../../session.constants";
+import type { BuilderSelectorOption } from "../../sessionsV2.types";
+
+import styles from "./Select.module.scss";
+
+interface BuilderSelectorCommonProps {
+  defaultValue?: BuilderSelectorOption | undefined;
+  disabled?: boolean;
+  name: string;
+  options: readonly BuilderSelectorOption[];
+  value: string;
+  onBlur?: () => void;
+  onChange?: (newValue?: string) => void;
+}
+
+export default function BuilderSelectorCommon({
+  defaultValue,
+  disabled,
+  name,
+  options,
+  value: value_,
+  onBlur,
+  onChange: onChange_,
+}: BuilderSelectorCommonProps) {
+  const value = useMemo(
+    () => BUILDER_TYPES.find(({ value }) => value === value_) ?? defaultValue,
+    [defaultValue, value_]
+  );
+
+  const onChange = useCallback(
+    (newValue: SingleValue<BuilderSelectorOption>) => {
+      onChange_?.(newValue?.value);
+    },
+    [onChange_]
+  );
+
+  // We need to set the default value by hand here
+  useEffect(() => {
+    if (onChange_ != null && defaultValue) {
+      onChange_(defaultValue.value);
+    }
+  }, [defaultValue, onChange_]);
+
+  return (
+    <Select
+      id="builder-environment-type-select"
+      inputId="builder-environment-type-select-input"
+      name={name}
+      isClearable={false}
+      isSearchable
+      options={options}
+      getOptionLabel={({ label }) => label}
+      getOptionValue={({ value }) => value}
+      unstyled
+      onChange={onChange}
+      onBlur={onBlur}
+      value={value}
+      isDisabled={disabled}
+      defaultValue={defaultValue}
+      classNames={selectClassNames}
+      components={selectComponents}
+    />
+  );
+}
+
+const selectClassNames: ClassNamesConfig<BuilderSelectorOption, false> = {
+  control: ({ menuIsOpen }) =>
+    cx(menuIsOpen ? "rounded-top" : "rounded", "border", styles.control),
+  dropdownIndicator: () => cx("pe-3"),
+  input: () => cx("px-3"),
+  menu: () => cx("bg-white", "rounded-bottom", "border"),
+  menuList: () => cx("d-grid"),
+  option: ({ isFocused, isSelected, isDisabled }) =>
+    cx(
+      "px-3",
+      "py-2",
+      isDisabled && "text-secondary",
+      styles.option,
+      isDisabled && styles.optionIsDisabled,
+      isFocused && !isDisabled && styles.optionIsFocused,
+      !isFocused && isSelected && !isDisabled && styles.optionIsSelected
+    ),
+  placeholder: () => cx("px-3"),
+  loadingMessage: () => cx("p-3"),
+  singleValue: () => cx("px-3"),
+};
+
+const selectComponents: SelectComponentsConfig<
+  BuilderSelectorOption,
+  false,
+  GroupBase<BuilderSelectorOption>
+> = {
+  DropdownIndicator: (props) => {
+    return (
+      <components.DropdownIndicator {...props}>
+        <ChevronDown className="bi" />
+      </components.DropdownIndicator>
+    );
+  },
+  Option: (
+    props: OptionProps<
+      BuilderSelectorOption,
+      false,
+      GroupBase<BuilderSelectorOption>
+    >
+  ) => {
+    const { data } = props;
+    return (
+      <components.Option {...props}>
+        <div className="fw-bold">{data.label}</div>
+        {data.description && <div>{data.description}</div>}
+      </components.Option>
+    );
+  },
+};

--- a/client/src/features/sessionsV2/components/SessionForm/BuilderSelectorCommon.tsx
+++ b/client/src/features/sessionsV2/components/SessionForm/BuilderSelectorCommon.tsx
@@ -17,7 +17,7 @@
  */
 
 import cx from "classnames";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { ChevronDown } from "react-bootstrap-icons";
 import Select, {
   components,
@@ -27,6 +27,7 @@ import Select, {
   type SelectComponentsConfig,
   type SingleValue,
 } from "react-select";
+
 import { BUILDER_TYPES } from "../../session.constants";
 import type { BuilderSelectorOption } from "../../sessionsV2.types";
 
@@ -66,6 +67,13 @@ export default function BuilderSelectorCommon({
     },
     [onChange_]
   );
+
+  // We need to set the default value by hand here
+  useEffect(() => {
+    if (onChange_ != null && defaultValue && !value_) {
+      onChange_(defaultValue.value);
+    }
+  }, [defaultValue, onChange_, value_]);
 
   return (
     <Select

--- a/client/src/features/sessionsV2/components/SessionForm/BuilderSelectorCommon.tsx
+++ b/client/src/features/sessionsV2/components/SessionForm/BuilderSelectorCommon.tsx
@@ -17,7 +17,7 @@
  */
 
 import cx from "classnames";
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { ChevronDown } from "react-bootstrap-icons";
 import Select, {
   components,
@@ -35,6 +35,8 @@ import styles from "./Select.module.scss";
 interface BuilderSelectorCommonProps {
   defaultValue?: BuilderSelectorOption | undefined;
   disabled?: boolean;
+  id: string;
+  inputId: string;
   name: string;
   options: readonly BuilderSelectorOption[];
   value: string;
@@ -45,6 +47,8 @@ interface BuilderSelectorCommonProps {
 export default function BuilderSelectorCommon({
   defaultValue,
   disabled,
+  id,
+  inputId,
   name,
   options,
   value: value_,
@@ -63,17 +67,10 @@ export default function BuilderSelectorCommon({
     [onChange_]
   );
 
-  // We need to set the default value by hand here
-  useEffect(() => {
-    if (onChange_ != null && defaultValue) {
-      onChange_(defaultValue.value);
-    }
-  }, [defaultValue, onChange_]);
-
   return (
     <Select
-      id="builder-environment-type-select"
-      inputId="builder-environment-type-select-input"
+      id={id}
+      inputId={inputId}
       name={name}
       isClearable={false}
       isSearchable

--- a/client/src/features/sessionsV2/components/SessionForm/BuilderTypeSelector.tsx
+++ b/client/src/features/sessionsV2/components/SessionForm/BuilderTypeSelector.tsx
@@ -17,8 +17,7 @@
  */
 
 import cx from "classnames";
-import { useCallback, useMemo } from "react";
-import { ChevronDown } from "react-bootstrap-icons";
+import { useMemo } from "react";
 import {
   Controller,
   type FieldValues,
@@ -26,20 +25,9 @@ import {
   type PathValue,
   type UseControllerProps,
 } from "react-hook-form";
-import Select, {
-  components,
-  type ClassNamesConfig,
-  type GroupBase,
-  type SelectComponentsConfig,
-  type SingleValue,
-} from "react-select";
 import { Label } from "reactstrap";
-
-import styles from "./Select.module.scss";
-
-/* eslint-disable spellcheck/spell-checker */
-const BUILDER_TYPES = ["python"] as const;
-/* eslint-enable spellcheck/spell-checker */
+import { BUILDER_TYPES } from "../../session.constants";
+import BuilderSelectorCommon from "./BuilderSelectorCommon";
 
 interface BuilderTypeSelectorProps<T extends FieldValues>
   extends UseControllerProps<T> {}
@@ -71,7 +59,7 @@ export default function BuilderTypeSelector<T extends FieldValues>({
               className={cx(error && "is-invalid")}
               data-cy="environment-type-select"
             >
-              <BuilderTypeSelect
+              <BuilderSelectorCommon
                 name={controllerProps.name}
                 defaultValue={defaultValue}
                 options={BUILDER_TYPES}
@@ -100,90 +88,3 @@ export default function BuilderTypeSelector<T extends FieldValues>({
     </div>
   );
 }
-
-interface BuilderTypeSelectProps {
-  name: string;
-
-  defaultValue?: string;
-
-  options: readonly string[];
-
-  onChange?: (newValue?: string) => void;
-  onBlur?: () => void;
-  value: string;
-  disabled?: boolean;
-}
-
-function BuilderTypeSelect({
-  name,
-  options,
-  defaultValue,
-  onBlur,
-  onChange: onChange_,
-  disabled,
-  value,
-}: BuilderTypeSelectProps) {
-  const onChange = useCallback(
-    (newValue: SingleValue<{ value: string }>) => {
-      onChange_?.(newValue?.value);
-    },
-    [onChange_]
-  );
-
-  return (
-    <Select
-      id="builder-environment-type-select"
-      inputId="builder-environment-type-select-input"
-      name={name}
-      isClearable={false}
-      isSearchable
-      options={options.map((value) => ({ value }))}
-      getOptionLabel={({ value }) => value}
-      getOptionValue={({ value }) => value}
-      unstyled
-      onChange={onChange}
-      onBlur={onBlur}
-      value={{ value }}
-      isDisabled={disabled}
-      defaultValue={defaultValue ? { value: defaultValue } : undefined}
-      classNames={selectClassNames}
-      components={selectComponents}
-    />
-  );
-}
-
-const selectClassNames: ClassNamesConfig<{ value: string }, false> = {
-  control: ({ menuIsOpen }) =>
-    cx(menuIsOpen ? "rounded-top" : "rounded", "border", styles.control),
-  dropdownIndicator: () => cx("pe-3"),
-  input: () => cx("px-3"),
-  menu: () => cx("bg-white", "rounded-bottom", "border"),
-  menuList: () => cx("d-grid"),
-  option: ({ isFocused, isSelected, isDisabled }) =>
-    cx(
-      "px-3",
-      "py-2",
-      isDisabled && "text-secondary",
-      styles.option,
-      isDisabled && styles.optionIsDisabled,
-      isFocused && !isDisabled && styles.optionIsFocused,
-      !isFocused && isSelected && !isDisabled && styles.optionIsSelected
-    ),
-  placeholder: () => cx("px-3"),
-  loadingMessage: () => cx("p-3"),
-  singleValue: () => cx("px-3"),
-};
-
-const selectComponents: SelectComponentsConfig<
-  { value: string },
-  false,
-  GroupBase<{ value: string }>
-> = {
-  DropdownIndicator: (props) => {
-    return (
-      <components.DropdownIndicator {...props}>
-        <ChevronDown className="bi" />
-      </components.DropdownIndicator>
-    );
-  },
-};

--- a/client/src/features/sessionsV2/components/SessionForm/BuilderTypeSelector.tsx
+++ b/client/src/features/sessionsV2/components/SessionForm/BuilderTypeSelector.tsx
@@ -18,6 +18,7 @@
 
 import cx from "classnames";
 import { useMemo } from "react";
+import { BoxArrowUpRight } from "react-bootstrap-icons";
 import {
   Controller,
   type FieldValues,
@@ -26,10 +27,9 @@ import {
   type UseControllerProps,
 } from "react-hook-form";
 import { Label } from "reactstrap";
+import { ExternalLink } from "../../../../components/ExternalLinks";
 import { BUILDER_TYPES } from "../../session.constants";
 import BuilderSelectorCommon from "./BuilderSelectorCommon";
-import { ExternalLink } from "../../../../components/ExternalLinks";
-import { BoxArrowUpRight } from "react-bootstrap-icons";
 
 interface BuilderTypeSelectorProps<T extends FieldValues>
   extends UseControllerProps<T> {}
@@ -69,13 +69,15 @@ export default function BuilderTypeSelector<T extends FieldValues>({
               data-cy="environment-type-select"
             >
               <BuilderSelectorCommon
-                name={controllerProps.name}
                 defaultValue={defaultValue}
-                options={BUILDER_TYPES}
+                disabled={disabled}
+                id="builder-environment-type-select"
+                inputId="builder-environment-type-select-input"
+                name={controllerProps.name}
                 onBlur={onBlur}
                 onChange={onChange}
+                options={BUILDER_TYPES}
                 value={value ?? ""}
-                disabled={disabled}
               />
             </div>
             <div className="invalid-feedback">

--- a/client/src/features/sessionsV2/components/SessionForm/BuilderTypeSelector.tsx
+++ b/client/src/features/sessionsV2/components/SessionForm/BuilderTypeSelector.tsx
@@ -28,6 +28,8 @@ import {
 import { Label } from "reactstrap";
 import { BUILDER_TYPES } from "../../session.constants";
 import BuilderSelectorCommon from "./BuilderSelectorCommon";
+import { ExternalLink } from "../../../../components/ExternalLinks";
+import { BoxArrowUpRight } from "react-bootstrap-icons";
 
 interface BuilderTypeSelectorProps<T extends FieldValues>
   extends UseControllerProps<T> {}
@@ -46,7 +48,14 @@ export default function BuilderTypeSelector<T extends FieldValues>({
   return (
     <div>
       <Label for="builder-environment-type-select-input">
-        Environment type
+        Environment type{" - "}
+        <ExternalLink
+          role="link"
+          url="https://www.notion.so/renku/UX-Research-How-to-create-a-custom-environment-from-a-code-repository-1960df2efafc801b88f6da59a0aa8234?pvs=4#1990df2efafc805f8548cbd5dafd200c"
+        >
+          Learn more
+          <BoxArrowUpRight className={cx("bi", "ms-1")} />
+        </ExternalLink>
       </Label>
       <Controller
         {...controllerProps}

--- a/client/src/features/sessionsV2/components/SessionForm/BuilderTypeSelector.tsx
+++ b/client/src/features/sessionsV2/components/SessionForm/BuilderTypeSelector.tsx
@@ -51,7 +51,7 @@ export default function BuilderTypeSelector<T extends FieldValues>({
         Environment type{" - "}
         <ExternalLink
           role="link"
-          url="https://www.notion.so/renku/UX-Research-How-to-create-a-custom-environment-from-a-code-repository-1960df2efafc801b88f6da59a0aa8234?pvs=4#1990df2efafc805f8548cbd5dafd200c"
+          url="https://renku.notion.site/How-to-create-a-custom-environment-from-a-code-repository-1960df2efafc801b88f6da59a0aa8234"
         >
           Learn more
           <BoxArrowUpRight className={cx("bi", "ms-1")} />

--- a/client/src/features/sessionsV2/components/SessionForm/BuilderTypeSelector.tsx
+++ b/client/src/features/sessionsV2/components/SessionForm/BuilderTypeSelector.tsx
@@ -22,8 +22,6 @@ import { BoxArrowUpRight } from "react-bootstrap-icons";
 import {
   Controller,
   type FieldValues,
-  type Path,
-  type PathValue,
   type UseControllerProps,
 } from "react-hook-form";
 import { Label } from "reactstrap";
@@ -94,7 +92,6 @@ export default function BuilderTypeSelector<T extends FieldValues>({
             required: "Please select an environment type.",
           }
         }
-        defaultValue={defaultValue as PathValue<T, Path<T>>}
       />
     </div>
   );

--- a/client/src/features/sessionsV2/components/SessionForm/EnvironmentKindField.tsx
+++ b/client/src/features/sessionsV2/components/SessionForm/EnvironmentKindField.tsx
@@ -84,7 +84,7 @@ export default function EnvironmentKindField({
               data-cy="environment-kind-builder"
               htmlFor="environment-kind-builder-radio"
             >
-              Create from a repository
+              Create from code
             </label>
           </ButtonGroup>
         </div>

--- a/client/src/features/sessionsV2/session.constants.ts
+++ b/client/src/features/sessionsV2/session.constants.ts
@@ -35,6 +35,7 @@ import faviconWaitingICO from "../../styles/assets/favicon/FaviconWaiting.ico";
 import faviconWaitingSVG from "../../styles/assets/favicon/FaviconWaiting.svg";
 import faviconWaiting16px from "../../styles/assets/favicon/FaviconWaiting16px.png";
 import faviconWaiting32px from "../../styles/assets/favicon/FaviconWaiting32px.png";
+import { BuilderSelectorOption } from "./sessionsV2.types";
 
 export const DEFAULT_URL = "/";
 export const DEFAULT_PORT = 8888;
@@ -89,3 +90,11 @@ export const CONTAINER_IMAGE_PATTERN =
   /^[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*(\/[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*)*(:[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}|@sha256:[a-fA-F0-9]{64}){0,1}$/;
 
 export const BUILDER_IMAGE_NOT_READY_VALUE = "image:unknown-at-the-moment";
+
+export const BUILDER_TYPES = [
+  {
+    value: "python",
+    label: "Python",
+    description: "Using conda is recommended. Blah blah blah.",
+  },
+] as readonly BuilderSelectorOption[];

--- a/client/src/features/sessionsV2/session.constants.ts
+++ b/client/src/features/sessionsV2/session.constants.ts
@@ -91,6 +91,7 @@ export const CONTAINER_IMAGE_PATTERN =
 
 export const BUILDER_IMAGE_NOT_READY_VALUE = "image:unknown-at-the-moment";
 
+/* eslint-disable spellcheck/spell-checker */
 export const BUILDER_TYPES = [
   {
     value: "python",
@@ -98,3 +99,15 @@ export const BUILDER_TYPES = [
     description: "Using conda is recommended. Blah blah blah.",
   },
 ] as readonly BuilderSelectorOption[];
+/* eslint-enable spellcheck/spell-checker */
+
+/* eslint-disable spellcheck/spell-checker */
+export const BUILDER_FRONTENDS = [
+  {
+    value: "vscodium",
+    label: "VSCodium",
+    description:
+      "VSCodium is a community-driven, freely-licensed binary distribution of Microsoft’s editor VS Code.",
+  },
+] as readonly BuilderSelectorOption[];
+/* eslint-enable spellcheck/spell-checker */

--- a/client/src/features/sessionsV2/session.constants.tsx
+++ b/client/src/features/sessionsV2/session.constants.tsx
@@ -91,7 +91,6 @@ export const CONTAINER_IMAGE_PATTERN =
 
 export const BUILDER_IMAGE_NOT_READY_VALUE = "image:unknown-at-the-moment";
 
-/* eslint-disable spellcheck/spell-checker */
 export const BUILDER_TYPES = [
   {
     value: "python",
@@ -106,12 +105,12 @@ export const BUILDER_TYPES = [
   },
 ] as readonly BuilderSelectorOption[];
 
-/* eslint-disable spellcheck/spell-checker */
 export const BUILDER_FRONTENDS = [
   {
+    /* eslint-disable spellcheck/spell-checker */
     value: "vscodium",
     label: "VSCodium",
     description: "A freely-licensed version Microsoft’s editor VS Code.",
+    /* eslint-enable spellcheck/spell-checker */
   },
 ] as readonly BuilderSelectorOption[];
-/* eslint-enable spellcheck/spell-checker */

--- a/client/src/features/sessionsV2/session.constants.tsx
+++ b/client/src/features/sessionsV2/session.constants.tsx
@@ -96,18 +96,22 @@ export const BUILDER_TYPES = [
   {
     value: "python",
     label: "Python",
-    description: "Using conda is recommended. Blah blah blah.",
+    description: (
+      <>
+        Create a Python environment from an <code>environment.yml</code> file.
+        This file must be at the root of the repository. See the documentation
+        for examples.
+      </>
+    ),
   },
 ] as readonly BuilderSelectorOption[];
-/* eslint-enable spellcheck/spell-checker */
 
 /* eslint-disable spellcheck/spell-checker */
 export const BUILDER_FRONTENDS = [
   {
     value: "vscodium",
     label: "VSCodium",
-    description:
-      "VSCodium is a community-driven, freely-licensed binary distribution of Microsoft’s editor VS Code.",
+    description: "A freely-licensed version Microsoft’s editor VS Code.",
   },
 ] as readonly BuilderSelectorOption[];
 /* eslint-enable spellcheck/spell-checker */

--- a/client/src/features/sessionsV2/sessionsV2.types.ts
+++ b/client/src/features/sessionsV2/sessionsV2.types.ts
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+import { ReactNode } from "react";
 import { ResourceClass } from "../dataServices/dataServices.types";
 import { CloudStorageDetailsOptions } from "../project/components/cloudStorage/projectCloudStorage.types";
 import type {
@@ -178,5 +179,5 @@ export interface DockerImage {
 export interface BuilderSelectorOption {
   label: string;
   value: string;
-  description: string;
+  description?: ReactNode;
 }

--- a/client/src/features/sessionsV2/sessionsV2.types.ts
+++ b/client/src/features/sessionsV2/sessionsV2.types.ts
@@ -174,3 +174,9 @@ export interface SessionImageParams {
 export interface DockerImage {
   error?: unknown;
 }
+
+export interface BuilderSelectorOption {
+  label: string;
+  value: string;
+  description: string;
+}


### PR DESCRIPTION
PR stack:
* #3529
  * #3534
    * (this) #3536
      * #3511

New UI:

![Screenshot 2025-02-25 at 09 21 15](https://github.com/user-attachments/assets/30efa6d4-c428-4fc0-b02d-3bb271fd578c)

![Screenshot 2025-02-25 at 09 21 24](https://github.com/user-attachments/assets/60dd3019-0e5d-439d-918d-4e074f0412db)

/deploy #notest renku=build/session-env-builders renku-data-services=kpack-resources renku-notebooks=leafty/shipwright-buildrun-cache extra-values=dataService.imageBuilders.enabled=true,dataService.imageBuilders.pushSecretName=flora-docker-secret,dataService.imageBuilders.buildRunRetentionAfterFailedSeconds=86400,dataService.imageBuilders.outputImagePrefix=harbor.dev.renku.ch/flora-dev/