### PR TITLE
Use a standard component for pagination

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -48,7 +48,6 @@
         "react-helmet": "^6.1.0",
         "react-hook-form": "^7.45.2",
         "react-ipynb-renderer": "^2.2.4",
-        "react-js-pagination": "^3.0.3",
         "react-katex": "^3.0.1",
         "react-markdown": "^8.0.7",
         "react-masonry-css": "^1.0.16",
@@ -10517,6 +10516,7 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -10611,16 +10611,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/block-stream": {
-      "version": "0.0.9",
-      "license": "ISC",
-      "dependencies": {
-        "inherits": "~2.0.0"
-      },
-      "engines": {
-        "node": "0.4 || >=0.5.8"
-      }
-    },
     "node_modules/bootstrap": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
@@ -10641,6 +10631,7 @@
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -11132,6 +11123,7 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/concurrently": {
@@ -15169,6 +15161,7 @@
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
@@ -15182,19 +15175,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/fstream": {
-      "version": "1.0.12",
-      "license": "ISC",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
-      },
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/function-bind": {
@@ -15379,6 +15359,7 @@
     },
     "node_modules/glob": {
       "version": "7.2.3",
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -15473,7 +15454,8 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -16575,6 +16557,7 @@
     },
     "node_modules/inflight": {
       "version": "1.0.6",
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -28574,6 +28557,7 @@
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -28586,6 +28570,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "devOptional": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -28633,6 +28618,7 @@
     },
     "node_modules/mkdirp": {
       "version": "0.5.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.6"
@@ -29557,6 +29543,7 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -29695,10 +29682,6 @@
       "integrity": "sha512-+vYvA/Y31l8Zk8dwxHhL3JfTuHPm6tlxM2A3GeQyl7ovYnSp1+mzAxClxaOr0qO1TtPxbQxetI7v5XqKLJZk7Q==",
       "license": "MIT"
     },
