### PR TITLE
refactor: make the getting help section clickable as links

### DIFF
--- a/client/src/features/dashboardV2/HelpV2.tsx
+++ b/client/src/features/dashboardV2/HelpV2.tsx
@@ -86,6 +86,28 @@ function HelpNav({ statuspageId }: HelpNavProps) {
   );
 }
 
+interface HelpCardBodyContentProps {
+  children: React.ReactNode;
+  url: string;
+}
+function HelpCardBodyContent({ children, url }: HelpCardBodyContentProps) {
+  return (
+    <a
+      className={cx(
+        "link-primary",
+        "stretched-link",
+        "text-body",
+        "text-decoration-none"
+      )}
+      href={url}
+      target="_blank"
+      rel="noreferrer noopener"
+    >
+      {children}
+    </a>
+  );
+}
+
 function HelpGetting() {
   return (
     <div>
@@ -106,10 +128,12 @@ function HelpGetting() {
               </h4>
             </CardHeader>
             <CardBody>
-              <p className="mb-0">
-                Find tutorials, how-to guides, and reference materials for
-                learning how to use Renku.
-              </p>
+              <HelpCardBodyContent url={Links.RENKU_2_DOCUMENTATION}>
+                <p className="mb-0">
+                  Find tutorials, how-to guides, and reference materials for
+                  learning how to use Renku.
+                </p>
+              </HelpCardBodyContent>
             </CardBody>
           </Card>
         </Col>
@@ -126,11 +150,14 @@ function HelpGetting() {
               </h4>
             </CardHeader>
             <CardBody>
-              <p className="mb-0">
-                Find dedicated best practices for teaching, research and events
-                with Renku, information about community events, how to access
-                dedicated compute resources, the Renku roadmap, and much more.
-              </p>
+              <HelpCardBodyContent url={Links.RENKU_2_COMMUNITY_PORTAL}>
+                <p className="mb-0">
+                  Find dedicated best practices for teaching, research and
+                  events with Renku, information about community events, how to
+                  access dedicated compute resources, the Renku roadmap, and
+                  much more.
+                </p>
+              </HelpCardBodyContent>
             </CardBody>
           </Card>
         </Col>
@@ -147,12 +174,12 @@ function HelpGetting() {
               </h4>
             </CardHeader>
             <CardBody>
-              <p className="mb-0">
-                We maintain a{" "}
-                <ExternalDocsLink url={Links.DISCOURSE} title="help forum" />{" "}
-                for discussion about Renku. This is a good place to ask
-                questions and find answers.
-              </p>
+              <HelpCardBodyContent url={Links.DISCOURSE}>
+                <p className="mb-0">
+                  We maintain a help forum for discussion about Renku. This is a
+                  good place to ask questions and find answers.
+                </p>
+              </HelpCardBodyContent>
             </CardBody>
           </Card>
         </Col>
@@ -169,11 +196,12 @@ function HelpGetting() {
               </h4>
             </CardHeader>
             <CardBody>
-              <p className="mb-0">
-                Want to reach out to the development team live? Contact us on{" "}
-                <ExternalDocsLink url={Links.GITTER} title="Gitter" />, we would
-                be happy to chat with you.
-              </p>
+              <HelpCardBodyContent url={Links.GITTER}>
+                <p className="mb-0">
+                  Want to reach out to the development team live? Contact us on
+                  Gitter, we would be happy to chat with you.
+                </p>
+              </HelpCardBodyContent>
             </CardBody>
           </Card>
         </Col>
@@ -190,13 +218,14 @@ function HelpGetting() {
               </h4>
             </CardHeader>
             <CardBody>
-              <p className="mb-0">
-                Renku is open source and being developed on{" "}
-                <ExternalDocsLink url={Links.GITHUB} title="GitHub" />. This is
-                the best place to report issues and ask for new features, but
-                feel free to contact us with questions, comments, or any kind of
-                feedback.
-              </p>
+              <HelpCardBodyContent url={Links.GITHUB}>
+                <p className="mb-0">
+                  Renku is open source and being developed on GitHub. This is
+                  the best place to report issues and ask for new features, but
+                  feel free to contact us with questions, comments, or any kind
+                  of feedback.
+                </p>
+              </HelpCardBodyContent>
             </CardBody>
           </Card>
         </Col>


### PR DESCRIPTION
This makes the whole Card element clickable in the "Getting Help" section.

![Peek 2025-07-22 15-09](https://github.com/user-attachments/assets/ea6e489f-68f5-4b26-9a8d-c83c39374ccd)

/deploy renku=release-2.5.0
