### PR TITLE
fix: show correctly the warning for writable DC

### DIFF
--- a/client/src/features/dataConnectorsV2/components/DataConnectorModal/DataConnectorModalBody.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorModal/DataConnectorModalBody.tsx
@@ -549,18 +549,19 @@ export function DataConnectorMount({
             rules={{ required: true }}
           />
           {!flatDataConnector.readOnly &&
-            (!hasPasswordFieldWithInput &&
-            flatDataConnector.visibility === "public" ? (
-              <ErrorAlert className="mt-1" dismissible={false}>
-                <p className="mb-0">
-                  Data security warning: This public and writable data connector
-                  is not protected by a password. Anyone on RenkuLab will be
-                  able to edit the data connected here. Protect your data with a
-                  password, select private visibility, or limit access to
-                  read-only.
-                </p>
-              </ErrorAlert>
-            ) : (
+          !hasPasswordFieldWithInput &&
+          flatDataConnector.visibility === "public" ? (
+            <ErrorAlert className="mt-1" dismissible={false}>
+              <p className="mb-0">
+                Data security warning: This public and writable data connector
+                is not protected by a password. Anyone on RenkuLab will be able
+                to edit the data connected here. Protect your data with a
+                password, select private visibility, or limit access to
+                read-only.
+              </p>
+            </ErrorAlert>
+          ) : (
+            !flatDataConnector.readOnly && (
               <WarnAlert className="mt-1" dismissible={false}>
                 <p className="mb-0">
                   You are mounting this storage in read-write mode. If you have
@@ -568,7 +569,8 @@ export function DataConnectorMount({
                   prevent errors with some storage types.
                 </p>
               </WarnAlert>
-            ))}
+            )
+          )}
           <div className={cx("form-text", "text-muted")}>
             Select &quot;Read Only&quot; to mount the storage without write
             access. You should always select this if you do not have credentials


### PR DESCRIPTION
Prevent showing RW warning message on data connectors when picking Read only

<img width="1102" height="485" alt="Screenshot_20251030_105824" src="https://github.com/user-attachments/assets/3a59357d-41c5-4911-9308-b9046a9f1e1e" />


/deploy
fix #3895