### PR TITLE
feat: create images for both amd64 and arm64

### DIFF
--- a/.github/workflows/test-and-ci.yml
+++ b/.github/workflows/test-and-ci.yml
@@ -150,6 +150,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: set up environment variables
         run: |
           echo "GIT_USER=Renku Bot" >> $GITHUB_ENV
@@ -157,6 +161,7 @@ jobs:
       - name: Push images
         uses: SwissDataScienceCenter/renku-actions/publish-chartpress-images@v1.18.2
         env:
+          PLATFORMS: "linux/amd64,linux/arm64"
           DOCKER_USERNAME: ${{ secrets.RENKU_DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.RENKU_DOCKER_PASSWORD }}
       - name: Update ui version


### PR DESCRIPTION
## Describe your changes

This PR implements building and publishing images for both amd64 and arm64 architecture.

This make renku-ui follow other packages such as renku-data-services that are available for both platforms.