### PR TITLE
demo doi data connectors

### DIFF
--- a/client/src/features/secretsV2/DataConnectorSecretItem.tsx
+++ b/client/src/features/secretsV2/DataConnectorSecretItem.tsx
@@ -157,7 +157,7 @@ function DataConnectorSecretUsedForItem({
   const dcSecret = useMemo(
     () =>
       dataConnectorSecrets?.find(({ secret_id }) => secret_id === secret.id),
-    [dataConnectorSecrets, secret.id]
+    [secret.id, dataConnectorSecrets]
   );
 
   const namespaceName = useMemo(


### PR DESCRIPTION
/deploy renku=release-0.68.0 extra-values=notebooks.cloudstorage.enabled=true,notebooks.cloudstorage.storageClass=csi-rclone-doi-zenodo,csi-rclone.storageClassName=csi-rclone-doi-zenodo,global.rcloneStorageClass=csi-rclone-doi-zenodo,amalthea-sessions.rcloneStorageClass=csi-rclone-doi-zenodo-secret-annotation
