### PR TITLE
fix: use higher uid/gid in docker image

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -21,42 +21,29 @@ COPY .storybook /app/.storybook
 RUN npm run storybook-build -- -o storybook-static
 
 FROM nginxinc/nginx-unprivileged:1.27-alpine
+ARG UID=65543
+ARG GID=65543
 
-COPY --from=builder /app/build /usr/share/nginx/html
-COPY --from=builder /app/storybook-static /usr/share/nginx/html/storybook
 COPY nginx.vh.default.conf /etc/nginx/conf.d/default.conf
-COPY docker-entrypoint.sh /app/docker-entrypoint.sh
-COPY scripts/generate_sitemap.sh /app/scripts/generate_sitemap.sh
+
+USER $UID:$GID
+COPY --from=builder --chown=$UID:$GID --chmod=a+rwx /app/build /tmp/nginx/html
+COPY --from=builder --chown=$UID:$GID --chmod=a+rwx /app/storybook-static /tmp/nginx/html/storybook
+COPY docker-entrypoint.sh /tmp/docker-entrypoint.sh
+COPY scripts/generate_sitemap.sh /tmp/scripts/generate_sitemap.sh
 
 # Set up the config files written by docker-entrypoint
-USER root
-RUN touch /usr/share/nginx/html/config.json
-RUN chmod a+r /usr/share/nginx/html/config.json
-RUN chown nginx /usr/share/nginx/html/config.json
+RUN touch /tmp/nginx/html/config.json && \
+	touch /tmp/nginx/html/robots.txt && \
+	touch /tmp/nginx/html/sitemap.xml && \
+	touch /tmp/nginx/html/privacy-statement.md && \
+	touch /tmp/nginx/html/terms-of-use.md && \
+	chmod a+rw -R /tmp/nginx/html
 
-RUN touch /usr/share/nginx/html/robots.txt
-RUN chmod a+r /usr/share/nginx/html/robots.txt
-RUN chown nginx /usr/share/nginx/html/robots.txt
-
-RUN touch /usr/share/nginx/html/sitemap.xml
-RUN chmod a+r /usr/share/nginx/html/sitemap.xml
-RUN chown nginx /usr/share/nginx/html/sitemap.xml
-
-RUN touch /usr/share/nginx/html/privacy-statement.md
-RUN chmod a+r /usr/share/nginx/html/privacy-statement.md
-RUN chown nginx /usr/share/nginx/html/privacy-statement.md
-
-RUN touch /usr/share/nginx/html/terms-of-use.md
-RUN chmod a+r /usr/share/nginx/html/terms-of-use.md
-RUN chown nginx /usr/share/nginx/html/terms-of-use.md
-
-USER nginx
-
-
-HEALTHCHECK --interval=20s --timeout=10s --retries=5 CMD test -e /var/run/nginx.pid
+HEALTHCHECK --interval=20s --timeout=10s --retries=5 CMD test -e /tmp/nginx.pid
 
 ARG SHORT_SHA
 ENV RENKU_UI_SHORT_SHA=$SHORT_SHA
 
-ENTRYPOINT ["/bin/sh", "/app/docker-entrypoint.sh"]
+ENTRYPOINT ["/bin/sh", "/tmp/docker-entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]

--- a/client/docker-entrypoint.sh
+++ b/client/docker-entrypoint.sh
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export NGINX_PATH=/usr/share/nginx/html
+export NGINX_PATH=/tmp/nginx/html
 
 echo "Config file contains the following settings:"
 echo "==================================================="
@@ -89,7 +89,7 @@ tee > "${NGINX_PATH}/config.json" << EOF
 EOF
 echo "config.json created in ${NGINX_PATH}"
 
-/app/scripts/generate_sitemap.sh "${BASE_URL}" "${NGINX_PATH}/sitemap.xml"
+/tmp/scripts/generate_sitemap.sh "${BASE_URL}" "${NGINX_PATH}/sitemap.xml"
 echo "sitemap.xml created in ${NGINX_PATH}"
 
 tee > "${NGINX_PATH}/robots.txt" << EOF

--- a/client/nginx.vh.default.conf
+++ b/client/nginx.vh.default.conf
@@ -32,7 +32,7 @@ types {
 server {
     listen       8080;
 
-    root /usr/share/nginx/html;
+    root /tmp/nginx/html;
     index index.html;
 
     # Handle /storybook without the trailing slash
@@ -77,7 +77,7 @@ server {
     }
 
     location /storybook/ {
-      alias /usr/share/nginx/html/storybook/;
+      alias /tmp/nginx/html/storybook/;
       index index.html;
       try_files $uri $uri/ /storybook/index.html;
     }

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -12,11 +12,14 @@ RUN npm install --silent && \
     npm run-script build
 
 FROM node:22-alpine
+ARG UID=65543
+ARG GID=65543
+USER $UID:$GID
 
-COPY --from=builder /app/dist app/dist
-COPY --from=builder /app/node_modules app/node_modules
-COPY --from=builder /app/package.json app/package.json
-COPY docker-entrypoint.sh /app/docker-entrypoint.sh
+COPY --from=builder --chown=$UID:$GID /app/dist app/dist
+COPY --from=builder --chown=$UID:$GID /app/node_modules app/node_modules
+COPY --from=builder --chown=$UID:$GID /app/package.json app/package.json
+COPY --chown=$UID:$GID docker-entrypoint.sh /app/docker-entrypoint.sh
 
 # HEALTHCHECK --interval=20s --timeout=10s --retries=5 CMD test -e /var/run/nginx.pid
 


### PR DESCRIPTION
This makes it so that the ui images can run with arbitrary uid/gid.

Also the nginx image is already setup to run with a bunch of things being in `/tmp`. The image has this in its `/etc/nginx.conf` file:

```
$ cat /etc/nginx/nginx.conf

worker_processes  auto;

error_log  /var/log/nginx/error.log notice;
pid        /tmp/nginx.pid;


events {
    worker_connections  1024;
}


http {
    proxy_temp_path /tmp/proxy_temp;
    client_body_temp_path /tmp/client_temp;
    fastcgi_temp_path /tmp/fastcgi_temp;
    uwsgi_temp_path /tmp/uwsgi_temp;
    scgi_temp_path /tmp/scgi_temp;
```

This is in line with the docs about running a non-privileged image here: (see running as non root)
https://hub.docker.com/_/nginx

To test locally:
```
cd client
docker build -t test .
docker run -ti --rm -p 8080:8080 -u 100000:100000 test
```
/deploy