### PR TITLE
fix: show badge for session numbers in project

### DIFF
--- a/client/src/features/sessionsV2/SessionsV2.tsx
+++ b/client/src/features/sessionsV2/SessionsV2.tsx
@@ -153,7 +153,7 @@ export default function SessionsV2({ project }: SessionsV2Props) {
             <PlayCircle className={cx("me-1", "bi")} />
             Sessions
           </h4>
-          {totalSessions && <Badge>{totalSessions}</Badge>}
+          <Badge>{totalSessions}</Badge>
         </div>
         <PermissionsGuard
           disabled={null}


### PR DESCRIPTION
This fixes the badge showing the number of sessions in the project page.

![image](https://github.com/user-attachments/assets/7fec58ca-f2cc-4195-9566-7a097a949860)

/deploy

