### PR TITLE
chore: show link to documentation in search pages

### DIFF
--- a/client/src/features/searchV2/components/SearchBar.tsx
+++ b/client/src/features/searchV2/components/SearchBar.tsx
@@ -22,6 +22,8 @@ import { Search, XCircleFill } from "react-bootstrap-icons";
 import { Controller, useForm } from "react-hook-form";
 import { Button, Form, InputGroup } from "reactstrap";
 
+import ExternalLink from "~/components/ExternalLink";
+import { NEW_DOCS_SEARCH_QUERY } from "~/utils/constants/NewDocs";
 import useAppDispatch from "../../../utils/customHooks/useAppDispatch.hook";
 import useAppSelector from "../../../utils/customHooks/useAppSelector.hook";
 import { applyParsedSearch, reset as resetSearch } from "../searchV2.slice";
@@ -35,7 +37,10 @@ interface SearchBarForm {
   query: string;
 }
 
-export default function SearchBar() {
+interface SearchBarProps {
+  showLinkToDocs?: boolean;
+}
+export default function SearchBar({ showLinkToDocs = true }: SearchBarProps) {
   const dispatch = useAppDispatch();
   const state = useAppSelector(({ searchV2 }) => searchV2);
 
@@ -70,8 +75,8 @@ export default function SearchBar() {
   );
 
   return (
-    <>
-      <Form className="mb-3" noValidate onSubmit={handleSubmit(onSubmit)}>
+    <div className="mb-3">
+      <Form noValidate onSubmit={handleSubmit(onSubmit)}>
         <InputGroup>
           <Controller
             control={control}
@@ -113,6 +118,15 @@ export default function SearchBar() {
           </Button>
         </InputGroup>
       </Form>
-    </>
+      {showLinkToDocs && (
+        <p className={cx("form-text", "mb-0", "mt-1")}>
+          We support{" "}
+          <ExternalLink href={NEW_DOCS_SEARCH_QUERY}>
+            a rich syntax
+          </ExternalLink>{" "}
+          for search queries.
+        </p>
+      )}
+    </div>
   );
 }

--- a/client/src/utils/constants/NewDocs.ts
+++ b/client/src/utils/constants/NewDocs.ts
@@ -95,3 +95,7 @@ export const NEW_DOCS_CREATE_ENV_CUSTOM_PACKAGES_INSTALLED = newDocsLinkPage(
 export const NEW_DOCS_HOW_RENKU_WORKS = newDocsLinkPage(
   "docs/users/knowledge-base/about"
 )(DEFAULT_NEW_DOC_LINK_ARGS);
+
+export const NEW_DOCS_SEARCH_QUERY = newDocsLinkPage(
+  "docs/users/search/search-query"
+)(DEFAULT_NEW_DOC_LINK_ARGS);


### PR DESCRIPTION
Shows a link to the Renku documentation for the search syntax when using the Search box

<img width="1590" height="698" alt="image" src="https://github.com/user-attachments/assets/9ae5f1fb-be72-41d9-9c70-efdb02110f81" />

/deploy renku=lorenzo/data-connector-modal
