### PR TITLE
feat: implement OAuth connection flow and update integration alerts

### DIFF
--- a/client/eslint.config.mjs
+++ b/client/eslint.config.mjs
@@ -163,6 +163,7 @@ const jsRules = {
         "nteract",
         "ntlm",
         "nullable",
+        "oauth",
         "oauth2",
         "objectstores",
         "oidc",

--- a/client/src/components/Alert.jsx
+++ b/client/src/components/Alert.jsx
@@ -31,8 +31,6 @@ import {
 } from "react-bootstrap-icons";
 import { Alert } from "reactstrap";
 
-import { ALERT_ICON_SIZE } from "./Alert.constants";
-
 /**
  * Display a alert that can be dismissed.
  *
@@ -87,10 +85,10 @@ class RenkuAlert extends Component {
 
   getIcon() {
     const icon = {
-      danger: <ExclamationTriangle size={ALERT_ICON_SIZE} />,
-      info: <InfoCircle size={ALERT_ICON_SIZE} />,
-      warning: <ExclamationTriangle size={ALERT_ICON_SIZE} />,
-      success: <CheckCircle size={ALERT_ICON_SIZE} />,
+      danger: <ExclamationTriangle />,
+      info: <InfoCircle />,
+      warning: <ExclamationTriangle />,
+      success: <CheckCircle />,
     }[this.props.color];
 
     return icon;
@@ -110,7 +108,7 @@ class RenkuAlert extends Component {
         data-cy={this.props.dataCy || this.props["data-cy"]}
       >
         <div className={cx("d-flex", "gap-3")}>
-          <div>{alertIcon}</div>
+          <div className="fs-1">{alertIcon}</div>
           <div className={cx("my-auto", "overflow-auto", "w-100")}>
             {this.props.children}
           </div>

--- a/client/src/components/navbar/NavBarItems.tsx
+++ b/client/src/components/navbar/NavBarItems.tsx
@@ -95,7 +95,7 @@ export function RenkuToolbarItemUser({ params }: RenkuToolbarItemUserProps) {
           User Secrets
         </DropdownItemTag>
 
-        <DropdownItemTag tag={Link} to={ABSOLUTE_ROUTES.v2.integrations}>
+        <DropdownItemTag tag={Link} to={ABSOLUTE_ROUTES.v2.integrations.root}>
           Integrations
         </DropdownItemTag>
 

--- a/client/src/features/ProjectPageV2/ProjectPageContent/CodeRepositories/CodeRepositoryDisplay.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/CodeRepositories/CodeRepositoryDisplay.tsx
@@ -708,7 +708,7 @@ function RepositoryView({
                           (
                           <Link
                             to={{
-                              pathname: ABSOLUTE_ROUTES.v2.integrations,
+                              pathname: ABSOLUTE_ROUTES.v2.integrations.root,
                               search,
                             }}
                           >
@@ -827,7 +827,7 @@ export function RepositoryCallToActionAlert({
                 <Link
                   className={cx("btn", "btn-outline-primary", "btn-sm", "ms-2")}
                   to={{
-                    pathname: ABSOLUTE_ROUTES.v2.integrations,
+                    pathname: ABSOLUTE_ROUTES.v2.integrations.root,
                     search: searchActionRequired,
                   }}
                 >
@@ -848,7 +848,7 @@ export function RepositoryCallToActionAlert({
                   currently supported{" "}
                   <Link
                     to={{
-                      pathname: ABSOLUTE_ROUTES.v2.integrations,
+                      pathname: ABSOLUTE_ROUTES.v2.integrations.root,
                     }}
                   >
                     <Plugin className={cx("bi", "me-1")} />
@@ -943,7 +943,7 @@ export function RepositoryCallToActionAlert({
         <Link
           className={cx("btn", "btn-outline-primary", "btn-sm", "ms-2")}
           to={{
-            pathname: ABSOLUTE_ROUTES.v2.integrations,
+            pathname: ABSOLUTE_ROUTES.v2.integrations.root,
             search: searchActionRequired,
           }}
         >
@@ -990,7 +990,7 @@ export function RepositoryCallToActionAlert({
         <Link
           className={cx("btn", "btn-outline-primary", "btn-sm", "ms-2")}
           to={{
-            pathname: ABSOLUTE_ROUTES.v2.integrations,
+            pathname: ABSOLUTE_ROUTES.v2.integrations.root,
             search: searchActionRequired,
           }}
         >

--- a/client/src/features/ProjectPageV2/ProjectPageContent/CodeRepositories/CodeRepositoryDisplay.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/CodeRepositories/CodeRepositoryDisplay.tsx
@@ -988,7 +988,7 @@ export function RepositoryCallToActionAlert({
           )
         )}
         <Link
-          className={cx("btn", "btn-primary", "btn-sm", "ms-2")}
+          className={cx("btn", "btn-outline-primary", "btn-sm", "ms-2")}
           to={{
             pathname: ABSOLUTE_ROUTES.v2.integrations,
             search: searchActionRequired,

--- a/client/src/features/ProjectPageV2/ProjectPageContent/CodeRepositories/CodeRepositoryDisplay.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/CodeRepositories/CodeRepositoryDisplay.tsx
@@ -668,6 +668,7 @@ function RepositoryView({
                       <RepositoryCallToActionAlert
                         hasWriteAccess={projectPermissions?.write}
                         repositoryUrl={repositoryUrl}
+                        project={project}
                       />
                     </div>
 
@@ -740,10 +741,12 @@ function LogInWarning() {
 interface RepositoryCallToActionAlertProps {
   hasWriteAccess: boolean;
   repositoryUrl: string;
+  project: Project;
 }
 export function RepositoryCallToActionAlert({
   hasWriteAccess,
   repositoryUrl,
+  project,
 }: RepositoryCallToActionAlertProps) {
   const dispatch = useAppDispatch();
   const { pathname, hash } = useLocation();
@@ -768,12 +771,14 @@ export function RepositoryCallToActionAlert({
   );
 
   const onRepositoryOAuthConnected = useCallback(() => {
-    dispatch(
-      repositoriesApi.util.invalidateTags([
-        { type: "Repository", id: repositoryUrl },
-      ])
-    );
-  }, [dispatch, repositoryUrl]);
+    project.repositories?.map((repoUrl) => {
+      dispatch(
+        repositoriesApi.util.invalidateTags([
+          { type: "Repository", id: repoUrl },
+        ])
+      );
+    });
+  }, [dispatch, project]);
 
   const search = useMemo(() => {
     return `?${new URLSearchParams({

--- a/client/src/features/ProjectPageV2/ProjectPageContent/CodeRepositories/CodeRepositoryDisplay.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/CodeRepositories/CodeRepositoryDisplay.tsx
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+import { skipToken } from "@reduxjs/toolkit/query";
 import cx from "classnames";
 import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 import {
@@ -52,16 +53,24 @@ import { CommandCopy } from "~/components/commandCopy/CommandCopy";
 import ExternalLink from "~/components/ExternalLink";
 import RenkuBadge from "~/components/renkuBadge/RenkuBadge";
 import {
+  useGetOauth2ProvidersQuery,
+  type ConnectionStatus,
+} from "~/features/connectedServices/api/connectedServices.api";
+import {
   SEARCH_PARAM_ACTION_REQUIRED,
   SEARCH_PARAM_PROVIDER,
   SEARCH_PARAM_SOURCE,
 } from "~/features/connectedServices/connectedServices.constants";
 import RepositoryGitLabWarnBadge from "~/features/legacy/RepositoryGitLabWarnBadge";
-import { useGetRepositoryQuery } from "~/features/repositories/api/repositories.api";
+import {
+  repositoriesApi,
+  useGetRepositoryQuery,
+} from "~/features/repositories/api/repositories.api";
 import { useGetUserQueryState } from "~/features/usersV2/api/users.api";
 import { ABSOLUTE_ROUTES } from "~/routing/routes.constants";
 import AppContext from "~/utils/context/appContext";
 import { DEFAULT_APP_PARAMS } from "~/utils/context/appParams.constants";
+import useAppDispatch from "~/utils/customHooks/useAppDispatch.hook";
 import { ButtonWithMenuV2 } from "../../../../components/buttons/Button";
 import RtkOrDataServicesError from "../../../../components/errors/RtkOrDataServicesError";
 import { Loader } from "../../../../components/Loader";
@@ -69,6 +78,7 @@ import PermissionsGuard from "../../../permissionsV2/PermissionsGuard";
 import { Project } from "../../../projectsV2/api/projectV2.api";
 import { usePatchProjectsByProjectIdMutation } from "../../../projectsV2/api/projectV2.enhanced-api";
 import useProjectPermissions from "../../utils/useProjectPermissions.hook";
+import { ConnectButton } from "./../../../connectedServices/ConnectedServicesPage";
 import { SshRepositoryUrlWarning } from "./AddCodeRepositoryModal";
 import {
   getRepositoryName,
@@ -735,6 +745,7 @@ export function RepositoryCallToActionAlert({
   hasWriteAccess,
   repositoryUrl,
 }: RepositoryCallToActionAlertProps) {
+  const dispatch = useAppDispatch();
   const { pathname, hash } = useLocation();
   const { params } = useContext(AppContext);
   const renkuContactEmail =
@@ -747,6 +758,22 @@ export function RepositoryCallToActionAlert({
   const anonymousUser = useMemo(() => {
     return userInfo && !userInfo?.isLoggedIn;
   }, [userInfo]);
+
+  const { data: oauthProviders } = useGetOauth2ProvidersQuery(
+    anonymousUser ? skipToken : undefined
+  );
+  const oauthProvider = useMemo(
+    () => oauthProviders?.find((p) => p.id === data?.provider?.id) ?? undefined,
+    [data?.provider?.id, oauthProviders]
+  );
+
+  const onRepositoryOAuthConnected = useCallback(() => {
+    dispatch(
+      repositoriesApi.util.invalidateTags([
+        { type: "Repository", id: repositoryUrl },
+      ])
+    );
+  }, [dispatch, repositoryUrl]);
 
   const search = useMemo(() => {
     return `?${new URLSearchParams({
@@ -788,19 +815,40 @@ export function RepositoryCallToActionAlert({
                   If you think you should have access, check your integration{" "}
                   <span className="fst-italic">{data.provider.name}</span>.
                 </p>
-                <Link
-                  className={cx("btn", "btn-primary", "btn-sm")}
-                  to={{
-                    pathname: ABSOLUTE_ROUTES.v2.integrations,
-                    search:
-                      data?.connection?.status === "connected"
-                        ? search
-                        : searchActionRequired,
-                  }}
-                >
-                  <Plugin className={cx("bi", "me-1")} />
-                  View integration
-                </Link>
+                {data?.connection?.status === "connected" ? (
+                  <Link
+                    className={cx("btn", "btn-primary", "btn-sm")}
+                    to={{
+                      pathname: ABSOLUTE_ROUTES.v2.integrations,
+                      search,
+                    }}
+                  >
+                    <Plugin className={cx("bi", "me-1")} />
+                    View integration
+                  </Link>
+                ) : oauthProvider ? (
+                  <ConnectButton
+                    className="btn-sm"
+                    connectionStatus={
+                      data.connection?.status as ConnectionStatus | undefined
+                    }
+                    includeSource
+                    onConnected={onRepositoryOAuthConnected}
+                    provider={oauthProvider}
+                    withIcon
+                  />
+                ) : (
+                  <Link
+                    className={cx("btn", "btn-primary", "btn-sm")}
+                    to={{
+                      pathname: ABSOLUTE_ROUTES.v2.integrations,
+                      search: searchActionRequired,
+                    }}
+                  >
+                    <Plugin className={cx("bi", "me-1")} />
+                    View integration
+                  </Link>
+                )}
               </>
             )}
           </>
@@ -896,16 +944,29 @@ export function RepositoryCallToActionAlert({
           <span className="fst-italic">{data.provider.name}</span> to enable
           pushing to repositories for which you have permissions.
         </p>
-        <Link
-          className={cx("btn", "btn-primary", "btn-sm")}
-          to={{
-            pathname: ABSOLUTE_ROUTES.v2.integrations,
-            search: searchActionRequired,
-          }}
-        >
-          <Plugin className={cx("bi", "me-1")} />
-          View integration
-        </Link>
+        {oauthProvider ? (
+          <ConnectButton
+            className="btn-sm"
+            connectionStatus={
+              data.connection?.status as ConnectionStatus | undefined
+            }
+            includeSource
+            onConnected={onRepositoryOAuthConnected}
+            provider={oauthProvider}
+            withIcon
+          />
+        ) : (
+          <Link
+            className={cx("btn", "btn-primary", "btn-sm")}
+            to={{
+              pathname: ABSOLUTE_ROUTES.v2.integrations,
+              search: searchActionRequired,
+            }}
+          >
+            <Plugin className={cx("bi", "me-1")} />
+            View integration
+          </Link>
+        )}
       </WarnAlert>
     );
   }
@@ -930,6 +991,17 @@ export function RepositoryCallToActionAlert({
         </p>
         {anonymousUser ? (
           <LogInWarning />
+        ) : oauthProvider ? (
+          <ConnectButton
+            className="btn-sm"
+            connectionStatus={
+              data.connection?.status as ConnectionStatus | undefined
+            }
+            includeSource
+            onConnected={onRepositoryOAuthConnected}
+            provider={oauthProvider}
+            withIcon
+          />
         ) : (
           <Link
             className={cx("btn", "btn-primary", "btn-sm")}

--- a/client/src/features/ProjectPageV2/ProjectPageContent/CodeRepositories/CodeRepositoryDisplay.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/CodeRepositories/CodeRepositoryDisplay.tsx
@@ -780,12 +780,6 @@ export function RepositoryCallToActionAlert({
     });
   }, [dispatch, project]);
 
-  const search = useMemo(() => {
-    return `?${new URLSearchParams({
-      [SEARCH_PARAM_PROVIDER]: data?.provider?.id ?? "",
-      [SEARCH_PARAM_SOURCE]: `${pathname}${hash}`,
-    }).toString()}`;
-  }, [data, pathname, hash]);
   const searchActionRequired = useMemo(() => {
     return `?${new URLSearchParams({
       [SEARCH_PARAM_PROVIDER]: data?.provider?.id ?? "",
@@ -809,29 +803,16 @@ export function RepositoryCallToActionAlert({
         {data?.provider?.id ? (
           <>
             <p className="mb-2">
-              Either the repository does not exist, or you do not have access to
-              it.
+              The repository is not accessible and your connection to{" "}
+              <span className="fst-italic">{data.provider.name}</span> is
+              invalid.
             </p>
             {anonymousUser ? (
               <LogInWarning />
             ) : (
               <>
-                <p className="mb-2">
-                  If you think you should have access, check your integration{" "}
-                  <span className="fst-italic">{data.provider.name}</span>.
-                </p>
-                {data?.connection?.status === "connected" ? (
-                  <Link
-                    className={cx("btn", "btn-primary", "btn-sm")}
-                    to={{
-                      pathname: ABSOLUTE_ROUTES.v2.integrations,
-                      search,
-                    }}
-                  >
-                    <Plugin className={cx("bi", "me-1")} />
-                    View integration
-                  </Link>
-                ) : oauthProvider ? (
+                <p className="mb-2">You can try to refresh it.</p>
+                {oauthProvider && (
                   <ConnectButton
                     className="btn-sm"
                     connectionStatus={
@@ -842,18 +823,16 @@ export function RepositoryCallToActionAlert({
                     provider={oauthProvider}
                     withIcon
                   />
-                ) : (
-                  <Link
-                    className={cx("btn", "btn-primary", "btn-sm")}
-                    to={{
-                      pathname: ABSOLUTE_ROUTES.v2.integrations,
-                      search: searchActionRequired,
-                    }}
-                  >
-                    <Plugin className={cx("bi", "me-1")} />
-                    View integration
-                  </Link>
                 )}
+                <Link
+                  className={cx("btn", "btn-outline-primary", "btn-sm", "ms-2")}
+                  to={{
+                    pathname: ABSOLUTE_ROUTES.v2.integrations,
+                    search: searchActionRequired,
+                  }}
+                >
+                  Check integration
+                </Link>
               </>
             )}
           </>
@@ -945,11 +924,11 @@ export function RepositoryCallToActionAlert({
         data-cy="code-repository-alert"
       >
         <p className="mb-2">
-          You can log in through the integration{" "}
+          You can connect to{" "}
           <span className="fst-italic">{data.provider.name}</span> to enable
           pushing to repositories for which you have permissions.
         </p>
-        {oauthProvider ? (
+        {oauthProvider && (
           <ConnectButton
             className="btn-sm"
             connectionStatus={
@@ -960,18 +939,16 @@ export function RepositoryCallToActionAlert({
             provider={oauthProvider}
             withIcon
           />
-        ) : (
-          <Link
-            className={cx("btn", "btn-primary", "btn-sm")}
-            to={{
-              pathname: ABSOLUTE_ROUTES.v2.integrations,
-              search: searchActionRequired,
-            }}
-          >
-            <Plugin className={cx("bi", "me-1")} />
-            View integration
-          </Link>
         )}
+        <Link
+          className={cx("btn", "btn-outline-primary", "btn-sm", "ms-2")}
+          to={{
+            pathname: ABSOLUTE_ROUTES.v2.integrations,
+            search: searchActionRequired,
+          }}
+        >
+          Check integration
+        </Link>
       </WarnAlert>
     );
   }
@@ -996,29 +973,29 @@ export function RepositoryCallToActionAlert({
         </p>
         {anonymousUser ? (
           <LogInWarning />
-        ) : oauthProvider ? (
-          <ConnectButton
-            className="btn-sm"
-            connectionStatus={
-              data.connection?.status as ConnectionStatus | undefined
-            }
-            includeSource
-            onConnected={onRepositoryOAuthConnected}
-            provider={oauthProvider}
-            withIcon
-          />
         ) : (
-          <Link
-            className={cx("btn", "btn-primary", "btn-sm")}
-            to={{
-              pathname: ABSOLUTE_ROUTES.v2.integrations,
-              search: searchActionRequired,
-            }}
-          >
-            <Plugin className={cx("bi", "me-1")} />
-            View integration
-          </Link>
+          oauthProvider && (
+            <ConnectButton
+              className="btn-sm"
+              connectionStatus={
+                data.connection?.status as ConnectionStatus | undefined
+              }
+              includeSource
+              onConnected={onRepositoryOAuthConnected}
+              provider={oauthProvider}
+              withIcon
+            />
+          )
         )}
+        <Link
+          className={cx("btn", "btn-primary", "btn-sm", "ms-2")}
+          to={{
+            pathname: ABSOLUTE_ROUTES.v2.integrations,
+            search: searchActionRequired,
+          }}
+        >
+          Check integration
+        </Link>
       </InfoAlert>
     );
   }

--- a/client/src/features/cloudStorage/AddOrEditCloudStorage.tsx
+++ b/client/src/features/cloudStorage/AddOrEditCloudStorage.tsx
@@ -56,7 +56,6 @@ import useAppSelector from "../../utils/customHooks/useAppSelector.hook";
 import {
   useGetOauth2ConnectionsQuery,
   useGetOauth2ProvidersQuery,
-  type ConnectionStatus,
 } from "../connectedServices/api/connectedServices.api";
 import { SEARCH_PARAM_PROVIDER } from "../connectedServices/connectedServices.constants";
 import type { DataConnectorSecret } from "../dataConnectorsV2/api/data-connectors.api";
@@ -1092,7 +1091,7 @@ export function IntegrationAlert({ schema }: IntegrationAlertProps) {
     const link = singleProvider && (
       <Link
         to={{
-          pathname: ABSOLUTE_ROUTES.v2.integrations,
+          pathname: ABSOLUTE_ROUTES.v2.integrations.root,
           search: new URLSearchParams({
             [SEARCH_PARAM_PROVIDER]: singleProvider.id,
           }).toString(),
@@ -1130,7 +1129,7 @@ export function IntegrationAlert({ schema }: IntegrationAlertProps) {
         </p>
         <ConnectButton
           className="btn-sm"
-          connectionStatus={connection?.status as ConnectionStatus | undefined}
+          connectionStatus={connection?.status}
           includeSource
           provider={provider}
           withIcon

--- a/client/src/features/cloudStorage/AddOrEditCloudStorage.tsx
+++ b/client/src/features/cloudStorage/AddOrEditCloudStorage.tsx
@@ -35,7 +35,7 @@ import {
   QuestionCircle,
 } from "react-bootstrap-icons";
 import { Control, Controller, FieldValues, useForm } from "react-hook-form";
-import { Link, useLocation } from "react-router";
+import { Link } from "react-router";
 import {
   Badge,
   Button,
@@ -56,14 +56,12 @@ import useAppSelector from "../../utils/customHooks/useAppSelector.hook";
 import {
   useGetOauth2ConnectionsQuery,
   useGetOauth2ProvidersQuery,
+  type ConnectionStatus,
 } from "../connectedServices/api/connectedServices.api";
-import {
-  SEARCH_PARAM_ACTION_REQUIRED,
-  SEARCH_PARAM_PROVIDER,
-  SEARCH_PARAM_SOURCE,
-} from "../connectedServices/connectedServices.constants";
+import { SEARCH_PARAM_PROVIDER } from "../connectedServices/connectedServices.constants";
 import type { DataConnectorSecret } from "../dataConnectorsV2/api/data-connectors.api";
 import { hasSchemaAccessMode } from "../dataConnectorsV2/components/dataConnector.utils";
+import { ConnectButton } from "./../connectedServices/ConnectedServicesPage";
 import {
   CLOUD_STORAGE_CONFIGURATION_PLACEHOLDER,
   CLOUD_STORAGE_INTEGRATION_KIND_MAP,
@@ -1034,8 +1032,6 @@ interface IntegrationAlertProps {
 }
 
 export function IntegrationAlert({ schema }: IntegrationAlertProps) {
-  const { pathname, hash } = useLocation();
-
   const {
     data: providers,
     error: providersError,
@@ -1119,29 +1115,26 @@ export function IntegrationAlert({ schema }: IntegrationAlertProps) {
   }
 
   if (providersForSchema && providersForSchema.length > 0) {
-    // We don't know which provider to pick when there are multiple.
     const provider = providersForSchema[0];
-    const link = (
-      <Link
-        to={{
-          pathname: ABSOLUTE_ROUTES.v2.integrations,
-          search: new URLSearchParams({
-            [SEARCH_PARAM_PROVIDER]: provider.id,
-            [SEARCH_PARAM_SOURCE]: `${pathname}${hash}`,
-            [SEARCH_PARAM_ACTION_REQUIRED]: "true",
-          }).toString(),
-        }}
-      >
-        {provider.display_name}
-      </Link>
+    const connection = connections?.find(
+      ({ provider_id }) => provider_id === provider.id
     );
 
     return (
       <WarnAlert dismissible={false}>
         <h3>Action required</h3>
-        <p className="mb-0">
-          Please connect with the {link} Renku integration first.
+        <p className="mb-2">
+          Please connect the{" "}
+          <span className="fst-italic">{provider.display_name}</span> Renku
+          integration first.
         </p>
+        <ConnectButton
+          className="btn-sm"
+          connectionStatus={connection?.status as ConnectionStatus | undefined}
+          includeSource
+          provider={provider}
+          withIcon
+        />
       </WarnAlert>
     );
   }

--- a/client/src/features/cloudStorage/AddOrEditCloudStorage.tsx
+++ b/client/src/features/cloudStorage/AddOrEditCloudStorage.tsx
@@ -35,7 +35,7 @@ import {
   QuestionCircle,
 } from "react-bootstrap-icons";
 import { Control, Controller, FieldValues, useForm } from "react-hook-form";
-import { Link } from "react-router";
+import { Link, useLocation } from "react-router";
 import {
   Badge,
   Button,
@@ -57,7 +57,11 @@ import {
   useGetOauth2ConnectionsQuery,
   useGetOauth2ProvidersQuery,
 } from "../connectedServices/api/connectedServices.api";
-import { SEARCH_PARAM_PROVIDER } from "../connectedServices/connectedServices.constants";
+import {
+  SEARCH_PARAM_ACTION_REQUIRED,
+  SEARCH_PARAM_PROVIDER,
+  SEARCH_PARAM_SOURCE,
+} from "../connectedServices/connectedServices.constants";
 import type { DataConnectorSecret } from "../dataConnectorsV2/api/data-connectors.api";
 import { hasSchemaAccessMode } from "../dataConnectorsV2/components/dataConnector.utils";
 import { ConnectButton } from "./../connectedServices/ConnectedServicesPage";
@@ -1043,6 +1047,7 @@ export function IntegrationAlert({ schema }: IntegrationAlertProps) {
   } = useGetOauth2ConnectionsQuery();
   const error = providersError ?? connectionsError;
   const isLoading = isLoadingProviders || isLoadingConnections;
+  const { pathname, hash } = useLocation();
 
   const providerKind = useMemo(
     () => CLOUD_STORAGE_INTEGRATION_KIND_MAP[schema.name],
@@ -1134,6 +1139,19 @@ export function IntegrationAlert({ schema }: IntegrationAlertProps) {
           provider={provider}
           withIcon
         />
+        <Link
+          className={cx("btn", "btn-outline-primary", "btn-sm", "ms-2")}
+          to={{
+            pathname: ABSOLUTE_ROUTES.v2.integrations.root,
+            search: new URLSearchParams({
+              [SEARCH_PARAM_PROVIDER]: provider.id,
+              [SEARCH_PARAM_SOURCE]: `${pathname}${hash}`,
+              [SEARCH_PARAM_ACTION_REQUIRED]: "true",
+            }).toString(),
+          }}
+        >
+          Check integration
+        </Link>
       </WarnAlert>
     );
   }

--- a/client/src/features/connectedServices/ConnectedServicesPage.tsx
+++ b/client/src/features/connectedServices/ConnectedServicesPage.tsx
@@ -42,9 +42,9 @@ import {
   ModalHeader,
 } from "reactstrap";
 
-import { AppInstallationsPaginated } from "~/features/connectedServices/api/connectedServices.types.ts";
-import { useOAuthProviderConnect } from "~/features/connectedServices/useOAuthProviderConnect.hook.ts";
-import { safeNewUrl } from "~/utils/helpers/safeNewUrl.utils.ts";
+import { AppInstallationsPaginated } from "~/features/connectedServices/api/connectedServices.types";
+import { useOAuthProviderConnect } from "~/features/connectedServices/useOAuthProviderConnect.hook";
+import { safeNewUrl } from "~/utils/helpers/safeNewUrl.utils";
 import { InfoAlert, WarnAlert } from "../../components/Alert";
 import RtkOrDataServicesError from "../../components/errors/RtkOrDataServicesError";
 import { ExternalLink } from "../../components/LegacyExternalLinks";
@@ -303,7 +303,6 @@ export interface ConnectButtonParams {
   onConnected?: () => void;
   labelConnect?: string;
   labelReconnect?: string;
-  /** When true, render with Plugin icon (for alert CTAs) */
   withIcon?: boolean;
 }
 
