### PR TITLE
build: add script to automate API spec retrieval

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -124,12 +124,12 @@
         "pretty-quick": "^3.3.1",
         "react-test-renderer": "^18.2.0",
         "storybook": "^8.6.4",
-        "ts-node": "^10.9.2",
         "typescript": "^5.3.2",
         "vite": "^6.2.4",
         "vite-bundle-visualizer": "^1.2.1",
         "vitest": "^3.0.8",
-        "wait-on": "^8.0.3"
+        "wait-on": "^8.0.3",
+        "yaml": "^2.7.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -885,6 +885,8 @@
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -897,6 +899,8 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -8118,22 +8122,30 @@
     "node_modules/@tsconfig/node10": {
       "version": "1.0.8",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.9",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.1",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.2",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/aria-query": {
       "version": "5.0.1",
@@ -9960,7 +9972,9 @@
     "node_modules/arg": {
       "version": "4.1.3",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -12353,7 +12367,9 @@
     "node_modules/create-require": {
       "version": "1.1.1",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -13277,6 +13293,8 @@
       "version": "4.0.2",
       "dev": true,
       "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -21827,7 +21845,9 @@
     "node_modules/make-error": {
       "version": "1.3.6",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/make-event-props": {
       "version": "1.6.2",
@@ -36104,6 +36124,8 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -36146,6 +36168,8 @@
       "version": "8.2.0",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -36628,7 +36652,9 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/v8-to-istanbul": {
       "version": "8.1.1",
@@ -37574,13 +37600,11 @@
       "optional": true
     },
     "node_modules/yaml": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
+      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
       "dev": true,
       "license": "ISC",
-      "optional": true,
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -37619,6 +37643,8 @@
       "version": "3.1.1",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }

--- a/client/package.json
+++ b/client/package.json
@@ -31,7 +31,8 @@
     "generate-api:searchV2": "rtk-query-codegen-openapi src/features/searchV2/api/searchV2.api-config.ts",
     "generate-api:sessionLaunchersV2": "rtk-query-codegen-openapi src/features/sessionsV2/api/sessionLaunchersV2.api-config.ts",
     "generate-api:sessionsV2": "rtk-query-codegen-openapi src/features/sessionsV2/api/sessionsV2.api-config.ts",
-    "generate-api:users": "rtk-query-codegen-openapi src/features/usersV2/api/users.api-config.ts"
+    "generate-api:users": "rtk-query-codegen-openapi src/features/usersV2/api/users.api-config.ts",
+    "update-api:users": "node scripts/update_api_spec.js users"
   },
   "type": "module",
   "dependencies": {
@@ -151,12 +152,12 @@
     "pretty-quick": "^3.3.1",
     "react-test-renderer": "^18.2.0",
     "storybook": "^8.6.4",
-    "ts-node": "^10.9.2",
     "typescript": "^5.3.2",
     "vite": "^6.2.4",
     "vite-bundle-visualizer": "^1.2.1",
     "vitest": "^3.0.8",
-    "wait-on": "^8.0.3"
+    "wait-on": "^8.0.3",
+    "yaml": "^2.7.1"
   },
   "overrides": {
     "addon-redux": {

--- a/client/scripts/update_api_spec.js
+++ b/client/scripts/update_api_spec.js
@@ -1,0 +1,70 @@
+/*!
+ * Copyright 2025 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { exec } from "node:child_process";
+import { open } from "node:fs/promises";
+import { join } from "node:path/posix";
+import { argv } from "node:process";
+import { parseDocument } from "yaml";
+
+const GH_BASE_URL = "https://raw.githubusercontent.com";
+const DATA_SERVICES_REPO = "SwissDataScienceCenter/renku-data-services";
+const DATA_SERVICES_RELEASE = "v0.37.1";
+
+async function main() {
+  argv.forEach((arg) => {
+    if (arg.trim() === "users") {
+      updateUsersApi();
+    }
+  });
+}
+
+async function updateUsersApi() {
+  const API_SPEC_FILE = "components/renku_data_services/users/api.spec.yaml";
+  const DEST_FILE = "src/features/usersV2/api/users.openapi.json";
+
+  console.log(
+    `Updating "${DEST_FILE}" with spec file from release ${DATA_SERVICES_RELEASE}...`
+  );
+
+  const fileUrl = new URL(
+    join(DATA_SERVICES_REPO, DATA_SERVICES_RELEASE, API_SPEC_FILE),
+    GH_BASE_URL
+  );
+  const res = await fetch(fileUrl);
+  if (res.status >= 400) {
+    throw new Error(`could not retrieve ${fileUrl}`);
+  }
+  const apiSpec = await res.text();
+  const parsedSpec = parseDocument(apiSpec);
+
+  const fh = await open(DEST_FILE, "w", 0o622);
+  fh.writeFile(JSON.stringify(parsedSpec, null, 2));
+
+  await new Promise((resolve, reject) => {
+    const cp = exec(["npx", "prettier", "-w", DEST_FILE].join(" "));
+    cp.on("error", (error) =>
+      reject(new Error("failed to run prettier", { cause: error }))
+    );
+    cp.on("exit", (code) => {
+      code == 0 ? resolve() : reject(new Error("failed to run prettier"));
+    });
+  });
+}
+
+main();

--- a/client/src/features/usersV2/api/users.openapi.json
+++ b/client/src/features/usersV2/api/users.openapi.json
@@ -745,7 +745,7 @@
         "description": "The slug used to identify a project",
         "minLength": 3,
         "example": "user/my-project",
-        "pattern": "[a-zA-Z0-9_.-/]"
+        "pattern": "^[a-zA-Z0-9]+([_.\\-/][a-zA-Z0-9]+)*[_.\\-/]?[a-zA-Z0-9]$"
       },
       "AddPinnedProject": {
         "type": "object",


### PR DESCRIPTION
Add a new script to automatically update `src/features/usersV2/api/users.openapi.json`. More spec files will be supported soon.

Run:
```bash
$ npm run update-api:users
```