### PR TITLE
feat: add a button to go to Legacy on the dashboard alert

### DIFF
--- a/client/src/components/navbar/AnonymousNavBar.tsx
+++ b/client/src/components/navbar/AnonymousNavBar.tsx
@@ -73,17 +73,30 @@ export default function AnonymousNavBar() {
             "renku-container"
           )}
         >
-          <Link
-            id="link-home"
-            to={ABSOLUTE_ROUTES.v1.root}
-            className="navbar-brand me-2 pb-0 pt-0"
+          <div
+            className={cx(
+              "align-items-center",
+              "d-flex",
+              "flex-row",
+              "gap-3",
+              "me-3"
+            )}
           >
-            <img src={RENKU_LOGO} alt="Renku" height="50" className="d-block" />
-          </Link>
-          <Badge color="warning" className="mx-2">
-            Legacy
-          </Badge>
-          <SunsetV1Button outline />
+            <Link
+              id="link-home"
+              to={ABSOLUTE_ROUTES.v1.root}
+              className={cx("m-0", "navbar-brand", "p-0")}
+            >
+              <img
+                src={RENKU_LOGO}
+                alt="Renku"
+                height="50"
+                className="d-block"
+              />
+            </Link>
+            <Badge color="warning">Legacy</Badge>
+            <SunsetV1Button outline />
+          </div>
           <NavbarToggler onClick={onToggle} className="border-0">
             <List className="bi text-rk-white" />
           </NavbarToggler>

--- a/client/src/components/navbar/LoggedInNavBar.tsx
+++ b/client/src/components/navbar/LoggedInNavBar.tsx
@@ -60,23 +60,31 @@ export default function LoggedInNavBar() {
           color="primary"
           className="container-fluid flex-wrap flex-lg-nowrap renku-container"
         >
-          <Link
-            id="link-home"
-            data-cy="link-home"
-            to={ABSOLUTE_ROUTES.v1.root}
-            className="navbar-brand me-2 pb-0 pt-0"
+          <div
+            className={cx(
+              "align-items-center",
+              "d-flex",
+              "flex-row",
+              "gap-3",
+              "me-3"
+            )}
           >
-            <img
-              src={RENKU_LOGO}
-              alt="Renku Legacy"
-              height="50"
-              className="d-block"
-            />
-          </Link>
-          <Badge color="warning" className="mx-2">
-            Legacy
-          </Badge>
-          <SunsetV1Button outline />
+            <Link
+              id="link-home"
+              data-cy="link-home"
+              to={ABSOLUTE_ROUTES.v1.root}
+              className={cx("m-0", "navbar-brand", "p-0")}
+            >
+              <img
+                src={RENKU_LOGO}
+                alt="Renku Legacy"
+                height="50"
+                className="d-block"
+              />
+            </Link>
+            <Badge color="warning">Legacy</Badge>
+            <SunsetV1Button outline />
+          </div>
           <NavbarToggler onClick={onToggle} className="border-0">
             <List className="bi text-rk-white" />
           </NavbarToggler>

--- a/client/src/features/projectMigrationV2/ProjectMigrationBanner.tsx
+++ b/client/src/features/projectMigrationV2/ProjectMigrationBanner.tsx
@@ -18,7 +18,7 @@
 
 import cx from "classnames";
 import { useCallback, useMemo, useState } from "react";
-import { BoxArrowInUp, XLg } from "react-bootstrap-icons";
+import { BoxArrowInUp, Link45deg, XLg } from "react-bootstrap-icons";
 import {
   Alert,
   Button,
@@ -35,6 +35,8 @@ import {
   UserPreferences,
 } from "../usersV2/api/users.api";
 import MigrationV2Modal from "./MigrationV2Modal";
+import { Link } from "react-router";
+import { ABSOLUTE_ROUTES } from "../../routing/routes.constants";
 
 export default function ProjectMigrationBanner() {
   const [isOpenModal, setIsOpenModal] = useState(false);
@@ -90,10 +92,19 @@ export default function ProjectMigrationBanner() {
           <p className={cx("text-primary", "mb-0")}>
             Looking for your Renku Legacy projects?
           </p>
-          <Button size="sm" color="outline-primary" onClick={toggle}>
-            <BoxArrowInUp size={20} className={cx("me-1")} /> Migrate from Renku
-            Legacy
-          </Button>
+          <div className={cx("d-flex", "flex-row", "gap-2")}>
+            <Link
+              className={cx("btn", "btn-outline-primary", "btn-sm")}
+              to={ABSOLUTE_ROUTES.v1.root}
+            >
+              <Link45deg className={cx("me-1")} />
+              Go to Legacy
+            </Link>
+            <Button size="sm" color="primary" onClick={toggle}>
+              <BoxArrowInUp className={cx("me-1")} />
+              Migrate from Legacy
+            </Button>
+          </div>
         </div>
         <MigrationV2Modal isOpen={isOpenModal} toggle={toggle} />
         <DismissMigrationConfirmationModal


### PR DESCRIPTION
This PR adds a button to go to the Legacy version from the Alert we have on the Dashboard 86824df731e26da5ea2c576af91b8d344c38865b

![image](https://github.com/user-attachments/assets/c1fb9260-3b3e-4e25-9e5c-ea250ba54605)

It also fixes spacing issues on the v1 navbar that were more evident on smaller browser windows 296fa51a1f2f57fff09d5a0e3b33991919408449

![image](https://github.com/user-attachments/assets/98e285bc-ee4f-45c0-8e48-6c272eb8af35)

/deploy
