### PR TITLE
fix: align longer keywords on the left

### DIFF
--- a/client/src/components/keywords/KeywordBadge.tsx
+++ b/client/src/components/keywords/KeywordBadge.tsx
@@ -54,6 +54,7 @@ export default function KeywordBadge({
         "fw-semibold",
         "gap-1",
         "text-break",
+        "text-start",
         "text-wrap",
         highlighted && "bg-success-subtle",
         className


### PR DESCRIPTION
This prevents longer keywords with wraps to align on the middle as in the following example

<img width="752" height="1032" alt="image" src="https://github.com/user-attachments/assets/17220fcf-6874-4207-a10e-e9c5b5d9f54d" />

/deploy
