### PR TITLE
fix: set nginx client server version to 1.27.4

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -20,7 +20,7 @@ COPY .storybook /app/.storybook
 
 RUN npm run storybook-build -- -o storybook-static
 
-FROM nginxinc/nginx-unprivileged:1.27-alpine
+FROM nginxinc/nginx-unprivileged:1.27.4-alpine
 
 COPY --from=builder /app/build /usr/share/nginx/html
 COPY --from=builder /app/storybook-static /usr/share/nginx/html/storybook


### PR DESCRIPTION
If we stick with `1.27` then we get newer versions and the latest one (which I think is 1.27.5) does not work because of permissions issue on `/var/nginx.pid`

The problem is this:
```
To fix nginx: [emerg] open() "/var/run/nginx.pid" failed (13: Permission denied), you have to specify a valid pid location by adding the line pid /tmp/nginx.pid; at the top level of your config. NOTE: NGINX 1.27.5 will complain about permissions for /run/nginx.pid due to a policy change for this path.
```

As described in the readme here: https://github.com/nginx/docker-nginx-unprivileged/blob/main/README.md#troubleshooting-tips