### PR TITLE
fix: prevent overflow problems with setting default resource class

### DIFF
--- a/client/src/features/sessionsV2/components/SessionModals/ModifyResourcesLauncher.tsx
+++ b/client/src/features/sessionsV2/components/SessionModals/ModifyResourcesLauncher.tsx
@@ -8,15 +8,14 @@ import {
   Input,
   InputGroup,
   InputGroupText,
+  Modal,
   ModalBody,
   ModalFooter,
   ModalHeader,
   UncontrolledTooltip,
 } from "reactstrap";
-
 import { SuccessAlert } from "../../../../components/Alert";
 import { Loader } from "../../../../components/Loader";
-import ScrollableModal from "../../../../components/modal/ScrollableModal";
 import { useGetResourcePoolsQuery } from "../../../dataServices/computeResources.api";
 import { ResourceClass } from "../../../dataServices/dataServices.types";
 import { SessionClassSelectorV2 } from "../../../session/components/options/SessionClassOption";
@@ -141,7 +140,7 @@ export function ModifyResourcesLauncherModal({
   );
 
   return (
-    <ScrollableModal
+    <Modal
       centered
       fullscreen="lg"
       isOpen={isOpen}
@@ -271,7 +270,7 @@ export function ModifyResourcesLauncherModal({
           Modify resources
         </Button>
       </ModalFooter>
-    </ScrollableModal>
+    </Modal>
   );
 }
 


### PR DESCRIPTION
This PR prevents the overflow problem described here https://github.com/SwissDataScienceCenter/renku-ui/discussions/3754

Mind that switching to a non-scrolling modal maintains consistency with the custom resource class selection modal, which can be triggered when launching a new session.

<img width="1047" height="685" alt="image" src="https://github.com/user-attachments/assets/981abeaf-9ba8-49cb-a07d-aea07edcd735" />

/deploy renku=release-2.5.0
