### PR TITLE
feat: add jupyterlab option for builders

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -20,7 +20,7 @@ COPY .storybook /app/.storybook
 
 RUN npm run storybook-build -- -o storybook-static
 
-FROM nginxinc/nginx-unprivileged:1.27.3-alpine
+FROM nginxinc/nginx-unprivileged:1.27.4-alpine
 
 COPY --from=builder /app/build /usr/share/nginx/html
 COPY --from=builder /app/storybook-static /usr/share/nginx/html/storybook

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -20,7 +20,7 @@ COPY .storybook /app/.storybook
 
 RUN npm run storybook-build -- -o storybook-static
 
-FROM nginxinc/nginx-unprivileged:1.27.4-alpine
+FROM nginxinc/nginx-unprivileged:1.27-alpine
 
 COPY --from=builder /app/build /usr/share/nginx/html
 COPY --from=builder /app/storybook-static /usr/share/nginx/html/storybook

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -20,7 +20,7 @@ COPY .storybook /app/.storybook
 
 RUN npm run storybook-build -- -o storybook-static
 
-FROM nginxinc/nginx-unprivileged:1.27-alpine
+FROM nginxinc/nginx-unprivileged:1.27.3-alpine
 
 COPY --from=builder /app/build /usr/share/nginx/html
 COPY --from=builder /app/storybook-static /usr/share/nginx/html/storybook

--- a/client/src/features/sessionsV2/components/SessionForm/BuilderSelectorCommon.tsx
+++ b/client/src/features/sessionsV2/components/SessionForm/BuilderSelectorCommon.tsx
@@ -28,7 +28,6 @@ import Select, {
   type SingleValue,
 } from "react-select";
 
-import { BUILDER_TYPES } from "../../session.constants";
 import type { BuilderSelectorOption } from "../../sessionsV2.types";
 
 import styles from "./Select.module.scss";
@@ -57,8 +56,8 @@ export default function BuilderSelectorCommon({
   onChange: onChange_,
 }: BuilderSelectorCommonProps) {
   const value = useMemo(
-    () => BUILDER_TYPES.find(({ value }) => value === value_) ?? defaultValue,
-    [defaultValue, value_]
+    () => options.find(({ value }) => value === value_) ?? defaultValue,
+    [defaultValue, value_, options]
   );
 
   const onChange = useCallback(

--- a/client/src/features/sessionsV2/session.constants.tsx
+++ b/client/src/features/sessionsV2/session.constants.tsx
@@ -113,6 +113,14 @@ export const BUILDER_FRONTENDS = [
     description: "A freely-licensed version Microsoft’s editor VS Code.",
     /* eslint-enable spellcheck/spell-checker */
   },
+  {
+    /* eslint-disable spellcheck/spell-checker */
+    value: "jupyterlab",
+    label: "Jupyterlab",
+    description:
+      "Web-based interactive development environment for Jupyter notebooks, code and data.",
+    /* eslint-enable spellcheck/spell-checker */
+  },
 ] as readonly BuilderSelectorOption[];
 
 export const IMAGE_BUILD_DOCS =


### PR DESCRIPTION
There is a working CI deployment over at https://github.com/SwissDataScienceCenter/renku-data-services/pull/801 which is using this PR for the ui.