### PR TITLE
fix: parse doi reference on the data connector view

### DIFF
--- a/client/src/features/dataConnectorsV2/components/DataConnectorView.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorView.tsx
@@ -59,6 +59,7 @@ import { useGetDataConnectorsByDataConnectorIdSecretsQuery } from "../api/data-c
 import { DATA_CONNECTORS_VISIBILITY_WARNING } from "./dataConnector.constants";
 import {
   getDataConnectorScope,
+  parseDoi,
   useGetDataConnectorSource,
 } from "./dataConnector.utils";
 import DataConnectorActions from "./DataConnectorActions";
@@ -421,6 +422,16 @@ function DataConnectorViewMetadata({
     [dataConnector.namespace, dataConnector.slug, scope]
   );
 
+  const doiReference = useMemo(
+    () =>
+      scope === "global" &&
+      dataConnector.storage.configuration["doi"] &&
+      typeof dataConnector.storage.configuration["doi"] === "string"
+        ? parseDoi(dataConnector.storage.configuration["doi"])
+        : null,
+    [dataConnector.storage.configuration, scope]
+  );
+
   const dataConnectorSource = useGetDataConnectorSource(dataConnector);
 
   return (
@@ -456,11 +467,11 @@ function DataConnectorViewMetadata({
               )}
             >
               <a
-                href={`https://doi.org/${dataConnector.storage.configuration["doi"]}`}
+                href={`https://doi.org/${doiReference}`}
                 rel="noreferrer noopener"
                 target="_blank"
               >
-                {dataConnector.storage.configuration["doi"] as string}
+                {doiReference}
               </a>
               <div>
                 <Clipboard

--- a/client/src/features/dataConnectorsV2/components/dataConnector.utils.ts
+++ b/client/src/features/dataConnectorsV2/components/dataConnector.utils.ts
@@ -267,7 +267,7 @@ export function useGetDataConnectorSource(dataConnector: DataConnector) {
  * - https://doi.org/10.1000/182 -> 10.1000/182
  * - doi:10.1000/182 -> 10.1000/182
  */
-function parseDoi(doi: string): string {
+export function parseDoi(doi: string): string {
   try {
     const doiURL = new URL(doi);
     if (doiURL.protocol.toLowerCase() === "doi:") {


### PR DESCRIPTION
Use a standard DOI reference to avoid showing specific flavours used once the global connector was created the first time.

See: https://github.com/SwissDataScienceCenter/renku/issues/4025.

/deploy renku=leafty/update-search-tests