### PR TITLE
fix: prevent session api errors from freezing the UI

### DIFF
--- a/client/src/features/dashboardV2/DashboardV2Sessions.tsx
+++ b/client/src/features/dashboardV2/DashboardV2Sessions.tsx
@@ -24,7 +24,7 @@ import { Col, ListGroup, Row } from "reactstrap";
 
 import { Loader } from "../../components/Loader";
 import EnvironmentLogsV2 from "../../components/LogsV2";
-import { RtkErrorAlert } from "../../components/errors/RtkErrorAlert";
+import { RtkOrNotebooksError } from "../../components/errors/RtkErrorAlert";
 import { ABSOLUTE_ROUTES } from "../../routing/routes.constants";
 import useAppSelector from "../../utils/customHooks/useAppSelector.hook";
 import { useGetProjectsByProjectIdQuery } from "../projectsV2/api/projectV2.enhanced-api";
@@ -82,8 +82,8 @@ function ErrorState({
 }) {
   return (
     <div>
-      <p className="mb-0">Cannot show sessions.</p>
-      <RtkErrorAlert error={error} />
+      <p>Cannot show sessions.</p>
+      <RtkOrNotebooksError error={error} />
     </div>
   );
 }

--- a/client/src/features/sessionsV2/SessionsV2.tsx
+++ b/client/src/features/sessionsV2/SessionsV2.tsx
@@ -32,7 +32,7 @@ import {
 
 import { Loader } from "../../components/Loader";
 import { ButtonWithMenuV2 } from "../../components/buttons/Button";
-import { RtkErrorAlert } from "../../components/errors/RtkErrorAlert";
+import { RtkOrNotebooksError } from "../../components/errors/RtkErrorAlert";
 import { ABSOLUTE_ROUTES } from "../../routing/routes.constants";
 import useLocationHash from "../../utils/customHooks/useLocationHash.hook";
 import useProjectPermissions from "../ProjectPageV2/utils/useProjectPermissions.hook";
@@ -105,10 +105,40 @@ export default function SessionsV2({ project }: SessionsV2Props) {
     </div>
   );
 
-  const errorAlert = error && <RtkErrorAlert error={error} />;
-
   const totalSessions =
     (launchers ? launchers?.length : 0) + orphanSessions.length;
+
+  const cardBody = error ? (
+    <RtkOrNotebooksError error={error} />
+  ) : (
+    <>
+      <p className="text-body-secondary">
+        {totalSessions > 0
+          ? "Session launchers are available to everyone who can see the project. Running sessions are only accessible to you."
+          : "Define interactive environments in which to do your work and share it  with others."}
+      </p>
+      {loading}
+      {totalSessions > 0 && !isLoading && (
+        <ListGroup flush>
+          {launchers?.map((launcher) => (
+            <SessionItemDisplay
+              key={`launcher-${launcher.id}`}
+              launcher={launcher}
+              project={project}
+            />
+          ))}
+          {orphanSessions?.map((session) => (
+            <OrphanSession
+              key={`orphan-${session.name}`}
+              session={session}
+              project={project}
+            />
+          ))}
+        </ListGroup>
+      )}
+    </>
+  );
+
   return (
     <Card data-cy="sessions-box">
       <CardHeader
@@ -123,7 +153,7 @@ export default function SessionsV2({ project }: SessionsV2Props) {
             <PlayCircle className={cx("me-1", "bi")} />
             Sessions
           </h4>
-          <Badge>{totalSessions}</Badge>
+          {totalSessions && <Badge>{totalSessions}</Badge>}
         </div>
         <PermissionsGuard
           disabled={null}
@@ -139,33 +169,7 @@ export default function SessionsV2({ project }: SessionsV2Props) {
           userPermissions={permissions}
         />
       </CardHeader>
-      <CardBody>
-        {errorAlert}
-        <p className="text-body-secondary">
-          {totalSessions > 0
-            ? "Session launchers are available to everyone who can see the project. Running sessions are only accessible to you."
-            : "Define interactive environments in which to do your work and share it  with others."}
-        </p>
-        {loading}
-        {totalSessions > 0 && !isLoading && (
-          <ListGroup flush>
-            {launchers?.map((launcher) => (
-              <SessionItemDisplay
-                key={`launcher-${launcher.id}`}
-                launcher={launcher}
-                project={project}
-              />
-            ))}
-            {orphanSessions?.map((session) => (
-              <OrphanSession
-                key={`orphan-${session.name}`}
-                session={session}
-                project={project}
-              />
-            ))}
-          </ListGroup>
-        )}
-      </CardBody>
+      <CardBody>{cardBody}</CardBody>
     </Card>
   );
 }


### PR DESCRIPTION
This prevents triggering an infinite loop (and freezing the UI) when the `GET `/data/sessions` API returns an error

![Screenshot_20250328_103701](https://github.com/user-attachments/assets/0c772ae1-591d-4b2b-9060-6dd46d28010b)

/deploy

fix #3620