### PR TITLE
fix: show cleaner messages for integrations

### DIFF
--- a/client/src/features/ProjectPageV2/ProjectPageContent/CodeRepositories/CodeRepositoryDisplay.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/CodeRepositories/CodeRepositoryDisplay.tsx
@@ -51,6 +51,11 @@ import { ErrorAlert, InfoAlert, WarnAlert } from "~/components/Alert";
 import { CommandCopy } from "~/components/commandCopy/CommandCopy";
 import { ExternalLink } from "~/components/ExternalLinks";
 import RenkuBadge from "~/components/renkuBadge/RenkuBadge";
+import {
+  SEARCH_PARAM_ACTION_REQUIRED,
+  SEARCH_PARAM_PROVIDER,
+  SEARCH_PARAM_SOURCE,
+} from "~/features/connectedServices/connectedServices.constants";
 import RepositoryGitLabWarnBadge from "~/features/legacy/RepositoryGitLabWarnBadge";
 import { useGetRepositoryQuery } from "~/features/repositories/api/repositories.api";
 import { useGetUserQueryState } from "~/features/usersV2/api/users.api";
@@ -569,8 +574,8 @@ function RepositoryView({
 
   const search = useMemo(() => {
     return `?${new URLSearchParams({
-      targetProvider: data?.provider?.id ?? "",
-      source: `${pathname}${hash}`,
+      [SEARCH_PARAM_PROVIDER]: data?.provider?.id ?? "",
+      [SEARCH_PARAM_SOURCE]: `${pathname}${hash}`,
     }).toString()}`;
   }, [data, pathname, hash]);
 
@@ -746,8 +751,15 @@ export function RepositoryCallToActionAlert({
 
   const search = useMemo(() => {
     return `?${new URLSearchParams({
-      targetProvider: data?.provider?.id ?? "",
-      source: `${pathname}${hash}`,
+      [SEARCH_PARAM_PROVIDER]: data?.provider?.id ?? "",
+      [SEARCH_PARAM_SOURCE]: `${pathname}${hash}`,
+    }).toString()}`;
+  }, [data, pathname, hash]);
+  const searchActionRequired = useMemo(() => {
+    return `?${new URLSearchParams({
+      [SEARCH_PARAM_PROVIDER]: data?.provider?.id ?? "",
+      [SEARCH_PARAM_SOURCE]: `${pathname}${hash}`,
+      [SEARCH_PARAM_ACTION_REQUIRED]: "true",
     }).toString()}`;
   }, [data, pathname, hash]);
 
@@ -780,7 +792,10 @@ export function RepositoryCallToActionAlert({
                   className={cx("btn", "btn-primary", "btn-sm")}
                   to={{
                     pathname: ABSOLUTE_ROUTES.v2.integrations,
-                    search,
+                    search:
+                      data?.connection?.status === "connected"
+                        ? search
+                        : searchActionRequired,
                   }}
                 >
                   <Plugin className={cx("bi", "me-1")} />
@@ -802,7 +817,6 @@ export function RepositoryCallToActionAlert({
                   <Link
                     to={{
                       pathname: ABSOLUTE_ROUTES.v2.integrations,
-                      search,
                     }}
                   >
                     <Plugin className={cx("bi", "me-1")} />
@@ -886,7 +900,7 @@ export function RepositoryCallToActionAlert({
           className={cx("btn", "btn-primary", "btn-sm")}
           to={{
             pathname: ABSOLUTE_ROUTES.v2.integrations,
-            search,
+            search: searchActionRequired,
           }}
         >
           <Plugin className={cx("bi", "me-1")} />
@@ -921,7 +935,7 @@ export function RepositoryCallToActionAlert({
             className={cx("btn", "btn-primary", "btn-sm")}
             to={{
               pathname: ABSOLUTE_ROUTES.v2.integrations,
-              search,
+              search: searchActionRequired,
             }}
           >
             <Plugin className={cx("bi", "me-1")} />

--- a/client/src/features/connectedServices/ConnectedServicesPage.tsx
+++ b/client/src/features/connectedServices/ConnectedServicesPage.tsx
@@ -23,6 +23,7 @@ import {
   BoxArrowUpRight,
   CircleFill,
   HandIndexThumb,
+  InfoCircle,
   Plugin,
   XLg,
 } from "react-bootstrap-icons";
@@ -64,6 +65,7 @@ import {
 } from "./api/connectedServices.api";
 import { AppInstallationsPaginated } from "./api/connectedServices.types";
 import {
+  SEARCH_PARAM_ACTION_REQUIRED,
   SEARCH_PARAM_PROVIDER,
   SEARCH_PARAM_SOURCE,
 } from "./connectedServices.constants";
@@ -79,6 +81,7 @@ export default function ConnectedServicesPage() {
   const [searchParams] = useSearchParams();
   const targetProviderId = searchParams.get(SEARCH_PARAM_PROVIDER);
   const source = searchParams.get(SEARCH_PARAM_SOURCE);
+  const actionRequired = searchParams.get(SEARCH_PARAM_ACTION_REQUIRED);
 
   const {
     data: providers,
@@ -120,6 +123,7 @@ export default function ConnectedServicesPage() {
       {sortedProviders.map((provider) => (
         <ConnectedServiceCard
           key={provider.id}
+          actionRequired={!!actionRequired}
           highlighted={provider.id === targetProviderId}
           provider={provider}
           source={
@@ -187,12 +191,14 @@ function ConnectedServiceStatus({ connection }: ConnectedServiceStatusProps) {
 }
 
 interface ConnectedServiceCardProps {
+  actionRequired?: boolean;
   highlighted?: boolean;
   provider: Provider;
   source?: string;
 }
 
 function ConnectedServiceCard({
+  actionRequired = false,
   highlighted = false,
   provider,
   source,
@@ -207,6 +213,12 @@ function ConnectedServiceCard({
     [connections, id]
   );
 
+  const goBackButton = source && (
+    <Link to={source} className={cx("primary")}>
+      go back to your project
+    </Link>
+  );
+
   return (
     <div data-cy="connected-services-card" className={cx("col-12", "col-lg-6")}>
       <Card
@@ -215,25 +227,35 @@ function ConnectedServiceCard({
         <CardBody>
           {highlighted && (
             <Alert
-              color="warning"
-              className={cx("border-warning", "shadow-sm")}
+              color={actionRequired ? "warning" : "info"}
+              className={cx(
+                actionRequired ? "border-warning" : "border-info",
+                "shadow-sm"
+              )}
             >
               <p className="mb-0">
-                <HandIndexThumb className={cx("bi", "me-1")} />
-                Action required. Please connect to this integration
-                {source && (
+                {actionRequired ? (
                   <>
-                    {" "}
-                    and then{" "}
-                    <Link to={source} className={cx("primary")}>
-                      go back to your project
-                    </Link>
+                    <HandIndexThumb className={cx("bi", "me-1")} />
+                    Action required. Please connect to this integration
+                    {source && <> and then {goBackButton}</>}.
+                  </>
+                ) : (
+                  <>
+                    <InfoCircle className={cx("bi", "me-1")} />
+                    Check your integration settings here.
+                    {source && (
+                      <span>
+                        <br />
+                        You can later {goBackButton}.
+                      </span>
+                    )}
                   </>
                 )}
-                .
               </p>
             </Alert>
           )}
+
           <CardTitle>
             <div className={cx("d-flex", "flex-wrap", "align-items-center")}>
               <h2 className="me-2">{display_name}</h2>

--- a/client/src/features/connectedServices/connectedServices.constants.ts
+++ b/client/src/features/connectedServices/connectedServices.constants.ts
@@ -18,4 +18,5 @@
 
 export const INTERNAL_GITLAB_PROVIDER_ID = "INTERNAL_GITLAB";
 export const SEARCH_PARAM_PROVIDER = "targetProvider";
+export const SEARCH_PARAM_ACTION_REQUIRED = "actionRequired";
 export const SEARCH_PARAM_SOURCE = "source";


### PR DESCRIPTION
Distinguish between "action required" and no actions necessary when pointing users to an integration

<img width="1418" height="797" alt="image" src="https://github.com/user-attachments/assets/ac3aa18d-7ece-41be-bb48-c896d2702c4e" />

/deploy
