### PR TITLE
feat: show session status and error in the logs modal

### DIFF
--- a/client/src/components/LogsV2.tsx
+++ b/client/src/components/LogsV2.tsx
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+import { useGetSessionsQuery } from "~/features/sessionsV2/api/sessionsV2.api";
 import { displaySlice } from "../features/display";
 import useAppDispatch from "../utils/customHooks/useAppDispatch.hook";
 import useAppSelector from "../utils/customHooks/useAppSelector.hook";
@@ -31,12 +32,13 @@ interface EnvironmentLogsPropsV2 {
   name: string;
 }
 export default function EnvironmentLogsV2({ name }: EnvironmentLogsPropsV2) {
+  // Get session information
+  const { data: sessions } = useGetSessionsQuery();
+  const currentSession = sessions?.find((s) => s.name === name);
+
+  // Handle modal
   const displayModal = useAppSelector(
     ({ display }) => display.modals.sessionLogs
-  );
-  const { logs, fetchLogs } = useGetSessionLogsV2(
-    displayModal.targetServer,
-    displayModal.show
   );
   const dispatch = useAppDispatch();
   const toggleLogs = function (target: string) {
@@ -45,13 +47,25 @@ export default function EnvironmentLogsV2({ name }: EnvironmentLogsPropsV2) {
     );
   };
 
+  // Get logs
+  const { logs, fetchLogs } = useGetSessionLogsV2(
+    displayModal.targetServer,
+    displayModal.show
+  );
+
   return (
     <EnvironmentLogsPresent
       fetchLogs={fetchLogs}
-      toggleLogs={toggleLogs}
       logs={logs}
       name={name}
+      sessionState={currentSession?.status?.state}
+      sessionError={
+        currentSession?.status?.state === "failed"
+          ? currentSession?.status?.message
+          : undefined
+      }
       title="Logs"
+      toggleLogs={toggleLogs}
     />
   );
 }


### PR DESCRIPTION
This PR adds some basic session information details in the Logs modal (only for v2 sessions).
It shows:
* The status of the session
* The error message (as an Alert) whenever the session is in a `failed` status

It also changes the text on missing logs to clarify that the primary button offers to refresh the logs, not download them. Note that the buttons at the bottom use different words for the two actions.

<img width="1128" height="574" alt="Screenshot_20250724_131620" src="https://github.com/user-attachments/assets/be4f3d6d-9cd1-408f-93f6-83133bae34c2" />

<img width="1128" height="1213" alt="Screenshot_20250724_131553" src="https://github.com/user-attachments/assets/aaa6c127-a32c-4a2b-90de-dafe8175301e" />


fix: https://www.notion.so/renku/Consolidate-Session-error-messages-logs-2230df2efafc80ec850cffce30361bc5