### PR TITLE
refactor: bump the statuspage cutoff from 1 to 2 weeks

### DIFF
--- a/client/src/features/platform/components/StatusBanner.tsx
+++ b/client/src/features/platform/components/StatusBanner.tsx
@@ -48,7 +48,7 @@ import StatusPageIncidentUpdates from "./StatusPageIncidentUpdates";
 const FIVE_MINUTES_MILLIS = Duration.fromObject({ minutes: 5 }).valueOf();
 
 const SOON_MAINTENANCE_CUTOFF = Duration.fromObject({ days: 2 });
-const MAINTENANCE_CUTOFF = Duration.fromObject({ days: 7 });
+const MAINTENANCE_CUTOFF = Duration.fromObject({ days: 14 });
 
 interface StatusBannerProps {
   params: AppParams | undefined;


### PR DESCRIPTION
This will show maintenance messages earlier since we promise to announce downtimes two weeks in advance.

/deploy
ref: https://swiss-data-science.slack.com/archives/C67N59QL8/p1754552892875009?thread_ts=1754486249.944139&cid=C67N59QL8