### PR TITLE
 feat: support private images and connected registries

### DIFF
--- a/client/src/features/ProjectPageV2/ProjectPageContent/CodeRepositories/CodeRepositoryDisplay.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/CodeRepositories/CodeRepositoryDisplay.tsx
@@ -395,7 +395,7 @@ function CodeRepositoryActions({
 
 interface CodeRepositoryErrorProps {
   error: FetchBaseQueryError | SerializedError;
-  provider: Pick<Provider, "id" | "kind"> | undefined;
+  provider: Pick<Provider, "id" | "kind" | "image_registry_url"> | undefined;
 }
 
 function CodeRepositoryError({ error, provider }: CodeRepositoryErrorProps) {
@@ -434,6 +434,7 @@ function CodeRepositoryError({ error, provider }: CodeRepositoryErrorProps) {
             connectionStatus="connected"
             id={provider.id}
             kind={provider.kind}
+            registryUrl={provider.image_registry_url}
           />
         </div>
       </WarnAlert>

--- a/client/src/features/admin/AddConnectedServiceButton.tsx
+++ b/client/src/features/admin/AddConnectedServiceButton.tsx
@@ -45,9 +45,9 @@ export default function AddConnectedServiceButton() {
 
   return (
     <>
-      <Button className="btn-outline-rk-green" onClick={toggle}>
+      <Button color="primary" onClick={toggle}>
         <PlusLg className={cx("bi", "me-1")} />
-        Add Service Provider
+        Add Integration
       </Button>
       <AddConnectedServiceModal isOpen={isOpen} toggle={toggle} />
     </>
@@ -64,7 +64,12 @@ function AddConnectedServiceModal({
 }: AddConnectedServiceModalProps) {
   const [createProvider, result] = usePostOauth2ProvidersMutation();
 
-  const { control, handleSubmit, reset } = useForm<ProviderForm>({
+  const {
+    control,
+    formState: { errors },
+    handleSubmit,
+    reset,
+  } = useForm<ProviderForm>({
     defaultValues: {
       id: "",
       kind: "gitlab",
@@ -132,7 +137,7 @@ function AddConnectedServiceModal({
         noValidate
         onSubmit={handleSubmit(onSubmit)}
       >
-        <ModalHeader toggle={toggle}>Add provider</ModalHeader>
+        <ModalHeader toggle={toggle}>Add integration</ModalHeader>
         <ModalBody>
           {result.error && <RtkOrNotebooksError error={result.error} />}
 
@@ -156,20 +161,20 @@ function AddConnectedServiceModal({
             />
           </div>
 
-          <ConnectedServiceFormContent control={control} />
+          <ConnectedServiceFormContent control={control} errors={errors} />
         </ModalBody>
         <ModalFooter>
-          <Button className="btn-outline-rk-green" onClick={toggle}>
+          <Button color="outline-primary" onClick={toggle}>
             <XLg className={cx("bi", "me-1")} />
             Cancel
           </Button>
-          <Button disabled={result.isLoading} type="submit">
+          <Button color="primary" disabled={result.isLoading} type="submit">
             {result.isLoading ? (
               <Loader className="me-1" inline size={16} />
             ) : (
               <PlusLg className={cx("bi", "me-1")} />
             )}
-            Add provider
+            Add integration
           </Button>
         </ModalFooter>
       </Form>

--- a/client/src/features/admin/AddConnectedServiceButton.tsx
+++ b/client/src/features/admin/AddConnectedServiceButton.tsx
@@ -64,12 +64,7 @@ function AddConnectedServiceModal({
 }: AddConnectedServiceModalProps) {
   const [createProvider, result] = usePostOauth2ProvidersMutation();
 
-  const {
-    control,
-    formState: { errors },
-    handleSubmit,
-    reset,
-  } = useForm<ProviderForm>({
+  const { control, handleSubmit, reset } = useForm<ProviderForm>({
     defaultValues: {
       id: "",
       kind: "gitlab",
@@ -161,7 +156,7 @@ function AddConnectedServiceModal({
             />
           </div>
 
-          <ConnectedServiceFormContent control={control} errors={errors} />
+          <ConnectedServiceFormContent control={control} />
         </ModalBody>
         <ModalFooter>
           <Button color="outline-primary" onClick={toggle}>

--- a/client/src/features/admin/ConnectedServiceFormContent.tsx
+++ b/client/src/features/admin/ConnectedServiceFormContent.tsx
@@ -17,17 +17,15 @@
  */
 
 import cx from "classnames";
-import { Control, Controller, FieldErrors, useWatch } from "react-hook-form";
+import { Control, Controller, useWatch } from "react-hook-form";
 import { Input, Label } from "reactstrap";
-import { InfoAlert, WarnAlert } from "~/components/Alert";
+import { InfoAlert } from "~/components/Alert";
 import type { ProviderForm } from "../connectedServices/api/connectedServices.types";
 
 export interface ConnectedServiceFormContentProps {
   control: Control<ProviderForm, unknown>;
-  errors: FieldErrors<ProviderForm>;
 }
 export default function ConnectedServiceFormContent({
-  errors,
   control,
 }: ConnectedServiceFormContentProps) {
   const watchKind = useWatch({ control, name: "kind" });
@@ -137,7 +135,7 @@ export default function ConnectedServiceFormContent({
           name="image_registry_url"
           render={({ field, fieldState: { error } }) => (
             <Input
-              className={cx("form-control", errors && "is-invalid")}
+              className={cx("form-control", error && "is-invalid")}
               id="addConnectedServiceImageRegistryUrl"
               placeholder="URL"
               type="text"

--- a/client/src/features/admin/ConnectedServiceFormContent.tsx
+++ b/client/src/features/admin/ConnectedServiceFormContent.tsx
@@ -17,15 +17,17 @@
  */
 
 import cx from "classnames";
-import { Control, Controller, useWatch } from "react-hook-form";
+import { Control, Controller, FieldErrors, useWatch } from "react-hook-form";
 import { Input, Label } from "reactstrap";
 
 import type { ProviderForm } from "../connectedServices/api/connectedServices.types";
 
 export interface ConnectedServiceFormContentProps {
   control: Control<ProviderForm, unknown>;
+  errors: FieldErrors<ProviderForm>;
 }
 export default function ConnectedServiceFormContent({
+  errors,
   control,
 }: ConnectedServiceFormContentProps) {
   const watchKind = useWatch({ control, name: "kind" });
@@ -120,6 +122,31 @@ export default function ConnectedServiceFormContent({
           rules={{ required: true }}
         />
         <div className="invalid-feedback">Please provide a URL</div>
+      </div>
+
+      <div className="mb-3">
+        <Label className="form-label" for="addConnectedServiceImageRegistryUrl">
+          Image Registry URL (optional)
+        </Label>
+        <Controller
+          control={control}
+          name="image_registry_url"
+          render={({ field }) => (
+            <Input
+              className={cx(
+                "form-control",
+                errors.image_registry_url && "is-invalid"
+              )}
+              id="addConnectedServiceImageRegistryUrl"
+              placeholder="URL"
+              type="text"
+              {...field}
+            />
+          )}
+        />
+        <div className="invalid-feedback">
+          Please provide a valid image registry URL
+        </div>
       </div>
 
       <div className="mb-3">

--- a/client/src/features/admin/ConnectedServiceFormContent.tsx
+++ b/client/src/features/admin/ConnectedServiceFormContent.tsx
@@ -135,12 +135,9 @@ export default function ConnectedServiceFormContent({
         <Controller
           control={control}
           name="image_registry_url"
-          render={({ field }) => (
+          render={({ field, fieldState: { error } }) => (
             <Input
-              className={cx(
-                "form-control",
-                errors.image_registry_url && "is-invalid"
-              )}
+              className={cx("form-control", errors && "is-invalid")}
               id="addConnectedServiceImageRegistryUrl"
               placeholder="URL"
               type="text"
@@ -149,8 +146,14 @@ export default function ConnectedServiceFormContent({
           )}
         />
         <div className="invalid-feedback">
-          Please provide a valid image registry URL
+          Please provide a valid URL or leave it empty
         </div>
+        {watchKind === "github" && !!watchImageRegistryUrl && (
+          <InfoAlert className={cx("mb-0", "mt-2")}>
+            For GitHub integrations, we only support the image registry for
+            OAuth Apps and not GitHub Apps.
+          </InfoAlert>
+        )}
       </div>
 
       <div className="mb-3">
@@ -242,34 +245,6 @@ export default function ConnectedServiceFormContent({
         <div className="invalid-feedback">
           Please provide a valid scope or leave it empty
         </div>
-      </div>
-
-      <div className="mb-0">
-        <Label className="form-label" for="addConnectedServiceImageRegistryUrl">
-          Image registry URL (optional, for GitLab integrations)
-        </Label>
-        <Controller
-          control={control}
-          name="image_registry_url"
-          render={({ field, fieldState: { error } }) => (
-            <Input
-              className={cx("form-control", error && "is-invalid")}
-              id="addConnectedServiceImageRegistryUrl"
-              placeholder="Image registry URL"
-              type="text"
-              {...field}
-            />
-          )}
-        />
-        <div className="invalid-feedback">
-          Please provide a valid URL or leave it empty
-        </div>
-        {watchKind === "github" && !!watchImageRegistryUrl && (
-          <InfoAlert className={cx("mb-0", "mt-2")}>
-            For GitHub integrations, we only support the image registry for
-            OAuth Apps and not GitHub Apps.
-          </InfoAlert>
-        )}
       </div>
 
       {watchKind === "generic_oidc" && (

--- a/client/src/features/admin/ConnectedServiceFormContent.tsx
+++ b/client/src/features/admin/ConnectedServiceFormContent.tsx
@@ -19,7 +19,7 @@
 import cx from "classnames";
 import { Control, Controller, FieldErrors, useWatch } from "react-hook-form";
 import { Input, Label } from "reactstrap";
-
+import { InfoAlert, WarnAlert } from "~/components/Alert";
 import type { ProviderForm } from "../connectedServices/api/connectedServices.types";
 
 export interface ConnectedServiceFormContentProps {
@@ -31,6 +31,10 @@ export default function ConnectedServiceFormContent({
   control,
 }: ConnectedServiceFormContentProps) {
   const watchKind = useWatch({ control, name: "kind" });
+  const watchImageRegistryUrl = useWatch({
+    control,
+    name: "image_registry_url",
+  });
 
   return (
     <>
@@ -240,7 +244,7 @@ export default function ConnectedServiceFormContent({
         </div>
       </div>
 
-      <div className="mb-3">
+      <div className="mb-0">
         <Label className="form-label" for="addConnectedServiceImageRegistryUrl">
           Image registry URL (optional, for GitLab integrations)
         </Label>
@@ -260,6 +264,12 @@ export default function ConnectedServiceFormContent({
         <div className="invalid-feedback">
           Please provide a valid URL or leave it empty
         </div>
+        {watchKind === "github" && !!watchImageRegistryUrl && (
+          <InfoAlert className={cx("mb-0", "mt-2")}>
+            For GitHub integrations, we only support the image registry for
+            OAuth Apps and not GitHub Apps.
+          </InfoAlert>
+        )}
       </div>
 
       {watchKind === "generic_oidc" && (

--- a/client/src/features/admin/ConnectedServicesSection.tsx
+++ b/client/src/features/admin/ConnectedServicesSection.tsx
@@ -43,7 +43,7 @@ import UpdateConnectedServiceButton from "./UpdateConnectedServiceButton";
 export default function ConnectedServicesSection() {
   return (
     <section className="mt-4">
-      <h2 className="fs-4">Connected Services - Renku 2.0</h2>
+      <h2 className="fs-4">Integrations</h2>
       <ConnectedServices />
     </section>
   );
@@ -135,6 +135,12 @@ function ConnectedService({ provider }: ConnectedServiceProps) {
               Application slug: {provider.app_slug}
             </CardText>
             <CardText className="mb-2">URL: {provider.url}</CardText>
+            <CardText className="mb-2">
+              Image Registry URL:{" "}
+              {provider.image_registry_url ?? (
+                <span className="fst-italic">Not configured</span>
+              )}
+            </CardText>
             <CardText className="mb-2">
               Client ID: {provider.client_id}
             </CardText>

--- a/client/src/features/admin/ConnectedServicesSection.tsx
+++ b/client/src/features/admin/ConnectedServicesSection.tsx
@@ -151,11 +151,6 @@ function ConnectedService({ provider }: ConnectedServiceProps) {
             <CardText className="mb-2">
               Use PKCE: {provider.use_pkce.toString()}
             </CardText>
-            {provider.image_registry_url && (
-              <CardText className="mb-2">
-                Image registry URL: {provider.image_registry_url}
-              </CardText>
-            )}
             {provider.oidc_issuer_url && (
               <CardText>
                 OpenID Connect Issuer URL: {provider.oidc_issuer_url}

--- a/client/src/features/admin/UpdateConnectedServiceButton.tsx
+++ b/client/src/features/admin/UpdateConnectedServiceButton.tsx
@@ -54,7 +54,7 @@ export default function UpdateConnectedServiceButton({
 
   return (
     <>
-      <Button color="outline-rk-green" onClick={toggle}>
+      <Button color="outline-primary" onClick={toggle}>
         <PencilSquare className={cx("bi", "me-1")} />
         Edit
       </Button>
@@ -83,7 +83,7 @@ function UpdateConnectedServiceModal({
 
   const {
     control,
-    formState: { isDirty },
+    formState: { errors, isDirty },
     handleSubmit,
     reset,
   } = useForm<ProviderForm>({
@@ -146,7 +146,7 @@ function UpdateConnectedServiceModal({
       scope: provider.scope,
       url: provider.url,
       use_pkce: provider.use_pkce,
-      image_registry_url: provider.image_registry_url ?? "",
+      image_registry_url: provider.image_registry_url,
       oidc_issuer_url: provider.oidc_issuer_url ?? "",
       ...(provider.client_secret &&
         provider.client_secret !== "redacted" && {
@@ -169,7 +169,7 @@ function UpdateConnectedServiceModal({
         noValidate
         onSubmit={handleSubmit(onSubmit)}
       >
-        <ModalHeader toggle={toggle}>Update provider</ModalHeader>
+        <ModalHeader toggle={toggle}>Update intergation</ModalHeader>
         <ModalBody>
           {result.error && <RtkOrNotebooksError error={result.error} />}
 
@@ -187,20 +187,24 @@ function UpdateConnectedServiceModal({
             />
           </div>
 
-          <ConnectedServiceFormContent control={control} />
+          <ConnectedServiceFormContent control={control} errors={errors} />
         </ModalBody>
         <ModalFooter>
-          <Button className="btn-outline-rk-green" onClick={toggle}>
+          <Button color="outline-primary" onClick={toggle}>
             <XLg className={cx("bi", "me-1")} />
             Cancel
           </Button>
-          <Button disabled={result.isLoading || !isDirty} type="submit">
+          <Button
+            color="primary"
+            disabled={result.isLoading || !isDirty}
+            type="submit"
+          >
             {result.isLoading ? (
               <Loader className="me-1" inline size={16} />
             ) : (
               <CheckLg className={cx("bi", "me-1")} />
             )}
-            Update provider
+            Update integration
           </Button>
         </ModalFooter>
       </Form>

--- a/client/src/features/admin/UpdateConnectedServiceButton.tsx
+++ b/client/src/features/admin/UpdateConnectedServiceButton.tsx
@@ -146,7 +146,7 @@ function UpdateConnectedServiceModal({
       scope: provider.scope,
       url: provider.url,
       use_pkce: provider.use_pkce,
-      image_registry_url: provider.image_registry_url,
+      image_registry_url: provider.image_registry_url ?? "",
       oidc_issuer_url: provider.oidc_issuer_url ?? "",
       ...(provider.client_secret &&
         provider.client_secret !== "redacted" && {

--- a/client/src/features/admin/UpdateConnectedServiceButton.tsx
+++ b/client/src/features/admin/UpdateConnectedServiceButton.tsx
@@ -83,7 +83,7 @@ function UpdateConnectedServiceModal({
 
   const {
     control,
-    formState: { errors, isDirty },
+    formState: { isDirty },
     handleSubmit,
     reset,
   } = useForm<ProviderForm>({
@@ -187,7 +187,7 @@ function UpdateConnectedServiceModal({
             />
           </div>
 
-          <ConnectedServiceFormContent control={control} errors={errors} />
+          <ConnectedServiceFormContent control={control} />
         </ModalBody>
         <ModalFooter>
           <Button color="outline-primary" onClick={toggle}>

--- a/client/src/features/connectedServices/ConnectedServicesPage.tsx
+++ b/client/src/features/connectedServices/ConnectedServicesPage.tsx
@@ -62,6 +62,10 @@ import {
   type ProviderKind,
 } from "./api/connectedServices.api";
 import { AppInstallationsPaginated } from "./api/connectedServices.types";
+import {
+  SEARCH_PARAM_PROVIDER,
+  SEARCH_PARAM_SOURCE,
+} from "./connectedServices.constants";
 import { getSettingsUrl } from "./connectedServices.utils";
 import ContactUsCard from "./ContactUsCard";
 
@@ -72,8 +76,8 @@ export default function ConnectedServicesPage() {
     (state) => state.stateModel.user.logged
   );
   const [searchParams] = useSearchParams();
-  const targetProviderId = searchParams.get("targetProvider");
-  const source = searchParams.get("source");
+  const targetProviderId = searchParams.get(SEARCH_PARAM_PROVIDER);
+  const source = searchParams.get(SEARCH_PARAM_SOURCE);
 
   const {
     data: providers,
@@ -216,13 +220,13 @@ function ConnectedServiceCard({
                 <HandIndexThumb className={cx("bi", "me-1")} />
                 Action required. Please connect to this integration
                 {source && (
-                  <span>
+                  <>
                     {" "}
                     and then{" "}
                     <Link to={source} className={cx("primary")}>
                       go back to your project
                     </Link>
-                  </span>
+                  </>
                 )}
                 .
               </p>

--- a/client/src/features/connectedServices/ConnectedServicesPage.tsx
+++ b/client/src/features/connectedServices/ConnectedServicesPage.tsx
@@ -19,9 +19,16 @@
 import { skipToken } from "@reduxjs/toolkit/query";
 import cx from "classnames";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { BoxArrowUpRight, CircleFill, XLg } from "react-bootstrap-icons";
-import { useSearchParams } from "react-router";
 import {
+  BoxArrowUpRight,
+  CircleFill,
+  HandIndexThumb,
+  Plugin,
+  XLg,
+} from "react-bootstrap-icons";
+import { Link, useSearchParams } from "react-router";
+import {
+  Alert,
   Badge,
   Button,
   Card,
@@ -33,7 +40,6 @@ import {
   ModalFooter,
   ModalHeader,
 } from "reactstrap";
-
 import { InfoAlert, WarnAlert } from "../../components/Alert";
 import { RtkOrNotebooksError } from "../../components/errors/RtkErrorAlert";
 import { ExternalLink } from "../../components/ExternalLinks";
@@ -43,6 +49,7 @@ import useLegacySelector from "../../utils/customHooks/useLegacySelector.hook";
 import { safeNewUrl } from "../../utils/helpers/safeNewUrl.utils";
 import {
   connectedServicesApi,
+  useDeleteOauth2ConnectionsByConnectionIdMutation,
   useGetOauth2ConnectionsByConnectionIdAccountQuery,
   useGetOauth2ConnectionsByConnectionIdInstallationsQuery,
   useGetOauth2ConnectionsQuery,
@@ -55,8 +62,8 @@ import {
   type ProviderKind,
 } from "./api/connectedServices.api";
 import { AppInstallationsPaginated } from "./api/connectedServices.types";
-import ContactUsCard from "./ContactUsCard";
 import { getSettingsUrl } from "./connectedServices.utils";
+import ContactUsCard from "./ContactUsCard";
 
 const CHECK_STATUS_QUERY_PARAM = "check-status";
 
@@ -64,6 +71,9 @@ export default function ConnectedServicesPage() {
   const isUserLoggedIn = useLegacySelector(
     (state) => state.stateModel.user.logged
   );
+  const [searchParams] = useSearchParams();
+  const targetProviderId = searchParams.get("targetProvider");
+  const source = searchParams.get("source");
 
   const {
     data: providers,
@@ -72,6 +82,15 @@ export default function ConnectedServicesPage() {
   } = useGetOauth2ProvidersQuery(isUserLoggedIn ? undefined : skipToken);
   const { isLoading: isLoadingConnections, error: connectionsError } =
     useGetOauth2ConnectionsQuery(isUserLoggedIn ? undefined : skipToken);
+
+  const targetProvider = useMemo(() => {
+    return providers?.find((provider) => provider.id === targetProviderId);
+  }, [providers, targetProviderId]);
+  const sortedProviders = useMemo(() => {
+    if (!providers) return [];
+    if (!targetProvider) return providers;
+    return [targetProvider, ...providers.filter((p) => p !== targetProvider)];
+  }, [providers, targetProvider]);
 
   const isLoading = isLoadingProviders || isLoadingConnections;
   const error = providersError || connectionsError;
@@ -93,8 +112,15 @@ export default function ConnectedServicesPage() {
     </>
   ) : (
     <div className={cx("row", "g-3")}>
-      {providers.map((provider) => (
-        <ConnectedServiceCard key={provider.id} provider={provider} />
+      {sortedProviders.map((provider) => (
+        <ConnectedServiceCard
+          key={provider.id}
+          highlighted={provider.id === targetProviderId}
+          provider={provider}
+          source={
+            provider.id === targetProviderId && source ? source : undefined
+          }
+        />
       ))}
       <ContactUsCard />
     </div>
@@ -102,8 +128,13 @@ export default function ConnectedServicesPage() {
 
   return (
     <div data-cy="connected-services-page">
-      <h1>Integrations</h1>
-      <p>These integrations are only supported in Renku 2.0</p>
+      <h1 className="fs-2">
+        <Plugin className={cx("bi", "me-1")} /> Integrations
+      </h1>
+      <p>
+        Integrations with external services allow you to connect your Renku
+        projects with external private repositories and images.
+      </p>
       {content}
     </div>
   );
@@ -150,10 +181,16 @@ function ConnectedServiceStatus({ connection }: ConnectedServiceStatusProps) {
 }
 
 interface ConnectedServiceCardProps {
+  highlighted?: boolean;
   provider: Provider;
+  source?: string;
 }
 
-function ConnectedServiceCard({ provider }: ConnectedServiceCardProps) {
+function ConnectedServiceCard({
+  highlighted = false,
+  provider,
+  source,
+}: ConnectedServiceCardProps) {
   const { id, display_name, kind, url } = provider;
 
   const { data: connections } =
@@ -166,16 +203,45 @@ function ConnectedServiceCard({ provider }: ConnectedServiceCardProps) {
 
   return (
     <div data-cy="connected-services-card" className={cx("col-12", "col-lg-6")}>
-      <Card className="h-100">
+      <Card
+        className={cx("h-100", highlighted && ["bg-primary", "bg-opacity-10"])}
+      >
         <CardBody>
+          {highlighted && (
+            <Alert
+              color="warning"
+              className={cx("border-warning", "shadow-sm")}
+            >
+              <p className="mb-0">
+                <HandIndexThumb className={cx("bi", "me-1")} />
+                Action required. Please connect to this integration
+                {source && (
+                  <span>
+                    {" "}
+                    and then{" "}
+                    <Link to={source} className={cx("primary")}>
+                      go back to your project
+                    </Link>
+                  </span>
+                )}
+                .
+              </p>
+            </Alert>
+          )}
           <CardTitle>
             <div className={cx("d-flex", "flex-wrap", "align-items-center")}>
               <h4 className="pe-2">{display_name}</h4>
-              <ConnectButton
-                id={id}
-                connectionStatus={connection?.status}
-                kind={kind}
-              />
+              <div className={cx("d-flex", "gap-2", "ms-auto")}>
+                <ConnectButton
+                  id={id}
+                  connectionStatus={connection?.status}
+                  kind={kind}
+                />
+                <DisconnectButton
+                  connectionStatus={connection?.status}
+                  connectionId={connection?.id}
+                />
+              </div>
             </div>
           </CardTitle>
           <CardText>
@@ -232,9 +298,40 @@ export function ConnectButton({
     connectionStatus === "connected" ? "btn-outline-primary" : "btn-primary";
 
   return (
-    <a className={cx(color, "btn", "ms-auto", className)} href={url}>
+    <a className={cx(color, "btn", className)} href={url}>
       {text}
     </a>
+  );
+}
+
+interface DisconnectButtonParams {
+  className?: string;
+  connectionStatus?: ConnectionStatus;
+  connectionId?: string;
+}
+export function DisconnectButton({
+  className,
+  connectionStatus,
+  connectionId,
+}: DisconnectButtonParams) {
+  const [deleteConnection] = useDeleteOauth2ConnectionsByConnectionIdMutation();
+
+  const onDisconnect = useCallback(() => {
+    if (connectionId) {
+      deleteConnection({ connectionId });
+    }
+  }, [deleteConnection, connectionId]);
+
+  if (connectionStatus !== "connected" || !connectionId) return null;
+
+  return (
+    <Button
+      color="outline-primary"
+      className={cx(className)}
+      onClick={onDisconnect}
+    >
+      Disconnect
+    </Button>
   );
 }
 

--- a/client/src/features/connectedServices/api/connectedServices.api.ts
+++ b/client/src/features/connectedServices/api/connectedServices.api.ts
@@ -57,10 +57,15 @@ const enhanced = connectedServicesGeneratedApi.enhanceEndpoints({
           ? [
               {
                 type: "ConnectedAccount" as const,
-                id: `${connectionId}-${result.username}`,
+                id: connectionId,
               },
             ]
           : [],
+    },
+    deleteOauth2ConnectionsByConnectionId: {
+      invalidatesTags: (_result, _error, { connectionId }) => [
+        { type: "Connection", id: connectionId },
+      ],
     },
     postOauth2Providers: {
       invalidatesTags: ["Provider"],
@@ -116,6 +121,7 @@ export const {
   useGetOauth2ProvidersByProviderIdQuery,
   usePatchOauth2ProvidersByProviderIdMutation,
   useDeleteOauth2ProvidersByProviderIdMutation,
+  useDeleteOauth2ConnectionsByConnectionIdMutation,
   useGetOauth2ProvidersByProviderIdAuthorizeQuery,
   useGetOauth2ConnectionsQuery,
   useGetOauth2ConnectionsByConnectionIdQuery,

--- a/client/src/features/connectedServices/api/connectedServices.openapi.json
+++ b/client/src/features/connectedServices/api/connectedServices.openapi.json
@@ -278,7 +278,8 @@
           "default": {
             "$ref": "#/components/responses/Error"
           }
-        }
+        },
+        "tags": ["oauth2"]
       }
     },
     "/oauth2/connections/{connection_id}/account": {

--- a/client/src/features/connectedServices/connectedServices.constants.ts
+++ b/client/src/features/connectedServices/connectedServices.constants.ts
@@ -17,3 +17,5 @@
  */
 
 export const INTERNAL_GITLAB_PROVIDER_ID = "INTERNAL_GITLAB";
+export const SEARCH_PARAM_PROVIDER = "targetProvider";
+export const SEARCH_PARAM_SOURCE = "source";

--- a/client/src/features/sessionsV2/DataConnectorSecretsModal.tsx
+++ b/client/src/features/sessionsV2/DataConnectorSecretsModal.tsx
@@ -622,7 +622,8 @@ function SkipConnectionTestButton({
     <>
       <span ref={skipButtonRef}>
         <Button color="outline-primary" className={cx("ms-2")} onClick={onSkip}>
-          Skip <SkipForward className={cx("bi", "me-1")} />
+          <SkipForward className={cx("bi", "me-1")} />
+          Skip
         </Button>
       </span>
       <UncontrolledTooltip target={skipButtonRef}>

--- a/client/src/features/sessionsV2/SessionImageModal.tsx
+++ b/client/src/features/sessionsV2/SessionImageModal.tsx
@@ -80,11 +80,11 @@ export default function SessionImageModal({
         {!data.connection && !data.provider ? (
           <>
             <p className="mb-2">
-              The image URL <code>{containerImage}</code> is invalid or points
-              to an unsupported registry.
+              The image reference <code>{containerImage}</code> is invalid or
+              points to an unsupported registry.
             </p>
             <p className="mb-0">
-              Please verify the URL and check if the registry is in the
+              Please verify the reference and check if the registry is in the
               currently supported{" "}
               <Link
                 to={{
@@ -95,7 +95,7 @@ export default function SessionImageModal({
                 <Plugin className={cx("bi", "me-1")} />
                 integrations
               </Link>
-              . If you{"'"}re certain the URL is correct and points to a
+              . If you{"'"}re certain the reference is correct and points to a
               registry we don{"'"}t currently support,{" "}
               <a
                 target="_blank"
@@ -111,7 +111,8 @@ export default function SessionImageModal({
         ) : data.connection?.status === "connected" ? (
           <>
             <p className="mb-0">
-              Either the image does not exist, or you do not have access to it.
+              Either the image reference does not exist, or you do not have
+              access to it.
             </p>
             {data?.provider?.id && (
               <>
@@ -135,9 +136,9 @@ export default function SessionImageModal({
         ) : (
           <>
             <p className="mb-2">
-              This image is from a supported registry, but you haven{"'"}t
-              activated the integration yet. Activate the integration to check
-              if you have access to this image.
+              This image reference is from a supported registry, but you haven
+              {"'"}t activated the integration yet. Activate the integration to
+              check if you have access to this image.
             </p>
             <Link
               className={cx("btn", "btn-primary", "btn-sm")}

--- a/client/src/features/sessionsV2/SessionImageModal.tsx
+++ b/client/src/features/sessionsV2/SessionImageModal.tsx
@@ -80,11 +80,11 @@ export default function SessionImageModal({
         {!data.connection && !data.provider ? (
           <>
             <p className="mb-2">
-              The image reference <code>{containerImage}</code> is invalid or
-              points to an unsupported registry.
+              The container image reference <code>{containerImage}</code> is
+              invalid or points to an unsupported registry.
             </p>
             <p className="mb-0">
-              Please verify the reference and check if the registry is in the
+              Please verify the image and check if the registry is in the
               currently supported{" "}
               <Link
                 to={{
@@ -95,8 +95,8 @@ export default function SessionImageModal({
                 <Plugin className={cx("bi", "me-1")} />
                 integrations
               </Link>
-              . If you{"'"}re certain the reference is correct and points to a
-              registry we don{"'"}t currently support,{" "}
+              . If you&apos;re certain the reference is correct and points to a
+              registry we don&apos;t currently support,{" "}
               <a
                 target="_blank"
                 rel="noreferrer noopener"
@@ -111,8 +111,8 @@ export default function SessionImageModal({
         ) : data.connection?.status === "connected" ? (
           <>
             <p className="mb-0">
-              Either the image reference does not exist, or you do not have
-              access to it.
+              Either the container image reference does not exist, or you do not
+              have access to it.
             </p>
             {data?.provider?.id && (
               <>
@@ -136,9 +136,9 @@ export default function SessionImageModal({
         ) : (
           <>
             <p className="mb-2">
-              This image reference is from a supported registry, but you haven
-              {"'"}t activated the integration yet. Activate the integration to
-              check if you have access to this image.
+              This container image reference is from a supported registry, but
+              you haven &apos;t activated the integration yet. Activate the
+              integration to check if you have access to this image.
             </p>
             <Link
               className={cx("btn", "btn-primary", "btn-sm")}

--- a/client/src/features/sessionsV2/SessionImageModal.tsx
+++ b/client/src/features/sessionsV2/SessionImageModal.tsx
@@ -1,0 +1,178 @@
+/*!
+ * Copyright 2025 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { skipToken } from "@reduxjs/toolkit/query";
+import cx from "classnames";
+import { useCallback, useMemo } from "react";
+import { Plugin, Send, SkipForward, XLg } from "react-bootstrap-icons";
+import { generatePath, Link, useLocation, useNavigate } from "react-router";
+import { Button, ModalBody, ModalFooter, ModalHeader } from "reactstrap";
+import { Loader } from "~/components/Loader";
+import ScrollableModal from "~/components/modal/ScrollableModal";
+import { ABSOLUTE_ROUTES } from "~/routing/routes.constants";
+import useAppDispatch from "~/utils/customHooks/useAppDispatch.hook";
+import type { Project } from "../projectsV2/api/projectV2.api";
+import { SessionLauncher } from "./api/sessionLaunchersV2.generated-api";
+import { useGetSessionsImagesQuery } from "./api/sessionsV2.api";
+import SessionImageBadge from "./components/SessionStatus/SessionImageBadge";
+import startSessionOptionsV2Slice from "./startSessionOptionsV2.slice";
+
+interface SessionImageModalProps {
+  isOpen: boolean;
+  launcher: SessionLauncher;
+  project: Project;
+}
+export default function SessionImageModal({
+  isOpen,
+  launcher,
+  project,
+}: SessionImageModalProps) {
+  const navigate = useNavigate();
+  const onCancel = useCallback(() => {
+    const url = generatePath(ABSOLUTE_ROUTES.v2.projects.show.root, {
+      namespace: project.namespace,
+      slug: project.slug,
+    });
+    navigate(url);
+  }, [navigate, project.namespace, project.slug]);
+
+  const containerImage = launcher.environment?.container_image ?? "";
+  const { data, isLoading } = useGetSessionsImagesQuery(
+    containerImage ? { imageUrl: containerImage } : skipToken
+  );
+
+  const { pathname, hash } = useLocation();
+  const search = useMemo(() => {
+    return `?${new URLSearchParams({
+      targetProvider: data?.provider?.id ?? "",
+      source: `${pathname}${hash}`,
+    }).toString()}`;
+  }, [data, pathname, hash]);
+
+  const dispatch = useAppDispatch();
+  const onSkip = useCallback(() => {
+    dispatch(startSessionOptionsV2Slice.actions.setImageReady(true));
+  }, [dispatch]);
+
+  const content =
+    isLoading || !data ? (
+      <Loader />
+    ) : (
+      <>
+        <div className="mb-2">
+          <SessionImageBadge data={data} loading={isLoading} />
+        </div>
+        {!data.connection && !data.provider ? (
+          <>
+            <p className="mb-2">
+              The image URL <code>{containerImage}</code> is invalid or points
+              to an unsupported registry.
+            </p>
+            <p className="mb-0">
+              Please verify the URL and check if the registry is in the
+              currently supported{" "}
+              <Link
+                to={{
+                  pathname: ABSOLUTE_ROUTES.v2.integrations,
+                  search,
+                }}
+              >
+                <Plugin className={cx("bi", "me-1")} />
+                integrations
+              </Link>
+              . If you{"'"}re certain the URL is correct and points to a
+              registry we don{"'"}t currently support,{" "}
+              <a
+                target="_blank"
+                rel="noreferrer noopener"
+                href="mailto:hello@renku.io"
+              >
+                <Send className={cx("bi", "me-1")} />
+                contact us
+              </a>{" "}
+              about adding an integration.
+            </p>
+          </>
+        ) : data.connection?.status === "connected" ? (
+          <>
+            <p className="mb-0">
+              Either the image does not exist, or you do not have access to it.
+            </p>
+            {data?.provider?.id && (
+              <>
+                <p className={cx("mb-2", "mt-2")}>
+                  If you think you should have access, check your integration
+                  configuration.
+                </p>
+                <Link
+                  className={cx("btn", "btn-primary", "btn-sm")}
+                  to={{
+                    pathname: ABSOLUTE_ROUTES.v2.integrations,
+                    search,
+                  }}
+                >
+                  <Plugin className={cx("bi", "me-1")} />
+                  View integration
+                </Link>
+              </>
+            )}
+          </>
+        ) : (
+          <>
+            <p className="mb-2">
+              This image is from a supported registry, but you haven{"'"}t
+              activated the integration yet. Activate the integration to check
+              if you have access to this image.
+            </p>
+            <Link
+              className={cx("btn", "btn-primary", "btn-sm")}
+              to={{
+                pathname: ABSOLUTE_ROUTES.v2.integrations,
+                search,
+              }}
+            >
+              <Plugin className={cx("bi", "me-1")} />
+              Go to Integration
+            </Link>
+          </>
+        )}
+      </>
+    );
+
+  return (
+    <ScrollableModal
+      centered
+      data-cy="session-secrets-modal"
+      isOpen={isOpen}
+      size="lg"
+    >
+      <ModalHeader>Session image not accessible</ModalHeader>
+      <ModalBody>{content}</ModalBody>
+      <ModalFooter>
+        <Button color="outline-danger" onClick={onCancel}>
+          <XLg className={cx("bi", "me-1")} />
+          Cancel
+        </Button>
+        <Button color="outline-danger" onClick={onSkip}>
+          <SkipForward className={cx("bi", "me-1")} />
+          Attempt launch
+        </Button>
+      </ModalFooter>
+    </ScrollableModal>
+  );
+}

--- a/client/src/features/sessionsV2/SessionList/SessionLauncherCard.tsx
+++ b/client/src/features/sessionsV2/SessionList/SessionLauncherCard.tsx
@@ -20,9 +20,7 @@ import cx from "classnames";
 import { useContext } from "react";
 import { CircleFill, Link45deg, Pencil, Trash } from "react-bootstrap-icons";
 import { Card, CardBody, Col, DropdownItem, Row } from "reactstrap";
-
 import SessionEnvironmentGitLabWarningBadge from "~/features/legacy/SessionEnvironmentGitLabWarnBadge";
-
 import { Loader } from "../../../components/Loader";
 import AppContext from "../../../utils/context/appContext";
 import { DEFAULT_APP_PARAMS } from "../../../utils/context/appParams.constants";
@@ -34,17 +32,19 @@ import {
   sessionLaunchersV2Api,
   useGetEnvironmentsByEnvironmentIdBuildsQuery as useGetBuildsQuery,
 } from "../api/sessionLaunchersV2.api";
+import { useGetSessionsImagesQuery } from "../api/sessionsV2.api";
+import {
+  BuildStatusBadge,
+  BuildStatusDescription,
+} from "../components/BuildStatusComponents";
 import {
   EnvironmentIcon,
   LauncherEnvironmentIcon,
 } from "../components/SessionForm/LauncherEnvironmentIcon";
 import { SessionLauncherButtons } from "../components/SessionLauncherButtons";
+import SessionImageBadge from "../components/SessionStatus/SessionImageBadge";
 import { SessionBadge } from "../components/SessionStatus/SessionStatus";
 import { SessionV2 } from "../sessionsV2.types";
-import {
-  BuildStatusBadge,
-  BuildStatusDescription,
-} from "../components/BuildStatusComponents";
 import SessionCard from "./SessionCard";
 
 import styles from "./Session.module.scss";
@@ -71,16 +71,18 @@ export default function SessionLauncherCard({
   toggleSessionView,
   toggleShareLink,
 }: SessionLauncherCardProps) {
-  const environment = launcher?.environment;
   const { params } = useContext(AppContext);
+  const environment = launcher?.environment;
   const imageBuildersEnabled =
     params?.IMAGE_BUILDERS_ENABLED ?? DEFAULT_APP_PARAMS.IMAGE_BUILDERS_ENABLED;
-
-  const isBuildEnvironment =
+  const isCodeEnvironment =
     environment && environment.environment_image_source === "build";
+  const isExternalImageEnvironment =
+    environment?.environment_kind === "CUSTOM" &&
+    environment?.environment_image_source === "image";
 
   const { data: builds, isLoading } = useGetBuildsQuery(
-    imageBuildersEnabled && isBuildEnvironment
+    imageBuildersEnabled && isCodeEnvironment
       ? { environmentId: environment.id }
       : skipToken
   );
@@ -92,7 +94,7 @@ export default function SessionLauncherCard({
   const hasSession = !!sessions?.length;
 
   sessionLaunchersV2Api.endpoints.getEnvironmentsByEnvironmentIdBuilds.useQuerySubscription(
-    isBuildEnvironment && lastBuild?.status === "in_progress"
+    isCodeEnvironment && lastBuild?.status === "in_progress"
       ? { environmentId: environment.id }
       : skipToken,
     {
@@ -115,6 +117,24 @@ export default function SessionLauncherCard({
       />
     );
 
+  const ENVIRONMENT_KIND_CLASSES = [
+    "align-items-center",
+    "d-flex",
+    "gap-2",
+    "me-2",
+    "small",
+    "text-muted",
+  ];
+
+  const { data: containerImage, isLoading: loadingContainerImage } =
+    useGetSessionsImagesQuery(
+      environment &&
+        environment.environment_kind === "CUSTOM" &&
+        environment.container_image
+        ? { imageUrl: environment.container_image }
+        : skipToken
+    );
+
   return (
     <Card
       className={cx(
@@ -130,7 +150,7 @@ export default function SessionLauncherCard({
       <CardBody className={cx("p-0")}>
         <div className={cx(hasSession && "border-bottom", "p-3")}>
           <Row className="g-2">
-            <Col className={cx("align-items-center")} xs={12} lg={5} xl={7}>
+            <Col className={cx("align-items-center")} xs={12} lg={6} xl={8}>
               <Row className={cx("g-2", "mb-0")}>
                 <Col
                   xs={12}
@@ -143,32 +163,24 @@ export default function SessionLauncherCard({
                 </Col>
                 <Col xs={12} xl="auto">
                   {environment?.environment_kind === "GLOBAL" ? (
-                    <span className={cx("small", "text-muted", "me-3")}>
-                      <EnvironmentIcon type="global" className="me-2" />
+                    <span className={cx(ENVIRONMENT_KIND_CLASSES)}>
+                      <EnvironmentIcon type="global" />
                       Global environment
                     </span>
-                  ) : environment?.environment_image_source === "build" ? (
-                    <span className={cx("small", "text-muted", "me-3")}>
-                      <EnvironmentIcon
-                        type="codeBased"
-                        size={16}
-                        className="me-2"
-                      />
+                  ) : isCodeEnvironment ? (
+                    <span className={cx(ENVIRONMENT_KIND_CLASSES)}>
+                      <EnvironmentIcon type="codeBased" size={16} />
                       Code based environment
                     </span>
-                  ) : environment?.environment_kind === "CUSTOM" ? (
-                    <span className={cx("small", "text-muted", "me-3")}>
-                      <EnvironmentIcon
-                        type="custom"
-                        size={16}
-                        className="me-2"
-                      />
-                      Custom image environment
+                  ) : isExternalImageEnvironment ? (
+                    <span className={cx(ENVIRONMENT_KIND_CLASSES)}>
+                      <EnvironmentIcon type="custom" size={16} />
+                      External image environment
                     </span>
                   ) : null}
                 </Col>
               </Row>
-              <Row className={cx("g-2", isBuildEnvironment && "mb-2")}>
+              <Row className={cx("g-2", isCodeEnvironment && "mb-2")}>
                 <Col
                   xs={12}
                   className={cx("d-inline-block", "link-primary", "text-body")}
@@ -190,61 +202,66 @@ export default function SessionLauncherCard({
                   <SessionEnvironmentGitLabWarningBadge launcher={launcher} />
                 </Col>
               </Row>
-              {isBuildEnvironment && (
-                <>
-                  <Row className="g-2">
-                    <Col xs={12} xl={4}>
-                      {isBuildEnvironment && isLoading ? (
-                        <SessionBadge
-                          className={cx("border-warning", "bg-warning-subtle")}
+              {isCodeEnvironment && (
+                <Row className="g-2">
+                  <Col xs={12} xl={4}>
+                    {isCodeEnvironment && isLoading ? (
+                      <SessionBadge
+                        className={cx("border-warning", "bg-warning-subtle")}
+                      >
+                        <Loader
+                          size={12}
+                          className={cx("me-1", "text-warning-emphasis")}
+                          inline
+                        />
+                        <span className="text-warning-emphasis">
+                          Loading build status
+                        </span>
+                      </SessionBadge>
+                    ) : isCodeEnvironment && lastBuild ? (
+                      <BuildStatusBadge status={lastBuild?.status} />
+                    ) : !hasSession ? (
+                      <SessionBadge
+                        className={cx("border-dark-subtle", "bg-light")}
+                      >
+                        <CircleFill
+                          className={cx("me-1", "bi", "text-light-emphasis")}
+                        />
+                        <span
+                          className="text-dark-emphasis"
+                          data-cy="session-status"
                         >
-                          <Loader
-                            size={12}
-                            className={cx("me-1", "text-warning-emphasis")}
-                            inline
-                          />
-                          <span className="text-warning-emphasis">
-                            Loading build status
-                          </span>
-                        </SessionBadge>
-                      ) : isBuildEnvironment && lastBuild ? (
-                        <BuildStatusBadge status={lastBuild?.status} />
-                      ) : !hasSession ? (
-                        <SessionBadge
-                          className={cx("border-dark-subtle", "bg-light")}
-                        >
-                          <CircleFill
-                            className={cx("me-1", "bi", "text-light-emphasis")}
-                          />
-                          <span
-                            className="text-dark-emphasis"
-                            data-cy="session-status"
-                          >
-                            Not Running
-                          </span>
-                        </SessionBadge>
-                      ) : null}
-                    </Col>
-                    <Col xs={12} xl="auto" className="d-flex">
-                      <BuildStatusDescription
-                        status={
-                          lastBuild?.status ?? lastSuccessfulBuild?.status
-                        }
-                        createdAt={
-                          lastBuild?.created_at ??
-                          lastSuccessfulBuild?.created_at
-                        }
-                        completedAt={
-                          lastBuild?.status === "succeeded"
-                            ? lastBuild?.result?.completed_at
-                            : lastSuccessfulBuild?.status === "succeeded"
-                            ? lastSuccessfulBuild?.result?.completed_at
-                            : undefined
-                        }
-                      />
-                    </Col>
-                  </Row>
-                </>
+                          Not Running
+                        </span>
+                      </SessionBadge>
+                    ) : null}
+                  </Col>
+                  <Col xs={12} xl="auto" className="d-flex">
+                    <BuildStatusDescription
+                      status={lastBuild?.status ?? lastSuccessfulBuild?.status}
+                      createdAt={
+                        lastBuild?.created_at ?? lastSuccessfulBuild?.created_at
+                      }
+                      completedAt={
+                        lastBuild?.status === "succeeded"
+                          ? lastBuild?.result?.completed_at
+                          : lastSuccessfulBuild?.status === "succeeded"
+                          ? lastSuccessfulBuild?.result?.completed_at
+                          : undefined
+                      }
+                    />
+                  </Col>
+                </Row>
+              )}
+              {isExternalImageEnvironment && (
+                <Row>
+                  <Col>
+                    <SessionImageBadge
+                      data={containerImage}
+                      loading={loadingContainerImage}
+                    />
+                  </Col>
+                </Row>
               )}
             </Col>
             <Col className={cx("ms-md-auto")} xs={12} md="auto">
@@ -265,12 +282,12 @@ export default function SessionLauncherCard({
                     otherActions={otherLauncherActions}
                     slug={project.slug}
                     useOldImage={
-                      isBuildEnvironment &&
+                      isCodeEnvironment &&
                       lastBuild?.status !== "succeeded" &&
                       !!lastSuccessfulBuild
                     }
                   />
-                  {isBuildEnvironment &&
+                  {isCodeEnvironment &&
                     lastBuild?.status !== "succeeded" &&
                     lastSuccessfulBuild && (
                       <BuildStatusDescription

--- a/client/src/features/sessionsV2/SessionSecretsModal.tsx
+++ b/client/src/features/sessionsV2/SessionSecretsModal.tsx
@@ -145,7 +145,8 @@ export default function SessionSecretsModal({
           Cancel
         </Button>
         <Button color="outline-primary" onClick={onSkip}>
-          Skip <SkipForward className={cx("bi", "me-1")} />
+          <SkipForward className={cx("bi", "me-1")} />
+          Skip
         </Button>
       </ModalFooter>
     </ScrollableModal>

--- a/client/src/features/sessionsV2/SessionView/EnvironmentCard.tsx
+++ b/client/src/features/sessionsV2/SessionView/EnvironmentCard.tsx
@@ -18,10 +18,12 @@
 
 import { skipToken } from "@reduxjs/toolkit/query";
 import cx from "classnames";
-import { ReactNode, useContext, useEffect } from "react";
-import { CircleFill, Clock } from "react-bootstrap-icons";
+import { ReactNode, useContext, useEffect, useMemo } from "react";
+import { CircleFill, Clock, Plugin, Send } from "react-bootstrap-icons";
+import { Link, useLocation } from "react-router";
 import { Badge, Card, CardBody, Col, Row } from "reactstrap";
-
+import { ErrorAlert, WarnAlert } from "~/components/Alert";
+import { ABSOLUTE_ROUTES } from "~/routing/routes.constants";
 import { RtkOrNotebooksError } from "../../../components/errors/RtkErrorAlert";
 import { ErrorLabel } from "../../../components/formlabels/FormLabels";
 import { Loader } from "../../../components/Loader";
@@ -34,15 +36,17 @@ import {
   sessionLaunchersV2Api,
   useGetEnvironmentsByEnvironmentIdBuildsQuery as useGetBuildsQuery,
 } from "../api/sessionLaunchersV2.api";
-import { EnvironmentIcon } from "../components/SessionForm/LauncherEnvironmentIcon";
-import { BUILDER_IMAGE_NOT_READY_VALUE } from "../session.constants";
-import { safeStringify } from "../session.utils";
+import { useGetSessionsImagesQuery } from "../api/sessionsV2.api";
 import {
   BuildActions,
   BuildErrorReason,
   BuildStatusBadge,
   BuildStatusDescription,
 } from "../components/BuildStatusComponents";
+import { EnvironmentIcon } from "../components/SessionForm/LauncherEnvironmentIcon";
+import SessionImageBadge from "../components/SessionStatus/SessionImageBadge";
+import { BUILDER_IMAGE_NOT_READY_VALUE } from "../session.constants";
+import { safeStringify } from "../session.utils";
 
 export default function EnvironmentCard({
   launcher,
@@ -104,7 +108,7 @@ export default function EnvironmentCard({
               ) : (
                 <>
                   <EnvironmentIcon type="custom" size={16} />
-                  Custom image environment
+                  External image environment
                 </>
               )}
             </EnvironmentRow>
@@ -160,14 +164,107 @@ function CustomImageEnvironmentValues({
 }: {
   launcher: SessionLauncher;
 }) {
+  const { pathname, hash } = useLocation();
   const environment = launcher.environment;
+
+  const { data, isLoading } = useGetSessionsImagesQuery(
+    environment &&
+      environment.environment_kind === "CUSTOM" &&
+      environment.container_image
+      ? { imageUrl: environment.container_image }
+      : skipToken
+  );
+  const search = useMemo(() => {
+    return `?${new URLSearchParams({
+      targetProvider: data?.provider?.id ?? "",
+      source: `${pathname}${hash}`,
+    }).toString()}`;
+  }, [data, pathname, hash]);
 
   if (environment.environment_kind !== "CUSTOM") {
     return null;
   }
-
   return (
     <>
+      <div className="mb-2">
+        <SessionImageBadge data={data} loading={isLoading} />
+        {!isLoading && data?.accessible === false && (
+          <div className="mt-2">
+            {!data.connection && !data.provider ? (
+              <ErrorAlert className="mb-0" dismissible={false}>
+                <p className="mb-2">
+                  The image URL is invalid or points to an unsupported registry.
+                  Please verify the URL and check if the registry is in the
+                  currently supported{" "}
+                  <Link
+                    to={{
+                      pathname: ABSOLUTE_ROUTES.v2.integrations,
+                      search,
+                    }}
+                  >
+                    <Plugin className={cx("bi", "me-1")} />
+                    integrations
+                  </Link>
+                  . If you{"'"}re certain the URL is correct and points to a
+                  registry we don{"'"}t currently support,{" "}
+                  <a
+                    target="_blank"
+                    rel="noreferrer noopener"
+                    href="mailto:hello@renku.io"
+                  >
+                    <Send className={cx("bi", "me-1")} />
+                    contact us
+                  </a>{" "}
+                  about adding an integration.
+                </p>
+              </ErrorAlert>
+            ) : data.connection?.status === "connected" ? (
+              <ErrorAlert className="mb-0" dismissible={false}>
+                <p className="mb-0">
+                  Either the image does not exist, or you do not have access to
+                  it.
+                </p>
+                {data?.provider?.id && (
+                  <>
+                    <p className={cx("mb-2", "mt-2")}>
+                      If you think you should have access, check your
+                      integration configuration.
+                    </p>
+                    <Link
+                      className={cx("btn", "btn-primary", "btn-sm")}
+                      to={{
+                        pathname: ABSOLUTE_ROUTES.v2.integrations,
+                        search,
+                      }}
+                    >
+                      <Plugin className={cx("bi", "me-1")} />
+                      View integration
+                    </Link>
+                  </>
+                )}
+              </ErrorAlert>
+            ) : (
+              <WarnAlert className="mb-0" dismissible={false}>
+                <p className="mb-2">
+                  This image is from a supported registry, but you haven{"'"}t
+                  activated the integration yet. Activate the integration to
+                  check if you have access to this image.
+                </p>
+                <Link
+                  className={cx("btn", "btn-primary", "btn-sm")}
+                  to={{
+                    pathname: ABSOLUTE_ROUTES.v2.integrations,
+                    search,
+                  }}
+                >
+                  <Plugin className={cx("bi", "me-1")} />
+                  Go to Integration
+                </Link>
+              </WarnAlert>
+            )}
+          </div>
+        )}
+      </div>
       <EnvironmentRowWithLabel
         label="Container image"
         value={environment?.container_image || ""}

--- a/client/src/features/sessionsV2/SessionView/EnvironmentCard.tsx
+++ b/client/src/features/sessionsV2/SessionView/EnvironmentCard.tsx
@@ -193,8 +193,8 @@ function CustomImageEnvironmentValues({
             {!data.connection && !data.provider ? (
               <ErrorAlert className="mb-0" dismissible={false}>
                 <p className="mb-2">
-                  The image reference is invalid or points to an unsupported
-                  registry. Please verify the reference and check if the
+                  The container image reference is invalid or points to an
+                  unsupported registry. Please verify the image and check if the
                   registry is in the currently supported{" "}
                   <Link
                     to={{
@@ -205,8 +205,8 @@ function CustomImageEnvironmentValues({
                     <Plugin className={cx("bi", "me-1")} />
                     integrations
                   </Link>
-                  . If you{"'"}re certain the reference is correct and points to
-                  a registry we don{"'"}t currently support,{" "}
+                  . If you&apos;re certain the image is correct and points to a
+                  registry we don&apos;t currently support,{" "}
                   <a
                     target="_blank"
                     rel="noreferrer noopener"
@@ -221,8 +221,8 @@ function CustomImageEnvironmentValues({
             ) : data.connection?.status === "connected" ? (
               <ErrorAlert className="mb-0" dismissible={false}>
                 <p className="mb-0">
-                  Either the image reference does not exist, or you do not have
-                  access to it.
+                  Either the container image reference does not exist, or you do
+                  not have access to it.
                 </p>
                 {data?.provider?.id && (
                   <>
@@ -246,9 +246,9 @@ function CustomImageEnvironmentValues({
             ) : (
               <WarnAlert className="mb-0" dismissible={false}>
                 <p className="mb-2">
-                  This image reference is from a supported registry, but you
-                  haven{"'"}t activated the integration yet. Activate the
-                  integration to check if you have access to this image.
+                  This container image reference is from a supported registry,
+                  but you haven&apos;t activated the integration yet. Activate
+                  the integration to check if you have access to this image.
                 </p>
                 <Link
                   className={cx("btn", "btn-primary", "btn-sm")}

--- a/client/src/features/sessionsV2/SessionView/EnvironmentCard.tsx
+++ b/client/src/features/sessionsV2/SessionView/EnvironmentCard.tsx
@@ -193,9 +193,9 @@ function CustomImageEnvironmentValues({
             {!data.connection && !data.provider ? (
               <ErrorAlert className="mb-0" dismissible={false}>
                 <p className="mb-2">
-                  The image URL is invalid or points to an unsupported registry.
-                  Please verify the URL and check if the registry is in the
-                  currently supported{" "}
+                  The image reference is invalid or points to an unsupported
+                  registry. Please verify the reference and check if the
+                  registry is in the currently supported{" "}
                   <Link
                     to={{
                       pathname: ABSOLUTE_ROUTES.v2.integrations,
@@ -205,8 +205,8 @@ function CustomImageEnvironmentValues({
                     <Plugin className={cx("bi", "me-1")} />
                     integrations
                   </Link>
-                  . If you{"'"}re certain the URL is correct and points to a
-                  registry we don{"'"}t currently support,{" "}
+                  . If you{"'"}re certain the reference is correct and points to
+                  a registry we don{"'"}t currently support,{" "}
                   <a
                     target="_blank"
                     rel="noreferrer noopener"
@@ -221,8 +221,8 @@ function CustomImageEnvironmentValues({
             ) : data.connection?.status === "connected" ? (
               <ErrorAlert className="mb-0" dismissible={false}>
                 <p className="mb-0">
-                  Either the image does not exist, or you do not have access to
-                  it.
+                  Either the image reference does not exist, or you do not have
+                  access to it.
                 </p>
                 {data?.provider?.id && (
                   <>
@@ -246,9 +246,9 @@ function CustomImageEnvironmentValues({
             ) : (
               <WarnAlert className="mb-0" dismissible={false}>
                 <p className="mb-2">
-                  This image is from a supported registry, but you haven{"'"}t
-                  activated the integration yet. Activate the integration to
-                  check if you have access to this image.
+                  This image reference is from a supported registry, but you
+                  haven{"'"}t activated the integration yet. Activate the
+                  integration to check if you have access to this image.
                 </p>
                 <Link
                   className={cx("btn", "btn-primary", "btn-sm")}

--- a/client/src/features/sessionsV2/api/sessionsV2.generated-api.ts
+++ b/client/src/features/sessionsV2/api/sessionsV2.generated-api.ts
@@ -134,7 +134,8 @@ const injectedRtkApi = api.injectEndpoints({
   overrideExisting: false,
 });
 export { injectedRtkApi as sessionsV2GeneratedApi };
-export type GetNotebooksImagesApiResponse = unknown;
+export type GetNotebooksImagesApiResponse =
+  /** status 200 undefined */ ImageCheckResponse;
 export type GetNotebooksImagesApiArg = {
   /** The Docker image URL (tag included) that should be fetched. */
   imageUrl: string;
@@ -223,14 +224,30 @@ export type GetSessionsBySessionIdLogsApiArg = {
   maxLines?: number;
 };
 export type GetSessionsImagesApiResponse =
-  /** status 200 The docker image can be found */ void;
+  /** status 200 Information about the accessibility of the image */ ImageCheckResponse;
 export type GetSessionsImagesApiArg = {
   /** The Docker image URL (tag included) that should be fetched. */
   imageUrl: string;
 };
-export type ServerLogs = {
-  "jupyter-server"?: string;
-  [key: string]: any;
+export type ImageConnectionStatus =
+  | "connected"
+  | "pending"
+  | "invalid_credentials";
+export type ImageConnection = {
+  id: string;
+  provider_id: string;
+  status: ImageConnectionStatus;
+};
+export type ImageProvider = {
+  id: string;
+  name: string;
+  url: string;
+};
+export type ImageCheckResponse = {
+  /** Whether the image is accessible or not. */
+  accessible: boolean;
+  connection?: ImageConnection;
+  provider?: ImageProvider;
 };
 export type ErrorResponse = {
   error: {
@@ -238,6 +255,10 @@ export type ErrorResponse = {
     detail?: string;
     message: string;
   };
+};
+export type ServerLogs = {
+  "jupyter-server"?: string;
+  [key: string]: any;
 };
 export type ServerName = string;
 export type Generated = {

--- a/client/src/features/sessionsV2/api/sessionsV2.openapi.json
+++ b/client/src/features/sessionsV2/api/sessionsV2.openapi.json
@@ -28,10 +28,23 @@
         ],
         "responses": {
           "200": {
-            "description": "The Docker image is available."
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImageCheckResponse"
+                }
+              }
+            }
           },
-          "404": {
-            "description": "The Docker image is not available."
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "The image url is malformed."
           }
         },
         "tags": ["notebooks"]
@@ -555,10 +568,17 @@
         ],
         "responses": {
           "200": {
-            "description": "The docker image can be found"
+            "description": "Information about the accessibility of the image",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImageCheckResponse"
+                }
+              }
+            }
           },
-          "404": {
-            "description": "The docker image cannot be found or the user does not have permissions to access it",
+          "422": {
+            "description": "The image url is malformed.",
             "content": {
               "application/json": {
                 "schema": {
@@ -566,9 +586,6 @@
                 }
               }
             }
-          },
-          "default": {
-            "$ref": "#/components/responses/Error"
           }
         },
         "tags": ["sessions"]
@@ -1429,9 +1446,62 @@
         "maxLength": 50,
         "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
         "example": "d185e68d-d43-renku-2-b9ac279a4e8a85ac28d08"
+      },
+      "ImageCheckResponse": {
+        "type": "object",
+        "properties": {
+          "accessible": {
+            "type": "boolean",
+            "description": "Whether the image is accessible or not."
+          },
+          "connection": {
+            "$ref": "#/components/schemas/ImageConnection"
+          },
+          "provider": {
+            "$ref": "#/components/schemas/ImageProvider"
+          }
+        },
+        "required": ["accessible"]
+      },
+      "ImageConnection": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "provider_id": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ImageConnectionStatus"
+          }
+        },
+        "required": ["id", "provider_id", "status"]
+      },
+      "ImageConnectionStatus": {
+        "type": "string",
+        "enum": ["connected", "pending", "invalid_credentials"]
+      },
+      "ImageProvider": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": ["id", "name", "url"]
       }
     },
     "responses": {
+      "ImageCheckResponse": {
+        "description": "Information about whether a docker image is available or not and if there is a connected service then which connected service can be used to access the image."
+      },
       "Error": {
         "description": "The schema for all 4xx and 5xx responses",
         "content": {

--- a/client/src/features/sessionsV2/components/SessionForm/EnvironmentField.tsx
+++ b/client/src/features/sessionsV2/components/SessionForm/EnvironmentField.tsx
@@ -34,19 +34,19 @@ import { GlobalEnvironmentFields } from "./GlobalEnvironmentFields";
 export interface EnvironmentFieldsProps {
   control: Control<SessionLauncherForm, unknown>;
   errors: FieldErrors<SessionLauncherForm>;
-  watch: UseFormWatch<SessionLauncherForm>;
+  setValue: UseFormSetValue<SessionLauncherForm>;
   touchedFields: Partial<
     Readonly<FieldNamesMarkedBoolean<SessionLauncherForm>>
   >;
-  setValue: UseFormSetValue<SessionLauncherForm>;
+  watch: UseFormWatch<SessionLauncherForm>;
 }
 
 export function EnvironmentFields({
-  watch,
   control,
   errors,
-  touchedFields,
   setValue,
+  touchedFields,
+  watch,
 }: EnvironmentFieldsProps) {
   const watchEnvironmentSelect = watch("environmentSelect");
   return (
@@ -59,22 +59,22 @@ export function EnvironmentFields({
       </div>
       <div className={cx(watchEnvironmentSelect !== "global" && "d-none")}>
         <GlobalEnvironmentFields
-          errors={errors}
-          touchedFields={touchedFields}
           control={control}
-          watch={watch}
+          errors={errors}
           setValue={setValue}
+          touchedFields={touchedFields}
+          watch={watch}
         />
       </div>
       <div
         className={cx(watchEnvironmentSelect !== "custom + image" && "d-none")}
       >
         <CustomEnvironmentFields
-          errors={errors}
-          touchedFields={touchedFields}
           control={control}
-          watch={watch}
+          errors={errors}
           setValue={setValue}
+          touchedFields={touchedFields}
+          watch={watch}
         />
       </div>
       {watchEnvironmentSelect === "custom + build" && (

--- a/client/src/features/sessionsV2/components/SessionModals/NewSessionLauncherModal.tsx
+++ b/client/src/features/sessionsV2/components/SessionModals/NewSessionLauncherModal.tsx
@@ -221,11 +221,11 @@ export default function NewSessionLauncherModal({
               {result.error && <RtkOrNotebooksError error={result.error} />}
               {step === "environment" && (
                 <EnvironmentFields
-                  errors={errors}
-                  touchedFields={touchedFields}
                   control={control}
-                  watch={watch}
+                  errors={errors}
                   setValue={setValue}
+                  touchedFields={touchedFields}
+                  watch={watch}
                 />
               )}
               {step === "launcherDetails" && (

--- a/client/src/features/sessionsV2/components/SessionStatus/SessionImageBadge.tsx
+++ b/client/src/features/sessionsV2/components/SessionStatus/SessionImageBadge.tsx
@@ -1,0 +1,68 @@
+/*!
+ * Copyright 2025 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CircleFill } from "react-bootstrap-icons";
+import { Loader } from "~/components/Loader";
+import RenkuBadge from "~/components/renkuBadge/RenkuBadge";
+import { ImageCheckResponse } from "../../api/sessionsV2.generated-api";
+
+interface SessionImageBadgeProps {
+  data?: ImageCheckResponse | null;
+  loading: boolean;
+}
+
+export default function SessionImageBadge({
+  data,
+  loading,
+}: SessionImageBadgeProps) {
+  return (
+    <RenkuBadge
+      color={
+        loading
+          ? "light"
+          : data?.accessible
+          ? "success"
+          : data?.provider?.id &&
+            (!data?.connection || data?.connection?.status !== "connected")
+          ? "warning"
+          : "danger"
+      }
+      className="fw-normal"
+      pill
+    >
+      {loading ? (
+        <>
+          <Loader size={12} inline /> Checking image status.
+        </>
+      ) : (
+        <>
+          <CircleFill className="bi" />{" "}
+          {data?.accessible
+            ? "Image accessible"
+            : data?.provider?.id &&
+              (!data?.connection || data?.connection?.status !== "connected")
+            ? "Integration required"
+            : data?.connection?.status === "connected" ||
+              data?.accessible === false
+            ? "Image inaccessible"
+            : "Image status unknown"}
+        </>
+      )}
+    </RenkuBadge>
+  );
+}

--- a/client/src/features/sessionsV2/components/SessionStatus/SessionImageBadge.tsx
+++ b/client/src/features/sessionsV2/components/SessionStatus/SessionImageBadge.tsx
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+import cx from "classnames";
 import { CircleFill } from "react-bootstrap-icons";
 import { Loader } from "~/components/Loader";
 import RenkuBadge from "~/components/renkuBadge/RenkuBadge";
@@ -47,11 +48,12 @@ export default function SessionImageBadge({
     >
       {loading ? (
         <>
-          <Loader size={12} inline /> Checking image status.
+          <Loader className="me-1" size={12} inline />
+          Checking image status.
         </>
       ) : (
         <>
-          <CircleFill className="bi" />{" "}
+          <CircleFill className={cx("bi", "me-1")} />
           {data?.accessible
             ? "Image accessible"
             : data?.provider?.id &&

--- a/client/src/features/sessionsV2/startSessionOptionsV2.slice.ts
+++ b/client/src/features/sessionsV2/startSessionOptionsV2.slice.ts
@@ -30,6 +30,7 @@ const initialState: StartSessionOptionsV2 = {
   cloudStorage: undefined,
   defaultUrl: "",
   environmentVariables: [],
+  imageReady: false,
   lfsAutoFetch: false,
   repositories: [],
   sessionClass: 0,
@@ -70,6 +71,9 @@ const startSessionOptionsV2Slice = createSlice({
     },
     setDefaultUrl: (state, action: PayloadAction<string>) => {
       state.defaultUrl = action.payload;
+    },
+    setImageReady: (state, action: PayloadAction<boolean>) => {
+      state.imageReady = action.payload;
     },
     setLfsAutoFetch: (state, action: PayloadAction<boolean>) => {
       state.lfsAutoFetch = action.payload;

--- a/client/src/features/sessionsV2/startSessionOptionsV2.types.ts
+++ b/client/src/features/sessionsV2/startSessionOptionsV2.types.ts
@@ -36,6 +36,7 @@ export interface StartSessionOptionsV2 {
   cloudStorage?: SessionStartDataConnectorConfiguration[];
   defaultUrl: string;
   environmentVariables: SessionEnvironmentVariable[];
+  imageReady: boolean;
   lfsAutoFetch: boolean;
   repositories: SessionRepository[];
   sessionClass: number;

--- a/client/src/features/sessionsV2/useSessionLaunchState.hook.ts
+++ b/client/src/features/sessionsV2/useSessionLaunchState.hook.ts
@@ -88,9 +88,11 @@ export default function useSessionLauncherState({
         : skipToken
     );
   const sessionImage = useMemo(() => {
-    if (isLoadingSessionImage) return undefined;
-    return dataSessionImage ?? { accessible: true };
-  }, [dataSessionImage, isLoadingSessionImage]);
+    if (isExternalImageEnvironment && containerImage) {
+      return dataSessionImage;
+    }
+    return { accessible: true };
+  }, [containerImage, dataSessionImage, isExternalImageEnvironment]);
 
   const startSessionOptionsV2 = useAppSelector(
     ({ startSessionOptionsV2 }) => startSessionOptionsV2

--- a/client/src/features/sessionsV2/useSessionLaunchState.hook.ts
+++ b/client/src/features/sessionsV2/useSessionLaunchState.hook.ts
@@ -18,7 +18,6 @@
 
 import { skipToken } from "@reduxjs/toolkit/query";
 import { useEffect, useMemo } from "react";
-
 import useAppDispatch from "~/utils/customHooks/useAppDispatch.hook";
 import useAppSelector from "~/utils/customHooks/useAppSelector.hook";
 import {
@@ -29,6 +28,7 @@ import useDataConnectorConfiguration from "../dataConnectorsV2/components/useDat
 import type { Project } from "../projectsV2/api/projectV2.api";
 import { useGetResourcePoolsQuery } from "./api/computeResources.api";
 import type { SessionLauncher } from "./api/sessionLaunchersV2.api";
+import { useGetSessionsImagesQuery } from "./api/sessionsV2.api";
 import { DEFAULT_URL } from "./session.constants";
 import startSessionOptionsV2Slice from "./startSessionOptionsV2.slice";
 import useSessionResourceClass from "./useSessionResourceClass.hook";
@@ -77,6 +77,20 @@ export default function useSessionLauncherState({
   } = useSessionSecrets({ projectId: project.id });
 
   const containerImage = launcher.environment?.container_image ?? "";
+  const isExternalImageEnvironment =
+    containerImage &&
+    launcher.environment?.environment_kind === "CUSTOM" &&
+    launcher.environment?.environment_image_source === "image";
+  const { data: dataSessionImage, isLoading: isLoadingSessionImage } =
+    useGetSessionsImagesQuery(
+      isExternalImageEnvironment && containerImage
+        ? { imageUrl: containerImage }
+        : skipToken
+    );
+  const sessionImage = useMemo(() => {
+    if (isLoadingSessionImage) return undefined;
+    return dataSessionImage ?? { accessible: true };
+  }, [dataSessionImage, isLoadingSessionImage]);
 
   const startSessionOptionsV2 = useAppSelector(
     ({ startSessionOptionsV2 }) => startSessionOptionsV2
@@ -150,14 +164,26 @@ export default function useSessionLauncherState({
     isReadyDataConnectorConfigs,
   ]);
 
+  useEffect(() => {
+    // check session image availability -- it should block only for external images
+    if (
+      !isExternalImageEnvironment ||
+      (!!sessionImage && sessionImage.accessible)
+    ) {
+      dispatch(startSessionOptionsV2Slice.actions.setImageReady(true));
+    }
+  }, [dispatch, isExternalImageEnvironment, sessionImage]);
+
   return {
     containerImage,
+    sessionImage,
     defaultSessionClass,
     isFetchingOrLoadingStorages,
-    resourcePools,
-    isPendingResourceClass,
-    setResourceClass,
     isFetchingSessionSecrets,
+    isLoadingSessionImage,
+    isPendingResourceClass,
+    resourcePools,
     sessionSecretSlotsWithSecrets,
+    setResourceClass,
   };
 }


### PR DESCRIPTION
This PR adds support for private images. Changes touch the following areas:

* Project page: check the image status for launchers using external images and let users go to the integration page to log in
    <img width="1501" height="1058" alt="Screenshot_20251003_162350" src="https://github.com/user-attachments/assets/be743073-19e8-4bb8-a1ac-6cfdfe2c9c43" />
* Session page: give feedback about image (un)availability when necessary
    <img width="1256" height="679" alt="Screenshot_20251003_162545" src="https://github.com/user-attachments/assets/0093055f-9b70-4e0c-bb72-b00cfda76da0" />
* Integrations page: highlight when redirected and disconnect button
    <img width="1529" height="784" alt="Screenshot_20251003_163923" src="https://github.com/user-attachments/assets/b66272af-defd-43e2-8651-912605964a29" />

* Admin page: minor adjustments

A few follow-ups are planned and will be part of a short pitch in the write:
* Add better feedback while creating the launcher and pasting the image URL (require some design)
* Show the required integrations in a modal or integrate in the current panel instead of redirecting (require update on connection APIs)
* Improve how we check code repos

Reference: https://www.notion.so/renku/Support-Private-images-from-external-registries-1b20df2efafc8013be5ed84283797d19

/deploy renku-data-services=main renku=release-2.9.0
