### PR TITLE
fix: provide the sample tos and privacy content

### DIFF
--- a/client/server.js
+++ b/client/server.js
@@ -1,7 +1,13 @@
 import compression from "compression";
 import express from "express";
 import morgan from "morgan";
-import { CONFIG_JSON, ROBOTS, SITEMAP } from "./server/constants.js";
+import {
+  CONFIG_JSON,
+  ROBOTS,
+  SAMPLE_PRIVACY_CONTENT,
+  SAMPLE_TERMS_CONTENT,
+  SITEMAP,
+} from "./server/constants.js";
 
 const BUILD_PATH = "./build/server/index.js";
 const DEVELOPMENT = process.env.NODE_ENV === "development";
@@ -38,14 +44,16 @@ app.get("/sitemap.xml", (_, res) => {
 app.get("/robots.txt", (_, res) => {
   res.send(ROBOTS);
 });
-if (CONFIG_JSON.PRIVACY_BANNER_ENABLED) {
-  app.get("/privacy-statement.md", (_, res) => {
-    res.send(CONFIG_JSON.PRIVACY_BANNER_CONTENT);
-  });
-}
 if (CONFIG_JSON.TERMS_PAGES_ENABLED) {
   app.get("/terms-of-use.md", (_, res) => {
-    res.send(CONFIG_JSON.TERMS_CONTENT);
+    CONFIG_JSON.TERMS_CONTENT.length > 0
+      ? res.send(CONFIG_JSON.TERMS_CONTENT)
+      : res.send(SAMPLE_TERMS_CONTENT);
+  });
+  app.get("/privacy-statement.md", (_, res) => {
+    CONFIG_JSON.PRIVACY_CONTENT.length > 0
+      ? res.send(CONFIG_JSON.PRIVACY_CONTENT)
+      : res.send(SAMPLE_PRIVACY_CONTENT);
   });
 }
 

--- a/client/server/constants.js
+++ b/client/server/constants.js
@@ -43,6 +43,7 @@ export const CONFIG_JSON = {
   PRIVACY_BANNER_LAYOUT: process.env.PRIVACY_BANNER_LAYOUT,
   TERMS_PAGES_ENABLED: process.env.TERMS_PAGES_ENABLED,
   TERMS_CONTENT: process.env.TERMS_CONTENT || "",
+  PRIVACY_CONTENT: process.env.PRIVACY_CONTENT || "",
   TEMPLATES: process.env.TEMPLATES,
   PREVIEW_THRESHOLD: process.env.PREVIEW_THRESHOLD,
   UPLOAD_THRESHOLD: process.env.UPLOAD_THRESHOLD,
@@ -54,3 +55,26 @@ export const CONFIG_JSON = {
   SESSION_CLASS_EMAIL_US: process.env.SESSION_CLASS_EMAIL_US,
   IMAGE_BUILDERS_ENABLED: process.env.IMAGE_BUILDERS_ENABLED,
 };
+
+export const SAMPLE_PRIVACY_CONTENT = `# Privacy statement
+The content of this page is only a template.
+## Information
+If you are reading this message, the Privacy page content has not been updated for this RenkuLab deployment.
+The following content is intended to be read by a RenkuLab admin.
+## Configure the Privacy Page
+You should customize the privacy statement in the Helm chart values file at \`ui.client.privacy.page.privacyPolicyContent\`.
+Any markdown formatted text works.
+If you do not wish to see this at all, then you can turn off this page and the terms of use page by setting \`ui.client.privacy.page.enabled\` to false.
+Consider changing the cookie banner content as well when the privacy page is not available.
+`;
+
+export const SAMPLE_TERMS_CONTENT = `# Terms of Use
+The content of this page is only a template.
+## Information
+If you are reading this message, the Terms of Use page content has not been updated for this RenkuLab deployment.
+The following content is intended to be read by a RenkuLab admin.
+## Configure the Terms of Use
+You should customize the terms of use content in the Helm chart values file at \`ui.client.privacy.page.termsContent\`.
+Any markdown formatted text works.
+If you do not wish to see this at all, then you can turn off this page and privacy statement page by setting \`ui.client.privacy.page.enabled\` to false.
+`;


### PR DESCRIPTION
I mixed up the privacy banner vs privacy page content. Thought they were one and the same but are not.

This fixes the problem.

/deploy