### PR TITLE
minor: show repo migration warning only on matching repos

### DIFF
--- a/client/src/features/ProjectPageV2/ProjectPageContent/CodeRepositories/CodeRepositoryDisplay.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/CodeRepositories/CodeRepositoryDisplay.tsx
@@ -513,7 +513,7 @@ export function RepositoryItem({
         </Row>
         <Row>
           <Col data-cy="repo-gitlab-warning">
-            <RepositoryGitLabWarnBadge project={project} />
+            <RepositoryGitLabWarnBadge project={project} url={url} />
           </Col>
         </Row>
       </ListGroupItem>

--- a/client/src/features/legacy/RepositoryGitLabWarnBadge.tsx
+++ b/client/src/features/legacy/RepositoryGitLabWarnBadge.tsx
@@ -21,15 +21,16 @@ import useProjectPermissions from "~/features/ProjectPageV2/utils/useProjectPerm
 import type { Project } from "~/features/projectsV2/api/projectV2.api";
 
 import InternalGitLabReferenceWarnBadge from "./InternalGitLabWarnBadge";
-import { doesProjectReferenceRenkulabGitLab } from "./legacy.utils";
+import { doesRepositoryReferenceRenkulabGitLab } from "./legacy.utils";
 
 interface RepositoryGitLabWarnBadgeProps {
   project: Project;
+  url: string;
 }
 
 function RepositoryGitLabWarnBadgeForProject({
   project,
-}: RepositoryGitLabWarnBadgeProps) {
+}: Pick<RepositoryGitLabWarnBadgeProps, "project">) {
   const userPermissions = useProjectPermissions({
     projectId: project.id,
   });
@@ -46,9 +47,9 @@ function RepositoryGitLabWarnBadgeForProject({
 
 export default function RepositoryGitLabWarnBadge({
   project,
+  url,
 }: RepositoryGitLabWarnBadgeProps) {
-  if (!doesProjectReferenceRenkulabGitLab(project.repositories, []))
-    return null;
+  if (!doesRepositoryReferenceRenkulabGitLab(url)) return null;
 
   return <RepositoryGitLabWarnBadgeForProject project={project} />;
 }

--- a/client/src/features/legacy/legacy.utils.ts
+++ b/client/src/features/legacy/legacy.utils.ts
@@ -46,19 +46,26 @@ export function doesProjectReferenceRenkulabGitLab(
   return repositories.length > 0 || launchers.length > 0;
 }
 
+export function doesRepositoryReferenceRenkulabGitLab(url: string) {
+  return doesUrlHostMatchHost(url, DEFAULT_INTERNAL_GITLAB_HOSTS.repository);
+}
+
+function doesImageReferenceRenkulabGitLab(imageRef: string) {
+  return doesUrlHostMatchHost(imageRef, DEFAULT_INTERNAL_GITLAB_HOSTS.images);
+}
+
 function projectReferencesToRenkulabGitLab(
   allRepositories: Project["repositories"],
   allLaunchers: SessionLaunchersList
 ) {
-  const hosts = DEFAULT_INTERNAL_GITLAB_HOSTS;
   const repositories =
     allRepositories?.filter((repo) =>
-      doesUrlHostMatchHost(repo, hosts.repository)
+      doesRepositoryReferenceRenkulabGitLab(repo)
     ) ?? [];
   const launchers = allLaunchers.filter(
     (launcher) =>
       launcher.environment.container_image != null &&
-      doesUrlHostMatchHost(launcher.environment.container_image, hosts.images)
+      doesImageReferenceRenkulabGitLab(launcher.environment.container_image)
   );
   return { repositories, launchers };
 }


### PR DESCRIPTION
Fix bug that causes migration warning to be shown on **all** repos, instead of only matching ones.

Compare:

### New

<img width="631" height="497" alt="image" src="https://github.com/user-attachments/assets/36e14844-96cb-4d48-9c6a-518d95eb3bdc" />


### Old

<img width="631" height="497" alt="image" src="https://github.com/user-attachments/assets/dbc30892-6de4-477c-9e3f-07db77b4dd96" />


/deploy