### PR TITLE
fix: prevent white-on-white text on disabled session button menu

### DIFF
--- a/client/src/features/session/components/SessionButton.tsx
+++ b/client/src/features/session/components/SessionButton.tsx
@@ -150,7 +150,7 @@ export default function SessionButton({
           <Link
             className={cx(
               "dropdown-item",
-              !supportLegacySessions && ["disabled", "text-white"]
+              !supportLegacySessions && "disabled"
             )}
             data-cy="start-legacy-session-with-options"
             to={sessionStartUrl}


### PR DESCRIPTION
As pointed out here https://github.com/SwissDataScienceCenter/renku/pull/4119#pullrequestreview-3111672244 , the "Start with options" button on the dropdown button reads white on white when Legacy sessions are disabled.

This PR fixes it

<img width="427" height="303" alt="image" src="https://github.com/user-attachments/assets/99d8fc96-182b-45bf-9a79-3c8a44f7b32a" />

/deploy