### PR TITLE
fix: adjust some minor glitches

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -204,8 +204,8 @@ function App(props) {
       <AppContext.Provider value={appContext}>
         <RenkuNavBar user={user} />
         <CentralContentContainer user={user} socket={webSocket} />
+        <FooterNavbar />
       </AppContext.Provider>
-      <FooterNavbar />
       <Cookie />
       <ToastContainer />
     </Fragment>

--- a/client/src/features/projectMigrationV2/ProjectMigrationBanner.module.scss
+++ b/client/src/features/projectMigrationV2/ProjectMigrationBanner.module.scss
@@ -1,7 +1,0 @@
-.ProjectMigrationBanner {
-  background-color: rgba(var(--bs-primary-rgb), 0.1) !important;
-
-  &:hover {
-    background-color: var(--bs-primary-bg-subtle) !important;
-  }
-}

--- a/client/src/features/projectMigrationV2/ProjectMigrationBanner.tsx
+++ b/client/src/features/projectMigrationV2/ProjectMigrationBanner.tsx
@@ -34,7 +34,6 @@ import {
   usePostUserPreferencesDismissProjectMigrationBannerMutation,
   UserPreferences,
 } from "../usersV2/api/users.api";
-import style from "./ProjectMigrationBanner.module.scss";
 import MigrationV2Modal from "./MigrationV2Modal";
 
 export default function ProjectMigrationBanner() {
@@ -70,11 +69,12 @@ export default function ProjectMigrationBanner() {
     showProjectMigrationBanner && (
       <Alert
         className={cx(
-          style.ProjectMigrationBanner,
-          "rounded-3",
-          "pt-3",
+          "bg-opacity-10",
+          "bg-primary",
           "border-0",
-          "card"
+          "card",
+          "mb-0",
+          "rounded-3"
         )}
         toggle={onToggleDismissAlert}
       >

--- a/client/src/features/sessionsV2/SessionList/SessionLauncherCard.tsx
+++ b/client/src/features/sessionsV2/SessionList/SessionLauncherCard.tsx
@@ -117,7 +117,6 @@ export default function SessionLauncherCard({
     <Card
       className={cx(
         styles.SessionLauncherCard,
-        "mt-2",
         "cursor-pointer",
         "shadow-none",
         "rounded-0"

--- a/client/src/features/sessionsV2/SessionsV2.tsx
+++ b/client/src/features/sessionsV2/SessionsV2.tsx
@@ -118,7 +118,7 @@ export default function SessionsV2({ project }: SessionsV2Props) {
       </p>
       {loading}
       {totalSessions > 0 && !isLoading && (
-        <div className={cx("d-flex", "flex-column", "gap-2")}>
+        <div className={cx("d-flex", "flex-column", "gap-3")}>
           {launchers?.map((launcher) => (
             <SessionLauncherDisplay
               key={`launcher-${launcher.id}`}

--- a/client/src/features/sessionsV2/components/BuildLauncherButtons.tsx
+++ b/client/src/features/sessionsV2/components/BuildLauncherButtons.tsx
@@ -122,7 +122,7 @@ export default function BuildLauncherButtons({
         size="sm"
       >
         <BootstrapReboot className={cx("bi", "me-1")} />
-        {"Rebuild"}
+        Rebuild
       </Button>
     </>
   );

--- a/client/src/features/sessionsV2/components/BuildStatusComponents.tsx
+++ b/client/src/features/sessionsV2/components/BuildStatusComponents.tsx
@@ -386,7 +386,7 @@ export function BuildActions({ launcher }: BuildActionsProps) {
       size="sm"
     >
       <BootstrapReboot className={cx("bi", "me-1")} />
-      {"Rebuild"}
+      Rebuild
     </Button>
   );
 

--- a/client/src/features/sessionsV2/components/SessionModals/NewSessionLauncherModal.tsx
+++ b/client/src/features/sessionsV2/components/SessionModals/NewSessionLauncherModal.tsx
@@ -29,9 +29,8 @@ import {
 import { useForm } from "react-hook-form";
 import { useParams } from "react-router";
 import { Button, Form, ModalBody, ModalFooter, ModalHeader } from "reactstrap";
-
 import { SuccessAlert } from "../../../../components/Alert";
-import { RtkErrorAlert } from "../../../../components/errors/RtkErrorAlert";
+import { RtkOrNotebooksError } from "../../../../components/errors/RtkErrorAlert";
 import { Loader } from "../../../../components/Loader";
 import ScrollableModal from "../../../../components/modal/ScrollableModal";
 import { useGetNamespacesByNamespaceProjectsAndSlugQuery } from "../../../projectsV2/api/projectV2.enhanced-api";
@@ -219,7 +218,7 @@ export default function NewSessionLauncherModal({
               </>
             )}
             <Form noValidate onSubmit={handleSubmit(onSubmit)}>
-              {result.error && <RtkErrorAlert error={result.error} />}
+              {result.error && <RtkOrNotebooksError error={result.error} />}
               {step === "environment" && (
                 <EnvironmentFields
                   errors={errors}


### PR DESCRIPTION
This PR fixes a few tiny glitches:

* Show the proper renku version on the footbar (bring the footbar in the AppContext 6f2ccd8762bc86eab9494358851ece060c69a9b0)
* Fix styling for the project migration banner on the landing page (remove the custom styling that changes background on hover and use standard bootstrap classes instead https://github.com/SwissDataScienceCenter/renku-ui/commit/d7d10221865c7d32ec69326816ab11388a71027b)
* Consolidate spacing and avoid using string variables instead of plain text in HTML elements (d7d10221865c7d32ec69326816ab11388a71027b and 8c90a276a01de643df3c08bf8795abf7db2c2246)

/deploy