### PR TITLE
fix: do not set z-index for session actions

### DIFF
--- a/client/src/features/dashboardV2/DashboardV2Sessions.tsx
+++ b/client/src/features/dashboardV2/DashboardV2Sessions.tsx
@@ -202,7 +202,7 @@ function DashboardSession({ session }: DashboardSessionProps) {
         </Row>
       </Link>
       {/* NOTE: The session actions button is visually placed within the link card, but its DOM tree is kept separate. */}
-      <div className={cx(styles.sessionButton, "position-absolute", "z-1")}>
+      <div className={cx(styles.sessionButton, "position-absolute")}>
         <ActiveSessionButton
           className="my-auto"
           session={session}


### PR DESCRIPTION
Closes #3569.

![image](https://github.com/user-attachments/assets/318a78d0-aa6d-41f3-83fd-35651ba8a3d2)

/deploy renku=build/session-env-builders