### PR TITLE
refine: improve build error reporting

### DIFF
--- a/client/src/features/sessionsV2/SessionView/EnvironmentCard.tsx
+++ b/client/src/features/sessionsV2/SessionView/EnvironmentCard.tsx
@@ -321,6 +321,13 @@ function CustomBuildEnvironmentValues({
         )}
       </EnvironmentRow>
 
+      {lastBuild && (
+        <EnvironmentRowWithLabel
+          label="Error reason"
+          value={lastBuild.status}
+        />
+      )}
+
       <EnvironmentRowWithLabel
         label="Built from code repository"
         value={repository || ""}

--- a/client/src/features/sessionsV2/SessionView/EnvironmentCard.tsx
+++ b/client/src/features/sessionsV2/SessionView/EnvironmentCard.tsx
@@ -704,6 +704,9 @@ function BuildErrorReason({ build }: BuildErrorReasonProps) {
     return null;
   }
 
+  // Note: We provide a help text for some of the error conditions for image builds.
+  // See Shipwright's documentation for the error reasons:
+  // https://shipwright.io/docs/build/buildrun/#understanding-the-state-of-a-buildrun
   const helpText =
     error_reason === "Failed" ? (
       <>

--- a/client/src/features/sessionsV2/SessionView/EnvironmentCard.tsx
+++ b/client/src/features/sessionsV2/SessionView/EnvironmentCard.tsx
@@ -28,6 +28,7 @@ import {
   useState,
 } from "react";
 import {
+  BoxArrowUpRight,
   Bricks,
   CircleFill,
   Clock,
@@ -52,6 +53,7 @@ import {
 
 import { ButtonWithMenuV2 } from "../../../components/buttons/Button";
 import { RtkOrNotebooksError } from "../../../components/errors/RtkErrorAlert";
+import { ExternalLink } from "../../../components/ExternalLinks";
 import { ErrorLabel } from "../../../components/formlabels/FormLabels";
 import { Loader } from "../../../components/Loader";
 import { type ILogs, EnvironmentLogsPresent } from "../../../components/Logs";
@@ -74,7 +76,10 @@ import {
   usePatchBuildsByBuildIdMutation as usePatchBuildMutation,
   usePostEnvironmentsByEnvironmentIdBuildsMutation as usePostBuildMutation,
 } from "../api/sessionLaunchersV2.api";
-import { BUILDER_IMAGE_NOT_READY_VALUE } from "../session.constants";
+import {
+  BUILDER_IMAGE_NOT_READY_VALUE,
+  IMAGE_BUILD_DOCS,
+} from "../session.constants";
 import { safeStringify } from "../session.utils";
 
 export function EnvironmentCard({ launcher }: { launcher: SessionLauncher }) {
@@ -321,13 +326,9 @@ function CustomBuildEnvironmentValues({
         )}
       </EnvironmentRow>
 
-      {lastBuild && (
-        <EnvironmentRowWithLabel
-          label="Error reason"
-          value={lastBuild.status}
-        />
+      {lastBuild && lastBuild.status === "failed" && (
+        <BuildErrorReason build={lastBuild} />
       )}
-
       <EnvironmentRowWithLabel
         label="Built from code repository"
         value={repository || ""}
@@ -689,5 +690,58 @@ function BuildLogsModal({ builds, isOpen, toggle }: BuildLogsModalProps) {
       name={name}
       title={`${hasInProgressBuild ? "Current" : "Last"} build logs`}
     />
+  );
+}
+
+interface BuildErrorReasonProps {
+  build: Build;
+}
+
+function BuildErrorReason({ build }: BuildErrorReasonProps) {
+  const { error_reason, status } = build;
+
+  if (status !== "failed") {
+    return null;
+  }
+
+  const helpText =
+    error_reason === "Failed" ? (
+      <>
+        The build process failed, consult the build logs and{" "}
+        <ExternalLink role="link" url={IMAGE_BUILD_DOCS}>
+          our documentation
+          <BoxArrowUpRight className={cx("bi", "ms-1")} />
+        </ExternalLink>{" "}
+        to see how to fix the issue.
+      </>
+    ) : error_reason === "BuildRunTimeout" ? (
+      <>
+        The build process did not complete in time. Try to identify which
+        packages may take too long to install or contact an administrator to see
+        if builds can have longer timeouts.
+      </>
+    ) : error_reason === "StepOutOfMemory" ? (
+      <>
+        The build process ran out of memory. Try to identify which packages may
+        cause issues or contact an administrator to see if builds can have
+        access to more memory.
+      </>
+    ) : error_reason === "BuildRegistrationFailed" ? (
+      <>
+        The container image build has an invalid configuration. Contact an
+        administrator to learn more.
+      </>
+    ) : null;
+
+  return (
+    <Col xs={12} className={cx("d-flex", "flex-column", "py-2", "gap-2")}>
+      <div className="d-block">
+        <label className={cx("text-nowrap", "mb-0", "me-2")}>
+          Error reason:
+        </label>
+        <code>{error_reason}</code>
+      </div>
+      {helpText && <p className="mb-0">{helpText}</p>}
+    </Col>
   );
 }

--- a/client/src/features/sessionsV2/SessionView/EnvironmentCard.tsx
+++ b/client/src/features/sessionsV2/SessionView/EnvironmentCard.tsx
@@ -738,13 +738,17 @@ function BuildErrorReason({ build }: BuildErrorReasonProps) {
 
   return (
     <Col xs={12} className={cx("d-flex", "flex-column", "py-2", "gap-2")}>
-      <div className="d-block">
-        <label className={cx("text-nowrap", "mb-0", "me-2")}>
-          Error reason:
-        </label>
-        <code>{error_reason}</code>
+      <div className={cx("alert", "alert-danger", "m-0")}>
+        <div className="d-block">
+          <label className={cx("text-nowrap", "mb-0", "me-2")}>
+            Error reason:
+          </label>
+          <code className={cx("text-danger-emphasis", "fw-bold")}>
+            {error_reason}
+          </code>
+        </div>
+        {helpText && <p className="mb-0">{helpText}</p>}
       </div>
-      {helpText && <p className="mb-0">{helpText}</p>}
     </Col>
   );
 }

--- a/client/src/features/sessionsV2/api/sessionLaunchersV2.generated-api.ts
+++ b/client/src/features/sessionsV2/api/sessionLaunchersV2.generated-api.ts
@@ -381,10 +381,12 @@ export type SessionLauncherPatch = {
   disk_storage?: DiskStoragePatch;
   environment?: EnvironmentPatchInLauncher | EnvironmentIdOnlyPatch;
 };
+export type ErrorReason = string;
 export type BuildCommonPart = {
   id: Ulid;
   environment_id: Ulid;
   created_at: CreationDate;
+  error_reason?: ErrorReason;
 };
 export type BuildNotCompletedPart = {
   status: "in_progress" | "failed" | "cancelled";

--- a/client/src/features/sessionsV2/api/sessionLaunchersV2.openapi.json
+++ b/client/src/features/sessionsV2/api/sessionLaunchersV2.openapi.json
@@ -1223,6 +1223,9 @@
           },
           "created_at": {
             "$ref": "#/components/schemas/CreationDate"
+          },
+          "error_reason": {
+            "$ref": "#/components/schemas/ErrorReason"
           }
         },
         "required": ["id", "environment_id", "created_at"],
@@ -1314,6 +1317,11 @@
         "type": "string",
         "enum": ["in_progress", "succeeded", "failed", "cancelled"],
         "example": "succeeded"
+      },
+      "ErrorReason": {
+        "description": "The reason why a container image build did not succeed, if available.",
+        "type": "string",
+        "example": "StepOutOfMemory"
       },
       "ErrorResponse": {
         "type": "object",

--- a/client/src/features/sessionsV2/components/SessionForm/BuilderTypeSelector.tsx
+++ b/client/src/features/sessionsV2/components/SessionForm/BuilderTypeSelector.tsx
@@ -26,7 +26,7 @@ import {
 } from "react-hook-form";
 import { Label } from "reactstrap";
 import { ExternalLink } from "../../../../components/ExternalLinks";
-import { BUILDER_TYPES } from "../../session.constants";
+import { BUILDER_TYPES, IMAGE_BUILD_DOCS } from "../../session.constants";
 import BuilderSelectorCommon from "./BuilderSelectorCommon";
 
 interface BuilderTypeSelectorProps<T extends FieldValues>
@@ -47,10 +47,7 @@ export default function BuilderTypeSelector<T extends FieldValues>({
     <div>
       <Label for="builder-environment-type-select-input">
         Environment type{" - "}
-        <ExternalLink
-          role="link"
-          url="https://renku.notion.site/How-to-create-a-custom-environment-from-a-code-repository-1960df2efafc801b88f6da59a0aa8234"
-        >
+        <ExternalLink role="link" url={IMAGE_BUILD_DOCS}>
           Learn more
           <BoxArrowUpRight className={cx("bi", "ms-1")} />
         </ExternalLink>

--- a/client/src/features/sessionsV2/session.constants.tsx
+++ b/client/src/features/sessionsV2/session.constants.tsx
@@ -114,3 +114,6 @@ export const BUILDER_FRONTENDS = [
     /* eslint-enable spellcheck/spell-checker */
   },
 ] as readonly BuilderSelectorOption[];
+
+export const IMAGE_BUILD_DOCS =
+  "https://renku.notion.site/How-to-create-a-custom-environment-from-a-code-repository-1960df2efafc801b88f6da59a0aa8234";

--- a/client/src/features/sessionsV2/session.utils.ts
+++ b/client/src/features/sessionsV2/session.utils.ts
@@ -178,6 +178,7 @@ export function getFormattedEnvironmentValuesForEdit(
     success: true,
     data: {
       environment_image_source: "build",
+      environment_kind: "CUSTOM",
       build_parameters: {
         builder_variant,
         frontend_variant,


### PR DESCRIPTION
Improve the user experience around image builds when the image build process fails.

Example can be found here: https://renku-ci-ui-3543.dev.renku.ch/v2/projects/flora.thiebaut/flora-test

/deploy #notest renku=build/session-env-builders renku-data-services=pitch/custom-environment-build renku-notebooks=leafty/shipwright-buildrun-cache extra-values=dataService.imageBuilders.enabled=true,dataService.imageBuilders.pushSecretName=flora-docker-secret,dataService.imageBuilders.buildRunTimeoutSeconds=30,dataService.imageBuilders.buildRunRetentionAfterFailedSeconds=86400,dataService.imageBuilders.nodeSelector.renku\.io/node-purpose=image-build,dataService.imageBuilders.tolerations[0].key=renku.io/dedicated,dataService.imageBuilders.tolerations[0].operator=Equal,dataService.imageBuilders.tolerations[0].effect=NoSchedule,dataService.imageBuilders.tolerations[0].value=image-build,dataService.imageBuilders.outputImagePrefix=harbor.dev.renku.ch/flora-dev/