### PR TITLE
fix: add missing space in the hidden data connectors popover

### DIFF
--- a/client/src/features/ProjectPageV2/ProjectPageContent/DataConnectors/ProjectDataConnectorsBox.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/DataConnectors/ProjectDataConnectorsBox.tsx
@@ -285,9 +285,8 @@ function MissingDataConnectorsBadge({
         +{inaccessibleConnectors} hidden
       </Badge>
       <UncontrolledTooltip target={ref}>
-        There {singular ? "is" : "are"} {inaccessibleConnectors}
-        data connector{singular ? "" : "s"} linked to this project but not
-        visible to you.
+        There {singular ? "is" : "are"} {inaccessibleConnectors} data connector
+        {singular ? "" : "s"} linked to this project but not visible to you.
       </UncontrolledTooltip>
     </>
   );


### PR DESCRIPTION
A space was missing in this sentence

![image](https://github.com/user-attachments/assets/a7a207a5-69d0-4d1f-acb9-b4c7aa042385)

Fixed in this PR

![image](https://github.com/user-attachments/assets/445291aa-03f2-4cc1-ac31-c655602fe506)

/deploy
