### PR TITLE
fix: adjust link clicking area

### DIFF
--- a/client/src/features/dataConnectorsV2/components/DataConnectorsBoxListDisplay.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorsBoxListDisplay.tsx
@@ -144,7 +144,7 @@ export default function DataConnectorBoxListDisplay({
           to={targetOffcanvasLocation}
         >
           <Row className={cx("align-items-center", "g-3", "mx-0")}>
-            <Col className={cx("d-flex", "flex-column", "min-w-0")}>
+            <Col className={cx("d-flex", "flex-column", "min-w-0", "px-0")}>
               <span className="fw-bold" data-cy="data-connector-name">
                 {name}
               </span>


### PR DESCRIPTION
This fixes the Link clickable area, making the part just below the list item content clickable again

<img width="867" height="233" alt="image" src="https://github.com/user-attachments/assets/bc9fce99-d3be-4558-8a3a-58d522fc1d99" />

/deploy renku-data-services=feat-add-apispec renku=lorenzo/tests-dc-update #extra-values=enableInternalGitlab=false
