### PR TITLE
chore: update first-time legacy message

### DIFF
--- a/client/src/features/dashboard/components/ProjectsDashboard.tsx
+++ b/client/src/features/dashboard/components/ProjectsDashboard.tsx
@@ -35,7 +35,6 @@ import ListBarSession from "../../../components/list/ListBarSessions";
 import { SortingOptions } from "../../../components/sortingEntities/SortingEntities";
 import { Notebook } from "../../../notebooks/components/session.types";
 import { urlMap } from "../../../project/list/ProjectList.container";
-import { Docs } from "../../../utils/constants/Docs";
 import AppContext from "../../../utils/context/appContext";
 import useAppDispatch from "../../../utils/customHooks/useAppDispatch.hook";
 import useAppSelector from "../../../utils/customHooks/useAppSelector.hook";
@@ -80,36 +79,36 @@ function ProjectAlert({ total }: ProjectAlertProps) {
           <strong>You do not have any projects yet.</strong>
         </h3>
         <p>
-          If you are here for your first time, we recommend you go to through
-          our{" "}
+          You are accessing the &quot;legacy&quot; version of Renku. If you are
+          here for your first time, we recommend you go to{" "}
           <ExternalLink
             role="text"
-            title="tutorial"
+            title="Renku 2.0"
             className="fw-bold"
-            url={Docs.READ_THE_DOCS_TUTORIALS_STARTING}
+            url={"/"}
           />
-          . You can also{" "}
+          , and follow the{" "}
           <ExternalLink
             role="text"
-            title="create a new project"
-            url="/v1/projects/new"
+            title="hands-on tutorial"
+            url="https://renku.notion.site/Hands-On-Tutorial-1a50df2efafc800f8554e30fd7458fa6"
             className="fw-bold"
           />
-          ,{" "}
+          . You may also{" "}
           <ExternalLink
             role="text"
             title="explore other projects"
-            url="/v1/search"
+            url="/search"
             className="fw-bold"
           />{" "}
-          or{" "}
+          or learn more about Renku features in our{" "}
           <ExternalLink
             role="text"
-            title="search"
-            url="/v1/search"
+            title="Community Portal"
+            url="https://renku.notion.site/Renku-Community-Portal-2a154d7d30b24ab8a5968c60c2592d87"
             className="fw-bold"
           />{" "}
-          for a specific project or dataset.
+          .
         </p>
       </div>
     </InfoAlert>

--- a/client/src/features/dashboard/components/ProjectsDashboard.tsx
+++ b/client/src/features/dashboard/components/ProjectsDashboard.tsx
@@ -81,14 +81,14 @@ function ProjectAlert({ total }: ProjectAlertProps) {
         </h3>
         <p>
           You are accessing the &quot;legacy&quot; version of Renku. If you are
-          here for your first time, we recommend you go to{" "}
+          here for your first time, we recommend that you go to{" "}
           <ExternalLink
             role="text"
             title="Renku 2.0"
             className="fw-bold"
             url={"/"}
           />
-          , and follow the{" "}
+          and follow the{" "}
           <ExternalLink
             role="text"
             title="hands-on tutorial"
@@ -108,7 +108,7 @@ function ProjectAlert({ total }: ProjectAlertProps) {
             title="Community Portal"
             url={Links.RENKU_2_COMMUNITY_PORTAL}
             className="fw-bold"
-          />{" "}
+          />
           .
         </p>
       </div>

--- a/client/src/features/dashboard/components/ProjectsDashboard.tsx
+++ b/client/src/features/dashboard/components/ProjectsDashboard.tsx
@@ -35,6 +35,7 @@ import ListBarSession from "../../../components/list/ListBarSessions";
 import { SortingOptions } from "../../../components/sortingEntities/SortingEntities";
 import { Notebook } from "../../../notebooks/components/session.types";
 import { urlMap } from "../../../project/list/ProjectList.container";
+import { Links } from "../../../utils/constants/Docs";
 import AppContext from "../../../utils/context/appContext";
 import useAppDispatch from "../../../utils/customHooks/useAppDispatch.hook";
 import useAppSelector from "../../../utils/customHooks/useAppSelector.hook";
@@ -91,7 +92,7 @@ function ProjectAlert({ total }: ProjectAlertProps) {
           <ExternalLink
             role="text"
             title="hands-on tutorial"
-            url="https://renku.notion.site/Hands-On-Tutorial-1a50df2efafc800f8554e30fd7458fa6"
+            url={Links.RENKU_2_HANDS_ON_TUTORIAL}
             className="fw-bold"
           />
           . You may also{" "}
@@ -105,7 +106,7 @@ function ProjectAlert({ total }: ProjectAlertProps) {
           <ExternalLink
             role="text"
             title="Community Portal"
-            url="https://renku.notion.site/Renku-Community-Portal-2a154d7d30b24ab8a5968c60c2592d87"
+            url={Links.RENKU_2_COMMUNITY_PORTAL}
             className="fw-bold"
           />{" "}
           .

--- a/client/src/features/dashboard/components/ProjectsDashboard.tsx
+++ b/client/src/features/dashboard/components/ProjectsDashboard.tsx
@@ -87,7 +87,7 @@ function ProjectAlert({ total }: ProjectAlertProps) {
             title="Renku 2.0"
             className="fw-bold"
             url={"/"}
-          />
+          />{" "}
           and follow the{" "}
           <ExternalLink
             role="text"

--- a/client/src/utils/constants/Docs.js
+++ b/client/src/utils/constants/Docs.js
@@ -52,9 +52,9 @@ const Links = {
   RENKU_2_HOW_TO_USE_OWN_DOCKER_IMAGE:
     "https://renku.notion.site/How-to-use-your-own-docker-image-for-a-session-launcher-11f0df2efafc80af848ffcaf9ccff31c",
   RENKU_2_COMMUNITY_PORTAL:
-    "https://www.notion.so/renku/Renku-Community-Portal-2a154d7d30b24ab8a5968c60c2592d87",
+    "https://renku.notion.site/Renku-Community-Portal-2a154d7d30b24ab8a5968c60c2592d87",
   RENKU_2_DOCUMENTATION:
-    "https://www.notion.so/renku/Documentation-db396cfc9a664cd2b161e4c6068a5ec9",
+    "https://renku.notion.site/Documentation-db396cfc9a664cd2b161e4c6068a5ec9",
   RENKU_2_RESEARCH:
     "https://renku.notion.site/Renku-for-Data-Scientists-21d46b16e76e4bc484add8367c44f884",
   RENKU_2_TEACHING:
@@ -62,9 +62,9 @@ const Links = {
   RENKU_2_EVENTS:
     "https://renku.notion.site/Renku-for-Events-18c0df2efafc800bb26ae93333b4318d",
   RENKU_2_QUICK_START_TUTORIAL:
-    "https://www.notion.so/renku/Quick-Start-tutorial-1460df2efafc80998204c1f61e333e63",
+    "https://renku.notion.site/Quick-Start-tutorial-1460df2efafc80998204c1f61e333e63",
   RENKU_2_GET_HELP:
-    "https://www.notion.so/renku/Get-help-1a2b4b7b0e4746769e246c0328d3d3ad",
+    "https://renku.notion.site/Get-help-1a2b4b7b0e4746769e246c0328d3d3ad",
   RENKU_2_WHY_RENKU:
     "https://renku.notion.site/Why-Renku-1900df2efafc80839b26cbad43f24778",
   RENKU_2_HANDS_ON_TUTORIAL:

--- a/client/src/utils/constants/Docs.js
+++ b/client/src/utils/constants/Docs.js
@@ -67,6 +67,8 @@ const Links = {
     "https://www.notion.so/renku/Get-help-1a2b4b7b0e4746769e246c0328d3d3ad",
   RENKU_2_WHY_RENKU:
     "https://renku.notion.site/Why-Renku-1900df2efafc80839b26cbad43f24778",
+  RENKU_2_HANDS_ON_TUTORIAL:
+    "https://renku.notion.site/Hands-On-Tutorial-1a50df2efafc800f8554e30fd7458fa6",
 };
 
 const GitlabLinks = {


### PR DESCRIPTION
The "First time" message still points people to the legacy docs and tutorial. This redirects them to 2.0. 

The banner now looks like this: 

![image](https://github.com/user-attachments/assets/9bbfcbd5-3a29-4127-bbd3-f769ffe55931)


/deploy