### PR TITLE
refactor: improve modal headers, fix close button position

### DIFF
--- a/client/src/components/modal/ModalHeader.tsx
+++ b/client/src/components/modal/ModalHeader.tsx
@@ -19,14 +19,15 @@
 import cx from "classnames";
 import { type ModalHeaderProps as BaseModalHeaderProps } from "reactstrap";
 
-interface ModalHeaderProps extends Omit<BaseModalHeaderProps, "title>"> {
-  title: React.ReactNode;
+interface ModalHeaderProps extends React.HTMLAttributes<HTMLDivElement> {
+  modalTitle: React.ReactNode;
+  toggle?: BaseModalHeaderProps["toggle"];
 }
 
 export default function ModalHeader({
   children,
   className,
-  title,
+  modalTitle,
   toggle,
   ...props
 }: ModalHeaderProps) {
@@ -36,7 +37,7 @@ export default function ModalHeader({
         className={cx(className, "modal-header", children && "border-0")}
         {...props}
       >
-        <h1 className={cx("modal-title", "fs-5")}>{title}</h1>
+        <h1 className={cx("modal-title", "fs-5")}>{modalTitle}</h1>
         {toggle && (
           <button
             type="button"

--- a/client/src/components/modal/ModalHeader.tsx
+++ b/client/src/components/modal/ModalHeader.tsx
@@ -1,0 +1,49 @@
+/*!
+ * Copyright 2025 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import cx from "classnames";
+import { type ModalHeaderProps } from "reactstrap";
+
+interface RenkuModalHeaderProps extends Omit<ModalHeaderProps, "title>"> {
+  title: React.ReactNode;
+}
+
+export default function RenkuModalHeader({
+  children,
+  className,
+  title,
+  ...props
+}: RenkuModalHeaderProps) {
+  return (
+    <>
+      <div
+        className={cx(className, "modal-header", children && "border-0")}
+        {...props}
+      >
+        <h1 className={cx("modal-title", "fs-5")}>{title}</h1>
+        <button
+          type="button"
+          className="btn-close"
+          data-bs-dismiss="modal"
+          aria-label="Close"
+        ></button>
+      </div>
+      {children && <div className={cx("modal-header", "pt-0")}>{children}</div>}
+    </>
+  );
+}

--- a/client/src/components/modal/ModalHeader.tsx
+++ b/client/src/components/modal/ModalHeader.tsx
@@ -27,6 +27,7 @@ export default function ModalHeader({
   children,
   className,
   title,
+  toggle,
   ...props
 }: ModalHeaderProps) {
   return (
@@ -36,12 +37,15 @@ export default function ModalHeader({
         {...props}
       >
         <h1 className={cx("modal-title", "fs-5")}>{title}</h1>
-        <button
-          type="button"
-          className="btn-close"
-          data-bs-dismiss="modal"
-          aria-label="Close"
-        />
+        {toggle && (
+          <button
+            type="button"
+            className="btn-close"
+            data-bs-dismiss="modal"
+            aria-label="Close"
+            onClick={toggle}
+          />
+        )}
       </div>
       {children && <div className={cx("modal-header", "pt-0")}>{children}</div>}
     </>

--- a/client/src/components/modal/ModalHeader.tsx
+++ b/client/src/components/modal/ModalHeader.tsx
@@ -17,18 +17,18 @@
  */
 
 import cx from "classnames";
-import { type ModalHeaderProps } from "reactstrap";
+import { type ModalHeaderProps as BaseModalHeaderProps } from "reactstrap";
 
-interface RenkuModalHeaderProps extends Omit<ModalHeaderProps, "title>"> {
+interface ModalHeaderProps extends Omit<BaseModalHeaderProps, "title>"> {
   title: React.ReactNode;
 }
 
-export default function RenkuModalHeader({
+export default function ModalHeader({
   children,
   className,
   title,
   ...props
-}: RenkuModalHeaderProps) {
+}: ModalHeaderProps) {
   return (
     <>
       <div
@@ -41,7 +41,7 @@ export default function RenkuModalHeader({
           className="btn-close"
           data-bs-dismiss="modal"
           aria-label="Close"
-        ></button>
+        />
       </div>
       {children && <div className={cx("modal-header", "pt-0")}>{children}</div>}
     </>

--- a/client/src/features/ProjectPageV2/ProjectPageContent/DataConnectors/ProjectConnectDataConnectorsModal.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/DataConnectors/ProjectConnectDataConnectorsModal.tsx
@@ -30,12 +30,12 @@ import {
   Label,
   Modal,
   ModalBody,
-  ModalHeader,
   ModalFooter,
 } from "reactstrap";
 
 import { RtkOrNotebooksError } from "../../../../components/errors/RtkErrorAlert";
 import { Loader } from "../../../../components/Loader";
+import ModalHeader from "../../../../components/modal/ModalHeader";
 import useAppDispatch from "../../../../utils/customHooks/useAppDispatch.hook";
 
 import {
@@ -89,14 +89,12 @@ export default function ProjectConnectDataConnectorsModal({
       toggle={toggle}
     >
       <ModalHeader
+        title={<ProjectConnectDataConnectorModalTitle />}
         toggle={toggle}
         data-cy="project-data-connector-connect-header"
       >
-        <ProjectConnectDataConnectorModalTitle />
-      </ModalHeader>
-      <div className="modal-header">
         <ProjectConnectDataConnectorModeSwitch mode={mode} setMode={setMode} />
-      </div>
+      </ModalHeader>
       {mode === "create" ? (
         <ProjectCreateDataConnectorBodyAndFooter
           {...{

--- a/client/src/features/ProjectPageV2/ProjectPageContent/DataConnectors/ProjectConnectDataConnectorsModal.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/DataConnectors/ProjectConnectDataConnectorsModal.tsx
@@ -92,8 +92,11 @@ export default function ProjectConnectDataConnectorsModal({
         toggle={toggle}
         data-cy="project-data-connector-connect-header"
       >
-        <ProjectConnectDataConnectorModalHeader mode={mode} setMode={setMode} />
+        <ProjectConnectDataConnectorModalTitle />
       </ModalHeader>
+      <div className="modal-header">
+        <ProjectConnectDataConnectorModeSwitch mode={mode} setMode={setMode} />
+      </div>
       {mode === "create" ? (
         <ProjectCreateDataConnectorBodyAndFooter
           {...{
@@ -117,13 +120,7 @@ export default function ProjectConnectDataConnectorsModal({
   );
 }
 
-function ProjectConnectDataConnectorModalHeader({
-  mode,
-  setMode,
-}: {
-  mode: ProjectConnectDataConnectorMode;
-  setMode: (mode: ProjectConnectDataConnectorMode) => void;
-}) {
+function ProjectConnectDataConnectorModalTitle() {
   const { flatDataConnector, cloudStorageState } = useAppSelector(
     (state) => state.dataConnectorFormSlice
   );
@@ -136,51 +133,58 @@ function ProjectConnectDataConnectorModalHeader({
       : "";
   return (
     <>
-      <div>
-        <Database className={cx("bi", "me-1")} /> Link or create data connector{" "}
-        {title.trim()}
-      </div>
-      <div className="mt-3">
-        <ButtonGroup>
-          <Input
-            type="radio"
-            className="btn-check"
-            id="project-data-controller-mode-link"
-            value="link"
-            checked={mode === "link"}
-            onChange={() => {
-              setMode("link");
-            }}
-          />
-          <Label
-            data-cy="project-data-controller-mode-link"
-            for="project-data-controller-mode-link"
-            className={cx("btn", "btn-outline-primary")}
-          >
-            <NodePlus className={cx("bi", "me-1")} />
-            Link a data connector
-          </Label>
-          <Input
-            type="radio"
-            className="btn-check"
-            id="project-data-controller-mode-create"
-            value="create"
-            checked={mode === "create"}
-            onChange={() => {
-              setMode("create");
-            }}
-          />
-          <Label
-            data-cy="project-data-controller-mode-create"
-            for="project-data-controller-mode-create"
-            className={cx("btn", "btn-outline-primary")}
-          >
-            <PlusLg className={cx("bi", "me-1")} />
-            Create a data connector
-          </Label>
-        </ButtonGroup>
-      </div>
+      <Database className={cx("bi", "me-1")} /> Link or create data connector{" "}
+      {title.trim()}
     </>
+  );
+}
+
+function ProjectConnectDataConnectorModeSwitch({
+  mode,
+  setMode,
+}: {
+  mode: ProjectConnectDataConnectorMode;
+  setMode: (mode: ProjectConnectDataConnectorMode) => void;
+}) {
+  return (
+    <ButtonGroup>
+      <Input
+        type="radio"
+        className="btn-check"
+        id="project-data-controller-mode-link"
+        value="link"
+        checked={mode === "link"}
+        onChange={() => {
+          setMode("link");
+        }}
+      />
+      <Label
+        data-cy="project-data-controller-mode-link"
+        for="project-data-controller-mode-link"
+        className={cx("btn", "btn-outline-primary", "mb-0")}
+      >
+        <NodePlus className={cx("bi", "me-1")} />
+        Link a data connector
+      </Label>
+      <Input
+        type="radio"
+        className="btn-check"
+        id="project-data-controller-mode-create"
+        value="create"
+        checked={mode === "create"}
+        onChange={() => {
+          setMode("create");
+        }}
+      />
+      <Label
+        data-cy="project-data-controller-mode-create"
+        for="project-data-controller-mode-create"
+        className={cx("btn", "btn-outline-primary", "mb-0")}
+      >
+        <PlusLg className={cx("bi", "me-1")} />
+        Create a data connector
+      </Label>
+    </ButtonGroup>
   );
 }
 

--- a/client/src/features/ProjectPageV2/ProjectPageContent/DataConnectors/ProjectConnectDataConnectorsModal.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/DataConnectors/ProjectConnectDataConnectorsModal.tsx
@@ -89,7 +89,7 @@ export default function ProjectConnectDataConnectorsModal({
       toggle={toggle}
     >
       <ModalHeader
-        title={<ProjectConnectDataConnectorModalTitle />}
+        modalTitle={<ProjectConnectDataConnectorModalTitle />}
         toggle={toggle}
         data-cy="project-data-connector-connect-header"
       >

--- a/client/src/features/ProjectPageV2/ProjectPageContent/DataConnectors/ProjectConnectDataConnectorsModal.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/DataConnectors/ProjectConnectDataConnectorsModal.tsx
@@ -131,8 +131,8 @@ function ProjectConnectDataConnectorModalTitle() {
       : "";
   return (
     <>
-      <Database className={cx("bi", "me-1")} /> Link or create data connector{" "}
-      {title.trim()}
+      <Database className={cx("bi", "me-1")} />
+      Link or create data connector {title.trim()}
     </>
   );
 }

--- a/client/src/features/ProjectPageV2/ProjectPageContent/Documentation/Documentation.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/Documentation/Documentation.tsx
@@ -208,7 +208,7 @@ function DocumentationModal({
       toggle={safeToggle}
     >
       <ModalHeader
-        title={
+        modalTitle={
           <>
             <FileEarmarkText className={cx("me-1", "bi")} />
             Documentation

--- a/client/src/features/ProjectPageV2/ProjectPageContent/Documentation/Documentation.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/Documentation/Documentation.tsx
@@ -28,13 +28,13 @@ import {
   CardHeader,
   Form,
   ModalBody,
-  ModalHeader,
   ModalFooter,
 } from "reactstrap";
 import { useForm } from "react-hook-form";
 
 import { RtkOrNotebooksError } from "../../../../components/errors/RtkErrorAlert";
 import { Loader } from "../../../../components/Loader";
+import ModalHeader from "../../../../components/modal/ModalHeader";
 import LazyRenkuMarkdown from "../../../../components/markdown/LazyRenkuMarkdown";
 import ScrollableModal from "../../../../components/modal/ScrollableModal";
 
@@ -207,10 +207,17 @@ function DocumentationModal({
       size="lg"
       toggle={safeToggle}
     >
-      <ModalHeader toggle={toggle} data-cy="project-documentation-modal-header">
-        <FileEarmarkText className={cx("me-1", "bi")} />
-        Documentation
-      </ModalHeader>
+      <ModalHeader
+        title={
+          <>
+            <FileEarmarkText className={cx("me-1", "bi")} />
+            Documentation
+          </>
+        }
+        toggle={toggle}
+        data-cy="project-documentation-modal-header"
+      />
+
       <Form noValidate onSubmit={handleSubmit(onSubmit)}>
         <ModalBody
           data-cy="project-documentation-modal-body"

--- a/client/src/features/ProjectPageV2/ProjectPageContent/Documentation/Documentation.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/Documentation/Documentation.tsx
@@ -208,10 +208,8 @@ function DocumentationModal({
       toggle={safeToggle}
     >
       <ModalHeader toggle={toggle} data-cy="project-documentation-modal-header">
-        <div>
-          <FileEarmarkText className={cx("me-1", "bi")} />
-          Documentation
-        </div>
+        <FileEarmarkText className={cx("me-1", "bi")} />
+        Documentation
       </ModalHeader>
       <Form noValidate onSubmit={handleSubmit(onSubmit)}>
         <ModalBody

--- a/client/src/features/groupsV2/new/GroupNew.tsx
+++ b/client/src/features/groupsV2/new/GroupNew.tsx
@@ -70,10 +70,10 @@ export default function GroupNew() {
         unmountOnClose={true}
         toggle={toggleModal}
       >
-        <ModalHeader tag="div" toggle={toggleModal}>
-          <h2>
-            <People className="bi" /> Create a new group
-          </h2>
+        <ModalHeader toggle={toggleModal}>
+          <People className="bi" /> Create a new group
+        </ModalHeader>
+        <ModalHeader tag="div">
           <p className={cx("fs-6", "fw-normal", "mb-0")}>
             Groups let you group together related projects and control who can
             access them.

--- a/client/src/features/groupsV2/new/GroupNew.tsx
+++ b/client/src/features/groupsV2/new/GroupNew.tsx
@@ -28,11 +28,11 @@ import {
   Modal,
   ModalBody,
   ModalFooter,
-  ModalHeader,
 } from "reactstrap";
 
 import { RtkOrNotebooksError } from "../../../components/errors/RtkErrorAlert";
 import { Loader } from "../../../components/Loader";
+import ModalHeader from "../../../components/modal/ModalHeader";
 import LoginAlert from "../../../components/loginAlert/LoginAlert";
 import { ABSOLUTE_ROUTES } from "../../../routing/routes.constants";
 import useLocationHash from "../../../utils/customHooks/useLocationHash.hook";
@@ -70,10 +70,14 @@ export default function GroupNew() {
         unmountOnClose={true}
         toggle={toggleModal}
       >
-        <ModalHeader toggle={toggleModal}>
-          <People className="bi" /> Create a new group
-        </ModalHeader>
-        <ModalHeader tag="div">
+        <ModalHeader
+          toggle={toggleModal}
+          title={
+            <>
+              <People className="bi" /> Create a new group
+            </>
+          }
+        >
           <p className={cx("fs-6", "fw-normal", "mb-0")}>
             Groups let you group together related projects and control who can
             access them.

--- a/client/src/features/groupsV2/new/GroupNew.tsx
+++ b/client/src/features/groupsV2/new/GroupNew.tsx
@@ -72,7 +72,7 @@ export default function GroupNew() {
       >
         <ModalHeader
           toggle={toggleModal}
-          title={
+          modalTitle={
             <>
               <People className="bi" />
               Create a new group

--- a/client/src/features/groupsV2/new/GroupNew.tsx
+++ b/client/src/features/groupsV2/new/GroupNew.tsx
@@ -74,7 +74,8 @@ export default function GroupNew() {
           toggle={toggleModal}
           title={
             <>
-              <People className="bi" /> Create a new group
+              <People className="bi" />
+              Create a new group
             </>
           }
         >

--- a/client/src/features/projectsV2/new/ProjectV2New.tsx
+++ b/client/src/features/projectsV2/new/ProjectV2New.tsx
@@ -29,12 +29,12 @@ import {
   Modal,
   ModalBody,
   ModalFooter,
-  ModalHeader,
 } from "reactstrap";
 
 import { RtkOrNotebooksError } from "../../../components/errors/RtkErrorAlert";
 import { Loader } from "../../../components/Loader";
 import LoginAlert from "../../../components/loginAlert/LoginAlert";
+import ModalHeader from "../../../components/modal/ModalHeader";
 import { ABSOLUTE_ROUTES } from "../../../routing/routes.constants";
 import useLocationHash from "../../../utils/customHooks/useLocationHash.hook";
 import { slugFromTitle } from "../../../utils/helpers/HelperFunctions";
@@ -73,10 +73,14 @@ export default function ProjectV2New() {
         unmountOnClose={true}
         toggle={toggleModal}
       >
-        <ModalHeader toggle={toggleModal}>
-          <Folder className="bi" /> Create a new project
-        </ModalHeader>
-        <ModalHeader tag="div">
+        <ModalHeader
+          toggle={toggleModal}
+          title={
+            <>
+              <Folder className="bi" /> Create a new project
+            </>
+          }
+        >
           <p className={cx("fs-6", "fw-normal", "mb-0")}>
             A Renku project groups together data, code, and compute resources
             for you and your collaborators.

--- a/client/src/features/projectsV2/new/ProjectV2New.tsx
+++ b/client/src/features/projectsV2/new/ProjectV2New.tsx
@@ -75,7 +75,7 @@ export default function ProjectV2New() {
       >
         <ModalHeader
           toggle={toggleModal}
-          title={
+          modalTitle={
             <>
               <Folder className="bi" />
               Create a new project

--- a/client/src/features/projectsV2/new/ProjectV2New.tsx
+++ b/client/src/features/projectsV2/new/ProjectV2New.tsx
@@ -77,7 +77,8 @@ export default function ProjectV2New() {
           toggle={toggleModal}
           title={
             <>
-              <Folder className="bi" /> Create a new project
+              <Folder className="bi" />
+              Create a new project
             </>
           }
         >

--- a/client/src/features/projectsV2/new/ProjectV2New.tsx
+++ b/client/src/features/projectsV2/new/ProjectV2New.tsx
@@ -73,10 +73,10 @@ export default function ProjectV2New() {
         unmountOnClose={true}
         toggle={toggleModal}
       >
-        <ModalHeader tag="div" toggle={toggleModal}>
-          <h2>
-            <Folder className="bi" /> Create a new project
-          </h2>
+        <ModalHeader toggle={toggleModal}>
+          <Folder className="bi" /> Create a new project
+        </ModalHeader>
+        <ModalHeader tag="div">
           <p className={cx("fs-6", "fw-normal", "mb-0")}>
             A Renku project groups together data, code, and compute resources
             for you and your collaborators.


### PR DESCRIPTION
There are multiple ways these problems can be fixed, but in discussion with @leafty, it seems that the best solution is just to ensure that the modal dialog titles are short, adding further information in their own header blocks.

<img width="872" alt="image" src="https://github.com/user-attachments/assets/ce54b743-eaeb-4336-b290-ec9409fb3639" />

<img width="872" alt="image" src="https://github.com/user-attachments/assets/1ca60510-d791-4024-a8ec-ab9d25b08109" />

<img width="872" alt="image" src="https://github.com/user-attachments/assets/b426e9da-bf9f-4e13-a76d-c4a7d17561a8" />


Fix #3410

/deploy