### PR TITLE
ci: do not run legacy tests by default

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -38,12 +38,12 @@ jobs:
       amalthea: ${{ steps.deploy-comment.outputs.amalthea}}
       amalthea-sessions: ${{ steps.deploy-comment.outputs.amalthea-sessions}}
       test-enabled: ${{ steps.deploy-comment.outputs.test-enabled}}
+      test-legacy-enabled: ${{ steps.deploy-comment.outputs.test-legacy-enabled}}
       extra-values: ${{ steps.deploy-comment.outputs.extra-values}}
     steps:
       - id: deploy-comment
         uses: SwissDataScienceCenter/renku-actions/check-pr-description@v1.14.1
         with:
-          string: /deploy
           pr_ref: ${{ github.event.number }}
 
   deploy-pr:
@@ -105,7 +105,7 @@ jobs:
     name: Legacy Cypress tests
     runs-on: ubuntu-24.04
     needs: [check-deploy, deploy-pr]
-    if: github.event.action != 'closed' && needs.check-deploy.outputs.pr-contains-string == 'true' && needs.check-deploy.outputs.test-enabled == 'true'
+    if: github.event.action != 'closed' && needs.check-deploy.outputs.pr-contains-string == 'true' && needs.check-deploy.outputs.test-legacy-enabled == 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -42,7 +42,7 @@ jobs:
       extra-values: ${{ steps.deploy-comment.outputs.extra-values}}
     steps:
       - id: deploy-comment
-        uses: SwissDataScienceCenter/renku-actions/check-pr-description@v1.14.1
+        uses: SwissDataScienceCenter/renku-actions/check-pr-description@v1.16.0
         with:
           pr_ref: ${{ github.event.number }}
 
@@ -74,7 +74,7 @@ jobs:
           body: |
             You can access the deployment of this PR at https://renku-ci-ui-${{ github.event.number }}.dev.renku.ch
       - name: Build and deploy
-        uses: SwissDataScienceCenter/renku-actions/deploy-renku@v1.14.1
+        uses: SwissDataScienceCenter/renku-actions/deploy-renku@v1.16.0
         env:
           DOCKER_PASSWORD: ${{ secrets.RENKU_DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.RENKU_DOCKER_USERNAME }}
@@ -121,7 +121,7 @@ jobs:
     steps:
       - name: Extract Renku repository reference
         run: echo "RENKU_REFERENCE=`echo '${{ needs.check-deploy.outputs.renku }}' | cut -d'@' -f2`" >> $GITHUB_ENV
-      - uses: SwissDataScienceCenter/renku-actions/test-renku-cypress@v1.14.1
+      - uses: SwissDataScienceCenter/renku-actions/test-renku-cypress@v1.16.0
         with:
           e2e-target: ${{ matrix.tests }}
           renku-reference: ${{ env.RENKU_REFERENCE }}
@@ -147,7 +147,7 @@ jobs:
     steps:
       - name: Extract Renku repository reference
         run: echo "RENKU_REFERENCE=`echo '${{ needs.check-deploy.outputs.renku }}' | cut -d'@' -f2`" >> $GITHUB_ENV
-      - uses: SwissDataScienceCenter/renku-actions/test-renku-cypress@v1.14.1
+      - uses: SwissDataScienceCenter/renku-actions/test-renku-cypress@v1.16.0
         with:
           e2e-target: ${{ matrix.tests }}
           renku-reference: ${{ env.RENKU_REFERENCE }}
@@ -178,7 +178,7 @@ jobs:
           body: |
             Tearing down the temporary RenkuLab deplyoment for this PR.
       - name: renku teardown
-        uses: SwissDataScienceCenter/renku-actions/cleanup-renku-ci-deployments@v1.14.1
+        uses: SwissDataScienceCenter/renku-actions/cleanup-renku-ci-deployments@v1.16.0
         env:
           HELM_RELEASE_REGEX: "^renku-ci-ui-${{ github.event.number }}$"
           GITLAB_TOKEN: ${{ secrets.DEV_GITLAB_TOKEN }}

--- a/.github/workflows/test-and-ci.yml
+++ b/.github/workflows/test-and-ci.yml
@@ -155,12 +155,12 @@ jobs:
           echo "GIT_USER=Renku Bot" >> $GITHUB_ENV
           echo "GIT_EMAIL=renku@datascience.ch" >> $GITHUB_ENV
       - name: Push images
-        uses: SwissDataScienceCenter/renku-actions/publish-chartpress-images@v1.14.1
+        uses: SwissDataScienceCenter/renku-actions/publish-chartpress-images@v1.16.0
         env:
           DOCKER_USERNAME: ${{ secrets.RENKU_DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.RENKU_DOCKER_PASSWORD }}
       - name: Update ui version
-        uses: SwissDataScienceCenter/renku-actions/update-component-version@v1.14.1
+        uses: SwissDataScienceCenter/renku-actions/update-component-version@v1.16.0
         env:
           GITHUB_TOKEN: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
           COMPONENT_NAME: renku-ui


### PR DESCRIPTION
With the new renku-action, we can disable running legacy acceptance tests in a simple way

/deploy
