### PR TITLE
fix: cast search params numbers properly on the group search page

### DIFF
--- a/client/src/features/groupsV2/search/GroupSearchResults.tsx
+++ b/client/src/features/groupsV2/search/GroupSearchResults.tsx
@@ -47,20 +47,27 @@ export default function GroupSearchResults() {
   const { data } = useGroupSearch();
 
   const currentPage = useMemo(() => {
+    const defaultValue = FILTER_PAGE.defaultValue as number;
     const pageParam = searchParams.get(FILTER_PAGE.name);
+    if (!pageParam) return defaultValue;
     try {
-      const page = parseInt(pageParam, 10)
-      return page > 0 ? page : 1;
+      const page = parseInt(pageParam, 10);
+      return page > 0 ? page : defaultValue;
     } catch {
-      return 1;
+      return defaultValue;
     }
   }, [searchParams]);
 
   const currentPerPage = useMemo(() => {
+    const defaultValue = FILTER_PER_PAGE.defaultValue as number;
     const perPageParam = searchParams.get(FILTER_PER_PAGE.name);
-    return perPageParam
-      ? parseInt(perPageParam)
-      : FILTER_PER_PAGE.defaultValue ?? 0;
+    if (!perPageParam) return defaultValue;
+    try {
+      const perPage = parseInt(perPageParam, 10);
+      return perPage > 0 ? perPage : defaultValue;
+    } catch {
+      return defaultValue;
+    }
   }, [searchParams]);
 
   return (


### PR DESCRIPTION
On the group search page, the numbers extracted from the query parameters were not cast properly. As a result, it occasionally occurred that the "next" and "previous" buttons were pointing to a wrong or non-existing page (`1+1` is not the same as `"1" + 1` :facepalm: ).

The screenshot uses the same data from the issue. The "next" button now points to page `2` instead of `11`

<img width="1529" height="1383" alt="image" src="https://github.com/user-attachments/assets/339e255c-0ee8-404e-84e9-3cc9f605fbce" />

/deploy
fix #3864