### PR TITLE
build: use current LTS version of NodeJS

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v4
         with:
-          node-version: "20.11.0"
+          node-version: "22"
       - name: Get old version
         id: get_old_version
         run: |

--- a/.github/workflows/test-and-ci.yml
+++ b/.github/workflows/test-and-ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up node ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
-          node-version: "20.11.0"
+          node-version: "22"
       - name: Install client dependencies
         run: npm clean-install
         env:
@@ -47,7 +47,7 @@ jobs:
       - name: Set up node ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
-          node-version: "20.11.0"
+          node-version: "22"
       - name: Install server dependencies
         run: npm clean-install
       - name: Build server
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20.11.0"
+          node-version: "22"
       - name: Install dependencies
         run: npm clean-install
       - name: Install Playwright
@@ -92,7 +92,7 @@ jobs:
       - name: Set up node ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
-          node-version: "20.11.0"
+          node-version: "22"
       - name: Install project e2e dependencies
         run: npm clean-install
       - name: Run format e2e

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.11.0 AS builder
+FROM node:22 AS builder
 
 RUN apt-get update && apt-get upgrade --quiet --assume-yes
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.11.0-alpine AS builder
+FROM node:22 AS builder
 
 WORKDIR /app
 
@@ -11,7 +11,7 @@ COPY src /app/src/
 RUN npm install --silent && \
     npm run-script build
 
-FROM node:20.11.0-alpine
+FROM node:22-alpine
 
 COPY --from=builder /app/dist app/dist
 COPY --from=builder /app/node_modules app/node_modules


### PR DESCRIPTION
See release schedule: https://nodejs.org/en/about/previous-releases.