### PR TITLE
Pass through env variables specified in query parameters

### DIFF
--- a/client/src/features/sessionsV2/SessionStartPage.tsx
+++ b/client/src/features/sessionsV2/SessionStartPage.tsx
@@ -193,8 +193,29 @@ function SaveCloudStorage({
   );
 }
 
+function envVariableOverrides(
+  envVariables: StartSessionFromLauncherProps["launcher"]["env_variables"],
+  searchParams: URLSearchParams
+) {
+  if (envVariables == null) return [];
+  const envVariableNames = envVariables.map((env) => env.name);
+  const envVariableOverrides = envVariableNames.map((name) => {
+    const value = searchParams.get(name);
+    if (value == null) return null;
+    return {
+      name,
+      value,
+    };
+  });
+  return envVariableOverrides.filter((env) => env != null) as {
+    name: string;
+    value: string;
+  }[];
+}
+
 function SessionStarting({ launcher, project }: StartSessionFromLauncherProps) {
   const [steps, setSteps] = useState<StepsProgressBar[]>([]);
+  const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
   const startSessionOptionsV2 = useAppSelector(
@@ -214,12 +235,18 @@ function SessionStarting({ launcher, project }: StartSessionFromLauncherProps) {
       cloudstorage: startSessionOptionsV2.cloudStorage
         ?.filter(({ active }) => active)
         .map((cs) => storageDefinitionFromConfig(cs)),
+      env_variable_overrides: envVariableOverrides(
+        launcher.env_variables,
+        searchParams
+      ),
     };
   }, [
+    launcher.env_variables,
     launcher.id,
     startSessionOptionsV2.storage,
     startSessionOptionsV2.sessionClass,
     startSessionOptionsV2.cloudStorage,
+    searchParams,
   ]);
 
   // Request session

--- a/client/src/features/sessionsV2/SessionStartPage.tsx
+++ b/client/src/features/sessionsV2/SessionStartPage.tsx
@@ -193,24 +193,15 @@ function SaveCloudStorage({
   );
 }
 
-function envVariableOverrides(
-  envVariables: StartSessionFromLauncherProps["launcher"]["env_variables"],
-  searchParams: URLSearchParams
-) {
-  if (envVariables == null) return [];
-  const envVariableNames = envVariables.map((env) => env.name);
-  const envVariableOverrides = envVariableNames.map((name) => {
-    const value = searchParams.get(name);
-    if (value == null) return null;
-    return {
+function envVariableOverrides(searchParams: URLSearchParams) {
+  const overrides = [];
+  for (const [name, value] of searchParams) {
+    overrides.push({
       name,
       value,
-    };
-  });
-  return envVariableOverrides.filter((env) => env != null) as {
-    name: string;
-    value: string;
-  }[];
+    });
+  }
+  return overrides;
 }
 
 function SessionStarting({ launcher, project }: StartSessionFromLauncherProps) {
@@ -235,13 +226,9 @@ function SessionStarting({ launcher, project }: StartSessionFromLauncherProps) {
       cloudstorage: startSessionOptionsV2.cloudStorage
         ?.filter(({ active }) => active)
         .map((cs) => storageDefinitionFromConfig(cs)),
-      env_variable_overrides: envVariableOverrides(
-        launcher.env_variables,
-        searchParams
-      ),
+      env_variable_overrides: envVariableOverrides(searchParams),
     };
   }, [
-    launcher.env_variables,
     launcher.id,
     startSessionOptionsV2.storage,
     startSessionOptionsV2.sessionClass,

--- a/client/src/features/sessionsV2/SessionStartPage.tsx
+++ b/client/src/features/sessionsV2/SessionStartPage.tsx
@@ -193,17 +193,6 @@ function SaveCloudStorage({
   );
 }
 
-function envVariableOverrides(searchParams: URLSearchParams) {
-  const overrides = [];
-  for (const [name, value] of searchParams) {
-    overrides.push({
-      name,
-      value,
-    });
-  }
-  return overrides;
-}
-
 function SessionStarting({ launcher, project }: StartSessionFromLauncherProps) {
   const [steps, setSteps] = useState<StepsProgressBar[]>([]);
   const [searchParams] = useSearchParams();
@@ -226,7 +215,10 @@ function SessionStarting({ launcher, project }: StartSessionFromLauncherProps) {
       cloudstorage: startSessionOptionsV2.cloudStorage
         ?.filter(({ active }) => active)
         .map((cs) => storageDefinitionFromConfig(cs)),
-      env_variable_overrides: envVariableOverrides(searchParams),
+      env_variable_overrides: Array.from(searchParams).map(([name, value]) => ({
+        name,
+        value,
+      })),
     };
   }, [
     launcher.id,

--- a/client/src/features/sessionsV2/api/sessionsV2.generated-api.ts
+++ b/client/src/features/sessionsV2/api/sessionsV2.generated-api.ts
@@ -427,12 +427,18 @@ export type SessionCloudStoragePost = {
   storage_id: Ulid & any;
 };
 export type SessionCloudStoragePostList = SessionCloudStoragePost[];
+export type EnvVarOverride = {
+  name: string;
+  value: string;
+};
+export type EnvVariableOverrides = EnvVarOverride[];
 export type SessionPostRequest = {
   launcher_id: Ulid;
   /** The size of disk storage for the session, in gigabytes */
   disk_storage?: number;
   resource_class_id?: number | null;
   cloudstorage?: SessionCloudStoragePostList;
+  env_variable_overrides?: EnvVariableOverrides;
 };
 export type SessionListResponse = SessionResponse[];
 export type SessionPatchRequest = {

--- a/client/src/features/sessionsV2/api/sessionsV2.openapi.json
+++ b/client/src/features/sessionsV2/api/sessionsV2.openapi.json
@@ -620,6 +620,30 @@
         "required": ["anonymous", "registered"],
         "type": "object"
       },
+      "EnvVariableOverrides": {
+        "description": "Environment variable overrides for the session pod",
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/EnvVarOverride"
+        }
+      },
+      "EnvVarOverride": {
+        "description": "Override an env variable defined in the session launcher",
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$",
+            "example": "MY_VAR"
+          },
+          "value": {
+            "type": "string",
+            "maxLength": 500
+          }
+        },
+        "required": ["name", "value"]
+      },
       "ErrorResponse": {
         "type": "object",
         "properties": {
@@ -1211,6 +1235,9 @@
           },
           "cloudstorage": {
             "$ref": "#/components/schemas/SessionCloudStoragePostList"
+          },
+          "env_variable_overrides": {
+            "$ref": "#/components/schemas/EnvVariableOverrides"
           }
         },
         "required": ["launcher_id"],


### PR DESCRIPTION
# Testing

This PR allows overriding environment variables by passing in values as query parameters. To test, create a project and add a session launcher. In the sidebar for the launcher, you can find and copy the session start link.

1. No variable defined

If an override is provided for a variable that is not defined in the launcher, the session will not start. Take the session start link and add a query parameter (e..g., `?FOO=value`). When following this link you should get an error message:

<img width="1339" alt="image" src="https://github.com/user-attachments/assets/4dd0d5e5-ae9e-4607-8fc7-cf380414779c" />

2. Variable defined

Add an environment variable to the session launcher. Then provide a different value as a query parameter to the session start link. In this case, the session should start, and the environment should have the variable defined and set to the value provided in the query parameter.

/deploy renku=release-0.68.0 renku-data-services=main