@@ -745,7 +744,6 @@ type GitHubOAuthCompleteFollowUpProps = Pick<
   "skipData" | "connection" | "provider"
 >;
 
-/** GitHub App follow-up on `/oauth/complete` when `check-status` is present */
 export function GitHubOAuthCompleteFollowUp({
   skipData,
   connection,

--- a/client/src/features/connectedServices/ConnectedServicesPage.tsx
+++ b/client/src/features/connectedServices/ConnectedServicesPage.tsx
@@ -42,37 +42,37 @@ import {
   ModalHeader,
 } from "reactstrap";
 
+import { AppInstallationsPaginated } from "~/features/connectedServices/api/connectedServices.types.ts";
+import { useOAuthProviderConnect } from "~/features/connectedServices/useOAuthProviderConnect.hook.ts";
+import { safeNewUrl } from "~/utils/helpers/safeNewUrl.utils.ts";
 import { InfoAlert, WarnAlert } from "../../components/Alert";
 import RtkOrDataServicesError from "../../components/errors/RtkOrDataServicesError";
 import { ExternalLink } from "../../components/LegacyExternalLinks";
 import { Loader } from "../../components/Loader";
 import PageLoader from "../../components/PageLoader";
-import { safeNewUrl } from "../../utils/helpers/safeNewUrl.utils";
 import { usersApi } from "../usersV2/api/users.api";
 import {
+  ConnectedAccount as Account,
   connectedServicesApi,
   useDeleteOauth2ConnectionsByConnectionIdMutation,
   useGetOauth2ConnectionsByConnectionIdAccountQuery,
   useGetOauth2ConnectionsByConnectionIdInstallationsQuery,
   useGetOauth2ConnectionsQuery,
   useGetOauth2ProvidersQuery,
-  type ConnectedAccount as Account,
   type AppInstallation,
   type Connection,
   type ConnectionStatus,
   type Provider,
-  type ProviderKind,
 } from "./api/connectedServices.api";
-import { AppInstallationsPaginated } from "./api/connectedServices.types";
 import {
+  CHECK_STATUS_QUERY_PARAM,
+  OAUTH_CONNECT_POLLING_INTERVAL_MS,
   SEARCH_PARAM_ACTION_REQUIRED,
   SEARCH_PARAM_PROVIDER,
   SEARCH_PARAM_SOURCE,
 } from "./connectedServices.constants";
 import { getSettingsUrl } from "./connectedServices.utils";
 import ContactUsCard from "./ContactUsCard";
-
-const CHECK_STATUS_QUERY_PARAM = "check-status";
 
 export default function ConnectedServicesPage() {
   const { data: user } = usersApi.endpoints.getUser.useQueryState();
@@ -202,7 +202,7 @@ function ConnectedServiceCard({
   provider,
   source,
 }: ConnectedServiceCardProps) {
-  const { id, display_name, kind, url } = provider;
+  const { id, display_name, url } = provider;
 
   const { data: connections } =
     connectedServicesApi.endpoints.getOauth2Connections.useQueryState();
@@ -260,10 +260,8 @@ function ConnectedServiceCard({
               <h2 className="me-2">{display_name}</h2>
               <div className={cx("d-flex", "gap-2", "ms-auto")}>
                 <ConnectButton
-                  id={id}
+                  provider={provider}
                   connectionStatus={connection?.status}
-                  kind={kind}
-                  registryUrl={provider.image_registry_url}
                 />
                 <DisconnectButton
                   connectionStatus={connection?.status}
@@ -297,40 +295,49 @@ function ConnectedServiceCard({
   );
 }
 
-interface ConnectButtonParams {
-  className?: string;
+export interface ConnectButtonParams {
+  provider: Provider | null | undefined;
   connectionStatus?: ConnectionStatus;
-  id: string;
-  kind?: ProviderKind;
-  registryUrl?: string;
+  className?: string;
+  includeSource?: boolean;
+  onConnected?: () => void;
+  labelConnect?: string;
+  labelReconnect?: string;
+  /** When true, render with Plugin icon (for alert CTAs) */
+  withIcon?: boolean;
 }
 
 export function ConnectButton({
+  provider,
   connectionStatus,
   className,
-  id,
-  kind,
-  registryUrl,
+  includeSource = false,
+  onConnected,
+  labelConnect = "Connect",
+  labelReconnect = "Reconnect",
+  withIcon = false,
 }: ConnectButtonParams) {
-  const hereUrl = useMemo(() => {
-    const here = new URL(window.location.href);
-    if (kind === "github" && !registryUrl) {
-      here.searchParams.append(CHECK_STATUS_QUERY_PARAM, id);
-    }
-    return here.href;
-  }, [id, kind, registryUrl]);
+  const { startConnect, authorizeHref } = useOAuthProviderConnect(provider, {
+    includeSource,
+    onConnected,
+  });
 
-  const authorizeUrl = `/api/data/oauth2/providers/${id}/authorize`;
-  const url = `${authorizeUrl}?next_url=${encodeURIComponent(hereUrl)}`;
+  if (!provider || !authorizeHref) return null;
 
-  const text = connectionStatus === "connected" ? "Reconnect" : "Connect";
-  const color =
-    connectionStatus === "connected" ? "btn-outline-primary" : "btn-primary";
+  const text = connectionStatus === "connected" ? labelReconnect : labelConnect;
+  const outline = connectionStatus === "connected";
 
   return (
-    <a className={cx(color, "btn", className)} href={url}>
+    <Button
+      className={cx("btn", className)}
+      color="primary"
+      onClick={startConnect}
+      outline={outline}
+      type="button"
+    >
+      {withIcon && <Plugin className={cx("bi", "me-1")} />}
       {text}
-    </a>
+    </Button>
   );
 }
 
@@ -589,76 +596,12 @@ function GitHubAppInstallationItem({
   );
 }
 
-interface GitHubStatusCheckProps {
-  account: Account;
-  installations: AppInstallationsPaginated;
+export interface GitHubStatusCheckModalProps {
   provider: Provider;
   refetchInstallations: () => void;
 }
 
-function GitHubStatusCheck({
-  account,
-  installations,
-  provider,
-  refetchInstallations,
-}: GitHubStatusCheckProps) {
-  const [search, setSearch] = useSearchParams();
-
-  const isEnabled = useMemo(
-    () => search.get(CHECK_STATUS_QUERY_PARAM) === provider.id,
-    [provider.id, search]
-  );
-
-  const isInstalledForUser = useMemo(() => {
-    const userInstallation = installations.data.find(
-      ({ account_login }) => account_login === account.username
-    );
-    return !!userInstallation && !userInstallation.suspended_at;
-  }, [account.username, installations.data]);
-
-  useEffect(() => {
-    if (
-      isEnabled &&
-      (isInstalledForUser || installations.pagination.totalPages > 1)
-    ) {
-      setSearch(
-        (prevSearch) => {
-          prevSearch.delete(CHECK_STATUS_QUERY_PARAM);
-          return prevSearch;
-        },
-        { replace: true }
-      );
-    }
-  }, [
-    installations.pagination.totalPages,
-    isEnabled,
-    isInstalledForUser,
-    setSearch,
-  ]);
-
-  //? NOTE: if the user has more than 100 installations, assume the app is installed for the user
-  if (
-    !isEnabled ||
-    isInstalledForUser ||
-    installations.pagination.totalPages > 1
-  ) {
-    return null;
-  }
-
-  return (
-    <GitHubStatusCheckModal
-      provider={provider}
-      refetchInstallations={refetchInstallations}
-    />
-  );
-}
-
-interface GitHubStatusCheckModalProps {
-  provider: Provider;
-  refetchInstallations: () => void;
-}
-
-function GitHubStatusCheckModal({
+export function GitHubStatusCheckModal({
   provider,
   refetchInstallations,
 }: GitHubStatusCheckModalProps) {
@@ -667,7 +610,6 @@ function GitHubStatusCheckModal({
   const [isOpen, setIsOpen] = useState(true);
   const [hasOpenedTheLink, setHasOpenedTheLink] = useState(false);
   const toggle = useCallback(() => {
-    // ? NOTE: refetch when the modal is closed in case the user has updated the settings
     if (hasOpenedTheLink) refetchInstallations();
     setIsOpen((open) => !open);
   }, [hasOpenedTheLink, refetchInstallations]);
@@ -732,5 +674,133 @@ function GitHubStatusCheckModal({
         </Button>
       </ModalFooter>
     </Modal>
+  );
+}
+
+export interface GitHubStatusCheckProps {
+  account: Account;
+  installations: AppInstallationsPaginated;
+  provider: Provider;
+  refetchInstallations: () => void;
+}
+
+export function GitHubStatusCheck({
+  account,
+  installations,
+  provider,
+  refetchInstallations,
+}: GitHubStatusCheckProps) {
+  const [search, setSearch] = useSearchParams();
+
+  const isEnabled = useMemo(
+    () => search.get(CHECK_STATUS_QUERY_PARAM) === provider.id,
+    [provider.id, search]
+  );
+
+  const isInstalledForUser = useMemo(() => {
+    const userInstallation = installations.data.find(
+      ({ account_login }) => account_login === account.username
+    );
+    return !!userInstallation && !userInstallation.suspended_at;
+  }, [account.username, installations.data]);
+
+  useEffect(() => {
+    if (
+      isEnabled &&
+      (isInstalledForUser || installations.pagination.totalPages > 1)
+    ) {
+      setSearch(
+        (prevSearch) => {
+          prevSearch.delete(CHECK_STATUS_QUERY_PARAM);
+          return prevSearch;
+        },
+        { replace: true }
+      );
+    }
+  }, [
+    installations.pagination.totalPages,
+    isEnabled,
+    isInstalledForUser,
+    setSearch,
+  ]);
+
+  if (
+    !isEnabled ||
+    isInstalledForUser ||
+    installations.pagination.totalPages > 1
+  ) {
+    return null;
+  }
+
+  return (
+    <GitHubStatusCheckModal
+      provider={provider}
+      refetchInstallations={refetchInstallations}
+    />
+  );
+}
+
+/** GitHub App follow-up on `/oauth/complete` when `check-status` is present */
+export function GitHubOAuthCompleteFollowUp() {
+  const [searchParams] = useSearchParams();
+  const checkId = searchParams.get(CHECK_STATUS_QUERY_PARAM);
+
+  const { data: providers } = useGetOauth2ProvidersQuery();
+
+  const provider = providers?.find((p) => p.id === checkId);
+  const hasRegistry = !!provider?.image_registry_url;
+  const isGithubFollowUp =
+    !!checkId && !!provider && provider.kind === "github" && !hasRegistry;
+
+  const { data: connections } =
+    connectedServicesApi.endpoints.getOauth2Connections.useQueryState();
+
+  const hasGithubConnection =
+    !!checkId &&
+    !!connections?.some(
+      (c) => c.provider_id === checkId && c.status === "connected"
+    );
+
+  connectedServicesApi.endpoints.getOauth2Connections.useQuerySubscription(
+    isGithubFollowUp && !hasGithubConnection ? undefined : skipToken,
+    { pollingInterval: OAUTH_CONNECT_POLLING_INTERVAL_MS }
+  );
+
+  const connection = connections?.find(
+    (c) => c.provider_id === checkId && c.status === "connected"
+  );
+
+  const skipData =
+    !checkId ||
+    !provider ||
+    provider.kind !== "github" ||
+    hasRegistry ||
+    !connection;
+
+  const { data: account } = useGetOauth2ConnectionsByConnectionIdAccountQuery(
+    skipData ? skipToken : { connectionId: connection.id }
+  );
+
+  const { data: installations, refetch: refetchInstallations } =
+    useGetOauth2ConnectionsByConnectionIdInstallationsQuery(
+      skipData
+        ? skipToken
+        : {
+            connectionId: connection.id,
+            params: { per_page: 100 },
+          }
+    );
+
+  if (skipData || account == null || installations == null) {
+    return null;
+  }
+
+  return (
+    <GitHubStatusCheck
+      account={account}
+      installations={installations}
+      provider={provider}
+      refetchInstallations={refetchInstallations}
+    />
   );
 }

--- a/client/src/features/connectedServices/ConnectedServicesPage.tsx
+++ b/client/src/features/connectedServices/ConnectedServicesPage.tsx
@@ -66,13 +66,13 @@ import {
 } from "./api/connectedServices.api";
 import {
   CHECK_STATUS_QUERY_PARAM,
-  OAUTH_CONNECT_POLLING_INTERVAL_MS,
   SEARCH_PARAM_ACTION_REQUIRED,
   SEARCH_PARAM_PROVIDER,
   SEARCH_PARAM_SOURCE,
 } from "./connectedServices.constants";
 import { getSettingsUrl } from "./connectedServices.utils";
 import ContactUsCard from "./ContactUsCard";
+import type { GithubOAuthCompleteFollowUpData } from "./useGithubOAuthCompleteFollowUpData.hook";
 
 export default function ConnectedServicesPage() {
   const { data: user } = usersApi.endpoints.getUser.useQueryState();
@@ -740,50 +740,24 @@ export function GitHubStatusCheckModal({
   );
 }
 
+type GitHubOAuthCompleteFollowUpProps = Pick<
+  GithubOAuthCompleteFollowUpData,
+  "skipData" | "connection" | "provider"
+>;
+
 /** GitHub App follow-up on `/oauth/complete` when `check-status` is present */
-export function GitHubOAuthCompleteFollowUp() {
-  const [searchParams] = useSearchParams();
-  const checkId = searchParams.get(CHECK_STATUS_QUERY_PARAM);
-
-  const { data: providers } = useGetOauth2ProvidersQuery();
-
-  const provider = providers?.find((p) => p.id === checkId);
-  const hasRegistry = !!provider?.image_registry_url;
-  const isGithubFollowUp =
-    !!checkId && !!provider && provider.kind === "github" && !hasRegistry;
-
-  const { data: connections } =
-    connectedServicesApi.endpoints.getOauth2Connections.useQueryState();
-
-  const hasGithubConnection =
-    !!checkId &&
-    !!connections?.some(
-      (c) => c.provider_id === checkId && c.status === "connected"
-    );
-
-  connectedServicesApi.endpoints.getOauth2Connections.useQuerySubscription(
-    isGithubFollowUp && !hasGithubConnection ? undefined : skipToken,
-    { pollingInterval: OAUTH_CONNECT_POLLING_INTERVAL_MS }
-  );
-
-  const connection = connections?.find(
-    (c) => c.provider_id === checkId && c.status === "connected"
-  );
-
-  const skipData =
-    !checkId ||
-    !provider ||
-    provider.kind !== "github" ||
-    hasRegistry ||
-    !connection;
-
+export function GitHubOAuthCompleteFollowUp({
+  skipData,
+  connection,
+  provider,
+}: GitHubOAuthCompleteFollowUpProps) {
   const { data: account } = useGetOauth2ConnectionsByConnectionIdAccountQuery(
-    skipData ? skipToken : { connectionId: connection.id }
+    skipData || !connection ? skipToken : { connectionId: connection.id }
   );
 
   const { data: installations, refetch: refetchInstallations } =
     useGetOauth2ConnectionsByConnectionIdInstallationsQuery(
-      skipData
+      skipData || !connection
         ? skipToken
         : {
             connectionId: connection.id,
@@ -791,7 +765,7 @@ export function GitHubOAuthCompleteFollowUp() {
           }
     );
 
-  if (skipData || account == null || installations == null) {
+  if (skipData || account == null || installations == null || !provider) {
     return null;
   }
 

--- a/client/src/features/connectedServices/ConnectedServicesPage.tsx
+++ b/client/src/features/connectedServices/ConnectedServicesPage.tsx
@@ -596,6 +596,69 @@ function GitHubAppInstallationItem({
   );
 }
 
+export interface GitHubStatusCheckProps {
+  account: Account;
+  installations: AppInstallationsPaginated;
+  provider: Provider;
+  refetchInstallations: () => void;
+}
+
+export function GitHubStatusCheck({
+  account,
+  installations,
+  provider,
+  refetchInstallations,
+}: GitHubStatusCheckProps) {
+  const [search, setSearch] = useSearchParams();
+
+  const isEnabled = useMemo(
+    () => search.get(CHECK_STATUS_QUERY_PARAM) === provider.id,
+    [provider.id, search]
+  );
+
+  const isInstalledForUser = useMemo(() => {
+    const userInstallation = installations.data.find(
+      ({ account_login }) => account_login === account.username
+    );
+    return !!userInstallation && !userInstallation.suspended_at;
+  }, [account.username, installations.data]);
+
+  useEffect(() => {
+    if (
+      isEnabled &&
+      (isInstalledForUser || installations.pagination.totalPages > 1)
+    ) {
+      setSearch(
+        (prevSearch) => {
+          prevSearch.delete(CHECK_STATUS_QUERY_PARAM);
+          return prevSearch;
+        },
+        { replace: true }
+      );
+    }
+  }, [
+    installations.pagination.totalPages,
+    isEnabled,
+    isInstalledForUser,
+    setSearch,
+  ]);
+
+  if (
+    !isEnabled ||
+    isInstalledForUser ||
+    installations.pagination.totalPages > 1
+  ) {
+    return null;
+  }
+
+  return (
+    <GitHubStatusCheckModal
+      provider={provider}
+      refetchInstallations={refetchInstallations}
+    />
+  );
+}
+
 export interface GitHubStatusCheckModalProps {
   provider: Provider;
   refetchInstallations: () => void;
@@ -674,69 +737,6 @@ export function GitHubStatusCheckModal({
         </Button>
       </ModalFooter>
     </Modal>
-  );
-}
-
-export interface GitHubStatusCheckProps {
-  account: Account;
-  installations: AppInstallationsPaginated;
-  provider: Provider;
-  refetchInstallations: () => void;
-}
-
-export function GitHubStatusCheck({
-  account,
-  installations,
-  provider,
-  refetchInstallations,
-}: GitHubStatusCheckProps) {
-  const [search, setSearch] = useSearchParams();
-
-  const isEnabled = useMemo(
-    () => search.get(CHECK_STATUS_QUERY_PARAM) === provider.id,
-    [provider.id, search]
-  );
-
-  const isInstalledForUser = useMemo(() => {
-    const userInstallation = installations.data.find(
-      ({ account_login }) => account_login === account.username
-    );
-    return !!userInstallation && !userInstallation.suspended_at;
-  }, [account.username, installations.data]);
-
-  useEffect(() => {
-    if (
-      isEnabled &&
-      (isInstalledForUser || installations.pagination.totalPages > 1)
-    ) {
-      setSearch(
-        (prevSearch) => {
-          prevSearch.delete(CHECK_STATUS_QUERY_PARAM);
-          return prevSearch;
-        },
-        { replace: true }
-      );
-    }
-  }, [
-    installations.pagination.totalPages,
-    isEnabled,
-    isInstalledForUser,
-    setSearch,
-  ]);
-
-  if (
-    !isEnabled ||
-    isInstalledForUser ||
-    installations.pagination.totalPages > 1
-  ) {
-    return null;
-  }
-
-  return (
-    <GitHubStatusCheckModal
-      provider={provider}
-      refetchInstallations={refetchInstallations}
-    />
   );
 }
 

--- a/client/src/features/connectedServices/LazyOAuthCompletePage.tsx
+++ b/client/src/features/connectedServices/LazyOAuthCompletePage.tsx
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2024 - Swiss Data Science Center (SDSC)
+ * Copyright 2026 - Swiss Data Science Center (SDSC)
  * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
  * Eidgenössische Technische Hochschule Zürich (ETHZ).
  *
@@ -16,12 +16,16 @@
  * limitations under the License.
  */
 
-export const SEARCH_PARAM_PROVIDER = "targetProvider";
-export const SEARCH_PARAM_ACTION_REQUIRED = "actionRequired";
-export const SEARCH_PARAM_SOURCE = "source";
+import { lazy, Suspense } from "react";
 
-/** OAuth callback / integrations: GitHub App install follow-up when present in URL */
-export const CHECK_STATUS_QUERY_PARAM = "check-status";
+import PageLoader from "../../components/PageLoader";
 
-export const OAUTH_CONNECT_POLLING_INTERVAL_MS = 2_000;
-export const OAUTH_CONNECT_POLLING_TIMEOUT_MS = 10 * 60 * 1000;
+const OAuthCompletePage = lazy(() => import("./OAuthCompletePage"));
+
+export default function LazyOAuthCompletePage() {
+  return (
+    <Suspense fallback={<PageLoader />}>
+      <OAuthCompletePage />
+    </Suspense>
+  );
+}

--- a/client/src/features/connectedServices/OAuthCompletePage.tsx
+++ b/client/src/features/connectedServices/OAuthCompletePage.tsx
@@ -1,0 +1,67 @@
+/*!
+ * Copyright 2026 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import cx from "classnames";
+import { useEffect } from "react";
+import { Link, useSearchParams } from "react-router";
+
+import ContainerWrap from "../../components/container/ContainerWrap";
+import { SEARCH_PARAM_SOURCE } from "./connectedServices.constants";
+import { GitHubOAuthCompleteFollowUp } from "./ConnectedServicesPage";
+
+const DEFAULT_WAITING_TIME = 500;
+
+export default function OAuthCompletePage() {
+  const [params] = useSearchParams();
+  const source = params.get(SEARCH_PARAM_SOURCE);
+
+  useEffect(() => {
+    const id = window.setTimeout(() => {
+      window.close();
+    }, DEFAULT_WAITING_TIME);
+    return () => window.clearTimeout(id);
+  }, []);
+
+  return (
+    <ContainerWrap>
+      <div
+        className={cx(
+          "d-flex",
+          "flex-column",
+          "gap-3",
+          "mx-auto",
+          "py-5",
+          "text-center"
+        )}
+        data-cy="oauth2-complete-page"
+        style={{ maxWidth: "36rem" }}
+      >
+        <h1 className={cx("h3")}>Connection complete</h1>
+        <p className={cx("mb-0")}>
+          You are now connected. You can close this tab and return to Renku.
+        </p>
+        {source && (
+          <p className={cx("mb-0")}>
+            <Link to={source}>Back to where you were</Link>
+          </p>
+        )}
+        <GitHubOAuthCompleteFollowUp />
+      </div>
+    </ContainerWrap>
+  );
+}

--- a/client/src/features/connectedServices/OAuthCompletePage.tsx
+++ b/client/src/features/connectedServices/OAuthCompletePage.tsx
@@ -19,17 +19,12 @@
 import cx from "classnames";
 import { useCallback, useEffect, useState } from "react";
 import { XLg } from "react-bootstrap-icons";
-import { useSearchParams } from "react-router";
+import { Link, useSearchParams } from "react-router";
 import { Button } from "reactstrap";
 
 import { ErrorAlert } from "../../components/Alert";
 import ContainerWrap from "../../components/container/ContainerWrap";
 import { ABSOLUTE_ROUTES } from "../../routing/routes.constants";
-import {
-  CHECK_STATUS_QUERY_PARAM,
-  SEARCH_PARAM_ACTION_REQUIRED,
-  SEARCH_PARAM_PROVIDER,
-} from "./connectedServices.constants";
 import { GitHubOAuthCompleteFollowUp } from "./ConnectedServicesPage";
 import {
   shouldAutoCloseAfterOAuth,
@@ -73,7 +68,6 @@ export default function OAuthCompletePage() {
     searchParams.get("message") ??
     oauthError;
   const hasError = oauthErrorMessage != null;
-  const checkStatusProviderId = searchParams.get(CHECK_STATUS_QUERY_PARAM);
   const githubFollowUpData = useGithubOAuthCompleteFollowUpData();
   const allowSuccessAutoClose = shouldAutoCloseAfterOAuth(
     hasError,
@@ -83,26 +77,6 @@ export default function OAuthCompletePage() {
   const onCloseTab = useCallback(() => {
     window.close();
   }, []);
-
-  const onTryAgain = () => {
-    if (window.opener && !window.opener.closed) {
-      const retryUrl = new URL(
-        ABSOLUTE_ROUTES.v2.integrations,
-        window.location.origin
-      );
-      if (checkStatusProviderId) {
-        retryUrl.searchParams.set(SEARCH_PARAM_PROVIDER, checkStatusProviderId);
-        retryUrl.searchParams.set(SEARCH_PARAM_ACTION_REQUIRED, "true");
-      }
-      window.opener.location.assign(retryUrl.toString());
-      window.opener.focus();
-      window.close();
-      return;
-    }
-
-    // Fallback for browsers that refuse closing manually-opened tabs.
-    window.location.assign(ABSOLUTE_ROUTES.v2.integrations);
-  };
 
   return (
     <ContainerWrap>
@@ -134,12 +108,21 @@ export default function OAuthCompletePage() {
               </p>
             </ErrorAlert>
             <p className={cx("mb-0")}>
-              <Button
-                color="primary"
-                className={cx("btn-primary", "btn-sm")}
-                onClick={onTryAgain}
+              <Link
+                className={cx("btn", "btn-primary", "btn-sm", "ms-2")}
+                to={{
+                  pathname: ABSOLUTE_ROUTES.v2.integrations,
+                }}
               >
-                Try again
+                Go to integration list to try again
+              </Link>
+              <Button
+                color="white"
+                className={cx("btn-outline-primary", "btn-sm", "ms-2")}
+                onClick={onCloseTab}
+              >
+                <XLg className={cx("bi", "me-1")} />
+                Close Tab
               </Button>
             </p>
           </>
@@ -156,18 +139,18 @@ export default function OAuthCompletePage() {
               connection={githubFollowUpData.connection}
               provider={githubFollowUpData.provider}
             />
+            <p>
+              <Button
+                color="primary"
+                className={cx("btn-primary", "btn-sm")}
+                onClick={onCloseTab}
+              >
+                <XLg className={cx("bi", "me-1")} />
+                Close Tab
+              </Button>
+            </p>
           </>
         )}
-        <p>
-          <Button
-            color="primary"
-            className={cx("btn-primary", "btn-sm")}
-            onClick={onCloseTab}
-          >
-            <XLg className={cx("bi", "me-1")} />
-            Close Tab
-          </Button>
-        </p>
       </div>
     </ContainerWrap>
   );

--- a/client/src/features/connectedServices/OAuthCompletePage.tsx
+++ b/client/src/features/connectedServices/OAuthCompletePage.tsx
@@ -22,7 +22,7 @@ import { XLg } from "react-bootstrap-icons";
 import { Link, useSearchParams } from "react-router";
 import { Button } from "reactstrap";
 
-import { ErrorAlert } from "../../components/Alert";
+import { ErrorAlert, SuccessAlert } from "../../components/Alert";
 import ContainerWrap from "../../components/container/ContainerWrap";
 import { ABSOLUTE_ROUTES } from "../../routing/routes.constants";
 import { GitHubOAuthCompleteFollowUp } from "./ConnectedServicesPage";
@@ -54,7 +54,7 @@ function SuccessAutoCloseMessage({ onAutoClose }: { onAutoClose: () => void }) {
   }, [onAutoClose]);
 
   return (
-    <p className={cx("mb-0")}>
+    <p className={cx("mb-0", "mt-3", "fst-italic")}>
       This tab will close automatically in {secondsRemaining} seconds.
     </p>
   );
@@ -81,35 +81,22 @@ export default function OAuthCompletePage() {
   return (
     <ContainerWrap>
       <div
-        className={cx(
-          "d-flex",
-          "flex-column",
-          "gap-3",
-          "mx-auto",
-          "py-5",
-          "text-center"
-        )}
+        className={cx("d-flex", "flex-column", "gap-3", "mx-auto", "py-5")}
         data-cy="oauth2-complete-page"
-        style={{ maxWidth: "36rem" }}
+        style={{ maxWidth: "48rem" }}
       >
-        <h1 className={cx("h3")}>
-          {hasError
-            ? "We could not complete the connection"
-            : "Connection complete"}
-        </h1>
         {hasError ? (
           <>
-            <p className={cx("mb-0")}>
-              Something went wrong while connecting your external service.
-            </p>
             <ErrorAlert dismissible={false}>
-              <p className={cx("mb-0")}>
-                {oauthErrorMessage ?? "Unexpected OAuth error."}
+              <h1 className={cx("h3")}>We could not complete the connection</h1>
+              <p>
+                Something went wrong while connecting your external service.
               </p>
+              <code>{oauthErrorMessage ?? "Unexpected OAuth error."}</code>
             </ErrorAlert>
-            <p className={cx("mb-0")}>
+            <div className={cx("mt-3")}>
               <Link
-                className={cx("btn", "btn-primary", "btn-sm", "ms-2")}
+                className={cx("btn", "btn-primary", "btn-sm")}
                 to={{
                   pathname: ABSOLUTE_ROUTES.v2.integrations,
                 }}
@@ -124,31 +111,37 @@ export default function OAuthCompletePage() {
                 <XLg className={cx("bi", "me-1")} />
                 Close Tab
               </Button>
-            </p>
+            </div>
           </>
         ) : (
           <>
-            <p className={cx("mb-0")}>
-              You are now connected. You can close this tab and return to Renku.
-            </p>
-            {allowSuccessAutoClose && (
-              <SuccessAutoCloseMessage onAutoClose={onCloseTab} />
-            )}
+            <SuccessAlert dismissible={false} timeout={0}>
+              <h1 className={cx("h3")}>Connection complete</h1>
+              <p className={cx("mb-0")}>
+                You are now connected. You can close this tab and return to
+                Renku.
+              </p>
+              <div className={cx("d-flex", "gap-2", "align-items-end")}>
+                {allowSuccessAutoClose && (
+                  <SuccessAutoCloseMessage onAutoClose={onCloseTab} />
+                )}
+                <div>
+                  <Button
+                    color="primary"
+                    className={cx("btn-primary", "btn-sm")}
+                    onClick={onCloseTab}
+                  >
+                    <XLg className={cx("bi", "me-1")} />
+                    Close Tab
+                  </Button>
+                </div>
+              </div>
+            </SuccessAlert>
             <GitHubOAuthCompleteFollowUp
               skipData={githubFollowUpData.skipData}
               connection={githubFollowUpData.connection}
               provider={githubFollowUpData.provider}
             />
-            <p>
-              <Button
-                color="primary"
-                className={cx("btn-primary", "btn-sm")}
-                onClick={onCloseTab}
-              >
-                <XLg className={cx("bi", "me-1")} />
-                Close Tab
-              </Button>
-            </p>
           </>
         )}
       </div>

--- a/client/src/features/connectedServices/OAuthCompletePage.tsx
+++ b/client/src/features/connectedServices/OAuthCompletePage.tsx
@@ -32,7 +32,7 @@ import {
 } from "./connectedServices.constants";
 import { GitHubOAuthCompleteFollowUp } from "./ConnectedServicesPage";
 import {
-  deriveOAuthCompleteSuccessAutoClose,
+  shouldAutoCloseAfterOAuth,
   useGithubOAuthCompleteFollowUpData,
 } from "./useGithubOAuthCompleteFollowUpData.hook";
 
@@ -75,7 +75,7 @@ export default function OAuthCompletePage() {
   const hasError = oauthErrorMessage != null;
   const checkStatusProviderId = searchParams.get(CHECK_STATUS_QUERY_PARAM);
   const githubFollowUpData = useGithubOAuthCompleteFollowUpData();
-  const allowSuccessAutoClose = deriveOAuthCompleteSuccessAutoClose(
+  const allowSuccessAutoClose = shouldAutoCloseAfterOAuth(
     hasError,
     githubFollowUpData
   );

--- a/client/src/features/connectedServices/OAuthCompletePage.tsx
+++ b/client/src/features/connectedServices/OAuthCompletePage.tsx
@@ -17,15 +17,91 @@
  */
 
 import cx from "classnames";
+import { useCallback, useEffect, useState } from "react";
 import { XLg } from "react-bootstrap-icons";
+import { useSearchParams } from "react-router";
 import { Button } from "reactstrap";
 
+import { ErrorAlert } from "../../components/Alert";
 import ContainerWrap from "../../components/container/ContainerWrap";
+import { ABSOLUTE_ROUTES } from "../../routing/routes.constants";
+import {
+  CHECK_STATUS_QUERY_PARAM,
+  SEARCH_PARAM_ACTION_REQUIRED,
+  SEARCH_PARAM_PROVIDER,
+} from "./connectedServices.constants";
 import { GitHubOAuthCompleteFollowUp } from "./ConnectedServicesPage";
+import {
+  deriveOAuthCompleteSuccessAutoClose,
+  useGithubOAuthCompleteFollowUpData,
+} from "./useGithubOAuthCompleteFollowUpData.hook";
+
+const SECONDS_TO_AUTO_CLOSE_TAB = 5;
+
+function SuccessAutoCloseMessage({ onAutoClose }: { onAutoClose: () => void }) {
+  const [secondsRemaining, setSecondsRemaining] = useState(
+    SECONDS_TO_AUTO_CLOSE_TAB
+  );
+
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      setSecondsRemaining((prev) => {
+        if (prev <= 1) {
+          window.clearInterval(id);
+          onAutoClose();
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    return () => window.clearInterval(id);
+  }, [onAutoClose]);
+
+  return (
+    <p className={cx("mb-0")}>
+      This tab will close automatically in {secondsRemaining} seconds.
+    </p>
+  );
+}
 
 export default function OAuthCompletePage() {
-  const onCloseTab = () => {
+  const [searchParams] = useSearchParams();
+  const oauthError = searchParams.get("error");
+  const oauthErrorMessage =
+    searchParams.get("error_description") ??
+    searchParams.get("message") ??
+    oauthError;
+  const hasError = oauthErrorMessage != null;
+  const checkStatusProviderId = searchParams.get(CHECK_STATUS_QUERY_PARAM);
+  const githubFollowUpData = useGithubOAuthCompleteFollowUpData();
+  const allowSuccessAutoClose = deriveOAuthCompleteSuccessAutoClose(
+    hasError,
+    githubFollowUpData
+  );
+
+  const onCloseTab = useCallback(() => {
     window.close();
+  }, []);
+
+  const onTryAgain = () => {
+    if (window.opener && !window.opener.closed) {
+      const retryUrl = new URL(
+        ABSOLUTE_ROUTES.v2.integrations,
+        window.location.origin
+      );
+      if (checkStatusProviderId) {
+        retryUrl.searchParams.set(SEARCH_PARAM_PROVIDER, checkStatusProviderId);
+        retryUrl.searchParams.set(SEARCH_PARAM_ACTION_REQUIRED, "true");
+      }
+      window.opener.location.assign(retryUrl.toString());
+      window.opener.focus();
+      window.close();
+      return;
+    }
+
+    // Fallback for browsers that refuse closing manually-opened tabs.
+    window.location.assign(ABSOLUTE_ROUTES.v2.integrations);
   };
 
   return (
@@ -42,11 +118,46 @@ export default function OAuthCompletePage() {
         data-cy="oauth2-complete-page"
         style={{ maxWidth: "36rem" }}
       >
-        <h1 className={cx("h3")}>Connection complete</h1>
-        <p className={cx("mb-0")}>
-          You are now connected. You can close this tab and return to Renku.
-        </p>
-        <GitHubOAuthCompleteFollowUp />
+        <h1 className={cx("h3")}>
+          {hasError
+            ? "We could not complete the connection"
+            : "Connection complete"}
+        </h1>
+        {hasError ? (
+          <>
+            <p className={cx("mb-0")}>
+              Something went wrong while connecting your external service.
+            </p>
+            <ErrorAlert dismissible={false}>
+              <p className={cx("mb-0")}>
+                {oauthErrorMessage ?? "Unexpected OAuth error."}
+              </p>
+            </ErrorAlert>
+            <p className={cx("mb-0")}>
+              <Button
+                color="primary"
+                className={cx("btn-primary", "btn-sm")}
+                onClick={onTryAgain}
+              >
+                Try again
+              </Button>
+            </p>
+          </>
+        ) : (
+          <>
+            <p className={cx("mb-0")}>
+              You are now connected. You can close this tab and return to Renku.
+            </p>
+            {allowSuccessAutoClose && (
+              <SuccessAutoCloseMessage onAutoClose={onCloseTab} />
+            )}
+            <GitHubOAuthCompleteFollowUp
+              skipData={githubFollowUpData.skipData}
+              connection={githubFollowUpData.connection}
+              provider={githubFollowUpData.provider}
+            />
+          </>
+        )}
         <p>
           <Button
             color="primary"

--- a/client/src/features/connectedServices/OAuthCompletePage.tsx
+++ b/client/src/features/connectedServices/OAuthCompletePage.tsx
@@ -17,15 +17,16 @@
  */
 
 import cx from "classnames";
-import { Link, useSearchParams } from "react-router";
+import { XLg } from "react-bootstrap-icons";
+import { Button } from "reactstrap";
 
 import ContainerWrap from "../../components/container/ContainerWrap";
-import { SEARCH_PARAM_SOURCE } from "./connectedServices.constants";
 import { GitHubOAuthCompleteFollowUp } from "./ConnectedServicesPage";
 
 export default function OAuthCompletePage() {
-  const [params] = useSearchParams();
-  const source = params.get(SEARCH_PARAM_SOURCE);
+  const onCloseTab = () => {
+    window.close();
+  };
 
   return (
     <ContainerWrap>
@@ -45,12 +46,17 @@ export default function OAuthCompletePage() {
         <p className={cx("mb-0")}>
           You are now connected. You can close this tab and return to Renku.
         </p>
-        {source && (
-          <p className={cx("mb-0")}>
-            <Link to={source}>Back to where you were</Link>
-          </p>
-        )}
         <GitHubOAuthCompleteFollowUp />
+        <p>
+          <Button
+            color="primary"
+            className={cx("btn-primary", "btn-sm")}
+            onClick={onCloseTab}
+          >
+            <XLg className={cx("bi", "me-1")} />
+            Close Tab
+          </Button>
+        </p>
       </div>
     </ContainerWrap>
   );

--- a/client/src/features/connectedServices/OAuthCompletePage.tsx
+++ b/client/src/features/connectedServices/OAuthCompletePage.tsx
@@ -18,7 +18,7 @@
 
 import cx from "classnames";
 import { useCallback, useEffect, useState } from "react";
-import { XLg } from "react-bootstrap-icons";
+import { Plugin, XLg } from "react-bootstrap-icons";
 import { Link, useSearchParams } from "react-router";
 import { Button } from "reactstrap";
 
@@ -85,16 +85,20 @@ export default function OAuthCompletePage() {
         data-cy="oauth2-complete-page"
         style={{ maxWidth: "48rem" }}
       >
+        <h1 className={cx("m-0", "h2")}>
+          <Plugin className={cx("bi", "me-1")} />
+          Authentication Status
+        </h1>
         {hasError ? (
           <>
-            <ErrorAlert dismissible={false}>
-              <h1 className={cx("h3")}>We could not complete the connection</h1>
+            <ErrorAlert dismissible={false} className={cx("mb-0")}>
+              <h3>We could not complete the connection</h3>
               <p>
                 Something went wrong while connecting your external service.
               </p>
               <code>{oauthErrorMessage ?? "Unexpected OAuth error."}</code>
             </ErrorAlert>
-            <div className={cx("mt-3")}>
+            <div className={cx("mt-0")}>
               <Link
                 className={cx("btn", "btn-primary", "btn-sm")}
                 to={{
@@ -115,28 +119,32 @@ export default function OAuthCompletePage() {
           </>
         ) : (
           <>
-            <SuccessAlert dismissible={false} timeout={0}>
+            <SuccessAlert
+              dismissible={false}
+              timeout={0}
+              className={cx("mb-0")}
+            >
               <h1 className={cx("h3")}>Connection complete</h1>
               <p className={cx("mb-0")}>
                 You are now connected. You can close this tab and return to
                 Renku.
               </p>
-              <div className={cx("d-flex", "gap-2", "align-items-end")}>
-                {allowSuccessAutoClose && (
-                  <SuccessAutoCloseMessage onAutoClose={onCloseTab} />
-                )}
-                <div>
-                  <Button
-                    color="primary"
-                    className={cx("btn-primary", "btn-sm")}
-                    onClick={onCloseTab}
-                  >
-                    <XLg className={cx("bi", "me-1")} />
-                    Close Tab
-                  </Button>
-                </div>
-              </div>
             </SuccessAlert>
+            <div className={cx("d-flex", "gap-2", "align-items-end")}>
+              {allowSuccessAutoClose && (
+                <SuccessAutoCloseMessage onAutoClose={onCloseTab} />
+              )}
+              <div>
+                <Button
+                  color="primary"
+                  className={cx("btn-primary", "btn-sm")}
+                  onClick={onCloseTab}
+                >
+                  <XLg className={cx("bi", "me-1")} />
+                  Close Tab
+                </Button>
+              </div>
+            </div>
             <GitHubOAuthCompleteFollowUp
               skipData={githubFollowUpData.skipData}
               connection={githubFollowUpData.connection}

--- a/client/src/features/connectedServices/OAuthCompletePage.tsx
+++ b/client/src/features/connectedServices/OAuthCompletePage.tsx
@@ -81,7 +81,7 @@ export default function OAuthCompletePage() {
   return (
     <ContainerWrap>
       <div
-        className={cx("d-flex", "flex-column", "gap-3", "mx-auto", "py-5")}
+        className={cx("d-flex", "flex-column", "gap-3", "mx-auto", "pt-5")}
         data-cy="oauth2-complete-page"
         style={{ maxWidth: "48rem" }}
       >
@@ -98,10 +98,10 @@ export default function OAuthCompletePage() {
               <Link
                 className={cx("btn", "btn-primary", "btn-sm")}
                 to={{
-                  pathname: ABSOLUTE_ROUTES.v2.integrations,
+                  pathname: ABSOLUTE_ROUTES.v2.integrations.root,
                 }}
               >
-                Go to integration list to try again
+                Go to integrations to retry
               </Link>
               <Button
                 color="white"

--- a/client/src/features/connectedServices/OAuthCompletePage.tsx
+++ b/client/src/features/connectedServices/OAuthCompletePage.tsx
@@ -17,25 +17,15 @@
  */
 
 import cx from "classnames";
-import { useEffect } from "react";
 import { Link, useSearchParams } from "react-router";
 
 import ContainerWrap from "../../components/container/ContainerWrap";
 import { SEARCH_PARAM_SOURCE } from "./connectedServices.constants";
 import { GitHubOAuthCompleteFollowUp } from "./ConnectedServicesPage";
 
-const DEFAULT_WAITING_TIME = 500;
-
 export default function OAuthCompletePage() {
   const [params] = useSearchParams();
   const source = params.get(SEARCH_PARAM_SOURCE);
-
-  useEffect(() => {
-    const id = window.setTimeout(() => {
-      window.close();
-    }, DEFAULT_WAITING_TIME);
-    return () => window.clearTimeout(id);
-  }, []);
 
   return (
     <ContainerWrap>

--- a/client/src/features/connectedServices/connectedServices.constants.ts
+++ b/client/src/features/connectedServices/connectedServices.constants.ts
@@ -24,4 +24,4 @@ export const SEARCH_PARAM_SOURCE = "source";
 export const CHECK_STATUS_QUERY_PARAM = "check-status";
 
 export const OAUTH_CONNECT_POLLING_INTERVAL_MS = 1_000;
-export const OAUTH_CONNECT_POLLING_TIMEOUT_MS = 10 * 60 * 1000;
+export const OAUTH_CONNECT_POLLING_TIMEOUT_MS = 600_000;

--- a/client/src/features/connectedServices/connectedServices.constants.ts
+++ b/client/src/features/connectedServices/connectedServices.constants.ts
@@ -23,5 +23,5 @@ export const SEARCH_PARAM_SOURCE = "source";
 /** OAuth callback / integrations: GitHub App install follow-up when present in URL */
 export const CHECK_STATUS_QUERY_PARAM = "check-status";
 
-export const OAUTH_CONNECT_POLLING_INTERVAL_MS = 2_000;
+export const OAUTH_CONNECT_POLLING_INTERVAL_MS = 1_000;
 export const OAUTH_CONNECT_POLLING_TIMEOUT_MS = 10 * 60 * 1000;

--- a/client/src/features/connectedServices/oauthComplete.utils.ts
+++ b/client/src/features/connectedServices/oauthComplete.utils.ts
@@ -1,0 +1,53 @@
+/*!
+ * Copyright 2026 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ABSOLUTE_ROUTES } from "~/routing/routes.constants.ts";
+import type { Provider } from "./api/connectedServices.api";
+import {
+  CHECK_STATUS_QUERY_PARAM,
+  SEARCH_PARAM_SOURCE,
+} from "./connectedServices.constants";
+
+export const OAUTH_DATA_API_AUTHORIZE_PREFIX = "/api/data/oauth2/providers";
+
+export function buildOAuthCompleteUrl(
+  provider: Provider,
+  source?: string
+): string {
+  const url = new URL(
+    ABSOLUTE_ROUTES.v2.oauth.complete,
+    window.location.origin
+  );
+  if (source) {
+    url.searchParams.set(SEARCH_PARAM_SOURCE, source);
+  }
+  if (provider.kind === "github" && !provider.image_registry_url) {
+    url.searchParams.set(CHECK_STATUS_QUERY_PARAM, provider.id);
+  }
+  return url.href;
+}
+
+export function buildOAuthAuthorizeUrl(
+  provider: Provider,
+  source?: string
+): string {
+  const nextUrl = buildOAuthCompleteUrl(provider, source);
+  return `${OAUTH_DATA_API_AUTHORIZE_PREFIX}/${
+    provider.id
+  }/authorize?next_url=${encodeURIComponent(nextUrl)}`;
+}

--- a/client/src/features/connectedServices/oauthComplete.utils.ts
+++ b/client/src/features/connectedServices/oauthComplete.utils.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { ABSOLUTE_ROUTES } from "~/routing/routes.constants.ts";
+import { ABSOLUTE_ROUTES } from "~/routing/routes.constants";
 import type { Provider } from "./api/connectedServices.api";
 import {
   CHECK_STATUS_QUERY_PARAM,

--- a/client/src/features/connectedServices/oauthComplete.utils.ts
+++ b/client/src/features/connectedServices/oauthComplete.utils.ts
@@ -30,7 +30,7 @@ export function buildOAuthCompleteUrl(
   source?: string
 ): string {
   const url = new URL(
-    ABSOLUTE_ROUTES.v2.oauth.complete,
+    ABSOLUTE_ROUTES.v2.integrations.complete,
     window.location.origin
   );
   if (source) {

--- a/client/src/features/connectedServices/useGithubOAuthCompleteFollowUpData.hook.ts
+++ b/client/src/features/connectedServices/useGithubOAuthCompleteFollowUpData.hook.ts
@@ -1,0 +1,113 @@
+/*!
+ * Copyright 2026 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { skipToken } from "@reduxjs/toolkit/query";
+import { useSearchParams } from "react-router";
+
+import {
+  connectedServicesApi,
+  useGetOauth2ConnectionsQuery,
+  useGetOauth2ProvidersQuery,
+  type Connection,
+  type Provider,
+} from "./api/connectedServices.api";
+import {
+  CHECK_STATUS_QUERY_PARAM,
+  OAUTH_CONNECT_POLLING_INTERVAL_MS,
+} from "./connectedServices.constants";
+
+export interface GithubOAuthCompleteFollowUpData {
+  checkId: string | null;
+  provider: Provider | undefined;
+  connection: Connection | undefined;
+  skipData: boolean;
+  isGithubAppFollowUp: boolean;
+  isLoadingProviders: boolean;
+  isLoadingConnections: boolean;
+}
+
+export function useGithubOAuthCompleteFollowUpData(): GithubOAuthCompleteFollowUpData {
+  const [searchParams] = useSearchParams();
+  const checkId = searchParams.get(CHECK_STATUS_QUERY_PARAM);
+
+  const { data: providers, isLoading: isLoadingProviders } =
+    useGetOauth2ProvidersQuery();
+  const { data: connections, isLoading: isLoadingConnections } =
+    useGetOauth2ConnectionsQuery();
+
+  const provider = providers?.find((p) => p.id === checkId);
+  const hasRegistry = !!provider?.image_registry_url;
+  const isGithubAppFollowUp =
+    !!checkId && !!provider && provider.kind === "github" && !hasRegistry;
+
+  const hasGithubConnection =
+    !!checkId &&
+    !!connections?.some(
+      (c) => c.provider_id === checkId && c.status === "connected"
+    );
+
+  connectedServicesApi.endpoints.getOauth2Connections.useQuerySubscription(
+    isGithubAppFollowUp && !hasGithubConnection ? undefined : skipToken,
+    { pollingInterval: OAUTH_CONNECT_POLLING_INTERVAL_MS }
+  );
+
+  const connection = connections?.find(
+    (c) => c.provider_id === checkId && c.status === "connected"
+  );
+
+  const skipData =
+    !checkId ||
+    !provider ||
+    provider.kind !== "github" ||
+    hasRegistry ||
+    !connection;
+
+  return {
+    checkId,
+    provider,
+    connection,
+    skipData,
+    isGithubAppFollowUp,
+    isLoadingProviders,
+    isLoadingConnections,
+  };
+}
+
+/**
+ * Whether the OAuth success page may auto-close: skip when a GitHub app
+ * follow-up might still run (same `skipData` semantics as the follow-up
+ * component), and while provider/connection queries are still loading.
+ */
+export function deriveOAuthCompleteSuccessAutoClose(
+  hasError: boolean,
+  data: GithubOAuthCompleteFollowUpData
+): boolean {
+  const {
+    checkId,
+    skipData,
+    isGithubAppFollowUp,
+    isLoadingProviders,
+    isLoadingConnections,
+  } = data;
+
+  if (hasError) return false;
+  if (!checkId) return true;
+  if (isLoadingProviders || isLoadingConnections) return false;
+  if (!isGithubAppFollowUp) return true;
+  return skipData;
+}

--- a/client/src/features/connectedServices/useGithubOAuthCompleteFollowUpData.hook.ts
+++ b/client/src/features/connectedServices/useGithubOAuthCompleteFollowUpData.hook.ts
@@ -88,12 +88,7 @@ export function useGithubOAuthCompleteFollowUpData(): GithubOAuthCompleteFollowU
   };
 }
 
-/**
- * Whether the OAuth success page may auto-close: skip when a GitHub app
- * follow-up might still run (same `skipData` semantics as the follow-up
- * component), and while provider/connection queries are still loading.
- */
-export function deriveOAuthCompleteSuccessAutoClose(
+export function shouldAutoCloseAfterOAuth(
   hasError: boolean,
   data: GithubOAuthCompleteFollowUpData
 ): boolean {

--- a/client/src/features/connectedServices/useOAuthProviderConnect.hook.ts
+++ b/client/src/features/connectedServices/useOAuthProviderConnect.hook.ts
@@ -1,0 +1,99 @@
+/*!
+ * Copyright 2025 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { skipToken } from "@reduxjs/toolkit/query";
+import {
+  startTransition,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useLocation } from "react-router";
+
+import { connectedServicesApi } from "./api/connectedServices.api";
+import type { Provider } from "./api/connectedServices.api";
+import {
+  OAUTH_CONNECT_POLLING_INTERVAL_MS,
+  OAUTH_CONNECT_POLLING_TIMEOUT_MS,
+} from "./connectedServices.constants";
+import { buildOAuthAuthorizeUrl } from "./oauthComplete.utils";
+
+export function useOAuthProviderConnect(
+  provider: Provider | null | undefined,
+  options?: {
+    includeSource?: boolean;
+    onConnected?: () => void;
+  }
+) {
+  const { pathname, hash } = useLocation();
+  const source =
+    options?.includeSource === true ? `${pathname}${hash}` : undefined;
+
+  const authorizeHref = useMemo(
+    () => (provider ? buildOAuthAuthorizeUrl(provider, source) : null),
+    [provider, source]
+  );
+
+  const providerId = provider?.id;
+  const [isPolling, setIsPolling] = useState(false);
+
+  const onConnectedRef = useRef(options?.onConnected);
+  useEffect(() => {
+    onConnectedRef.current = options?.onConnected;
+  }, [options?.onConnected]);
+
+  connectedServicesApi.endpoints.getOauth2Connections.useQuerySubscription(
+    isPolling ? undefined : skipToken,
+    { pollingInterval: OAUTH_CONNECT_POLLING_INTERVAL_MS }
+  );
+
+  const { data: connections } =
+    connectedServicesApi.endpoints.getOauth2Connections.useQueryState();
+
+  useEffect(() => {
+    if (!isPolling || !providerId) return;
+    const connected = connections?.some(
+      ({ provider_id, status }) =>
+        provider_id === providerId && status === "connected"
+    );
+    if (connected) {
+      startTransition(() => {
+        setIsPolling(false);
+      });
+      onConnectedRef.current?.();
+    }
+  }, [connections, isPolling, providerId]);
+
+  useEffect(() => {
+    if (!isPolling) return;
+    const t = window.setTimeout(() => {
+      setIsPolling(false);
+    }, OAUTH_CONNECT_POLLING_TIMEOUT_MS);
+    return () => window.clearTimeout(t);
+  }, [isPolling]);
+
+  const startConnect = useCallback(() => {
+    if (!authorizeHref) return;
+    window.open(authorizeHref, "_blank", "noopener,noreferrer");
+    setIsPolling(true);
+  }, [authorizeHref]);
+
+  return { authorizeHref, startConnect, isPolling };
+}

--- a/client/src/features/connectedServices/useOAuthProviderConnect.hook.ts
+++ b/client/src/features/connectedServices/useOAuthProviderConnect.hook.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2025 - Swiss Data Science Center (SDSC)
+ * Copyright 2026 - Swiss Data Science Center (SDSC)
  * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
  * Eidgenössische Technische Hochschule Zürich (ETHZ).
  *

--- a/client/src/features/dataConnectorsV2/deposits/DepositIntegrationInfo.tsx
+++ b/client/src/features/dataConnectorsV2/deposits/DepositIntegrationInfo.tsx
@@ -34,7 +34,7 @@ export default function DepositIntegrationInfo({
   const link = provider && (
     <Link
       to={{
-        pathname: ABSOLUTE_ROUTES.v2.integrations,
+        pathname: ABSOLUTE_ROUTES.v2.integrations.root,
         search: new URLSearchParams({
           [SEARCH_PARAM_PROVIDER]: provider.id,
           [SEARCH_PARAM_SOURCE]: `${pathname}${hash}`,

--- a/client/src/features/rootV2/RootV2.tsx
+++ b/client/src/features/rootV2/RootV2.tsx
@@ -142,7 +142,7 @@ export default function RootV2() {
             }
           />
           <Route
-            path={RELATIVE_ROUTES.v2.integrations}
+            path={RELATIVE_ROUTES.v2.integrations.root}
             element={
               <ContainerWrap>
                 <LazyConnectedServicesPage />
@@ -150,7 +150,7 @@ export default function RootV2() {
             }
           />
           <Route
-            path={RELATIVE_ROUTES.v2.oauth.complete}
+            path={RELATIVE_ROUTES.v2.integrations.complete}
             element={<LazyOAuthCompletePage />}
           />
           <Route

--- a/client/src/features/rootV2/RootV2.tsx
+++ b/client/src/features/rootV2/RootV2.tsx
@@ -150,7 +150,7 @@ export default function RootV2() {
             }
           />
           <Route
-            path={RELATIVE_ROUTES.v2.integrations.complete}
+            path={`${RELATIVE_ROUTES.v2.integrations.root}/${RELATIVE_ROUTES.v2.integrations.complete}`}
             element={<LazyOAuthCompletePage />}
           />
           <Route

--- a/client/src/features/rootV2/RootV2.tsx
+++ b/client/src/features/rootV2/RootV2.tsx
@@ -37,6 +37,7 @@ import useAppDispatch from "../../utils/customHooks/useAppDispatch.hook";
 import useAppSelector from "../../utils/customHooks/useAppSelector.hook";
 import { setFlag } from "../../utils/feature-flags/featureFlags.slice";
 import LazyConnectedServicesPage from "../connectedServices/LazyConnectedServicesPage";
+import LazyOAuthCompletePage from "../connectedServices/LazyOAuthCompletePage";
 import LazyDashboardV2 from "../dashboardV2/LazyDashboardV2";
 import GroupNew from "../groupsV2/new/GroupNew";
 import LazyProjectV2ShowByProjectId from "../projectsV2/LazyProjectV2ShowByProjectId";
@@ -147,6 +148,10 @@ export default function RootV2() {
                 <LazyConnectedServicesPage />
               </ContainerWrap>
             }
+          />
+          <Route
+            path={RELATIVE_ROUTES.v2.oauth.complete}
+            element={<LazyOAuthCompletePage />}
           />
           <Route
             path={RELATIVE_ROUTES.v2.secrets}

--- a/client/src/features/sessionsV2/SessionImageModal.tsx
+++ b/client/src/features/sessionsV2/SessionImageModal.tsx
@@ -94,7 +94,7 @@ export default function SessionImageModal({
               currently supported{" "}
               <Link
                 to={{
-                  pathname: ABSOLUTE_ROUTES.v2.integrations,
+                  pathname: ABSOLUTE_ROUTES.v2.integrations.root,
                   search,
                 }}
               >
@@ -129,7 +129,7 @@ export default function SessionImageModal({
                 <Link
                   className={cx("btn", "btn-primary", "btn-sm")}
                   to={{
-                    pathname: ABSOLUTE_ROUTES.v2.integrations,
+                    pathname: ABSOLUTE_ROUTES.v2.integrations.root,
                     search,
                   }}
                 >
@@ -149,7 +149,7 @@ export default function SessionImageModal({
             <Link
               className={cx("btn", "btn-primary", "btn-sm")}
               to={{
-                pathname: ABSOLUTE_ROUTES.v2.integrations,
+                pathname: ABSOLUTE_ROUTES.v2.integrations.root,
                 search,
               }}
             >

--- a/client/src/features/sessionsV2/SessionRepositoriesModal.tsx
+++ b/client/src/features/sessionsV2/SessionRepositoriesModal.tsx
@@ -114,6 +114,7 @@ export default function SessionRepositoriesModal({
               key={repository.url}
               hasWriteAccess={projectPermissions?.write}
               repository={repository}
+              project={project}
             />
           ))}
         </ListGroup>
@@ -154,10 +155,12 @@ export default function SessionRepositoriesModal({
 interface SessionRepositoryWarningProps {
   hasWriteAccess: boolean;
   repository: GetRepositoriesApiResponse;
+  project: Project;
 }
 function SessionRepositoryWarning({
   hasWriteAccess,
   repository,
+  project,
 }: SessionRepositoryWarningProps) {
   const title = getRepositoryName(repository.url);
 
@@ -174,6 +177,7 @@ function SessionRepositoryWarning({
       <RepositoryCallToActionAlert
         hasWriteAccess={hasWriteAccess}
         repositoryUrl={repository.url}
+        project={project}
       />
     </ListGroupItem>
   );

--- a/client/src/features/sessionsV2/SessionView/EnvironmentCard.tsx
+++ b/client/src/features/sessionsV2/SessionView/EnvironmentCard.tsx
@@ -258,7 +258,7 @@ function CustomImageEnvironmentValues({
                   registry is in the currently supported{" "}
                   <Link
                     to={{
-                      pathname: ABSOLUTE_ROUTES.v2.integrations,
+                      pathname: ABSOLUTE_ROUTES.v2.integrations.root,
                       search,
                     }}
                   >
@@ -293,7 +293,7 @@ function CustomImageEnvironmentValues({
                     <Link
                       className={cx("btn", "btn-primary", "btn-sm")}
                       to={{
-                        pathname: ABSOLUTE_ROUTES.v2.integrations,
+                        pathname: ABSOLUTE_ROUTES.v2.integrations.root,
                         search,
                       }}
                     >
@@ -313,7 +313,7 @@ function CustomImageEnvironmentValues({
                 <Link
                   className={cx("btn", "btn-primary", "btn-sm")}
                   to={{
-                    pathname: ABSOLUTE_ROUTES.v2.integrations,
+                    pathname: ABSOLUTE_ROUTES.v2.integrations.root,
                     search,
                   }}
                 >

--- a/client/src/routing/routes.constants.ts
+++ b/client/src/routing/routes.constants.ts
@@ -54,10 +54,10 @@ export const ABSOLUTE_ROUTES = {
   v2: {
     root: "/",
     admin: "/admin",
-    oauth: {
-      complete: "/oauth/complete",
+    integrations: {
+      root: "/integrations",
+      complete: "/integrations/complete",
     },
-    integrations: "/integrations",
     groups: {
       show: {
         root: "/g/:slug",
@@ -123,10 +123,10 @@ export const RELATIVE_ROUTES = {
     root: "/*",
     admin: "admin",
     betaRoot: "/v2/*",
-    oauth: {
-      complete: "oauth/complete",
+    integrations: {
+      root: "integrations",
+      complete: "complete",
     },
-    integrations: "integrations",
     groups: {
       root: "g",
       show: {

--- a/client/src/routing/routes.constants.ts
+++ b/client/src/routing/routes.constants.ts
@@ -54,6 +54,9 @@ export const ABSOLUTE_ROUTES = {
   v2: {
     root: "/",
     admin: "/admin",
+    oauth: {
+      complete: "/oauth/complete",
+    },
     integrations: "/integrations",
     groups: {
       show: {
@@ -120,6 +123,9 @@ export const RELATIVE_ROUTES = {
     root: "/*",
     admin: "admin",
     betaRoot: "/v2/*",
+    oauth: {
+      complete: "oauth/complete",
+    },
     integrations: "integrations",
     groups: {
       root: "g",

--- a/tests/cypress/e2e/connectedServicesV2.spec.ts
+++ b/tests/cypress/e2e/connectedServicesV2.spec.ts
@@ -44,7 +44,7 @@ describe("Interact with Connected services", () => {
       .contains("Not connected");
     cy.getDataCy("connected-services-card")
       .filter(`:contains("GitHub.com")`)
-      .contains("a", "Connect");
+      .contains("button", "Connect");
 
     // ? Instead of clicking the Connect link, we just load the connection.
     fixtures.listConnectedServicesConnections();
@@ -55,7 +55,7 @@ describe("Interact with Connected services", () => {
       .contains("Connected");
     cy.getDataCy("connected-services-card")
       .filter(`:contains("GitHub.com")`)
-      .contains("a", "Reconnect");
+      .contains("button", "Reconnect");
   });
 
   it("GitHub user - check account", () => {

--- a/tests/cypress/e2e/projectV2setup.spec.ts
+++ b/tests/cypress/e2e/projectV2setup.spec.ts
@@ -768,7 +768,7 @@ describe("Customize session environment variables", () => {
   });
 });
 
-describe("Repository connection cases", () => {
+describe.only("Repository connection cases", () => {
   beforeEach(() => {
     fixtures
       .config()
@@ -819,6 +819,9 @@ describe("Repository connection cases", () => {
     cy.getDataCy("code-repository-pull-permission")
       .contains("Yes")
       .should("be.visible");
+    cy.getDataCy("code-repository-details").within(() => {
+      cy.getDataCy("code-repository-alert").should("not.exist");
+    });
   });
 
   it("read only", () => {
@@ -845,6 +848,9 @@ describe("Repository connection cases", () => {
     cy.getDataCy("code-repository-pull-permission")
       .contains("Yes")
       .should("be.visible");
+    cy.getDataCy("code-repository-details").within(() => {
+      cy.getDataCy("code-repository-alert").should("not.exist");
+    });
   });
 
   it("inaccessible", () => {
@@ -871,6 +877,18 @@ describe("Repository connection cases", () => {
     cy.getDataCy("code-repository-pull-permission")
       .contains("No")
       .should("be.visible");
+    cy.getDataCy("code-repository-alert")
+      .should("be.visible")
+      .and("contain", "The repository is not accessible")
+      .and("contain", "GitHub.com")
+      .and("contain", "invalid");
+    cy.getDataCy("code-repository-alert").within(() => {
+      cy.contains("You can try to refresh it.").should("be.visible");
+      cy.contains("button", "Reconnect").should("be.visible");
+      cy.get("a.btn-outline-primary")
+        .contains("Check integration")
+        .should("be.visible");
+    });
   });
 
   it("request integration", () => {
@@ -897,6 +915,15 @@ describe("Repository connection cases", () => {
     cy.getDataCy("code-repository-pull-permission")
       .contains("Yes")
       .should("be.visible");
+    cy.getDataCy("code-repository-alert")
+      .should("be.visible")
+      .and("contain", "don't currently support this version control platform");
+    cy.getDataCy("code-repository-alert").within(() => {
+      cy.contains("a", "contact us")
+        .should("be.visible")
+        .and("have.attr", "href")
+        .and("match", /^mailto:/);
+    });
   });
 
   it("integration required", () => {
@@ -923,5 +950,166 @@ describe("Repository connection cases", () => {
     cy.getDataCy("code-repository-pull-permission")
       .contains("No")
       .should("be.visible");
+    cy.getDataCy("code-repository-alert")
+      .should("be.visible")
+      .and("contain", "The repository is not accessible")
+      .and("contain", "GitHub.com");
+    cy.getDataCy("code-repository-alert").within(() => {
+      cy.contains("You can try to refresh it.").should("be.visible");
+      cy.get("a.btn-outline-primary")
+        .contains("Check integration")
+        .should("be.visible");
+    });
+  });
+
+  it("integration recommended", () => {
+    fixtures
+      .getRepositoryMetadata({
+        repositoryUrl: "https://github.com/renku/url-repo.git",
+        fixture:
+          "repositories/repository-metadata-integration-recommended.json",
+      })
+      .listConnectedServicesConnections()
+      .listConnectedServicesProviders();
+    cy.visit("/p/user1-uuid/test-2-v2-project");
+    cy.wait("@readProjectV2WithoutDocumentation");
+    cy.wait("@getRepositoryMetadata");
+
+    cy.getDataCy("code-repository-permission-badge")
+      .contains("Integration recommended")
+      .should("be.visible");
+
+    cy.getDataCy("code-repository-item").click();
+    cy.getDataCy("code-repository-alert")
+      .should("be.visible")
+      .and("contain", "You can connect to")
+      .and("contain", "GitHub.com");
+    cy.getDataCy("code-repository-alert").within(() => {
+      cy.contains("button", "Connect").should("be.visible");
+      cy.get("a.btn-outline-primary")
+        .contains("Check integration")
+        .should("be.visible");
+    });
+  });
+
+  it("integration recommended connect button", () => {
+    fixtures
+      .getProjectV2Permissions({
+        fixture: "projectV2/projectV2-permissions-viewer.json",
+      })
+      .getRepositoryMetadata({
+        repositoryUrl: "https://github.com/renku/url-repo.git",
+        fixture:
+          "repositories/repository-metadata-integration-recommended.json",
+      })
+      .listConnectedServicesConnections()
+      .listConnectedServicesProviders();
+    cy.visit("/p/user1-uuid/test-2-v2-project");
+    cy.wait("@readProjectV2WithoutDocumentation");
+    cy.wait("@getRepositoryMetadata");
+
+    cy.getDataCy("code-repository-permission-badge")
+      .contains("Read only")
+      .should("be.visible");
+
+    cy.getDataCy("code-repository-item").click();
+    cy.getDataCy("code-repository-alert")
+      .should("be.visible")
+      .and("contain", "log in through the integration")
+      .and("contain", "GitHub.com");
+    cy.getDataCy("code-repository-alert").within(() => {
+      cy.contains("button", "Connect").should("be.visible");
+      cy.get("a.btn-outline-primary")
+        .contains("Check integration")
+        .should("be.visible");
+    });
+  });
+
+  it("inaccessible without provider with error and contact us button", () => {
+    fixtures
+      .getRepositoryMetadata({
+        repositoryUrl: "https://github.com/renku/url-repo.git",
+        fixture:
+          "repositories/repository-metadata-inaccessible-no-provider.json",
+      })
+      .listConnectedServicesConnections()
+      .listConnectedServicesProviders();
+    cy.visit("/p/user1-uuid/test-2-v2-project");
+    cy.wait("@readProjectV2WithoutDocumentation");
+    cy.wait("@getRepositoryMetadata");
+
+    cy.getDataCy("code-repository-permission-badge")
+      .contains("Inaccessible")
+      .should("be.visible");
+
+    cy.getDataCy("code-repository-item").click();
+    cy.getDataCy("code-repository-alert")
+      .should("be.visible")
+      .and("contain", "version control platform we currently do not support");
+    cy.getDataCy("code-repository-alert").within(() => {
+      cy.contains("a", "integrations list.").should("be.visible");
+      cy.contains("a", "contact us")
+        .should("be.visible")
+        .and("have.attr", "href")
+        .and("match", /^mailto:/);
+    });
+  });
+
+  it("inaccessible without provider viewer", () => {
+    fixtures
+      .getProjectV2Permissions({
+        fixture: "projectV2/projectV2-permissions-viewer.json",
+      })
+      .getRepositoryMetadata({
+        repositoryUrl: "https://github.com/renku/url-repo.git",
+        fixture:
+          "repositories/repository-metadata-inaccessible-no-provider.json",
+      })
+      .listConnectedServicesConnections()
+      .listConnectedServicesProviders();
+    cy.visit("/p/user1-uuid/test-2-v2-project");
+    cy.wait("@readProjectV2WithoutDocumentation");
+    cy.wait("@getRepositoryMetadata");
+
+    cy.getDataCy("code-repository-permission-badge")
+      .contains("Inaccessible")
+      .should("be.visible");
+
+    cy.getDataCy("code-repository-item").click();
+    cy.getDataCy("code-repository-alert")
+      .should("be.visible")
+      .and("contain", "version control platform we currently do not support");
+    cy.getDataCy("code-repository-alert").within(() => {
+      cy.contains("a", "integrations list.").should("not.exist");
+      cy.contains("a", "contact us").should("not.exist");
+    });
+  });
+
+  it("inaccessible repository shows log-in warning for anonymous user", () => {
+    fixtures.userNone();
+    fixtures
+      .getRepositoryMetadata({
+        repositoryUrl: "https://github.com/renku/url-repo.git",
+        fixture: "repositories/repository-metadata-inaccessible.json",
+      })
+      .listConnectedServicesConnections()
+      .listConnectedServicesProviders();
+    cy.visit("/p/user1-uuid/test-2-v2-project");
+    cy.wait("@readProjectV2WithoutDocumentation");
+    cy.wait("@getRepositoryMetadata");
+
+    cy.getDataCy("code-repository-item").click();
+    cy.getDataCy("code-repository-alert")
+      .should("be.visible")
+      .and("contain", "The repository is not accessible");
+    cy.getDataCy("code-repository-alert")
+      .invoke("text")
+      .should(
+        "include",
+        "You need to be logged in to activate integrations and access private repositories."
+      );
+    cy.getDataCy("code-repository-alert")
+      .invoke("text")
+      .should("not.include", "You can try to refresh it.");
   });
 });

--- a/tests/cypress/e2e/projectV2setup.spec.ts
+++ b/tests/cypress/e2e/projectV2setup.spec.ts
@@ -768,7 +768,7 @@ describe("Customize session environment variables", () => {
   });
 });
 
-describe.only("Repository connection cases", () => {
+describe("Repository connection cases", () => {
   beforeEach(() => {
     fixtures
       .config()

--- a/tests/cypress/fixtures/repositories/repository-metadata-inaccessible-no-provider.json
+++ b/tests/cypress/fixtures/repositories/repository-metadata-inaccessible-no-provider.json
@@ -1,0 +1,4 @@
+{
+  "status": "invalid",
+  "error_code": "metadata_unknown"
+}

--- a/tests/cypress/fixtures/repositories/repository-metadata-integration-recommended.json
+++ b/tests/cypress/fixtures/repositories/repository-metadata-integration-recommended.json
@@ -1,0 +1,19 @@
+{
+  "status": "valid",
+  "connection": {
+    "id": "0100933QTQVNX4R5CC8P177VTC",
+    "provider_id": "github.com",
+    "status": "pending"
+  },
+  "provider": {
+    "id": "github.com",
+    "name": "GitHub.com",
+    "url": "https://github.com"
+  },
+  "metadata": {
+    "git_url": "https://github.com/renku/url-repo.git",
+    "web_url": "https://github.com/renku/url-repo",
+    "pull_permission": true,
+    "push_permission": false
+  }
+}


### PR DESCRIPTION
This PR lets users connect to OAuth providers (like GitHub/GitLab) directly from integration alert banners, without navigating away to the integrations page.
### What's changed
- OAuth connection flow: Added a ConnectButton to repository and cloud storage alert banners. The flow opens in a new tab, polls for completion, then auto-refreshes the relevant statuses. The completion page now has a "close tab" button, auto-close, and clear error handling on failure.
- Clearer alert copy: Warning messages are more specific and actionable. "View integration" is now "Check integration", styled as a secondary button alongside the new connect button.
- Auto-refresh: After a successful OAuth connection, all project repositories are re-fetched automatically, no manual reload needed.
- Added Cypress e2e tests for the integration warning scenarios.

/deploy renku=lorenzo/data-connector-modal