-    "node_modules/paginator": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
     "node_modules/pako": {
       "version": "1.0.11",
       "license": "(MIT AND Zlib)"
@@ -29756,6 +29739,7 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -31500,30 +31484,6 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "license": "MIT"
-    },
-    "node_modules/react-js-pagination": {
-      "version": "3.0.3",
-      "license": "CC0-1.0",
-      "dependencies": {
-        "classnames": "^2.2.5",
-        "fstream": "1.0.12",
-        "paginator": "^1.0.0",
-        "prop-types": "15.x.x - 16.x.x",
-        "react": "15.x.x - 16.x.x",
-        "tar": "2.2.2"
-      }
-    },
-    "node_modules/react-js-pagination/node_modules/react": {
-      "version": "16.14.0",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/react-katex": {
       "version": "3.0.1",
@@ -34223,16 +34183,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/rimraf": {
-      "version": "2.7.1",
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
     "node_modules/robust-predicates": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
@@ -35764,15 +35714,6 @@
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "license": "MIT"
-    },
-    "node_modules/tar": {
-      "version": "2.2.2",
-      "license": "ISC",
-      "dependencies": {
-        "block-stream": "*",
-        "fstream": "^1.0.12",
-        "inherits": "2"
-      }
     },
     "node_modules/tar-fs": {
       "version": "2.1.1",
@@ -37435,6 +37376,7 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {

--- a/client/package.json
+++ b/client/package.json
@@ -75,7 +75,6 @@
     "react-helmet": "^6.1.0",
     "react-hook-form": "^7.45.2",
     "react-ipynb-renderer": "^2.2.4",
-    "react-js-pagination": "^3.0.3",
     "react-katex": "^3.0.1",
     "react-markdown": "^8.0.7",
     "react-masonry-css": "^1.0.16",

--- a/client/src/components/Pagination.tsx
+++ b/client/src/components/Pagination.tsx
@@ -54,9 +54,9 @@ export default function Pagination({
         onChange={onPageChange}
         innerClass={className}
         // Some defaults for the styling
-        itemClass={"page-item"}
-        linkClass={"page-link"}
-        activeClass={"page-item active"}
+        itemClass="page-item"
+        linkClass="page-link"
+        activeClass="page-item active"
         hideFirstLastPages={false}
         hideDisabled
       />

--- a/client/src/components/Pagination.tsx
+++ b/client/src/components/Pagination.tsx
@@ -17,7 +17,7 @@
  */
 
 import cx from "classnames";
-import ReactPagination from "react-js-pagination";
+import { PaginationItem, PaginationLink } from "reactstrap";
 
 interface PaginationProps {
   className?: string;
@@ -47,18 +47,12 @@ export default function Pagination({
 
   return (
     <div className={cx("d-flex", "align-items-center", "flex-column")}>
-      <ReactPagination
+      <CustomPagination
         activePage={currentPage}
-        itemsCountPerPage={perPage}
-        totalItemsCount={totalItems}
-        onChange={onPageChange}
         innerClass={className}
-        // Some defaults for the styling
-        itemClass="page-item"
-        linkClass="page-link"
-        activeClass="page-item active"
-        hideFirstLastPages={false}
-        hideDisabled
+        itemsCountPerPage={perPage}
+        onChange={onPageChange}
+        totalItemsCount={totalItems}
       />
       {showDescription && totalInPage && (
         <ExtraInfoPagination
@@ -69,6 +63,133 @@ export default function Pagination({
         />
       )}
     </div>
+  );
+}
+
+interface CustomPaginationProps {
+  activePage: number;
+  innerClass?: string;
+  itemsCountPerPage: number;
+  maxPages?: number;
+  onChange: (pageNumber: number) => void;
+  totalItemsCount: number;
+}
+
+function CustomPagination({
+  activePage,
+  innerClass,
+  itemsCountPerPage,
+  onChange,
+  maxPages = 5,
+  totalItemsCount,
+}: CustomPaginationProps) {
+  if (itemsCountPerPage === 0 || totalItemsCount === 0 || maxPages <= 0) {
+    return null;
+  }
+  const totalPages = Math.ceil(totalItemsCount / itemsCountPerPage);
+  if (totalPages <= 1) {
+    return null;
+  }
+
+  const half = Math.floor(maxPages / 2);
+  const start = Math.max(1, activePage - half);
+  const end = Math.min(totalPages, start + maxPages - 1);
+  const startPage =
+    end === totalPages ? Math.max(1, totalPages - maxPages + 1) : start;
+
+  const pages = [];
+
+  // First page button: only show if the first page is not already shown
+  if (startPage !== 1) {
+    pages.push(
+      <PaginationElement
+        ariaLabel="first page"
+        content="⟪"
+        onClick={() => onChange(1)}
+        key="first"
+      />
+    );
+  }
+
+  // Previous page button: only show if there's a previous page
+  if (activePage > 1) {
+    pages.push(
+      <PaginationElement
+        ariaLabel="previous page"
+        content="⟨"
+        onClick={() => onChange(activePage - 1)}
+        key="prev"
+      />
+    );
+  }
+
+  // Page number buttons
+  for (let pageNumber = startPage; pageNumber <= end; pageNumber++) {
+    pages.push(
+      <PaginationElement
+        ariaLabel={`page ${pageNumber.toString()} of ${totalPages}`}
+        content={pageNumber}
+        onClick={() => onChange(pageNumber)}
+        extraClass={pageNumber === activePage ? "active" : ""}
+        key={pageNumber}
+      />
+    );
+  }
+
+  // Next page button: only show if there's a next page
+  if (activePage < totalPages) {
+    pages.push(
+      <PaginationElement
+        ariaLabel="next page"
+        content="⟩"
+        onClick={() => onChange(activePage + 1)}
+        key="next"
+      />
+    );
+  }
+
+  // Last page button: show it if the last page is not already included in the loop
+  if (end !== totalPages) {
+    pages.push(
+      <PaginationElement
+        ariaLabel="last page"
+        content="⟫"
+        onClick={() => onChange(totalPages)}
+        key="last"
+      />
+    );
+  }
+
+  return <ul className={cx(innerClass)}>{pages}</ul>;
+}
+
+interface PaginationElementProps {
+  ariaLabel?: string;
+  content: React.ReactNode;
+  extraClass?: string;
+  key: string | number;
+  onClick: () => void;
+}
+function PaginationElement({
+  ariaLabel = "",
+  content,
+  extraClass = "",
+  key,
+  onClick,
+}: PaginationElementProps) {
+  return (
+    <PaginationItem key={key} className={extraClass}>
+      <PaginationLink
+        aria-label={ariaLabel}
+        href="#"
+        onClick={(e) => {
+          e.preventDefault();
+          onClick();
+        }}
+      >
+        {content}
+      </PaginationLink>
+    </PaginationItem>
   );
 }
 

--- a/client/src/components/Pagination.tsx
+++ b/client/src/components/Pagination.tsx
@@ -82,7 +82,7 @@ interface PaginationNavProps {
 
 const PaginationNav = memo(function PaginationNav({
   activePage,
-  ariaLabel = "Page navigation",
+  ariaLabel = "page navigation",
   innerClassName,
   itemsCountPerPage,
   onChange,
@@ -135,10 +135,10 @@ const PaginationNav = memo(function PaginationNav({
   for (let pageNumber = startPage; pageNumber <= end; pageNumber++) {
     pages.push(
       <PaginationElement
-        ariaLabel={`page ${pageNumber.toString()} of ${totalPages}`}
+        ariaLabel={`page ${pageNumber} of ${totalPages}`}
         onClick={() => onChange(pageNumber)}
-        className={pageNumber === activePage ? "active" : ""}
-        key={pageNumber}
+        className={cx(pageNumber === activePage && "active")}
+        key={`page-${pageNumber}`}
       >
         {pageNumber}
       </PaginationElement>
@@ -180,14 +180,14 @@ const PaginationNav = memo(function PaginationNav({
 
 interface PaginationElementProps {
   ariaLabel?: string;
-  children: React.ReactNode;
+  children?: React.ReactNode;
   className?: string;
   onClick: () => void;
 }
 function PaginationElement({
-  ariaLabel = "",
+  ariaLabel,
   children,
-  className = "",
+  className,
   onClick,
 }: PaginationElementProps) {
   return (

--- a/client/src/components/Pagination.tsx
+++ b/client/src/components/Pagination.tsx
@@ -17,9 +17,11 @@
  */
 
 import cx from "classnames";
+import { memo } from "react";
 import { PaginationItem, PaginationLink } from "reactstrap";
 
 interface PaginationProps {
+  ariaLabel?: string;
   className?: string;
   currentPage: number;
   onPageChange: (pageNumber: number) => void;
@@ -30,6 +32,7 @@ interface PaginationProps {
 }
 
 export default function Pagination({
+  ariaLabel,
   className: className_,
   currentPage,
   onPageChange,
@@ -47,9 +50,10 @@ export default function Pagination({
 
   return (
     <div className={cx("d-flex", "align-items-center", "flex-column")}>
-      <CustomPagination
+      <PaginationNav
         activePage={currentPage}
-        innerClass={className}
+        ariaLabel={ariaLabel}
+        innerClassName={className}
         itemsCountPerPage={perPage}
         onChange={onPageChange}
         totalItemsCount={totalItems}
@@ -66,23 +70,25 @@ export default function Pagination({
   );
 }
 
-interface CustomPaginationProps {
+interface PaginationNavProps {
   activePage: number;
-  innerClass?: string;
+  ariaLabel?: string;
+  innerClassName?: string;
   itemsCountPerPage: number;
   maxPages?: number;
   onChange: (pageNumber: number) => void;
   totalItemsCount: number;
 }
 
-function CustomPagination({
+const PaginationNav = memo(function PaginationNav({
   activePage,
-  innerClass,
+  ariaLabel = "Page navigation",
+  innerClassName,
   itemsCountPerPage,
   onChange,
   maxPages = 5,
   totalItemsCount,
-}: CustomPaginationProps) {
+}: PaginationNavProps) {
   if (itemsCountPerPage === 0 || totalItemsCount === 0 || maxPages <= 0) {
     return null;
   }
@@ -104,10 +110,11 @@ function CustomPagination({
     pages.push(
       <PaginationElement
         ariaLabel="first page"
-        content="⟪"
         onClick={() => onChange(1)}
         key="first"
-      />
+      >
+        ⟪
+      </PaginationElement>
     );
   }
 
@@ -116,10 +123,11 @@ function CustomPagination({
     pages.push(
       <PaginationElement
         ariaLabel="previous page"
-        content="⟨"
         onClick={() => onChange(activePage - 1)}
         key="prev"
-      />
+      >
+        ⟨
+      </PaginationElement>
     );
   }
 
@@ -128,11 +136,12 @@ function CustomPagination({
     pages.push(
       <PaginationElement
         ariaLabel={`page ${pageNumber.toString()} of ${totalPages}`}
-        content={pageNumber}
         onClick={() => onChange(pageNumber)}
-        extraClass={pageNumber === activePage ? "active" : ""}
+        className={pageNumber === activePage ? "active" : ""}
         key={pageNumber}
-      />
+      >
+        {pageNumber}
+      </PaginationElement>
     );
   }
 
@@ -141,10 +150,11 @@ function CustomPagination({
     pages.push(
       <PaginationElement
         ariaLabel="next page"
-        content="⟩"
         onClick={() => onChange(activePage + 1)}
         key="next"
-      />
+      >
+        ⟩
+      </PaginationElement>
     );
   }
 
@@ -153,41 +163,45 @@ function CustomPagination({
     pages.push(
       <PaginationElement
         ariaLabel="last page"
-        content="⟫"
         onClick={() => onChange(totalPages)}
         key="last"
-      />
+      >
+        ⟫
+      </PaginationElement>
     );
   }
 
-  return <ul className={cx(innerClass)}>{pages}</ul>;
-}
+  return (
+    <nav aria-label={ariaLabel}>
+      <ul className={innerClassName}>{pages}</ul>
+    </nav>
+  );
+});
 
 interface PaginationElementProps {
   ariaLabel?: string;
-  content: React.ReactNode;
-  extraClass?: string;
-  key: string | number;
+  children: React.ReactNode;
+  className?: string;
   onClick: () => void;
 }
 function PaginationElement({
   ariaLabel = "",
-  content,
-  extraClass = "",
-  key,
+  children,
+  className = "",
   onClick,
 }: PaginationElementProps) {
   return (
-    <PaginationItem key={key} className={extraClass}>
+    <PaginationItem className={className}>
       <PaginationLink
         aria-label={ariaLabel}
         href="#"
+        // This should be converted to use Link and allow for smooth navigation
         onClick={(e) => {
           e.preventDefault();
           onClick();
         }}
       >
-        {content}
+        {children}
       </PaginationLink>
     </PaginationItem>
   );

--- a/client/src/components/Pagination.tsx
+++ b/client/src/components/Pagination.tsx
@@ -115,6 +115,7 @@ const PaginationNav = memo(function PaginationNav({
   if (startPage !== 1) {
     pages.push(
       <PaginationElement
+        linkClassName="px-2"
         ariaLabel="first page"
         onClick={() => onChange(1)}
         key="first"
@@ -128,6 +129,7 @@ const PaginationNav = memo(function PaginationNav({
   if (activePage > 1) {
     pages.push(
       <PaginationElement
+        linkClassName="px-2"
         ariaLabel="previous page"
         onClick={() => onChange(activePage - 1)}
         key="prev"
@@ -155,6 +157,7 @@ const PaginationNav = memo(function PaginationNav({
   if (activePage < totalPages) {
     pages.push(
       <PaginationElement
+        linkClassName="px-2"
         ariaLabel="next page"
         onClick={() => onChange(activePage + 1)}
         key="next"
@@ -168,6 +171,7 @@ const PaginationNav = memo(function PaginationNav({
   if (end !== totalPages) {
     pages.push(
       <PaginationElement
+        linkClassName="px-2"
         ariaLabel="last page"
         onClick={() => onChange(totalPages)}
         key="last"
@@ -188,18 +192,21 @@ interface PaginationElementProps {
   ariaLabel?: string;
   children?: React.ReactNode;
   className?: string;
+  linkClassName?: string;
   onClick: () => void;
 }
 function PaginationElement({
   ariaLabel,
   children,
   className,
+  linkClassName,
   onClick,
 }: PaginationElementProps) {
   return (
     <PaginationItem className={className}>
       <PaginationLink
         aria-label={ariaLabel}
+        className={linkClassName}
         href="#"
         // This should be converted to use Link and allow for smooth navigation
         onClick={(e) => {

--- a/client/src/components/Pagination.tsx
+++ b/client/src/components/Pagination.tsx
@@ -18,6 +18,12 @@
 
 import cx from "classnames";
 import { memo } from "react";
+import {
+  ChevronDoubleLeft,
+  ChevronDoubleRight,
+  ChevronLeft,
+  ChevronRight,
+} from "react-bootstrap-icons";
 import { PaginationItem, PaginationLink } from "reactstrap";
 
 interface PaginationProps {
@@ -113,7 +119,7 @@ const PaginationNav = memo(function PaginationNav({
         onClick={() => onChange(1)}
         key="first"
       >
-        ⟪
+        <ChevronDoubleLeft className="bi" />
       </PaginationElement>
     );
   }
@@ -126,7 +132,7 @@ const PaginationNav = memo(function PaginationNav({
         onClick={() => onChange(activePage - 1)}
         key="prev"
       >
-        ⟨
+        <ChevronLeft className="bi" />
       </PaginationElement>
     );
   }
@@ -153,7 +159,7 @@ const PaginationNav = memo(function PaginationNav({
         onClick={() => onChange(activePage + 1)}
         key="next"
       >
-        ⟩
+        <ChevronRight className="bi" />
       </PaginationElement>
     );
   }
@@ -166,7 +172,7 @@ const PaginationNav = memo(function PaginationNav({
         onClick={() => onChange(totalPages)}
         key="last"
       >
-        ⟫
+        <ChevronDoubleRight className="bi" />
       </PaginationElement>
     );
   }

--- a/client/src/features/dataConnectorsV2/components/DataConnectorsBox.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorsBox.tsx
@@ -230,15 +230,11 @@ function DataConnectorBoxContent({
             </ListGroup>
           )}
           <Pagination
+            className="mt-3"
             currentPage={data.page}
+            onPageChange={onPageChange}
             perPage={perPage}
             totalItems={data.total}
-            onPageChange={onPageChange}
-            className={cx(
-              "d-flex",
-              "justify-content-center",
-              "rk-search-pagination"
-            )}
           />
         </CardBody>
       </Card>

--- a/client/src/features/projectsV2/list/ProjectV2ListDisplay.tsx
+++ b/client/src/features/projectsV2/list/ProjectV2ListDisplay.tsx
@@ -151,15 +151,11 @@ export default function ProjectListDisplay({
                 </ListGroup>
               </div>
               <Pagination
+                className="mt-3"
                 currentPage={data.page}
+                onPageChange={onPageChange}
                 perPage={perPage}
                 totalItems={data.total}
-                onPageChange={onPageChange}
-                className={cx(
-                  "d-flex",
-                  "justify-content-center",
-                  "rk-search-pagination"
-                )}
               />
             </>
           )}


### PR DESCRIPTION
This PR removes the dependency `react-js-pagination` using a standard solution based on Bootstrap 5.
This will fix the following 2 high-level vulnerabilities:

https://github.com/SwissDataScienceCenter/renku-ui/security/dependabot/24
https://github.com/SwissDataScienceCenter/renku-ui/security/dependabot/20

/deploy
