### PR TITLE
feat: add a data connector page

### DIFF
--- a/client/src/components/PageNav.tsx
+++ b/client/src/components/PageNav.tsx
@@ -24,8 +24,9 @@ import RenkuNavLinkV2 from "./RenkuNavLinkV2";
 
 export interface PageNavOptions {
   overviewUrl: string;
-  searchUrl: string;
+  searchUrl?: string;
   settingsUrl?: string;
+  type: "dataConnector" | "group" | "user";
 }
 export default function PageNav({ options }: { options: PageNavOptions }) {
   return (
@@ -36,30 +37,32 @@ export default function PageNav({ options }: { options: PageNavOptions }) {
             end
             to={options.overviewUrl}
             title="Overview"
-            data-cy="group-overview-link"
+            data-cy={`${options.type}-overview-link`}
           >
             <Eye className={cx("bi", "me-1")} />
             Overview
           </RenkuNavLinkV2>
         </NavItem>
-        <NavItem>
-          <RenkuNavLinkV2
-            end
-            to={options.searchUrl}
-            title="Search"
-            data-cy="group-search-link"
-          >
-            <Search className={cx("bi", "me-1")} />
-            Search
-          </RenkuNavLinkV2>
-        </NavItem>
+        {options.searchUrl && (
+          <NavItem>
+            <RenkuNavLinkV2
+              end
+              to={options.searchUrl}
+              title="Search"
+              data-cy={`${options.type}-search-link`}
+            >
+              <Search className={cx("bi", "me-1")} />
+              Search
+            </RenkuNavLinkV2>
+          </NavItem>
+        )}
         {options.settingsUrl && (
           <NavItem>
             <RenkuNavLinkV2
               end
               to={options.settingsUrl}
               title="Settings"
-              data-cy="group-settings-link"
+              data-cy={`${options.type}-settings-link`}
             >
               <Sliders className={cx("bi", "me-1")} />
               Settings

--- a/client/src/components/entityWatermark/EntityWatermark.tsx
+++ b/client/src/components/entityWatermark/EntityWatermark.tsx
@@ -17,13 +17,13 @@
  */
 
 import cx from "classnames";
-import { Folder, People, Person } from "react-bootstrap-icons";
+import { Database, Folder, People, Person } from "react-bootstrap-icons";
 
 import styles from "./entityWatermark.module.scss";
 
 interface EntityWatermarkProps {
   className?: string;
-  type: "group" | "user" | "project";
+  type: "dataConnector" | "group" | "user" | "project";
 }
 export function EntityWatermark({ className, type }: EntityWatermarkProps) {
   return (
@@ -40,6 +40,8 @@ export function EntityWatermark({ className, type }: EntityWatermarkProps) {
         <People />
       ) : type === "user" ? (
         <Person />
+      ) : type === "dataConnector" ? (
+        <Database />
       ) : (
         <Folder />
       )}

--- a/client/src/components/entityWatermark/EntityWatermark.tsx
+++ b/client/src/components/entityWatermark/EntityWatermark.tsx
@@ -38,26 +38,21 @@ export function EntityWatermark({ className, type }: EntityWatermarkProps) {
           "text-body-secondary",
           "top-0",
           className,
-          styles.EntityWatermark
+          type === "dataConnector"
+            ? styles.EntityWatermarkDatabase
+            : styles.EntityWatermark
         )}
       >
         {type === "group" ? (
           <People />
         ) : type === "user" ? (
           <Person />
+        ) : type === "dataConnector" ? (
+          <Database />
         ) : (
           <Folder />
         )}
       </div>
     </div>
   );
-}
-
-interface EntityWatermarkPlaceholderProps {
-  className?: string;
-}
-export function EntityWatermarkPlaceholder({
-  className,
-}: EntityWatermarkPlaceholderProps) {
-  return <div className={cx(className, styles.EntityWatermarkPlaceholder)} />;
 }

--- a/client/src/components/entityWatermark/EntityWatermark.tsx
+++ b/client/src/components/entityWatermark/EntityWatermark.tsx
@@ -52,3 +52,12 @@ export function EntityWatermark({ className, type }: EntityWatermarkProps) {
     </div>
   );
 }
+
+interface EntityWatermarkPlaceholderProps {
+  className?: string;
+}
+export function EntityWatermarkPlaceholder({
+  className,
+}: EntityWatermarkPlaceholderProps) {
+  return <div className={cx(className, styles.EntityWatermarkPlaceholder)} />;
+}

--- a/client/src/components/entityWatermark/EntityWatermark.tsx
+++ b/client/src/components/entityWatermark/EntityWatermark.tsx
@@ -28,7 +28,7 @@ interface EntityWatermarkProps {
 export function EntityWatermark({ className, type }: EntityWatermarkProps) {
   return (
     <div className="position-relative">
-      <div className={cx(className, styles.EntityWatermarkPlaceholder)} />
+      <div className={cx(className, styles.EntityWatermark)} />
       <div
         className={cx(
           "d-flex",

--- a/client/src/components/entityWatermark/EntityWatermark.tsx
+++ b/client/src/components/entityWatermark/EntityWatermark.tsx
@@ -17,13 +17,13 @@
  */
 
 import cx from "classnames";
-import { Folder, People, Person } from "react-bootstrap-icons";
+import { Database, Folder, People, Person } from "react-bootstrap-icons";
 
 import styles from "./entityWatermark.module.scss";
 
 interface EntityWatermarkProps {
   className?: string;
-  type: "group" | "user" | "project";
+  type: "dataConnector" | "group" | "user" | "project";
 }
 export function EntityWatermark({ className, type }: EntityWatermarkProps) {
   return (

--- a/client/src/components/entityWatermark/EntityWatermark.tsx
+++ b/client/src/components/entityWatermark/EntityWatermark.tsx
@@ -28,7 +28,14 @@ interface EntityWatermarkProps {
 export function EntityWatermark({ className, type }: EntityWatermarkProps) {
   return (
     <div className="position-relative">
-      <div className={cx(className, styles.EntityWatermark)} />
+      <div
+        className={cx(
+          className,
+          type === "dataConnector"
+            ? styles.EntityWatermarkDatabasePlaceholder
+            : styles.EntityWatermarkPlaceholder
+        )}
+      />
       <div
         className={cx(
           "d-flex",

--- a/client/src/components/entityWatermark/entityWatermark.module.scss
+++ b/client/src/components/entityWatermark/entityWatermark.module.scss
@@ -2,6 +2,11 @@
   font-size: 100px;
 }
 
+// All icons have the same size but only the footprint of the database fills the very bottom
+.EntityWatermarkDatabase {
+  font-size: 90px;
+}
+
 .EntityWatermarkPlaceholder {
   width: 100px;
 }

--- a/client/src/components/entityWatermark/entityWatermark.module.scss
+++ b/client/src/components/entityWatermark/entityWatermark.module.scss
@@ -6,7 +6,3 @@
 .EntityWatermarkDatabase {
   font-size: 90px;
 }
-
-.EntityWatermarkPlaceholder {
-  width: 100px;
-}

--- a/client/src/components/entityWatermark/entityWatermark.module.scss
+++ b/client/src/components/entityWatermark/entityWatermark.module.scss
@@ -6,3 +6,11 @@
 .EntityWatermarkDatabase {
   font-size: 90px;
 }
+
+.EntityWatermarkPlaceholder {
+  width: 100px;
+}
+
+.EntityWatermarkDatabasePlaceholder {
+  width: 90px;
+}

--- a/client/src/features/ProjectPageV2/ProjectPageLayout/ProjectPageLayout.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageLayout/ProjectPageLayout.tsx
@@ -45,6 +45,9 @@ export default function ProjectPageLayout({
       <Row className="my-3">
         <Col xs={12}>
           <Row>
+            <Col className={cx("d-block", "d-md-none")} xs={12}>
+              <span className="text-muted">Project</span>
+            </Col>
             <Col className="mb-3">
               <ProjectPageHeader project={project} />
             </Col>

--- a/client/src/features/dataConnectorsV2/LazyDataConnectorSettings.tsx
+++ b/client/src/features/dataConnectorsV2/LazyDataConnectorSettings.tsx
@@ -1,0 +1,15 @@
+import { lazy, Suspense } from "react";
+
+import PageLoader from "../../components/PageLoader";
+
+const DataConnectorSettings = lazy(
+  () => import("./show/DataConnectorSettings")
+);
+
+export default function LazyDataConnectorSettings() {
+  return (
+    <Suspense fallback={<PageLoader />}>
+      <DataConnectorSettings />
+    </Suspense>
+  );
+}

--- a/client/src/features/dataConnectorsV2/LazyDataConnectorShow.tsx
+++ b/client/src/features/dataConnectorsV2/LazyDataConnectorShow.tsx
@@ -1,0 +1,13 @@
+import { lazy, Suspense } from "react";
+
+import PageLoader from "../../components/PageLoader";
+
+const DataConnectorShow = lazy(() => import("./show/DataConnectorShow"));
+
+export default function LazyDataConnectorShow() {
+  return (
+    <Suspense fallback={<PageLoader />}>
+      <DataConnectorShow />
+    </Suspense>
+  );
+}

--- a/client/src/features/dataConnectorsV2/api/data-connectors.empty-api.ts
+++ b/client/src/features/dataConnectorsV2/api/data-connectors.empty-api.ts
@@ -18,9 +18,15 @@
 
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 
+import { API_BASE_URL } from "~/utils/api/api.constants";
+import { prepareHeaders } from "~/utils/api/api.utils";
+
 // initialize an empty api service that we'll inject endpoints into later as needed
 export const dataConnectorsEmptyApi = createApi({
-  baseQuery: fetchBaseQuery({ baseUrl: "/api/data" }),
+  baseQuery: fetchBaseQuery({
+    baseUrl: API_BASE_URL,
+    prepareHeaders,
+  }),
   endpoints: () => ({}),
   reducerPath: "dataConnectorsApi",
 });

--- a/client/src/features/dataConnectorsV2/api/data-connectors.enhanced-api.ts
+++ b/client/src/features/dataConnectorsV2/api/data-connectors.enhanced-api.ts
@@ -163,10 +163,12 @@ const enhancedApi = injectedApi.enhanceEndpoints({
   ],
   endpoints: {
     deleteDataConnectorsByDataConnectorId: {
-      invalidatesTags: ["DataConnectors"],
+      invalidatesTags: (_result, error) => (error ? [] : ["DataConnectors"]),
       onQueryStarted: async (_arg, { dispatch, queryFulfilled }) => {
-        queryFulfilled.finally(() => {
-          dispatch(searchV2Api.util.invalidateTags(["SearchV2"]));
+        queryFulfilled.then(() => {
+          if (_arg.dataConnectorId) {
+            dispatch(searchV2Api.util.invalidateTags(["SearchV2"]));
+          }
         });
       },
     },

--- a/client/src/features/dataConnectorsV2/components/DataConnectorActions.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorActions.tsx
@@ -70,30 +70,30 @@ import { getDataConnectorScope } from "./dataConnector.utils";
 import DataConnectorCredentialsModal from "./DataConnectorCredentialsModal";
 
 interface DataConnectorRemoveModalProps {
-  dataConnector: DataConnectorRead;
+  dataConnector?: DataConnectorRead | null;
   dataConnectorLink?: DataConnectorToProjectLink;
   isOpen: boolean;
   onDelete: () => void;
   toggleModal: () => void;
 }
 
-function DataConnectorRemoveDeleteModal({
+export function DataConnectorRemoveDeleteModal({
   dataConnector,
   onDelete,
   toggleModal,
   isOpen,
 }: DataConnectorRemoveModalProps) {
   const { permissions, isLoading: isLoadingPermissions } =
-    useDataConnectorPermissions({ dataConnectorId: dataConnector.id });
+    useDataConnectorPermissions({ dataConnectorId: dataConnector?.id });
 
   const {
     data: dataConnectorLinks,
     isLoading: isLoadingLinks,
     isError: isLoadingLinksError,
   } = useGetDataConnectorsByDataConnectorIdProjectLinksQuery({
-    dataConnectorId: dataConnector.id,
+    dataConnectorId: dataConnector?.id ?? "",
   });
-  const [deleteDataConnector, { isLoading, isSuccess }] =
+  const [deleteDataConnector, { error, isLoading, isSuccess }] =
     useDeleteDataConnectorsByDataConnectorIdMutation();
 
   const [typedName, setTypedName] = useState("");
@@ -111,9 +111,9 @@ function DataConnectorRemoveDeleteModal({
   }, [isOpen, isSuccess, onDelete]);
   const onDeleteDataCollector = useCallback(() => {
     deleteDataConnector({
-      dataConnectorId: dataConnector.id,
+      dataConnectorId: dataConnector?.id ?? "",
     });
-  }, [deleteDataConnector, dataConnector.id]);
+  }, [deleteDataConnector, dataConnector?.id]);
 
   return (
     <Modal size="lg" isOpen={isOpen} toggle={toggleModal} centered>
@@ -144,7 +144,7 @@ function DataConnectorRemoveDeleteModal({
                       possible that it is used in some projects.
                     </p>
                     <p>
-                      Please type <strong>{dataConnector.slug}</strong>, the
+                      Please type <strong>{dataConnector?.slug}</strong>, the
                       slug of the data connector, to confirm.
                     </p>
                     <Input
@@ -179,7 +179,7 @@ function DataConnectorRemoveDeleteModal({
                       )}
                     </p>
                     <p>
-                      Please type <strong>{dataConnector.slug}</strong>, the
+                      Please type <strong>{dataConnector?.slug}</strong>, the
                       slug of the data connector, to confirm.
                     </p>
                     <Input
@@ -195,6 +195,12 @@ function DataConnectorRemoveDeleteModal({
             userPermissions={permissions}
           />
         )}
+        {error && (
+          <RtkOrDataServicesError
+            className={cx("mb-0", "mt-3")}
+            error={error}
+          />
+        )}
       </ModalBody>
       <ModalFooter>
         <div className="d-flex justify-content-end">
@@ -208,9 +214,8 @@ function DataConnectorRemoveDeleteModal({
               <Button
                 color="danger"
                 className={cx("float-right", "ms-2")}
-                disabled={isLoading || typedName !== dataConnector.slug.trim()}
+                disabled={isLoading || typedName !== dataConnector?.slug.trim()}
                 data-cy="delete-data-connector-modal-button"
-                type="submit"
                 onClick={onDeleteDataCollector}
               >
                 {isLoading ? (
@@ -274,10 +279,10 @@ function DataConnectorRemoveUnlinkModal({
     if (!linkId) return;
 
     unlinkDataConnector({
-      dataConnectorId: dataConnector.id,
+      dataConnectorId: dataConnector?.id ?? "",
       linkId,
     });
-  }, [unlinkDataConnector, dataConnector.id, linkId]);
+  }, [unlinkDataConnector, dataConnector?.id, linkId]);
 
   return (
     <Modal size="lg" isOpen={isOpen} toggle={toggleModal} centered>
@@ -307,7 +312,7 @@ function DataConnectorRemoveUnlinkModal({
                     <>
                       <p>
                         Are you sure you want to unlink the data connector{" "}
-                        <strong>{dataConnector.slug}</strong> from the project{" "}
+                        <strong>{dataConnector?.slug}</strong> from the project{" "}
                         <strong>
                           {projectNamespace}/{projectSlug}
                         </strong>
@@ -340,7 +345,7 @@ function DataConnectorRemoveUnlinkModal({
                     className={cx("float-right", "ms-2")}
                     disabled={isLoadingUnlink}
                     data-cy="delete-data-connector-modal-button"
-                    type="submit"
+                    type="button"
                     onClick={onDeleteDataCollector}
                   >
                     {isLoadingUnlink ? (

--- a/client/src/features/dataConnectorsV2/components/DataConnectorActions.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorActions.tsx
@@ -27,7 +27,7 @@ import {
   Trash,
   XLg,
 } from "react-bootstrap-icons";
-import { matchPath, useLocation } from "react-router";
+import { matchPath, useLocation, useNavigate } from "react-router";
 import {
   Button,
   Col,
@@ -72,16 +72,18 @@ import DataConnectorCredentialsModal from "./DataConnectorCredentialsModal";
 interface DataConnectorRemoveModalProps {
   dataConnector?: DataConnectorRead | null;
   dataConnectorLink?: DataConnectorToProjectLink;
+  executeOnSuccess?: () => void;
   isOpen: boolean;
-  onDelete: () => void;
+  redirectOnSuccess?: string;
   toggleModal: () => void;
 }
 
 export function DataConnectorRemoveDeleteModal({
   dataConnector,
-  onDelete,
-  toggleModal,
+  executeOnSuccess,
   isOpen,
+  redirectOnSuccess,
+  toggleModal,
 }: DataConnectorRemoveModalProps) {
   const { permissions, isLoading: isLoadingPermissions } =
     useDataConnectorPermissions({ dataConnectorId: dataConnector?.id });
@@ -104,16 +106,25 @@ export function DataConnectorRemoveDeleteModal({
     [setTypedName]
   );
 
+  const navigate = useNavigate();
+
   useEffect(() => {
-    if (isSuccess && isOpen) {
-      onDelete();
+    if (isSuccess && executeOnSuccess) {
+      executeOnSuccess();
     }
-  }, [isOpen, isSuccess, onDelete]);
-  const onDeleteDataCollector = useCallback(() => {
-    deleteDataConnector({
-      dataConnectorId: dataConnector?.id ?? "",
-    });
-  }, [deleteDataConnector, dataConnector?.id]);
+  }, [isSuccess, executeOnSuccess]);
+  const onDeleteDataConnector = useCallback(async () => {
+    if (!dataConnector?.id) return;
+
+    try {
+      await deleteDataConnector({
+        dataConnectorId: dataConnector.id,
+      }).unwrap();
+      if (redirectOnSuccess) navigate(redirectOnSuccess);
+    } catch {
+      // keep existing `error` rendering from the mutation result
+    }
+  }, [dataConnector, deleteDataConnector, redirectOnSuccess, navigate]);
 
   return (
     <Modal size="lg" isOpen={isOpen} toggle={toggleModal} centered>
@@ -216,7 +227,7 @@ export function DataConnectorRemoveDeleteModal({
                 color="danger"
                 data-cy="delete-data-connector-modal-button"
                 disabled={isLoading || typedName !== dataConnector?.slug.trim()}
-                onClick={onDeleteDataCollector}
+                onClick={onDeleteDataConnector}
                 type="button"
               >
                 {isLoading ? (
@@ -251,11 +262,11 @@ interface DataConnectorRemoveUnlinkModalProps
 function DataConnectorRemoveUnlinkModal({
   dataConnector,
   dataConnectorLink,
-  onDelete,
+  executeOnSuccess,
+  isOpen,
   projectNamespace,
   projectSlug,
   toggleModal,
-  isOpen,
 }: DataConnectorRemoveUnlinkModalProps) {
   const [
     unlinkDataConnector,
@@ -271,12 +282,12 @@ function DataConnectorRemoveUnlinkModal({
   const linkId = dataConnectorLink.id;
 
   useEffect(() => {
-    if (isSuccess && isOpen) {
-      onDelete();
+    if (isSuccess && executeOnSuccess) {
+      executeOnSuccess();
     }
-  }, [isOpen, isSuccess, onDelete]);
+  }, [isSuccess, executeOnSuccess]);
 
-  const onDeleteDataCollector = useCallback(() => {
+  const onDeleteDataConnector = useCallback(() => {
     if (!linkId) return;
 
     unlinkDataConnector({
@@ -350,7 +361,7 @@ function DataConnectorRemoveUnlinkModal({
                     color="danger"
                     data-cy="delete-data-connector-modal-button"
                     disabled={isLoadingUnlink}
-                    onClick={onDeleteDataCollector}
+                    onClick={onDeleteDataConnector}
                     type="button"
                   >
                     {isLoadingUnlink ? (
@@ -612,8 +623,8 @@ function DataConnectorActionsInner({
       <DataConnectorRemoveDeleteModal
         dataConnector={dataConnector}
         dataConnectorLink={dataConnectorLink}
+        executeOnSuccess={onDelete}
         isOpen={isDeleteOpen}
-        onDelete={onDelete}
         toggleModal={toggleDelete}
       />
       <DepositCreationModal
@@ -642,8 +653,8 @@ function DataConnectorActionsInner({
         <DataConnectorRemoveUnlinkModal
           dataConnector={dataConnector}
           dataConnectorLink={dataConnectorLink}
+          executeOnSuccess={onUnlink}
           isOpen={isUnlinkOpen}
-          onDelete={onUnlink}
           projectNamespace={namespace!}
           projectSlug={slug!}
           toggleModal={toggleUnlink}

--- a/client/src/features/dataConnectorsV2/components/DataConnectorActions.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorActions.tsx
@@ -204,7 +204,7 @@ export function DataConnectorRemoveDeleteModal({
       </ModalBody>
       <ModalFooter>
         <div className="d-flex justify-content-end">
-          <Button color="outline-danger" onClick={toggleModal}>
+          <Button color="outline-danger" onClick={toggleModal} type="button">
             <XLg className={cx("bi", "me-1")} />
             Cancel
           </Button>
@@ -212,11 +212,12 @@ export function DataConnectorRemoveDeleteModal({
             disabled={null}
             enabled={
               <Button
-                color="danger"
                 className={cx("float-right", "ms-2")}
-                disabled={isLoading || typedName !== dataConnector?.slug.trim()}
+                color="danger"
                 data-cy="delete-data-connector-modal-button"
+                disabled={isLoading || typedName !== dataConnector?.slug.trim()}
                 onClick={onDeleteDataCollector}
+                type="button"
               >
                 {isLoading ? (
                   <>
@@ -333,7 +334,11 @@ function DataConnectorRemoveUnlinkModal({
           <ModalFooter>
             {error && <RtkOrDataServicesError error={error} />}
             <div className="d-flex justify-content-end">
-              <Button color="outline-danger" onClick={toggleModal}>
+              <Button
+                color="outline-danger"
+                onClick={toggleModal}
+                type="button"
+              >
                 <XLg className={cx("bi", "me-1")} />
                 Cancel
               </Button>
@@ -341,12 +346,12 @@ function DataConnectorRemoveUnlinkModal({
                 disabled={null}
                 enabled={
                   <Button
-                    color="danger"
                     className={cx("float-right", "ms-2")}
-                    disabled={isLoadingUnlink}
+                    color="danger"
                     data-cy="delete-data-connector-modal-button"
-                    type="button"
+                    disabled={isLoadingUnlink}
                     onClick={onDeleteDataCollector}
+                    type="button"
                   >
                     {isLoadingUnlink ? (
                       <>

--- a/client/src/features/dataConnectorsV2/components/DataConnectorCredentialsBox.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorCredentialsBox.tsx
@@ -1,0 +1,101 @@
+import cx from "classnames";
+import { useMemo } from "react";
+import { Key, Lock, PersonBadge } from "react-bootstrap-icons";
+import { Card, CardBody, CardHeader } from "reactstrap";
+
+import RenkuBadge from "~/components/renkuBadge/RenkuBadge";
+import { CredentialMoreInfo } from "~/features/cloudStorage/CloudStorageItem";
+import { CLOUD_STORAGE_SENSITIVE_FIELD_TOKEN } from "~/features/cloudStorage/projectCloudStorage.constants";
+import { getCredentialFieldDefinitions } from "~/features/cloudStorage/projectCloudStorage.utils";
+import { storageSecretNameToFieldName } from "~/features/secretsV2/secrets.utils";
+import { DataConnectorRead } from "../api/data-connectors.api";
+import { useGetDataConnectorsByDataConnectorIdSecretsQuery } from "../api/data-connectors.enhanced-api";
+import { InfoEntry } from "./DataConnectorInfoBox";
+
+interface DataConnectorCredentialsBoxProps {
+  dataConnector: DataConnectorRead;
+  headerTag?: "h2" | "h3" | "h4";
+}
+export default function DataConnectorCredentialsBox({
+  dataConnector,
+  headerTag = "h2",
+}: DataConnectorCredentialsBoxProps) {
+  // Sensitive fields
+  const sensitiveFields = dataConnector.storage.sensitive_fields
+    ? dataConnector.storage.sensitive_fields.map((f) => f.name)
+    : [];
+  const anySensitiveField = Object.keys(
+    dataConnector.storage.configuration
+  ).some((key) => sensitiveFields.includes(key));
+
+  // Fields requiring credentials and their status
+  const credentialFieldDefinitions = useMemo(
+    () =>
+      getCredentialFieldDefinitions({
+        storage: dataConnector.storage,
+        sensitive_fields: dataConnector.storage.sensitive_fields,
+      }),
+    [dataConnector]
+  );
+  const requiredCredentials = useMemo(
+    () =>
+      credentialFieldDefinitions?.filter((field) => field.requiredCredential),
+    [credentialFieldDefinitions]
+  );
+  const { data: connectorSecrets } =
+    useGetDataConnectorsByDataConnectorIdSecretsQuery({
+      dataConnectorId: dataConnector.id,
+    });
+  const savedCredentialFields =
+    connectorSecrets?.reduce((acc: Record<string, string>, s) => {
+      acc[storageSecretNameToFieldName(s)] = s.name;
+      return acc;
+    }, {}) ?? {};
+
+  return (
+    <Card data-cy="data-connector-credentials-box">
+      <CardHeader tag={headerTag}>
+        <span className={cx("align-items-center", "d-flex")}>
+          <PersonBadge className="me-1" />
+          Credentials
+        </span>
+      </CardHeader>
+      <CardBody className={cx("d-flex", "flex-column", "gap-3")}>
+        <InfoEntry title="Requires credentials" dataCy="requires-credentials">
+          {anySensitiveField ? "Yes" : "No"}
+        </InfoEntry>
+        {requiredCredentials &&
+          requiredCredentials.length > 0 &&
+          requiredCredentials.map(({ name, help }) => {
+            if (!name) return null;
+            const title = (
+              <>
+                Field <span className="fst-italic">{name}</span>{" "}
+                {help && <CredentialMoreInfo help={help} />}
+              </>
+            );
+            return (
+              <>
+                <InfoEntry title={title} dataCy={name}>
+                  {savedCredentialFields[name] ? (
+                    <RenkuBadge color="success">
+                      <Key className="me-1" />
+                      Credentials saved
+                    </RenkuBadge>
+                  ) : dataConnector.storage.configuration[name]?.toString() ==
+                    CLOUD_STORAGE_SENSITIVE_FIELD_TOKEN ? (
+                    <RenkuBadge color="warning">
+                      <Lock className="me-1" />
+                      Requires credentials
+                    </RenkuBadge>
+                  ) : (
+                    dataConnector.storage.configuration[name]?.toString()
+                  )}
+                </InfoEntry>
+              </>
+            );
+          })}
+      </CardBody>
+    </Card>
+  );
+}

--- a/client/src/features/dataConnectorsV2/components/DataConnectorCredentialsBox.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorCredentialsBox.tsx
@@ -21,12 +21,17 @@ export default function DataConnectorCredentialsBox({
   headerTag = "h2",
 }: DataConnectorCredentialsBoxProps) {
   // Sensitive fields
-  const sensitiveFields = dataConnector.storage.sensitive_fields
-    ? dataConnector.storage.sensitive_fields.map((f) => f.name)
-    : [];
-  const anySensitiveField = Object.keys(
-    dataConnector.storage.configuration
-  ).some((key) => sensitiveFields.includes(key));
+  const sensitiveFieldNames = useMemo(
+    () => dataConnector.storage.sensitive_fields?.map((f) => f.name) ?? [],
+    [dataConnector.storage.sensitive_fields]
+  );
+  const anySensitiveField = useMemo(
+    () =>
+      Object.keys(dataConnector.storage.configuration).some((key) =>
+        sensitiveFieldNames.includes(key)
+      ),
+    [dataConnector.storage.configuration, sensitiveFieldNames]
+  );
 
   // Fields requiring credentials and their status
   const credentialFieldDefinitions = useMemo(
@@ -35,7 +40,7 @@ export default function DataConnectorCredentialsBox({
         storage: dataConnector.storage,
         sensitive_fields: dataConnector.storage.sensitive_fields,
       }),
-    [dataConnector]
+    [dataConnector.storage]
   );
   const requiredCredentials = useMemo(
     () =>

--- a/client/src/features/dataConnectorsV2/components/DataConnectorCredentialsModal.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorCredentialsModal.tsx
@@ -36,7 +36,7 @@ import useDataConnectorConfiguration, {
 interface DataConnectorCredentialsModalProps {
   isOpen: boolean;
   setOpen: (isOpen: boolean) => void;
-  dataConnector: DataConnectorRead;
+  dataConnector?: DataConnectorRead | null;
 }
 export default function DataConnectorCredentialsModal({
   isOpen,
@@ -44,7 +44,7 @@ export default function DataConnectorCredentialsModal({
   setOpen,
 }: DataConnectorCredentialsModalProps) {
   const { dataConnectorConfigs } = useDataConnectorConfiguration({
-    dataConnectors: [dataConnector],
+    dataConnectors: dataConnector ? [dataConnector] : undefined,
   });
 
   const [saveCredentials, saveCredentialsResult] =
@@ -57,13 +57,13 @@ export default function DataConnectorCredentialsModal({
       const activeConfigs = configs.filter((c) => c.active);
       if (activeConfigs.length === 0) {
         if (!deleteCredentialsResult.isUninitialized) return;
-        deleteCredentials({ dataConnectorId: dataConnector.id });
+        deleteCredentials({ dataConnectorId: dataConnector?.id ?? "" });
         return;
       }
       if (!saveCredentialsResult.isUninitialized) return;
       const config = configs[0];
       saveCredentials({
-        dataConnectorId: dataConnector.id,
+        dataConnectorId: dataConnector?.id ?? "",
         dataConnectorSecretPatchList: Object.entries(
           config.sensitiveFieldValues
         ).map(([key, value]) => ({
@@ -75,7 +75,7 @@ export default function DataConnectorCredentialsModal({
     [
       deleteCredentials,
       deleteCredentialsResult,
-      dataConnector,
+      dataConnector?.id,
       saveCredentials,
       saveCredentialsResult,
     ]
@@ -88,8 +88,8 @@ export default function DataConnectorCredentialsModal({
   }, [deleteCredentialsResult, saveCredentialsResult.isSuccess, setOpen]);
   if (!isOpen) return null;
   if (
-    dataConnector.storage.sensitive_fields == null ||
-    dataConnector.storage.sensitive_fields.length === 0
+    dataConnector?.storage.sensitive_fields == null ||
+    dataConnector?.storage.sensitive_fields.length === 0
   ) {
     return (
       <Modal

--- a/client/src/features/dataConnectorsV2/components/DataConnectorInfoBox.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorInfoBox.tsx
@@ -1,0 +1,330 @@
+import { skipToken } from "@reduxjs/toolkit/query";
+import cx from "classnames";
+import { capitalize } from "lodash-es";
+import { useMemo, useRef } from "react";
+import {
+  Folder,
+  Globe2,
+  InfoCircle,
+  Journals,
+  Lock,
+} from "react-bootstrap-icons";
+import { generatePath, Link } from "react-router";
+import { Card, CardBody, CardHeader, UncontrolledTooltip } from "reactstrap";
+
+import { WarnAlert } from "~/components/Alert";
+import { Clipboard } from "~/components/clipboard/Clipboard";
+import ExternalLink from "~/components/ExternalLink";
+import KeywordBadge from "~/components/keywords/KeywordBadge";
+import KeywordContainer from "~/components/keywords/KeywordContainer";
+import { Loader } from "~/components/Loader";
+import LazyMarkdown from "~/components/markdown/LazyMarkdown";
+import { STORAGES_WITH_ACCESS_MODE } from "~/features/cloudStorage/projectCloudStorage.constants";
+import { getCredentialFieldDefinitions } from "~/features/cloudStorage/projectCloudStorage.utils";
+import { useGetNamespacesByNamespaceSlugQuery } from "~/features/projectsV2/api/projectV2.enhanced-api";
+import EntityPill from "~/features/searchV2/components/EntityPill";
+import UserAvatar from "~/features/usersV2/show/UserAvatar";
+import { ABSOLUTE_ROUTES } from "~/routing/routes.constants";
+import { DataConnectorRead } from "../api/data-connectors.api";
+import {
+  getDataConnectorScope,
+  parseDoi,
+  useGetDataConnectorSource,
+} from "../components/dataConnector.utils";
+import { DATA_CONNECTORS_VISIBILITY_WARNING } from "./dataConnector.constants";
+
+interface DataConnectorInfoBoxProps {
+  dataConnector: DataConnectorRead;
+  headerTag?: "h2" | "h3" | "h4";
+  visibilityWarning?: boolean;
+}
+export default function DataConnectorInfoBox({
+  dataConnector,
+  headerTag = "h2",
+  visibilityWarning,
+}: DataConnectorInfoBoxProps) {
+  // Get useful DC info
+  const scope = useMemo(
+    () => getDataConnectorScope(dataConnector.namespace),
+    [dataConnector.namespace]
+  );
+  const identifier = useMemo(
+    () =>
+      scope === "global"
+        ? `${dataConnector.slug}`
+        : `${dataConnector.namespace}/${dataConnector.slug}`,
+    [dataConnector.namespace, dataConnector.slug, scope]
+  );
+  const dataConnectorSource = useGetDataConnectorSource(dataConnector);
+
+  const sortedKeywords = useMemo(() => {
+    if (!dataConnector.keywords) return [];
+    return dataConnector.keywords
+      .map((keyword) => keyword.trim())
+      .sort((a, b) => a.localeCompare(b));
+  }, [dataConnector.keywords]);
+
+  // Global only
+  const doiReference = useMemo(() => {
+    if (!dataConnector) return null;
+    const doi =
+      scope === "global" &&
+      dataConnector.storage.configuration["doi"] &&
+      typeof dataConnector.storage.configuration["doi"] === "string"
+        ? parseDoi(dataConnector.storage.configuration["doi"])
+        : null;
+    if (doi) {
+      return doi;
+    }
+    if (dataConnector.doi) {
+      return parseDoi(dataConnector.doi);
+    }
+    return null;
+  }, [dataConnector, scope]);
+
+  // Non-global only
+  const { data: referenceNamespace, isLoading: isLoadingReferenceNamespace } =
+    useGetNamespacesByNamespaceSlugQuery(
+      dataConnector.namespace
+        ? {
+            namespaceSlug: dataConnector.namespace,
+          }
+        : skipToken
+    );
+  const namespaceUrl = useMemo(
+    () =>
+      scope === "global" || !dataConnector.namespace
+        ? null
+        : scope === "project"
+        ? generatePath(ABSOLUTE_ROUTES.v2.projects.show.root, {
+            namespace: dataConnector.namespace.split("/")[0],
+            slug: dataConnector.namespace.split("/")[1],
+          })
+        : referenceNamespace?.namespace_kind === "user"
+        ? generatePath(ABSOLUTE_ROUTES.v2.users.show.root, {
+            username: dataConnector.namespace,
+          })
+        : generatePath(ABSOLUTE_ROUTES.v2.groups.show.root, {
+            slug: dataConnector.namespace,
+          }),
+    [dataConnector.namespace, referenceNamespace, scope]
+  );
+
+  return (
+    <Card data-cy="data-connector-info-box">
+      <CardHeader tag={headerTag}>
+        <span className={cx("align-items-center", "d-flex")}>
+          <InfoCircle className="me-1" />
+          Info
+        </span>
+      </CardHeader>
+      <CardBody className={cx("d-flex", "flex-column", "gap-3")}>
+        <InfoEntry title="Identifier">
+          <div className={cx("align-items-center", "d-flex", "gap-2")}>
+            {identifier}
+            <Clipboard
+              className={cx("border-0", "btn", "p-0", "shadow-none")}
+              clipboardText={identifier}
+            />
+          </div>
+        </InfoEntry>
+
+        {dataConnector.description && (
+          <InfoEntry title="Description">
+            <LazyMarkdown>{dataConnector.description}</LazyMarkdown>
+          </InfoEntry>
+        )}
+
+        {scope !== "global" && (
+          <InfoEntry title="Owner">
+            <div className={cx("align-items-center", "d-flex", "gap-2")}>
+              {scope === "project" ? (
+                <>
+                  <Folder className={cx("bi", "flex-shrink-0")} />
+                  <Link to={namespaceUrl ?? ""}>
+                    @{dataConnector.namespace}
+                  </Link>
+                </>
+              ) : (
+                <>
+                  <UserAvatar namespace={dataConnector.namespace as string} />
+                  <Link to={namespaceUrl ?? ""}>
+                    @{dataConnector.namespace}
+                  </Link>
+                  {isLoadingReferenceNamespace ? (
+                    <Loader inline size={16} />
+                  ) : referenceNamespace?.namespace_kind === "user" ? (
+                    <EntityPill
+                      entityType="User"
+                      size="sm"
+                      tooltipPlacement="bottom"
+                    />
+                  ) : referenceNamespace?.namespace_kind === "group" ? (
+                    <EntityPill
+                      entityType="Group"
+                      size="sm"
+                      tooltipPlacement="bottom"
+                    />
+                  ) : null}
+                </>
+              )}
+            </div>
+          </InfoEntry>
+        )}
+
+        <InfoEntry title="Visibility">
+          {dataConnector.visibility === "private" ? (
+            <>
+              <Lock className={cx("bi", "me-1")} />
+              Private
+            </>
+          ) : (
+            <>
+              <Globe2 className={cx("bi", "me-1")} />
+              Public
+            </>
+          )}
+
+          {visibilityWarning && (
+            <WarnAlert
+              className={cx("mb-0", "mt-2")}
+              timeout={0}
+              dismissible={false}
+            >
+              {DATA_CONNECTORS_VISIBILITY_WARNING}
+            </WarnAlert>
+          )}
+        </InfoEntry>
+
+        {scope === "global" && (
+          <>
+            <InfoEntry title="Source">
+              <div className={cx("align-items-center", "d-flex", "gap-1")}>
+                <Journals className={cx("me-1", "flex-shrink-0")} />
+                DOI from {dataConnectorSource}
+              </div>
+            </InfoEntry>
+            <InfoEntry title="DOI">
+              <div className={cx("align-items-center", "d-flex", "gap-2")}>
+                <ExternalLink href={`https://doi.org/${doiReference}`}>
+                  {doiReference}
+                </ExternalLink>
+                <Clipboard
+                  className={cx("border-0", "btn", "p-0", "shadow-none")}
+                  clipboardText={
+                    dataConnector.storage.configuration["doi"] as string
+                  }
+                />
+              </div>
+            </InfoEntry>
+          </>
+        )}
+
+        {dataConnector.keywords && dataConnector.keywords.length > 0 && (
+          <InfoEntry title="Keywords">
+            <KeywordContainer>
+              {sortedKeywords.map((keyword, index) => (
+                <KeywordBadge key={index} searchKeyword={keyword}>
+                  {keyword}
+                </KeywordBadge>
+              ))}
+            </KeywordContainer>
+          </InfoEntry>
+        )}
+
+        <InfoEntry title={<MountPointHead />} dataCy="mount-point">
+          {dataConnector.storage.target_path}
+        </InfoEntry>
+
+        <InfoEntry title="Access mode">
+          {dataConnector.storage.readonly
+            ? "Force Read-only"
+            : "Allow Read-Write (requires adequate privileges on the storage)"}
+        </InfoEntry>
+
+        <InfoEntry title="Source path">
+          {dataConnector.storage.source_path}
+        </InfoEntry>
+
+        <DataConnectorAdditionalFields dataConnector={dataConnector} />
+      </CardBody>
+    </Card>
+  );
+}
+
+interface InfoEntryProps {
+  children: React.ReactNode;
+  dataCy?: string;
+  title: string | React.ReactNode;
+}
+export function InfoEntry({ children, title, dataCy }: InfoEntryProps) {
+  return (
+    <div>
+      <p className={cx("mb-1", "fw-semibold")}>{title}</p>
+      <div
+        data-cy={
+          dataCy
+            ? `data-connector-${dataCy}`
+            : typeof title === "string"
+            ? `data-connector-${title.toLocaleLowerCase().replace(/\s/g, "-")}`
+            : undefined
+        }
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function MountPointHead() {
+  const ref = useRef(null);
+  return (
+    <>
+      <span>Mount Point</span>
+      <span ref={ref}>
+        <InfoCircle className="ms-1" />
+      </span>
+      <UncontrolledTooltip target={ref} placement="bottom">
+        This is where the data connector will be mounted during sessions.
+      </UncontrolledTooltip>
+    </>
+  );
+}
+
+interface DataConnectorAdditionalFieldsProps {
+  dataConnector: DataConnectorRead;
+}
+function DataConnectorAdditionalFields({
+  dataConnector,
+}: DataConnectorAdditionalFieldsProps) {
+  const credentialFieldDefinitions =
+    getCredentialFieldDefinitions(dataConnector);
+
+  const nonCredentialFields = Object.keys(
+    dataConnector.storage.configuration
+  ).filter((k) => !credentialFieldDefinitions?.some((f) => f.name === k));
+
+  const hasAccessMode = useMemo(
+    () =>
+      STORAGES_WITH_ACCESS_MODE.includes(dataConnector.storage.storage_type),
+    [dataConnector.storage.storage_type]
+  );
+
+  return (
+    <>
+      {nonCredentialFields.map((fieldName) => {
+        const title =
+          fieldName == "provider" && hasAccessMode
+            ? "Mode"
+            : capitalize(fieldName);
+        const value =
+          dataConnector.storage.configuration[fieldName]?.toString() ?? "";
+        return (
+          <>
+            <InfoEntry title={title}>{value}</InfoEntry>
+          </>
+        );
+      })}
+    </>
+  );
+}

--- a/client/src/features/dataConnectorsV2/components/DataConnectorInfoBox.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorInfoBox.tsx
@@ -320,9 +320,9 @@ function DataConnectorAdditionalFields({
         const value =
           dataConnector.storage.configuration[fieldName]?.toString() ?? "";
         return (
-          <>
-            <InfoEntry title={title}>{value}</InfoEntry>
-          </>
+          <InfoEntry key={fieldName} title={title}>
+            {value}
+          </InfoEntry>
         );
       })}
     </>

--- a/client/src/features/dataConnectorsV2/components/DataConnectorProjectsBox.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorProjectsBox.tsx
@@ -1,0 +1,49 @@
+import cx from "classnames";
+import { Folder } from "react-bootstrap-icons";
+import { Card, CardBody, CardHeader, ListGroup } from "reactstrap";
+
+import { Loader } from "~/components/Loader";
+import ProjectShortHandDisplay from "~/features/projectsV2/show/ProjectShortHandDisplay";
+import { DataConnectorRead } from "../api/data-connectors.api";
+import useDataConnectorProjects from "./useDataConnectorProjects.hook";
+
+interface DataConnectorProjectsBoxProps {
+  dataConnector: DataConnectorRead;
+  headerTag?: "h2" | "h3" | "h4";
+}
+export default function DataConnectorProjectsBox({
+  dataConnector,
+  headerTag = "h2",
+}: DataConnectorProjectsBoxProps) {
+  const { projects, isLoading } = useDataConnectorProjects({ dataConnector });
+
+  return (
+    <Card data-cy="data-connector-projects-box">
+      <CardHeader tag={headerTag}>
+        <span className={cx("align-items-center", "d-flex")}>
+          <Folder className={cx("bi", "me-1")} />
+          Linked projects
+        </span>
+      </CardHeader>
+      <CardBody className={cx("d-flex", "flex-column", "gap-3")}>
+        {isLoading ? (
+          <Loader />
+        ) : projects.length > 0 ? (
+          <ListGroup flush data-cy="dashboard-project-list">
+            {projects.map((project) => (
+              <ProjectShortHandDisplay
+                displayRows={["description", "namespace"]}
+                key={project.id}
+                project={project}
+              />
+            ))}
+          </ListGroup>
+        ) : (
+          <p className="mb-0">
+            This data connector is not used in any project you can access.
+          </p>
+        )}
+      </CardBody>
+    </Card>
+  );
+}

--- a/client/src/features/dataConnectorsV2/components/DataConnectorView.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorView.tsx
@@ -209,16 +209,64 @@ export default function DataConnectorView({
   );
 }
 
+export function DataConnectorLastDepositBody({
+  deposit,
+}: DataConnectorLastDepositProps) {
+  return (
+    <>
+      <DataConnectorPropertyValue key="name" title="Name">
+        {deposit.name}
+      </DataConnectorPropertyValue>
+      <DataConnectorPropertyValue key="provider" title="Provider">
+        {deposit.provider}
+      </DataConnectorPropertyValue>
+      {deposit.external_url && (
+        <DataConnectorPropertyValue key="external_url" title="URL">
+          <ExternalLink href={deposit.external_url}>
+            {deposit.external_url}
+          </ExternalLink>
+        </DataConnectorPropertyValue>
+      )}
+      <DataConnectorPropertyValue key="status" title="Status">
+        <DepositStatusBadge status={deposit.status} />
+      </DataConnectorPropertyValue>
+      <DataConnectorPropertyValue key="path" title="Path">
+        {deposit.path ?? <span className="fst-italic">N/A</span>}
+      </DataConnectorPropertyValue>
+      {deposit.creation_date && (
+        <DataConnectorPropertyValue key="creation_date" title="Created">
+          <TimeCaption
+            datetime={deposit.creation_date}
+            enableTooltip
+            noCaption
+            prefix=""
+          />
+        </DataConnectorPropertyValue>
+      )}
+      {deposit.updated_at && deposit.updated_at !== deposit.creation_date && (
+        <DataConnectorPropertyValue key="updated_at" title="Last updated">
+          <TimeCaption
+            datetime={deposit.updated_at}
+            enableTooltip
+            noCaption
+            prefix=""
+          />
+        </DataConnectorPropertyValue>
+      )}
+    </>
+  );
+}
+
 interface DataConnectorLastDepositProps {
-  dataConnector: DataConnectorRead;
+  dataConnector?: DataConnectorRead | null;
   deposit: Deposit;
 }
-function DataConnectorLastDeposit({
+export function DataConnectorLastDeposit({
   dataConnector,
   deposit,
 }: DataConnectorLastDepositProps) {
   const { permissions } = useDataConnectorPermissions({
-    dataConnectorId: dataConnector.id,
+    dataConnectorId: dataConnector?.id,
   });
 
   return (
@@ -246,45 +294,7 @@ function DataConnectorLastDeposit({
         />
       </div>
       <div>
-        <DataConnectorPropertyValue key="name" title="Name">
-          {deposit.name}
-        </DataConnectorPropertyValue>
-        <DataConnectorPropertyValue key="provider" title="Provider">
-          {deposit.provider}
-        </DataConnectorPropertyValue>
-        {deposit.external_url && (
-          <DataConnectorPropertyValue key="external_url" title="URL">
-            <ExternalLink href={deposit.external_url}>
-              {deposit.external_url}
-            </ExternalLink>
-          </DataConnectorPropertyValue>
-        )}
-        <DataConnectorPropertyValue key="status" title="Status">
-          <DepositStatusBadge status={deposit.status} />
-        </DataConnectorPropertyValue>
-        <DataConnectorPropertyValue key="path" title="Path">
-          {deposit.path ?? <span className="fst-italic">N/A</span>}
-        </DataConnectorPropertyValue>
-        {deposit.creation_date && (
-          <DataConnectorPropertyValue key="creation_date" title="Created">
-            <TimeCaption
-              datetime={deposit.creation_date}
-              enableTooltip
-              noCaption
-              prefix=""
-            />
-          </DataConnectorPropertyValue>
-        )}
-        {deposit.updated_at && deposit.updated_at !== deposit.creation_date && (
-          <DataConnectorPropertyValue key="updated_at" title="Last updated">
-            <TimeCaption
-              datetime={deposit.updated_at}
-              enableTooltip
-              noCaption
-              prefix=""
-            />
-          </DataConnectorPropertyValue>
-        )}
+        <DataConnectorLastDepositBody deposit={deposit} />
       </div>
     </section>
   );

--- a/client/src/features/dataConnectorsV2/components/DataConnectorView.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorView.tsx
@@ -21,6 +21,7 @@ import cx from "classnames";
 import { capitalize } from "lodash-es";
 import { useCallback, useMemo, useRef, useState } from "react";
 import {
+  ArrowsAngleExpand,
   CardText,
   Cloud,
   CloudArrowUp,
@@ -135,6 +136,16 @@ export default function DataConnectorView({
     [dataConnector.namespace]
   );
 
+  const namespaceParts = dataConnector.namespace?.split("/") ?? [];
+  const dataConnectorStandaloneLink = generatePath(
+    ABSOLUTE_ROUTES.v2.dataConnectors.show.root,
+    {
+      projectNamespace: namespaceParts[0] ?? null,
+      dataConnectorNamespace: namespaceParts[1] ?? null,
+      slug: dataConnector.slug,
+    }
+  );
+
   return (
     <Offcanvas
       toggle={toggleView}
@@ -143,7 +154,7 @@ export default function DataConnectorView({
       backdrop={true}
     >
       <OffcanvasBody data-cy="data-connector-view">
-        <div className="mb-3">
+        <div className={cx("mb-3", "d-flex", "gap-2")}>
           <button
             aria-label="Close"
             className="btn-close"
@@ -151,6 +162,13 @@ export default function DataConnectorView({
             data-bs-dismiss="offcanvas"
             onClick={toggleView}
           ></button>
+          <Link
+            className="link-secondary"
+            data-cy="data-connector-standalone-page-link"
+            to={dataConnectorStandaloneLink}
+          >
+            <ArrowsAngleExpand />
+          </Link>
         </div>
         <DataConnectorViewHeader
           {...{ dataConnector, dataConnectorLink, toggleView, toggleEdit }}

--- a/client/src/features/dataConnectorsV2/components/DataConnectorView.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorView.tsx
@@ -21,7 +21,7 @@ import cx from "classnames";
 import { capitalize } from "lodash-es";
 import { useCallback, useMemo, useRef, useState } from "react";
 import {
-  ArrowsAngleExpand,
+  ArrowsFullscreen,
   CardText,
   Cloud,
   CloudArrowUp,
@@ -34,6 +34,7 @@ import {
   Lock,
   Pencil,
   PersonBadge,
+  XLg,
 } from "react-bootstrap-icons";
 import { generatePath, Link } from "react-router";
 import {
@@ -146,6 +147,9 @@ export default function DataConnectorView({
     }
   );
 
+  const refClose = useRef(null);
+  const refExpand = useRef(null);
+
   return (
     <Offcanvas
       toggle={toggleView}
@@ -154,21 +158,41 @@ export default function DataConnectorView({
       backdrop={true}
     >
       <OffcanvasBody data-cy="data-connector-view">
-        <div className={cx("mb-3", "d-flex", "gap-2")}>
+        <div className={cx("align-items-center", "d-flex", "gap-2", "mb-3")}>
           <button
             aria-label="Close"
-            className="btn-close"
+            className={cx(
+              "border-0",
+              "btn",
+              "d-flex",
+              "fs-2",
+              "link-secondary",
+              "p-0",
+              "shadow-none"
+            )}
             data-cy="data-connector-view-back-button"
             data-bs-dismiss="offcanvas"
+            ref={refClose}
             onClick={toggleView}
-          ></button>
+          >
+            <XLg />
+            <span className="visually-hidden">Close side panel</span>
+          </button>
+          <UncontrolledTooltip target={refClose}>
+            Close side panel
+          </UncontrolledTooltip>
           <Link
-            className="link-secondary"
+            className={cx("d-flex", "fs-3", "link-secondary")}
             data-cy="data-connector-standalone-page-link"
+            ref={refExpand}
             to={dataConnectorStandaloneLink}
           >
-            <ArrowsAngleExpand />
+            <ArrowsFullscreen />
+            <span className="visually-hidden">Open full page</span>
           </Link>
+          <UncontrolledTooltip target={refExpand}>
+            Open full page
+          </UncontrolledTooltip>
         </div>
         <DataConnectorViewHeader
           {...{ dataConnector, dataConnectorLink, toggleView, toggleEdit }}

--- a/client/src/features/dataConnectorsV2/components/dataConnector.constants.ts
+++ b/client/src/features/dataConnectorsV2/components/dataConnector.constants.ts
@@ -1,2 +1,2 @@
 export const DATA_CONNECTORS_VISIBILITY_WARNING =
-  "Some members of this project may not be able to access this data connector";
+  "Some members of this project may not be able to access this data connector.";

--- a/client/src/features/dataConnectorsV2/components/dataConnector.utils.ts
+++ b/client/src/features/dataConnectorsV2/components/dataConnector.utils.ts
@@ -210,27 +210,29 @@ export function getDataConnectorScope(namespace?: string): DataConnectorScope {
   return "namespace";
 }
 
-export function useGetDataConnectorSource(dataConnector: DataConnector) {
+export function useGetDataConnectorSource(
+  dataConnector: DataConnector | undefined
+) {
   const scope = useMemo(
-    () => getDataConnectorScope(dataConnector.namespace),
-    [dataConnector.namespace]
+    () => getDataConnectorScope(dataConnector?.namespace),
+    [dataConnector?.namespace]
   );
 
   const { currentData: resolverResponse, isSuccess } = useGetHandlesByDoiQuery(
     scope === "global" &&
-      typeof dataConnector.storage.configuration["doi"] === "string"
+      typeof dataConnector?.storage.configuration["doi"] === "string"
       ? { doi: parseDoi(dataConnector.storage.configuration["doi"]), index: 1 }
       : skipToken
   );
   const source = useMemo(() => {
-    if (dataConnector.publisher_name != null) {
+    if (dataConnector?.publisher_name != null) {
       return dataConnector.publisher_name;
     }
     if (
       scope !== "global" ||
-      typeof dataConnector.storage.configuration["doi"] !== "string"
+      typeof dataConnector?.storage.configuration["doi"] !== "string"
     ) {
-      return dataConnector.namespace || "unknown";
+      return dataConnector?.namespace || "unknown";
     }
 
     if (
@@ -260,9 +262,9 @@ export function useGetDataConnectorSource(dataConnector: DataConnector) {
       return dataConnector.storage.configuration["doi"];
     }
   }, [
-    dataConnector.namespace,
-    dataConnector.storage.configuration,
-    dataConnector.publisher_name,
+    dataConnector?.namespace,
+    dataConnector?.storage.configuration,
+    dataConnector?.publisher_name,
     isSuccess,
     resolverResponse,
     scope,

--- a/client/src/features/dataConnectorsV2/deposits/DepositActions.tsx
+++ b/client/src/features/dataConnectorsV2/deposits/DepositActions.tsx
@@ -190,7 +190,7 @@ interface DepositRemovalModalProps {
   onDelete: () => void;
   toggleModal: () => void;
 }
-function DepositRemovalModal({
+export function DepositRemovalModal({
   deposit,
   onDelete,
   toggleModal,
@@ -284,7 +284,7 @@ interface DepositLogsModalProps {
   isOpen: boolean;
   toggleModal: () => void;
 }
-function DepositLogsModal({
+export function DepositLogsModal({
   deposit,
   toggleModal,
   isOpen,

--- a/client/src/features/dataConnectorsV2/deposits/DepositCreationModal.tsx
+++ b/client/src/features/dataConnectorsV2/deposits/DepositCreationModal.tsx
@@ -29,7 +29,7 @@ import { PROVIDER_OPTIONS } from "./deposits.constants";
 import { CreateDepositionForm } from "./deposits.types";
 
 interface DepositCreationModalProps {
-  dataConnector: DataConnectorRead;
+  dataConnector?: DataConnectorRead | null;
   isOpen: boolean;
   setOpen: (isOpen: boolean) => void;
   toggleModal: () => void;
@@ -89,14 +89,14 @@ export default function DepositCreationModal({
     (data: CreateDepositionForm) => {
       postDeposit({
         depositPost: {
-          data_connector_id: dataConnector.id,
+          data_connector_id: dataConnector?.id ?? "",
           name: data.name,
           path: data.path,
           provider: data.provider,
         },
       });
     },
-    [dataConnector.id, postDeposit]
+    [dataConnector?.id, postDeposit]
   );
 
   useEffect(() => {

--- a/client/src/features/dataConnectorsV2/show/DataConnectorPageLayout.tsx
+++ b/client/src/features/dataConnectorsV2/show/DataConnectorPageLayout.tsx
@@ -4,10 +4,7 @@ import { generatePath } from "react-router";
 import { Col, Row } from "reactstrap";
 
 import ContainerWrap from "~/components/container/ContainerWrap";
-import {
-  EntityWatermark,
-  EntityWatermarkPlaceholder,
-} from "~/components/entityWatermark/EntityWatermark";
+import { EntityWatermark } from "~/components/entityWatermark/EntityWatermark";
 import PageNav, { PageNavOptions } from "~/components/PageNav";
 import GroupNew from "~/features/groupsV2/new/GroupNew";
 import ProjectV2New from "~/features/projectsV2/new/ProjectV2New";
@@ -54,13 +51,7 @@ export default function DataConnectorPageLayout({
               <DataConnectorHeader name={dataConnector.name} />
             </Col>
             <Col className={cx("d-md-block", "d-none")} md="auto">
-              <div className="position-relative">
-                <EntityWatermarkPlaceholder />
-                <EntityWatermark
-                  className={cx("end-0", "position-absolute", "top-0")}
-                  type="dataConnector"
-                />
-              </div>
+              <EntityWatermark type="dataConnector" />
             </Col>
           </Row>
         </Col>

--- a/client/src/features/dataConnectorsV2/show/DataConnectorPageLayout.tsx
+++ b/client/src/features/dataConnectorsV2/show/DataConnectorPageLayout.tsx
@@ -79,5 +79,9 @@ interface DataConnectorHeaderProps {
   name: string;
 }
 function DataConnectorHeader({ name }: DataConnectorHeaderProps) {
-  return <h1 data-cy="data-connector-name">{name}</h1>;
+  return (
+    <h1 className={cx("mb-0", "text-break")} data-cy="data-connector-name">
+      {name}
+    </h1>
+  );
 }

--- a/client/src/features/dataConnectorsV2/show/DataConnectorPageLayout.tsx
+++ b/client/src/features/dataConnectorsV2/show/DataConnectorPageLayout.tsx
@@ -1,0 +1,83 @@
+import cx from "classnames";
+import { ReactNode } from "react";
+import { generatePath } from "react-router";
+import { Col, Row } from "reactstrap";
+
+import ContainerWrap from "~/components/container/ContainerWrap";
+import {
+  EntityWatermark,
+  EntityWatermarkPlaceholder,
+} from "~/components/entityWatermark/EntityWatermark";
+import PageNav, { PageNavOptions } from "~/components/PageNav";
+import GroupNew from "~/features/groupsV2/new/GroupNew";
+import ProjectV2New from "~/features/projectsV2/new/ProjectV2New";
+import { ABSOLUTE_ROUTES } from "~/routing/routes.constants";
+import { DataConnectorRead } from "../api/data-connectors.api";
+
+interface DataConnectorPageLayoutProps {
+  dataConnector: DataConnectorRead;
+  children?: ReactNode;
+  routeParams: {
+    projectNamespace: string | null;
+    dataConnectorNamespace: string | null;
+    slug: string;
+  };
+}
+export default function DataConnectorPageLayout({
+  dataConnector,
+  children,
+  routeParams,
+}: DataConnectorPageLayoutProps) {
+  const options: PageNavOptions = {
+    overviewUrl: generatePath(ABSOLUTE_ROUTES.v2.dataConnectors.show.root, {
+      dataConnectorNamespace: routeParams.dataConnectorNamespace,
+      projectNamespace: routeParams.projectNamespace,
+      slug: routeParams.slug,
+    }),
+    settingsUrl: generatePath(ABSOLUTE_ROUTES.v2.dataConnectors.show.settings, {
+      dataConnectorNamespace: routeParams.dataConnectorNamespace,
+      projectNamespace: routeParams.projectNamespace,
+      slug: routeParams.slug,
+    }),
+    type: "dataConnector",
+  };
+
+  return (
+    <ContainerWrap>
+      <ProjectV2New />
+      <GroupNew />
+
+      <Row className="my-3">
+        <Col xs={12}>
+          <Row>
+            <Col className="mb-3">
+              <DataConnectorHeader name={dataConnector.name} />
+            </Col>
+            <Col className={cx("d-md-block", "d-none")} md="auto">
+              <div className="position-relative">
+                <EntityWatermarkPlaceholder />
+                <EntityWatermark
+                  className={cx("end-0", "position-absolute", "top-0")}
+                  type="dataConnector"
+                />
+              </div>
+            </Col>
+          </Row>
+        </Col>
+        <Col xs={12} className="mb-3">
+          <PageNav options={options} />
+        </Col>
+        <Col xs={12}>
+          <main>{children}</main>
+        </Col>
+      </Row>
+    </ContainerWrap>
+  );
+}
+
+interface DataConnectorHeaderProps {
+  name: string;
+}
+function DataConnectorHeader({ name }: DataConnectorHeaderProps) {
+  return <h1 data-cy="data-connector-name">{name}</h1>;
+}

--- a/client/src/features/dataConnectorsV2/show/DataConnectorPageLayout.tsx
+++ b/client/src/features/dataConnectorsV2/show/DataConnectorPageLayout.tsx
@@ -47,6 +47,9 @@ export default function DataConnectorPageLayout({
       <Row className="my-3">
         <Col xs={12}>
           <Row>
+            <Col className={cx("d-block", "d-md-none")} xs={12}>
+              <span className="text-muted">Data connector</span>
+            </Col>
             <Col className="mb-3">
               <DataConnectorHeader name={dataConnector.name} />
             </Col>

--- a/client/src/features/dataConnectorsV2/show/DataConnectorSettings.tsx
+++ b/client/src/features/dataConnectorsV2/show/DataConnectorSettings.tsx
@@ -1,6 +1,16 @@
+import { skipToken } from "@reduxjs/toolkit/query";
 import cx from "classnames";
 import { useCallback, useMemo, useState } from "react";
-import { Pencil, Plug, Sliders, Trash } from "react-bootstrap-icons";
+import {
+  CloudArrowUp,
+  DatabaseLock,
+  FileEarmarkText,
+  Lock,
+  Pencil,
+  Plug,
+  Sliders,
+  Trash,
+} from "react-bootstrap-icons";
 import { generatePath, useNavigate } from "react-router";
 import { Button, Card, CardBody, CardHeader } from "reactstrap";
 
@@ -8,9 +18,23 @@ import { InfoAlert } from "~/components/Alert";
 import PermissionsGuard from "~/features/permissionsV2/PermissionsGuard";
 import { useNamespaceContext } from "~/features/searchV2/hooks/useNamespaceContext.hook";
 import { ABSOLUTE_ROUTES } from "~/routing/routes.constants";
+import { useGetDataConnectorsByDataConnectorIdDepositsQuery } from "../api/data-connectors.enhanced-api";
 import { getDataConnectorScope } from "../components/dataConnector.utils";
 import { DataConnectorRemoveDeleteModal } from "../components/DataConnectorActions";
+import DataConnectorCredentialsModal from "../components/DataConnectorCredentialsModal";
 import DataConnectorModal from "../components/DataConnectorModal";
+import { DataConnectorLastDepositBody } from "../components/DataConnectorView";
+import {
+  DepositLogsModal,
+  DepositRemovalModal,
+} from "../deposits/DepositActions";
+import DepositCreationModal from "../deposits/DepositCreationModal";
+import DepositEditModal from "../deposits/DepositEditModal";
+import DepositFinalizationModal from "../deposits/DepositFinalizationModal";
+import {
+  LAST_DEPOSIT_QUERY_PARAMS,
+  POLL_TIME_INACTIVE_DEPOSITS,
+} from "../deposits/deposits.constants";
 import useDataConnectorPermissions from "../utils/useDataConnectorPermissions.hook";
 
 export default function DataConnectorSettings() {
@@ -26,7 +50,7 @@ export default function DataConnectorSettings() {
     dataConnectorId: dataConnector?.id,
   });
 
-  // modals
+  // General and connection settings modals
   const [isGeneralSettingsOpen, setIsGeneralSettingsOpen] = useState(false);
   const toggleGeneralSettings = useCallback(() => {
     setIsGeneralSettingsOpen((open) => !open);
@@ -37,6 +61,7 @@ export default function DataConnectorSettings() {
     setIsConnectionInformationOpen((open) => !open);
   }, []);
 
+  // Delete modal
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
   const toggleDelete = useCallback(() => {
     setIsDeleteOpen((open) => !open);
@@ -46,6 +71,56 @@ export default function DataConnectorSettings() {
     const homeUrl = generatePath(ABSOLUTE_ROUTES.v2.index);
     navigate(homeUrl);
   }, [navigate]);
+
+  // Credentials modal
+  const [isCredentialsOpen, setCredentialsOpen] = useState(false);
+  const toggleCredentials = useCallback(() => {
+    setCredentialsOpen((open) => !open);
+  }, []);
+  const sensitiveFields = dataConnector?.storage.sensitive_fields
+    ? dataConnector.storage.sensitive_fields.map((f) => f.name)
+    : [];
+  const anySensitiveField = Object.keys(
+    dataConnector?.storage.configuration ?? {}
+  ).some((key) => sensitiveFields.includes(key));
+
+  // Deposits
+  const [isNewDepositOpen, setNewDepositOpen] = useState(false);
+  const [isEditDepositOpen, setEditDepositOpen] = useState(false);
+  const [isFinalizationDepositOpen, setFinalizationDepositOpen] =
+    useState(false);
+  const [isShowDepositLogsOpen, setShowDepositLogsOpen] = useState(false);
+  const [isDeleteDepositOpen, setDeleteDepositOpen] = useState(false);
+
+  const toggleNewDeposit = useCallback(() => {
+    setNewDepositOpen((open) => !open);
+  }, []);
+  const toggleEditDeposit = useCallback(() => {
+    setEditDepositOpen((open) => !open);
+  }, []);
+  const toggleFinalizationDepositOpen = useCallback(() => {
+    setFinalizationDepositOpen((open) => !open);
+  }, []);
+  const toggleShowDepositLogsOpen = useCallback(() => {
+    setShowDepositLogsOpen((open) => !open);
+  }, []);
+  const toggleDeleteDepositOpen = useCallback(() => {
+    setDeleteDepositOpen((open) => !open);
+  }, []);
+
+  const deposits = useGetDataConnectorsByDataConnectorIdDepositsQuery(
+    dataConnector?.id
+      ? {
+          dataConnectorId: dataConnector.id,
+          params: LAST_DEPOSIT_QUERY_PARAMS,
+        }
+      : skipToken,
+    { pollingInterval: POLL_TIME_INACTIVE_DEPOSITS }
+  );
+  const lastDeposit = useMemo(() => {
+    if (!deposits.data || deposits.data.deposits.length === 0) return undefined;
+    return deposits.data.deposits[0];
+  }, [deposits.data]);
 
   if (scope === "global") {
     return (
@@ -140,15 +215,135 @@ export default function DataConnectorSettings() {
           </CardBody>
         </Card>
 
+        {anySensitiveField && (
+          <Card data-cy="data-connector-credentials-settings">
+            <CardHeader>
+              <h2 className="mb-0">
+                <Lock className="me-1" />
+                Credentials
+              </h2>
+            </CardHeader>
+            <CardBody>
+              <p>Manage the credentials for this data connector.</p>
+
+              <div className={cx("d-flex", "gap-2")}>
+                <PermissionsGuard
+                  disabled={null}
+                  enabled={
+                    <Button
+                      className="ms-auto"
+                      color="primary"
+                      data-cy="data-connector-credentials-settings-button"
+                      onClick={toggleCredentials}
+                    >
+                      <Lock className="me-1" />
+                      Manage credentials
+                    </Button>
+                  }
+                  requestedPermission="write"
+                  userPermissions={permissions}
+                />
+              </div>
+            </CardBody>
+          </Card>
+        )}
+
+        {permissions?.write && (
+          <Card data-cy="data-connector-deposits-settings">
+            <CardHeader>
+              <h2 className="mb-0">
+                <CloudArrowUp className="me-1" />
+                Data export
+              </h2>
+            </CardHeader>
+            <CardBody>
+              {lastDeposit ? (
+                <>
+                  <DataConnectorLastDepositBody deposit={lastDeposit} />
+                </>
+              ) : (
+                <>
+                  <p>
+                    You can export data from this data connector to a supported
+                    external platform.
+                  </p>
+                </>
+              )}
+              <div className="d-flex">
+                <div className={cx("ms-auto", "d-flex", "gap-2")}>
+                  {!lastDeposit && (
+                    <Button
+                      color="primary"
+                      data-cy="data-connector-deposits-export-button"
+                      onClick={toggleNewDeposit}
+                    >
+                      <CloudArrowUp className={cx("bi", "me-1")} />
+                      Export data
+                    </Button>
+                  )}
+
+                  {lastDeposit && (
+                    <Button
+                      color="outline-danger"
+                      data-cy="data-connector-deposits-delete-button"
+                      onClick={toggleDeleteDepositOpen}
+                    >
+                      <Trash className={cx("bi", "me-1")} />
+                      Delete
+                    </Button>
+                  )}
+                  {lastDeposit && lastDeposit.status !== "complete" && (
+                    <Button
+                      color={
+                        lastDeposit.status === "upload_complete"
+                          ? "outline-primary"
+                          : "primary"
+                      }
+                      data-cy="data-connector-deposits-edit-button"
+                      onClick={toggleEditDeposit}
+                    >
+                      <Pencil className={cx("me-1", "bi")} />
+                      Edit or rerun
+                    </Button>
+                  )}
+                  {lastDeposit && lastDeposit.status === "upload_complete" && (
+                    <>
+                      <Button
+                        color="outline-primary"
+                        data-cy="data-connector-deposits-show-logs-button"
+                        onClick={toggleShowDepositLogsOpen}
+                      >
+                        <FileEarmarkText className={cx("bi", "me-1")} />
+                        Show logs
+                      </Button>
+                      <Button
+                        color="primary"
+                        data-cy="data-connector-deposits-finalize-button"
+                        onClick={toggleFinalizationDepositOpen}
+                      >
+                        <DatabaseLock className={cx("me-1", "bi")} />
+                        Finalize
+                      </Button>
+                    </>
+                  )}
+                </div>
+              </div>
+            </CardBody>
+          </Card>
+        )}
+
         <Card data-cy="data-connector-delete-settings">
           <CardHeader>
             <h2 className="mb-0">
               <Trash className="me-1" />
-              Delete data connector
+              Delete permanently
             </h2>
           </CardHeader>
           <CardBody>
-            <p>Delete a data connector. This action cannot be undone!</p>
+            <p>
+              Delete this data connector permanently. This action cannot be
+              undone!
+            </p>
 
             <div className={cx("d-flex", "gap-2")}>
               <PermissionsGuard
@@ -190,6 +385,49 @@ export default function DataConnectorSettings() {
         onDelete={onDelete}
         toggleModal={toggleDelete}
       />
+
+      <DataConnectorCredentialsModal
+        dataConnector={dataConnector}
+        setOpen={setCredentialsOpen}
+        isOpen={isCredentialsOpen}
+      />
+
+      <DepositCreationModal
+        dataConnector={dataConnector}
+        isOpen={isNewDepositOpen}
+        setOpen={setNewDepositOpen}
+        toggleModal={toggleNewDeposit}
+      />
+
+      {lastDeposit && (
+        <>
+          <DepositEditModal
+            deposit={lastDeposit}
+            isOpen={isEditDepositOpen}
+            setOpen={toggleEditDeposit}
+          />
+
+          <DepositRemovalModal
+            deposit={lastDeposit}
+            isOpen={isDeleteDepositOpen}
+            onDelete={() => setDeleteDepositOpen(false)}
+            toggleModal={toggleDeleteDepositOpen}
+          />
+
+          <DepositLogsModal
+            deposit={lastDeposit}
+            isOpen={isShowDepositLogsOpen}
+            toggleModal={toggleShowDepositLogsOpen}
+          />
+
+          <DepositFinalizationModal
+            deposit={lastDeposit}
+            isOpen={isFinalizationDepositOpen}
+            setOpen={() => setFinalizationDepositOpen(true)}
+            toggleModal={toggleFinalizationDepositOpen}
+          />
+        </>
+      )}
     </>
   );
 }

--- a/client/src/features/dataConnectorsV2/show/DataConnectorSettings.tsx
+++ b/client/src/features/dataConnectorsV2/show/DataConnectorSettings.tsx
@@ -1,12 +1,15 @@
 import cx from "classnames";
 import { useCallback, useMemo, useState } from "react";
-import { Pencil, Plug, Sliders } from "react-bootstrap-icons";
+import { Pencil, Plug, Sliders, Trash } from "react-bootstrap-icons";
+import { generatePath, useNavigate } from "react-router";
 import { Button, Card, CardBody, CardHeader } from "reactstrap";
 
 import { InfoAlert } from "~/components/Alert";
 import PermissionsGuard from "~/features/permissionsV2/PermissionsGuard";
 import { useNamespaceContext } from "~/features/searchV2/hooks/useNamespaceContext.hook";
+import { ABSOLUTE_ROUTES } from "~/routing/routes.constants";
 import { getDataConnectorScope } from "../components/dataConnector.utils";
+import { DataConnectorRemoveDeleteModal } from "../components/DataConnectorActions";
 import DataConnectorModal from "../components/DataConnectorModal";
 import useDataConnectorPermissions from "../utils/useDataConnectorPermissions.hook";
 
@@ -33,6 +36,16 @@ export default function DataConnectorSettings() {
   const toggleConnectionInformation = useCallback(() => {
     setIsConnectionInformationOpen((open) => !open);
   }, []);
+
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+  const toggleDelete = useCallback(() => {
+    setIsDeleteOpen((open) => !open);
+  }, []);
+  const navigate = useNavigate();
+  const onDelete = useCallback(() => {
+    const homeUrl = generatePath(ABSOLUTE_ROUTES.v2.index);
+    navigate(homeUrl);
+  }, [navigate]);
 
   if (scope === "global") {
     return (
@@ -113,11 +126,42 @@ export default function DataConnectorSettings() {
                   <Button
                     className="ms-auto"
                     color="primary"
-                    data-cy="data-connector-general-settings-update-button"
+                    data-cy="data-connector-connection-settings-update-button"
                     onClick={toggleConnectionInformation}
                   >
                     <Pencil className="me-1" />
                     Edit
+                  </Button>
+                }
+                requestedPermission="write"
+                userPermissions={permissions}
+              />
+            </div>
+          </CardBody>
+        </Card>
+
+        <Card data-cy="data-connector-delete-settings">
+          <CardHeader>
+            <h2 className="mb-0">
+              <Trash className="me-1" />
+              Delete data connector
+            </h2>
+          </CardHeader>
+          <CardBody>
+            <p>Delete a data connector. This action cannot be undone!</p>
+
+            <div className={cx("d-flex", "gap-2")}>
+              <PermissionsGuard
+                disabled={null}
+                enabled={
+                  <Button
+                    className="ms-auto"
+                    color="danger"
+                    data-cy="data-connector-delete-settings-button"
+                    onClick={toggleDelete}
+                  >
+                    <Trash className="me-1" />
+                    Delete
                   </Button>
                 }
                 requestedPermission="write"
@@ -138,6 +182,13 @@ export default function DataConnectorSettings() {
             : toggleConnectionInformation
         }
         initialStep={isGeneralSettingsOpen ? 3 : 2}
+      />
+
+      <DataConnectorRemoveDeleteModal
+        dataConnector={dataConnector}
+        isOpen={isDeleteOpen}
+        onDelete={onDelete}
+        toggleModal={toggleDelete}
       />
     </>
   );

--- a/client/src/features/dataConnectorsV2/show/DataConnectorSettings.tsx
+++ b/client/src/features/dataConnectorsV2/show/DataConnectorSettings.tsx
@@ -1,0 +1,39 @@
+import cx from "classnames";
+import { PersonGear, Sliders } from "react-bootstrap-icons";
+import { Card, CardBody, CardHeader } from "reactstrap";
+
+export default function DataConnectorSettings() {
+  return (
+    <div className={cx("d-flex", "flex-column", "gap-3")}>
+      <section>
+        <Card data-cy="data-connector-general-settings">
+          <CardHeader>
+            <h2 className="mb-0">
+              <Sliders className={cx("me-1", "bi")} />
+              General settings
+            </h2>
+          </CardHeader>
+          <CardBody>
+            {/* <GroupMetadataForm group={group} /> */}
+            WIP
+          </CardBody>
+        </Card>
+      </section>
+
+      <section>
+        <Card data-cy="data-connector-members-settings">
+          <CardHeader>
+            <h2 className="mb-0">
+              <PersonGear className={cx("me-1", "bi")} />
+              Data Connector Members
+            </h2>
+          </CardHeader>
+          <CardBody>
+            {/* <GroupSettingsMembers group={group} /> */}
+            WIP
+          </CardBody>
+        </Card>
+      </section>
+    </div>
+  );
+}

--- a/client/src/features/dataConnectorsV2/show/DataConnectorSettings.tsx
+++ b/client/src/features/dataConnectorsV2/show/DataConnectorSettings.tsx
@@ -1,39 +1,144 @@
 import cx from "classnames";
-import { PersonGear, Sliders } from "react-bootstrap-icons";
-import { Card, CardBody, CardHeader } from "reactstrap";
+import { useCallback, useMemo, useState } from "react";
+import { Pencil, Plug, Sliders } from "react-bootstrap-icons";
+import { Button, Card, CardBody, CardHeader } from "reactstrap";
+
+import { InfoAlert } from "~/components/Alert";
+import PermissionsGuard from "~/features/permissionsV2/PermissionsGuard";
+import { useNamespaceContext } from "~/features/searchV2/hooks/useNamespaceContext.hook";
+import { getDataConnectorScope } from "../components/dataConnector.utils";
+import DataConnectorModal from "../components/DataConnectorModal";
+import useDataConnectorPermissions from "../utils/useDataConnectorPermissions.hook";
 
 export default function DataConnectorSettings() {
+  const ctx = useNamespaceContext();
+  const dataConnector = ctx.kind === "dataConnector" ? ctx.dataConnector : null;
+
+  const scope = useMemo(
+    () => getDataConnectorScope(dataConnector?.namespace),
+    [dataConnector?.namespace]
+  );
+
+  const { permissions } = useDataConnectorPermissions({
+    dataConnectorId: dataConnector?.id,
+  });
+
+  // modals
+  const [isGeneralSettingsOpen, setIsGeneralSettingsOpen] = useState(false);
+  const toggleGeneralSettings = useCallback(() => {
+    setIsGeneralSettingsOpen((open) => !open);
+  }, []);
+  const [isConnectionInformationOpen, setIsConnectionInformationOpen] =
+    useState(false);
+  const toggleConnectionInformation = useCallback(() => {
+    setIsConnectionInformationOpen((open) => !open);
+  }, []);
+
+  if (scope === "global") {
+    return (
+      <Card data-cy="data-connector-general-settings">
+        <CardHeader>
+          <h2 className="mb-0">
+            <Sliders className={cx("me-1", "bi")} />
+            Settings
+          </h2>
+        </CardHeader>
+        <CardBody>
+          <InfoAlert timeout={0}>
+            This data connector is imported from an external source and is
+            shared across the entire Renku instance.
+          </InfoAlert>
+          <p className="mb-0">
+            Global data connectors cannot be manually changed.
+          </p>
+        </CardBody>
+      </Card>
+    );
+  }
+
   return (
-    <div className={cx("d-flex", "flex-column", "gap-3")}>
-      <section>
+    <>
+      <div className={cx("d-flex", "flex-column", "gap-4")}>
         <Card data-cy="data-connector-general-settings">
           <CardHeader>
             <h2 className="mb-0">
-              <Sliders className={cx("me-1", "bi")} />
+              <Sliders className="me-1" />
               General settings
             </h2>
           </CardHeader>
           <CardBody>
-            {/* <GroupMetadataForm group={group} /> */}
-            WIP
+            <p>
+              Change generic properties like name, owner, visibility, access
+              mode, keywords, and mount point.
+            </p>
+
+            <div className={cx("d-flex", "gap-2")}>
+              <PermissionsGuard
+                disabled={null}
+                enabled={
+                  <Button
+                    className="ms-auto"
+                    color="primary"
+                    data-cy="data-connector-general-settings-update-button"
+                    onClick={toggleGeneralSettings}
+                  >
+                    <Pencil className="me-1" />
+                    Edit
+                  </Button>
+                }
+                requestedPermission="write"
+                userPermissions={permissions}
+              />
+            </div>
           </CardBody>
         </Card>
-      </section>
 
-      <section>
-        <Card data-cy="data-connector-members-settings">
+        <Card data-cy="data-connector-connection-settings">
           <CardHeader>
             <h2 className="mb-0">
-              <PersonGear className={cx("me-1", "bi")} />
-              Data Connector Members
+              <Plug className="me-1" />
+              Connection information
             </h2>
           </CardHeader>
           <CardBody>
-            {/* <GroupSettingsMembers group={group} /> */}
-            WIP
+            <p>
+              Change fields specific to the type of data connector. Mind that
+              you cannot change the type of data connector.
+            </p>
+
+            <div className={cx("d-flex", "gap-2")}>
+              <PermissionsGuard
+                disabled={null}
+                enabled={
+                  <Button
+                    className="ms-auto"
+                    color="primary"
+                    data-cy="data-connector-general-settings-update-button"
+                    onClick={toggleConnectionInformation}
+                  >
+                    <Pencil className="me-1" />
+                    Edit
+                  </Button>
+                }
+                requestedPermission="write"
+                userPermissions={permissions}
+              />
+            </div>
           </CardBody>
         </Card>
-      </section>
-    </div>
+      </div>
+
+      <DataConnectorModal
+        dataConnector={dataConnector}
+        isOpen={isGeneralSettingsOpen || isConnectionInformationOpen}
+        namespace={dataConnector?.namespace}
+        toggle={
+          isGeneralSettingsOpen
+            ? toggleGeneralSettings
+            : toggleConnectionInformation
+        }
+        initialStep={isGeneralSettingsOpen ? 3 : 2}
+      />
+    </>
   );
 }

--- a/client/src/features/dataConnectorsV2/show/DataConnectorSettings.tsx
+++ b/client/src/features/dataConnectorsV2/show/DataConnectorSettings.tsx
@@ -11,7 +11,7 @@ import {
   Sliders,
   Trash,
 } from "react-bootstrap-icons";
-import { generatePath, useNavigate } from "react-router";
+import { generatePath } from "react-router";
 import { Button, Card, CardBody, CardHeader } from "reactstrap";
 
 import { InfoAlert } from "~/components/Alert";
@@ -66,11 +66,6 @@ export default function DataConnectorSettings() {
   const toggleDelete = useCallback(() => {
     setIsDeleteOpen((open) => !open);
   }, []);
-  const navigate = useNavigate();
-  const onDelete = useCallback(() => {
-    const homeUrl = generatePath(ABSOLUTE_ROUTES.v2.index);
-    navigate(homeUrl);
-  }, [navigate]);
 
   // Credentials modal
   const [isCredentialsOpen, setCredentialsOpen] = useState(false);
@@ -382,7 +377,7 @@ export default function DataConnectorSettings() {
       <DataConnectorRemoveDeleteModal
         dataConnector={dataConnector}
         isOpen={isDeleteOpen}
-        onDelete={onDelete}
+        redirectOnSuccess={generatePath(ABSOLUTE_ROUTES.v2.index)}
         toggleModal={toggleDelete}
       />
 

--- a/client/src/features/dataConnectorsV2/show/DataConnectorShow.tsx
+++ b/client/src/features/dataConnectorsV2/show/DataConnectorShow.tsx
@@ -1,8 +1,215 @@
+import cx from "classnames";
+import { useMemo } from "react";
+import {
+  Globe2,
+  InfoCircle,
+  Journals,
+  Lock,
+  PersonBadge,
+} from "react-bootstrap-icons";
+import { Card, CardBody, CardHeader, Col, Row } from "reactstrap";
+
+import { Clipboard } from "~/components/clipboard/Clipboard";
+import ExternalLink from "~/components/ExternalLink";
+import KeywordBadge from "~/components/keywords/KeywordBadge";
+import KeywordContainer from "~/components/keywords/KeywordContainer";
+import LazyMarkdown from "~/components/markdown/LazyMarkdown";
+import { useNamespaceContext } from "~/features/searchV2/hooks/useNamespaceContext.hook";
+import {
+  getDataConnectorScope,
+  parseDoi,
+  useGetDataConnectorSource,
+} from "../components/dataConnector.utils";
+
 export default function DataConnectorShow() {
   // APIs to use:
   // 3-segments: /namespaces/{namespace}/projects/{project}/data_connectors/{slug}
   // 2-segments: /namespaces/{namespace}/data_connectors/{slug}
   // 1-segment:  /data_connectors/global/{slug}
 
-  return <p>Data connector page</p>;
+  return (
+    <Row className="g-4">
+      <Col xs={12} md={8} xl={9}>
+        <Row className="g-4">
+          <Col xs={12}>
+            <DataConnectorInformation />
+          </Col>
+        </Row>
+      </Col>
+      <Col xs={12} md={4} xl={3}>
+        <DataConnectorCredentials />
+      </Col>
+    </Row>
+  );
+}
+
+function DataConnectorInformation() {
+  const ctx = useNamespaceContext();
+  const { kind } = ctx;
+  const dataConnector = ctx.kind === "dataConnector" ? ctx.dataConnector : null;
+
+  const scope = useMemo(
+    () => getDataConnectorScope(dataConnector?.namespace),
+    [dataConnector]
+  );
+
+  const identifier = useMemo(
+    () =>
+      scope === "global"
+        ? `${dataConnector?.slug}`
+        : `${dataConnector?.namespace}/${dataConnector?.slug}`,
+    [dataConnector?.namespace, dataConnector?.slug, scope]
+  );
+
+  const dataConnectorSource = useGetDataConnectorSource(
+    dataConnector ?? undefined
+  );
+
+  const doiReference = useMemo(() => {
+    if (!dataConnector) return null;
+    const doi =
+      scope === "global" &&
+      dataConnector.storage.configuration["doi"] &&
+      typeof dataConnector.storage.configuration["doi"] === "string"
+        ? parseDoi(dataConnector.storage.configuration["doi"])
+        : null;
+    if (doi) {
+      return doi;
+    }
+    if (dataConnector.doi) {
+      return parseDoi(dataConnector.doi);
+    }
+    return null;
+  }, [dataConnector, scope]);
+
+  const sortedKeywords = useMemo(() => {
+    if (!dataConnector?.keywords) return [];
+    return dataConnector.keywords
+      .map((keyword) => keyword.trim())
+      .sort((a, b) => a.localeCompare(b));
+  }, [dataConnector]);
+
+  if (!ctx || kind !== "dataConnector" || !dataConnector) return null;
+
+  return (
+    <Card data-cy="group-info-card">
+      <CardHeader>
+        <div
+          className={cx(
+            "align-items-center",
+            "d-flex",
+            "justify-content-between"
+          )}
+        >
+          <h2 className="mb-0">
+            <InfoCircle className={cx("me-1", "bi")} />
+            Info
+          </h2>
+        </div>
+      </CardHeader>
+      <CardBody className={cx("d-flex", "flex-column", "gap-4")}>
+        <InfoEntry title="Identifier">
+          <div className={cx("align-items-center", "d-flex", "gap-2")}>
+            {identifier}
+            <Clipboard
+              className={cx("border-0", "btn", "p-0", "shadow-none")}
+              clipboardText={identifier}
+            />
+          </div>
+        </InfoEntry>
+        {dataConnector.description && (
+          <InfoEntry title="Description">
+            <LazyMarkdown>{dataConnector.description}</LazyMarkdown>
+          </InfoEntry>
+        )}
+        <InfoEntry title="Visibility">
+          {dataConnector.visibility === "private" ? (
+            <>
+              <Lock className={cx("bi", "me-1")} />
+              Private
+            </>
+          ) : (
+            <>
+              <Globe2 className={cx("bi", "me-1")} />
+              Public
+            </>
+          )}
+
+          {/* //! TODO: dataConnectorPotentiallyInaccessible */}
+        </InfoEntry>
+
+        {scope === "global" ? (
+          <>
+            <InfoEntry title="Source">
+              <div className={cx("align-items-center", "d-flex", "gap-1")}>
+                <Journals className={cx("me-1", "flex-shrink-0")} />
+                DOI from {dataConnectorSource}
+              </div>
+            </InfoEntry>
+            <InfoEntry title="DOI">
+              <div className={cx("align-items-center", "d-flex", "gap-2")}>
+                <ExternalLink href={`https://doi.org/${doiReference}`}>
+                  {doiReference}
+                </ExternalLink>
+                <Clipboard
+                  className={cx("border-0", "btn", "p-0", "shadow-none")}
+                  clipboardText={
+                    dataConnector.storage.configuration["doi"] as string
+                  }
+                />
+              </div>
+            </InfoEntry>
+          </>
+        ) : null}
+
+        {dataConnector.keywords && dataConnector.keywords.length > 0 && (
+          <InfoEntry title="Keywords">
+            <KeywordContainer>
+              {sortedKeywords.map((keyword, index) => (
+                <KeywordBadge key={index} searchKeyword={keyword}>
+                  {keyword}
+                </KeywordBadge>
+              ))}
+            </KeywordContainer>
+          </InfoEntry>
+        )}
+      </CardBody>
+    </Card>
+  );
+}
+
+function DataConnectorCredentials() {
+  return (
+    <Card data-cy="group-credentials-card">
+      <CardHeader>
+        <h2 className="mb-0">
+          <PersonBadge className="me-1" />
+          Credentials
+        </h2>
+      </CardHeader>
+      <CardBody>
+        <p>WIP</p>
+        {/* <DataConnectorPropertyValue title="Requires credentials">
+                <span data-cy="requires-credentials-section">
+                  {anySensitiveField ? "Yes" : "No"}
+                </span>
+              </DataConnectorPropertyValue> */}
+      </CardBody>
+    </Card>
+  );
+}
+
+interface InfoEntryProps {
+  children: React.ReactNode;
+  title: string;
+}
+function InfoEntry({ children, title }: InfoEntryProps) {
+  return (
+    <div>
+      <p className={cx("mb-1", "fw-semibold")}>{title}</p>
+      <div data-cy={title.toLocaleLowerCase().replace(/\s/g, "-")}>
+        {children}
+      </div>
+    </div>
+  );
 }

--- a/client/src/features/dataConnectorsV2/show/DataConnectorShow.tsx
+++ b/client/src/features/dataConnectorsV2/show/DataConnectorShow.tsx
@@ -1,0 +1,8 @@
+export default function DataConnectorShow() {
+  // APIs to use:
+  // 3-segments: /namespaces/{namespace}/projects/{project}/data_connectors/{slug}
+  // 2-segments: /namespaces/{namespace}/data_connectors/{slug}
+  // 1-segment:  /data_connectors/global/{slug}
+
+  return <p>Data connector page</p>;
+}

--- a/client/src/features/dataConnectorsV2/show/DataConnectorShow.tsx
+++ b/client/src/features/dataConnectorsV2/show/DataConnectorShow.tsx
@@ -1,215 +1,61 @@
-import cx from "classnames";
-import { useMemo } from "react";
-import {
-  Globe2,
-  InfoCircle,
-  Journals,
-  Lock,
-  PersonBadge,
-} from "react-bootstrap-icons";
-import { Card, CardBody, CardHeader, Col, Row } from "reactstrap";
+import { Col, Row } from "reactstrap";
 
-import { Clipboard } from "~/components/clipboard/Clipboard";
-import ExternalLink from "~/components/ExternalLink";
-import KeywordBadge from "~/components/keywords/KeywordBadge";
-import KeywordContainer from "~/components/keywords/KeywordContainer";
-import LazyMarkdown from "~/components/markdown/LazyMarkdown";
 import { useNamespaceContext } from "~/features/searchV2/hooks/useNamespaceContext.hook";
-import {
-  getDataConnectorScope,
-  parseDoi,
-  useGetDataConnectorSource,
-} from "../components/dataConnector.utils";
+import DataConnectorCredentialsBox from "../components/DataConnectorCredentialsBox";
+import DataConnectorInfoBox from "../components/DataConnectorInfoBox";
+import DataConnectorProjectsBox from "../components/DataConnectorProjectsBox";
 
 export default function DataConnectorShow() {
-  // APIs to use:
-  // 3-segments: /namespaces/{namespace}/projects/{project}/data_connectors/{slug}
-  // 2-segments: /namespaces/{namespace}/data_connectors/{slug}
-  // 1-segment:  /data_connectors/global/{slug}
-
   return (
     <Row className="g-4">
       <Col xs={12} md={8} xl={9}>
         <Row className="g-4">
           <Col xs={12}>
-            <DataConnectorInformation />
+            <DataConnectorInformationWrapper />
+          </Col>
+          <Col xs={12}>
+            <DataConnectorProjectsBoxWrapper />
           </Col>
         </Row>
       </Col>
       <Col xs={12} md={4} xl={3}>
-        <DataConnectorCredentials />
+        <DataConnectorCredentialsWrapper />
       </Col>
     </Row>
   );
 }
 
-function DataConnectorInformation() {
+function DataConnectorInformationWrapper() {
   const ctx = useNamespaceContext();
   const { kind } = ctx;
   const dataConnector = ctx.kind === "dataConnector" ? ctx.dataConnector : null;
 
-  const scope = useMemo(
-    () => getDataConnectorScope(dataConnector?.namespace),
-    [dataConnector]
-  );
+  // ? Not that any of this should ever happen... Hence the return null.
+  if (!ctx || kind !== "dataConnector" || !dataConnector) return null;
 
-  const identifier = useMemo(
-    () =>
-      scope === "global"
-        ? `${dataConnector?.slug}`
-        : `${dataConnector?.namespace}/${dataConnector?.slug}`,
-    [dataConnector?.namespace, dataConnector?.slug, scope]
-  );
+  return <DataConnectorInfoBox dataConnector={dataConnector} headerTag="h2" />;
+}
 
-  const dataConnectorSource = useGetDataConnectorSource(
-    dataConnector ?? undefined
-  );
-
-  const doiReference = useMemo(() => {
-    if (!dataConnector) return null;
-    const doi =
-      scope === "global" &&
-      dataConnector.storage.configuration["doi"] &&
-      typeof dataConnector.storage.configuration["doi"] === "string"
-        ? parseDoi(dataConnector.storage.configuration["doi"])
-        : null;
-    if (doi) {
-      return doi;
-    }
-    if (dataConnector.doi) {
-      return parseDoi(dataConnector.doi);
-    }
-    return null;
-  }, [dataConnector, scope]);
-
-  const sortedKeywords = useMemo(() => {
-    if (!dataConnector?.keywords) return [];
-    return dataConnector.keywords
-      .map((keyword) => keyword.trim())
-      .sort((a, b) => a.localeCompare(b));
-  }, [dataConnector]);
+function DataConnectorCredentialsWrapper() {
+  const ctx = useNamespaceContext();
+  const { kind } = ctx;
+  const dataConnector = ctx.kind === "dataConnector" ? ctx.dataConnector : null;
 
   if (!ctx || kind !== "dataConnector" || !dataConnector) return null;
 
   return (
-    <Card data-cy="group-info-card">
-      <CardHeader>
-        <div
-          className={cx(
-            "align-items-center",
-            "d-flex",
-            "justify-content-between"
-          )}
-        >
-          <h2 className="mb-0">
-            <InfoCircle className={cx("me-1", "bi")} />
-            Info
-          </h2>
-        </div>
-      </CardHeader>
-      <CardBody className={cx("d-flex", "flex-column", "gap-4")}>
-        <InfoEntry title="Identifier">
-          <div className={cx("align-items-center", "d-flex", "gap-2")}>
-            {identifier}
-            <Clipboard
-              className={cx("border-0", "btn", "p-0", "shadow-none")}
-              clipboardText={identifier}
-            />
-          </div>
-        </InfoEntry>
-        {dataConnector.description && (
-          <InfoEntry title="Description">
-            <LazyMarkdown>{dataConnector.description}</LazyMarkdown>
-          </InfoEntry>
-        )}
-        <InfoEntry title="Visibility">
-          {dataConnector.visibility === "private" ? (
-            <>
-              <Lock className={cx("bi", "me-1")} />
-              Private
-            </>
-          ) : (
-            <>
-              <Globe2 className={cx("bi", "me-1")} />
-              Public
-            </>
-          )}
-
-          {/* //! TODO: dataConnectorPotentiallyInaccessible */}
-        </InfoEntry>
-
-        {scope === "global" ? (
-          <>
-            <InfoEntry title="Source">
-              <div className={cx("align-items-center", "d-flex", "gap-1")}>
-                <Journals className={cx("me-1", "flex-shrink-0")} />
-                DOI from {dataConnectorSource}
-              </div>
-            </InfoEntry>
-            <InfoEntry title="DOI">
-              <div className={cx("align-items-center", "d-flex", "gap-2")}>
-                <ExternalLink href={`https://doi.org/${doiReference}`}>
-                  {doiReference}
-                </ExternalLink>
-                <Clipboard
-                  className={cx("border-0", "btn", "p-0", "shadow-none")}
-                  clipboardText={
-                    dataConnector.storage.configuration["doi"] as string
-                  }
-                />
-              </div>
-            </InfoEntry>
-          </>
-        ) : null}
-
-        {dataConnector.keywords && dataConnector.keywords.length > 0 && (
-          <InfoEntry title="Keywords">
-            <KeywordContainer>
-              {sortedKeywords.map((keyword, index) => (
-                <KeywordBadge key={index} searchKeyword={keyword}>
-                  {keyword}
-                </KeywordBadge>
-              ))}
-            </KeywordContainer>
-          </InfoEntry>
-        )}
-      </CardBody>
-    </Card>
+    <DataConnectorCredentialsBox dataConnector={dataConnector} headerTag="h2" />
   );
 }
 
-function DataConnectorCredentials() {
-  return (
-    <Card data-cy="group-credentials-card">
-      <CardHeader>
-        <h2 className="mb-0">
-          <PersonBadge className="me-1" />
-          Credentials
-        </h2>
-      </CardHeader>
-      <CardBody>
-        <p>WIP</p>
-        {/* <DataConnectorPropertyValue title="Requires credentials">
-                <span data-cy="requires-credentials-section">
-                  {anySensitiveField ? "Yes" : "No"}
-                </span>
-              </DataConnectorPropertyValue> */}
-      </CardBody>
-    </Card>
-  );
-}
+function DataConnectorProjectsBoxWrapper() {
+  const ctx = useNamespaceContext();
+  const { kind } = ctx;
+  const dataConnector = ctx.kind === "dataConnector" ? ctx.dataConnector : null;
 
-interface InfoEntryProps {
-  children: React.ReactNode;
-  title: string;
-}
-function InfoEntry({ children, title }: InfoEntryProps) {
+  if (!ctx || kind !== "dataConnector" || !dataConnector) return null;
+
   return (
-    <div>
-      <p className={cx("mb-1", "fw-semibold")}>{title}</p>
-      <div data-cy={title.toLocaleLowerCase().replace(/\s/g, "-")}>
-        {children}
-      </div>
-    </div>
+    <DataConnectorProjectsBox dataConnector={dataConnector} headerTag="h2" />
   );
 }

--- a/client/src/features/dataConnectorsV2/utils/useDataConnectorPermissions.hook.ts
+++ b/client/src/features/dataConnectorsV2/utils/useDataConnectorPermissions.hook.ts
@@ -27,7 +27,7 @@ import {
 } from "../api/data-connectors.enhanced-api";
 
 interface UseDataConnectorPermissionsArgs {
-  dataConnectorId: string;
+  dataConnectorId?: string;
 }
 type UseQueryStateResult = ReturnType<
   typeof useGetDataConnectorsByDataConnectorIdPermissionsQuery

--- a/client/src/features/groupsV2/show/GroupPageLayout.tsx
+++ b/client/src/features/groupsV2/show/GroupPageLayout.tsx
@@ -49,6 +49,7 @@ export default function GroupPageLayout({
     settingsUrl: generatePath(ABSOLUTE_ROUTES.v2.groups.show.settings, {
       slug: group.slug,
     }),
+    type: "group",
   };
   return (
     <ContainerWrap>

--- a/client/src/features/groupsV2/show/GroupPageLayout.tsx
+++ b/client/src/features/groupsV2/show/GroupPageLayout.tsx
@@ -52,6 +52,7 @@ export default function GroupPageLayout({
     settingsUrl: generatePath(ABSOLUTE_ROUTES.v2.groups.show.settings, {
       slug: group.slug,
     }),
+    type: "group",
   };
   return (
     <ContainerWrap>

--- a/client/src/features/groupsV2/show/GroupPageLayout.tsx
+++ b/client/src/features/groupsV2/show/GroupPageLayout.tsx
@@ -59,6 +59,9 @@ export default function GroupPageLayout({
       <Row className="my-3">
         <Col xs={12}>
           <Row>
+            <Col className={cx("d-block", "d-md-none")} xs={12}>
+              <span className="text-muted">Group</span>
+            </Col>
             <Col className="mb-3">
               <GroupHeader group={group} slug={group.slug} />
             </Col>

--- a/client/src/features/projectsV2/notFound/DataConnectorNotFound.tsx
+++ b/client/src/features/projectsV2/notFound/DataConnectorNotFound.tsx
@@ -1,0 +1,79 @@
+import { SerializedError } from "@reduxjs/toolkit";
+import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
+import cx from "classnames";
+import { ArrowLeft } from "react-bootstrap-icons";
+import { Link, useParams } from "react-router";
+
+import ContainerWrap from "../../../components/container/ContainerWrap";
+import RtkOrDataServicesError from "../../../components/errors/RtkOrDataServicesError";
+import { ABSOLUTE_ROUTES } from "../../../routing/routes.constants";
+import rkNotFoundImgV2 from "../../../styles/assets/not-foundV2.svg";
+
+interface DataConnectorNotFoundProps {
+  error?: FetchBaseQueryError | SerializedError | undefined | null;
+}
+
+export default function DataConnectorNotFound({
+  error,
+}: DataConnectorNotFoundProps) {
+  const { dataConnectorNamespace, projectNamespace, slug } = useParams<{
+    dataConnectorNamespace?: string;
+    projectNamespace?: string;
+    slug: string;
+  }>();
+
+  const dataConnectorSlug = [projectNamespace, dataConnectorNamespace, slug]
+    .filter((value) => value != null)
+    .join("/");
+
+  const notFoundText = dataConnectorSlug ? (
+    <>
+      We could not find the data connector{" "}
+      <span className={cx("fw-bold", "user-select-all")}>
+        {dataConnectorSlug}
+      </span>
+      .
+    </>
+  ) : (
+    <>We could not find the requested data connector.</>
+  );
+
+  return (
+    <ContainerWrap>
+      <div className="d-flex">
+        <div className={cx("m-auto", "d-flex", "flex-column")}>
+          <h3
+            className={cx(
+              "text-primary",
+              "fw-bold",
+              "my-0",
+              "d-flex",
+              "align-items-center",
+              "gap-3"
+            )}
+          >
+            <img src={rkNotFoundImgV2} />
+            Data Connector not found
+          </h3>
+          <div className={cx("text-start", "mt-3")}>
+            <p>{notFoundText}</p>
+            <p>
+              It is possible that the data connector has been deleted by its
+              owner or you do not have the necessary permissions to view it.
+            </p>
+            {error && (
+              <RtkOrDataServicesError error={error} dismissible={false} />
+            )}
+            <Link
+              to={`${ABSOLUTE_ROUTES.v2.search}?type=DataConnector`}
+              className={cx("btn", "btn-primary")}
+            >
+              <ArrowLeft className={cx("bi", "me-1")} />
+              Go to the data connectors list
+            </Link>
+          </div>
+        </div>
+      </div>
+    </ContainerWrap>
+  );
+}

--- a/client/src/features/projectsV2/show/ProjectShortHandDisplay.tsx
+++ b/client/src/features/projectsV2/show/ProjectShortHandDisplay.tsx
@@ -25,13 +25,26 @@ import UserAvatar from "../../usersV2/show/UserAvatar";
 import { Project } from "../api/projectV2.api";
 import VisibilityIconV2 from "./VisibilityIconV2";
 
+type ProjectDisplayRows =
+  | "creation_or_update_time"
+  | "description"
+  | "namespace"
+  | "visibility";
+
 interface ProjectShortHandDisplayProps {
   className?: string | string[];
+  displayRows?: ProjectDisplayRows[];
   project: Project;
 }
 
 export default function ProjectShortHandDisplay({
   className,
+  displayRows = [
+    "creation_or_update_time",
+    "description",
+    "namespace",
+    "visibility",
+  ],
   project,
 }: ProjectShortHandDisplayProps) {
   const content = (
@@ -39,49 +52,37 @@ export default function ProjectShortHandDisplay({
       className={cx("d-flex", "flex-column", "flex-grow-1", "gap-1")}
       data-cy="project-item"
     >
-      <div className={cx("d-flex", "flex-column", "flex-md-row")}>
-        <p className={cx("m-0", "fw-bold", "text-truncate", "me-2")}>
-          {project.name}
-        </p>
-      </div>
+      <p className={cx("m-0", "fw-bold", "text-truncate")}>{project.name}</p>
 
-      <div
-        className={cx(
-          "d-flex",
-          "flex-row",
-          "text-truncate",
-          "gap-2",
-          "align-items-center"
-        )}
-      >
-        <UserAvatar namespace={project.namespace} size="sm" />
-        <p className={cx("mb-0", "text-truncate")}>{project.namespace}</p>
-      </div>
-
-      {project.description && (
-        <div className={cx("d-flex", "flex-column", "flex-md-row")}>
-          <p className={cx("mb-0", "text-truncate")}>{project.description}</p>
+      {displayRows.includes("namespace") && (
+        <div
+          className={cx(
+            "align-items-center",
+            "d-flex",
+            "gap-2",
+            "text-truncate"
+          )}
+        >
+          <UserAvatar namespace={project.namespace} size="sm" />
+          <p className={cx("mb-0", "text-truncate")}>{project.namespace}</p>
         </div>
       )}
 
-      <div className={cx("d-flex", "flex-column", "flex-md-row")}>
-        <VisibilityIconV2 visibility={project.visibility} />
-        {project.updated_at ? (
+      {project.description && displayRows.includes("description") && (
+        <p className={cx("mb-0", "text-truncate")}>{project.description}</p>
+      )}
+
+      {displayRows.includes("creation_or_update_time") && (
+        <div className={cx("d-flex", "flex-column", "flex-md-row")}>
+          <VisibilityIconV2 visibility={project.visibility} />
           <TimeCaption
-            className={cx("ms-0", "ms-md-auto", "my-auto", "text-truncate")}
-            datetime={project.updated_at}
+            className={cx("ms-md-auto", "my-auto", "text-truncate")}
+            datetime={project.updated_at ?? project.creation_date}
             enableTooltip
-            prefix="Updated"
+            prefix={project.updated_at ? "Updated" : "Created"}
           />
-        ) : (
-          <TimeCaption
-            className={cx("ms-auto", "my-auto", "text-truncate")}
-            datetime={project.creation_date}
-            enableTooltip
-            prefix="Created"
-          />
-        )}
-      </div>
+        </div>
+      )}
     </div>
   );
 
@@ -89,11 +90,10 @@ export default function ProjectShortHandDisplay({
     <Link
       className={cx(
         "link-primary",
-        "text-body",
-        "text-decoration-none",
-        className,
+        "list-group-item-action",
         "list-group-item",
-        "list-group-item-action"
+        "text-body",
+        className
       )}
       to={generatePath(ABSOLUTE_ROUTES.v2.projects.show.root, {
         namespace: project.namespace,

--- a/client/src/features/searchV2/components/EntityPill.tsx
+++ b/client/src/features/searchV2/components/EntityPill.tsx
@@ -74,7 +74,7 @@ export default function EntityPill({
             "border-dark-subtle",
             "border",
             "d-flex",
-            "p-2",
+            size === "sm" ? "p-1" : "p-2",
             "text-dark-emphasis",
             sizeClass
           )}

--- a/client/src/features/searchV2/hooks/useNamespaceContext.hook.ts
+++ b/client/src/features/searchV2/hooks/useNamespaceContext.hook.ts
@@ -18,10 +18,20 @@
 
 import { useOutletContext } from "react-router";
 
+import { DataConnectorRead } from "~/features/dataConnectorsV2/api/data-connectors.api";
 import type { GroupResponse } from "~/features/projectsV2/api/namespace.api";
 import type { UserWithId } from "~/features/usersV2/api/users.api";
 
 export type NamespaceContextType =
+  | {
+      dataConnector: DataConnectorRead;
+      namespace: string;
+      kind: "dataConnector";
+    }
+  | {
+      kind: "global";
+      namespace: undefined;
+    }
   | {
       kind: "group";
       namespace: string;
@@ -31,19 +41,16 @@ export type NamespaceContextType =
       kind: "user";
       namespace: string;
       user: UserWithId;
-    }
-  | {
-      kind: "global";
-      namespace: undefined;
     };
 
 export function useNamespaceContext() {
   const ctx = useOutletContext<NamespaceContextType | undefined>();
   if (!ctx) {
     return {
+      dataConnector: undefined,
+      group: undefined,
       kind: "global",
       namespace: undefined,
-      group: undefined,
       user: undefined,
     };
   }

--- a/client/src/features/usersV2/show/UserPageLayout.tsx
+++ b/client/src/features/usersV2/show/UserPageLayout.tsx
@@ -54,6 +54,7 @@ export default function UserPageLayout({
     searchUrl: generatePath(ABSOLUTE_ROUTES.v2.users.show.search, {
       username: user.username,
     }),
+    type: "user",
   };
   return (
     <ContainerWrap>

--- a/client/src/features/usersV2/show/UserPageLayout.tsx
+++ b/client/src/features/usersV2/show/UserPageLayout.tsx
@@ -57,6 +57,7 @@ export default function UserPageLayout({
     searchUrl: generatePath(ABSOLUTE_ROUTES.v2.users.show.search, {
       username: user.username,
     }),
+    type: "user",
   };
   return (
     <ContainerWrap>

--- a/client/src/features/usersV2/show/UserPageLayout.tsx
+++ b/client/src/features/usersV2/show/UserPageLayout.tsx
@@ -64,6 +64,9 @@ export default function UserPageLayout({
       <Row className="my-3">
         <Col xs={12}>
           <Row>
+            <Col className={cx("d-block", "d-md-none")} xs={12}>
+              <span className="text-muted">User</span>
+            </Col>
             <Col className="mb-3">
               <UserHeader name={name ?? ""} username={user.username} />
             </Col>

--- a/client/src/routes.ts
+++ b/client/src/routes.ts
@@ -62,6 +62,23 @@ export default [
     // Not found page for /u/*
     route("*", "routes/users/catchall.tsx"),
   ]),
+  // Data connector pages
+  ...prefix(RELATIVE_ROUTES.v2.dataConnectors.root, [
+    index("routes/dataConnectors/searchRedirect.tsx"),
+    route(
+      RELATIVE_ROUTES.v2.dataConnectors.show.root,
+      "routes/dataConnectors/root.tsx",
+      [
+        index("routes/dataConnectors/index.tsx"),
+        route(
+          RELATIVE_ROUTES.v2.dataConnectors.show.settings,
+          "routes/dataConnectors/settings.tsx"
+        ),
+      ]
+    ),
+    // Not found page for /d/*
+    route("*", "routes/dataConnectors/catchall.tsx"),
+  ]),
   // Legacy projects (may redirect)
   route(RELATIVE_ROUTES.projects.splat, "routes/legacy/projects.tsx"),
   // * matches all URLs, the ? makes it optional so it will match / as well

--- a/client/src/routes.ts
+++ b/client/src/routes.ts
@@ -60,6 +60,23 @@ export default [
     // Not found page for /u/*
     route("*", "routes/users/catchall.tsx"),
   ]),
+  // Data connector pages
+  ...prefix(RELATIVE_ROUTES.v2.dataConnectors.root, [
+    index("routes/dataConnectors/searchRedirect.tsx"),
+    route(
+      RELATIVE_ROUTES.v2.dataConnectors.show.root,
+      "routes/dataConnectors/root.tsx",
+      [
+        index("routes/dataConnectors/index.tsx"),
+        route(
+          RELATIVE_ROUTES.v2.dataConnectors.show.settings,
+          "routes/dataConnectors/settings.tsx"
+        ),
+      ]
+    ),
+    // Not found page for /d/*
+    route("*", "routes/dataConnectors/catchall.tsx"),
+  ]),
   // * matches all URLs, the ? makes it optional so it will match / as well
   route("*?", "routes/catchall.tsx"),
 ] satisfies RouteConfig;

--- a/client/src/routes/dataConnectors/catchall.tsx
+++ b/client/src/routes/dataConnectors/catchall.tsx
@@ -1,0 +1,18 @@
+import { data, type MetaDescriptor } from "react-router";
+
+import NotFound from "~/not-found/NotFound";
+import { makeMeta, makeMetaTitle } from "~/utils/meta/meta";
+
+const title = makeMetaTitle(["Page Not Found", "Renku"]);
+const meta_ = makeMeta({ title });
+
+export function meta(): MetaDescriptor[] {
+  return meta_;
+}
+export async function loader() {
+  return data(undefined, { status: 404 });
+}
+
+export default function DataConnectorCatchallPage() {
+  return <NotFound />;
+}

--- a/client/src/routes/dataConnectors/index.tsx
+++ b/client/src/routes/dataConnectors/index.tsx
@@ -1,0 +1,5 @@
+import LazyDataConnectorShow from "~/features/dataConnectorsV2/LazyDataConnectorShow";
+
+export default function DataConnectorOverviewPage() {
+  return <LazyDataConnectorShow />;
+}

--- a/client/src/routes/dataConnectors/root.tsx
+++ b/client/src/routes/dataConnectors/root.tsx
@@ -263,6 +263,11 @@ export default function DataConnectorPagesRoot({
 
   const [isCacheReady, setIsCacheReady] = useState<boolean>(false);
 
+  const shouldQuery =
+    loaderData.clientSideFetch ||
+    isCacheReady ||
+    loaderData.dataConnector == null;
+
   //? Inject the server-side data into the RTK Query cache
   useEffect(() => {
     if (loaderData.dataConnector == null) return;
@@ -325,15 +330,11 @@ export default function DataConnectorPagesRoot({
   //? * once the cache is ready (will use cache data)
   const globalQuery =
     dataConnectorsApi.endpoints.getDataConnectorsGlobalBySlug.useQuery(
-      !projectNamespace && (loaderData.clientSideFetch || isCacheReady)
-        ? { slug }
-        : skipToken
+      !projectNamespace && shouldQuery ? { slug } : skipToken
     );
 
   const namespaceQuery = useGetNamespacesByNamespaceDataConnectorsAndSlugQuery(
-    projectNamespace &&
-      !dataConnectorNamespace &&
-      (loaderData.clientSideFetch || isCacheReady)
+    projectNamespace && !dataConnectorNamespace && shouldQuery
       ? {
           namespace: projectNamespace,
           slug,
@@ -343,9 +344,7 @@ export default function DataConnectorPagesRoot({
 
   const projectQuery =
     useGetNamespacesByNamespaceProjectsAndProjectDataConnectorsSlugQuery(
-      projectNamespace &&
-        dataConnectorNamespace &&
-        (loaderData.clientSideFetch || isCacheReady)
+      projectNamespace && dataConnectorNamespace && shouldQuery
         ? {
             namespace: projectNamespace,
             project: dataConnectorNamespace,
@@ -354,15 +353,17 @@ export default function DataConnectorPagesRoot({
         : skipToken
     );
 
-  const {
-    currentData: dataConnector,
-    isLoading,
-    error,
-  } = projectNamespace && dataConnectorNamespace
-    ? projectQuery
-    : projectNamespace
-    ? namespaceQuery
-    : globalQuery;
+  const queryResult =
+    projectNamespace && dataConnectorNamespace
+      ? projectQuery
+      : projectNamespace
+      ? namespaceQuery
+      : globalQuery;
+
+  const dataConnector = queryResult.currentData ?? loaderData.dataConnector;
+  const error =
+    queryResult.error ?? (dataConnector == null ? loaderData.error : undefined);
+  const isLoading = queryResult.isLoading || queryResult.isFetching;
 
   useEffect(() => {
     if (dataConnector == null) return;

--- a/client/src/routes/dataConnectors/root.tsx
+++ b/client/src/routes/dataConnectors/root.tsx
@@ -17,6 +17,7 @@ import {
   useGetNamespacesByNamespaceProjectsAndProjectDataConnectorsSlugQuery,
 } from "~/features/dataConnectorsV2/api/data-connectors.enhanced-api";
 import DataConnectorPageLayout from "~/features/dataConnectorsV2/show/DataConnectorPageLayout";
+import DataConnectorNotFound from "~/features/projectsV2/notFound/DataConnectorNotFound";
 import { NamespaceContextType } from "~/features/searchV2/hooks/useNamespaceContext.hook";
 import { ABSOLUTE_ROUTES } from "~/routing/routes.constants";
 import { store } from "~/store/store";
@@ -426,9 +427,7 @@ export default function DataConnectorPagesRoot({
   }
 
   if (error || dataConnector == null) {
-    return <h1>TODO: DC not found</h1>;
-    // ! Implement that "not found" page
-    // return <DataConnectorNotFound error={error ?? loaderData.error} />;
+    return <DataConnectorNotFound error={error ?? loaderData.error} />;
   }
 
   const routeParams = {

--- a/client/src/routes/dataConnectors/root.tsx
+++ b/client/src/routes/dataConnectors/root.tsx
@@ -21,6 +21,7 @@ import { NamespaceContextType } from "~/features/searchV2/hooks/useNamespaceCont
 import { ABSOLUTE_ROUTES } from "~/routing/routes.constants";
 import { store } from "~/store/store";
 import { storeContext } from "~/store/store.utils.server";
+import renkuDataConnectorSocialCard from "~/styles/assets/renkuDataSocialCard.png";
 import useAppDispatch from "~/utils/customHooks/useAppDispatch.hook";
 import { makeMeta, makeMetaTitle } from "~/utils/meta/meta";
 import type { Route } from "./+types/root";
@@ -232,6 +233,7 @@ export function meta({
   if (dataConnector == null) {
     return makeMeta({
       title: makeMetaTitle(["Data Connector", "Renku"]),
+      image: renkuDataConnectorSocialCard,
     });
   }
   const matchSettings = matchPath(
@@ -248,6 +250,7 @@ export function meta({
   return makeMeta({
     title,
     description: dataConnector.description || undefined,
+    image: renkuDataConnectorSocialCard,
   });
 }
 

--- a/client/src/routes/dataConnectors/root.tsx
+++ b/client/src/routes/dataConnectors/root.tsx
@@ -1,0 +1,452 @@
+import { skipToken } from "@reduxjs/toolkit/query";
+import { useEffect, useState } from "react";
+import {
+  data,
+  generatePath,
+  matchPath,
+  Outlet,
+  useLocation,
+  useNavigate,
+  type MetaDescriptor,
+} from "react-router";
+
+import { Loader } from "~/components/Loader";
+import {
+  dataConnectorsApi,
+  useGetNamespacesByNamespaceDataConnectorsAndSlugQuery,
+  useGetNamespacesByNamespaceProjectsAndProjectDataConnectorsSlugQuery,
+} from "~/features/dataConnectorsV2/api/data-connectors.enhanced-api";
+import DataConnectorPageLayout from "~/features/dataConnectorsV2/show/DataConnectorPageLayout";
+import { NamespaceContextType } from "~/features/searchV2/hooks/useNamespaceContext.hook";
+import { ABSOLUTE_ROUTES } from "~/routing/routes.constants";
+import { store } from "~/store/store";
+import { storeContext } from "~/store/store.utils.server";
+import useAppDispatch from "~/utils/customHooks/useAppDispatch.hook";
+import { makeMeta, makeMetaTitle } from "~/utils/meta/meta";
+import type { Route } from "./+types/root";
+
+// We have 3 different scopes for API, each one with different APIs.
+// Global, user/group-scoped, project-scoped
+type DataConnectorLookup =
+  | {
+      kind: "project";
+      namespace: string;
+      project: string;
+      slug: string;
+    }
+  | {
+      kind: "namespace";
+      namespace: string;
+      slug: string;
+    }
+  | {
+      kind: "global";
+      slug: string;
+    };
+
+function getDataConnectorLookup(
+  params: Route.LoaderArgs["params"]
+): DataConnectorLookup {
+  const { projectNamespace, dataConnectorNamespace, slug } = params;
+
+  if (projectNamespace && dataConnectorNamespace) {
+    return {
+      kind: "project",
+      namespace: projectNamespace,
+      project: dataConnectorNamespace,
+      slug,
+    };
+  }
+
+  if (projectNamespace) {
+    return {
+      kind: "namespace",
+      namespace: projectNamespace,
+      slug,
+    };
+  }
+
+  return {
+    kind: "global",
+    slug,
+  };
+}
+
+export async function loader({ context, params }: Route.LoaderArgs) {
+  const store = context.get(storeContext);
+  const clientSideFetch = store == null || process.env.CYPRESS === "1";
+  if (clientSideFetch) {
+    return data({
+      clientSideFetch,
+      dataConnector: undefined,
+      error: undefined,
+    });
+  }
+
+  const lookup = getDataConnectorLookup(params);
+  let dataConnector;
+  let error;
+
+  if (lookup.kind === "project") {
+    const endpoint =
+      dataConnectorsApi.endpoints
+        .getNamespacesByNamespaceProjectsAndProjectDataConnectorsSlug;
+    const apiArgs = {
+      namespace: lookup.namespace,
+      project: lookup.project,
+      slug: lookup.slug,
+    };
+
+    store.dispatch(endpoint.initiate(apiArgs));
+    await Promise.all(
+      store.dispatch(dataConnectorsApi.util.getRunningQueriesThunk())
+    );
+
+    ({ data: dataConnector, error } = endpoint.select(apiArgs)(
+      store.getState()
+    ));
+  } else if (lookup.kind === "namespace") {
+    const endpoint =
+      dataConnectorsApi.endpoints.getNamespacesByNamespaceDataConnectorsAndSlug;
+    const apiArgs = {
+      namespace: lookup.namespace,
+      slug: lookup.slug,
+    };
+
+    store.dispatch(endpoint.initiate(apiArgs));
+    await Promise.all(
+      store.dispatch(dataConnectorsApi.util.getRunningQueriesThunk())
+    );
+
+    ({ data: dataConnector, error } = endpoint.select(apiArgs)(
+      store.getState()
+    ));
+  } else {
+    const endpoint = dataConnectorsApi.endpoints.getDataConnectorsGlobalBySlug;
+    const apiArgs = {
+      slug: lookup.slug,
+    };
+
+    store.dispatch(endpoint.initiate(apiArgs));
+    await Promise.all(
+      store.dispatch(dataConnectorsApi.util.getRunningQueriesThunk())
+    );
+
+    ({ data: dataConnector, error } = endpoint.select(apiArgs)(
+      store.getState()
+    ));
+  }
+
+  store.dispatch(dataConnectorsApi.util.resetApiState());
+  if (error && "status" in error && typeof error.status === "number") {
+    return data({ clientSideFetch, dataConnector, error }, error.status);
+  }
+
+  return data({ clientSideFetch, dataConnector, error });
+}
+
+export async function clientLoader({ params }: Route.ClientLoaderArgs) {
+  const lookup = getDataConnectorLookup(params);
+
+  let dataConnector;
+  let error;
+
+  if (lookup.kind === "project") {
+    const endpoint =
+      dataConnectorsApi.endpoints
+        .getNamespacesByNamespaceProjectsAndProjectDataConnectorsSlug;
+    const apiArgs = {
+      namespace: lookup.namespace,
+      project: lookup.project,
+      slug: lookup.slug,
+    };
+
+    const promise = store.dispatch(endpoint.initiate(apiArgs));
+    await Promise.all(
+      store.dispatch(dataConnectorsApi.util.getRunningQueriesThunk())
+    );
+
+    ({ data: dataConnector, error } = endpoint.select(apiArgs)(
+      store.getState()
+    ));
+    promise.unsubscribe();
+  } else if (lookup.kind === "namespace") {
+    const endpoint =
+      dataConnectorsApi.endpoints.getNamespacesByNamespaceDataConnectorsAndSlug;
+    const apiArgs = {
+      namespace: lookup.namespace,
+      slug: lookup.slug,
+    };
+
+    const promise = store.dispatch(endpoint.initiate(apiArgs));
+    await Promise.all(
+      store.dispatch(dataConnectorsApi.util.getRunningQueriesThunk())
+    );
+
+    ({ data: dataConnector, error } = endpoint.select(apiArgs)(
+      store.getState()
+    ));
+    promise.unsubscribe();
+  } else {
+    const endpoint = dataConnectorsApi.endpoints.getDataConnectorsGlobalBySlug;
+    const apiArgs = {
+      slug: lookup.slug,
+    };
+
+    const promise = store.dispatch(endpoint.initiate(apiArgs));
+    await Promise.all(
+      store.dispatch(dataConnectorsApi.util.getRunningQueriesThunk())
+    );
+
+    ({ data: dataConnector, error } = endpoint.select(apiArgs)(
+      store.getState()
+    ));
+    promise.unsubscribe();
+  }
+
+  return {
+    clientSideFetch: true,
+    dataConnector,
+    error,
+  };
+}
+
+const metaNotFound = makeMeta({
+  title: makeMetaTitle(["Data Connector Not Found", "Renku"]),
+});
+const metaError = makeMeta({
+  title: makeMetaTitle(["Error", "Renku"]),
+});
+
+export function meta({
+  loaderData,
+  location,
+}: Route.MetaArgs): MetaDescriptor[] {
+  const { dataConnector, error } = loaderData;
+  if (error && "status" in error && error.status == 404) {
+    return metaNotFound;
+  }
+  if (error) {
+    return metaError;
+  }
+  if (dataConnector == null) {
+    return makeMeta({
+      title: makeMetaTitle(["Data Connector", "Renku"]),
+    });
+  }
+  const matchSettings = matchPath(
+    ABSOLUTE_ROUTES.v2.dataConnectors.show.settings,
+    location.pathname
+  );
+  const title = makeMetaTitle([
+    ...(matchSettings ? ["Settings"] : []),
+    dataConnector.name,
+    "Data Connector",
+    "Renku",
+  ]);
+
+  return makeMeta({
+    title,
+    description: dataConnector.description || undefined,
+  });
+}
+
+export default function DataConnectorPagesRoot({
+  loaderData,
+  params,
+}: Route.ComponentProps) {
+  const { projectNamespace, dataConnectorNamespace, slug } = params;
+
+  const { pathname } = useLocation();
+  const navigate = useNavigate();
+  const dispatch = useAppDispatch();
+
+  const [isCacheReady, setIsCacheReady] = useState<boolean>(false);
+
+  //? Inject the server-side data into the RTK Query cache
+  useEffect(() => {
+    if (loaderData.dataConnector == null) return;
+
+    let ignore = false;
+
+    const promise =
+      projectNamespace && dataConnectorNamespace
+        ? dispatch(
+            dataConnectorsApi.util.upsertQueryData(
+              "getNamespacesByNamespaceProjectsAndProjectDataConnectorsSlug",
+              {
+                namespace: projectNamespace,
+                project: dataConnectorNamespace,
+                slug,
+              },
+              loaderData.dataConnector
+            )
+          )
+        : projectNamespace
+        ? dispatch(
+            dataConnectorsApi.util.upsertQueryData(
+              "getNamespacesByNamespaceDataConnectorsAndSlug",
+              {
+                namespace: projectNamespace,
+                slug,
+              },
+              loaderData.dataConnector
+            )
+          )
+        : dispatch(
+            dataConnectorsApi.util.upsertQueryData(
+              "getDataConnectorsGlobalBySlug",
+              {
+                slug,
+              },
+              loaderData.dataConnector
+            )
+          );
+
+    promise.then(() => {
+      if (!ignore) {
+        setIsCacheReady(true);
+      }
+    });
+
+    return () => {
+      ignore = true;
+    };
+  }, [
+    dataConnectorNamespace,
+    dispatch,
+    loaderData.dataConnector,
+    projectNamespace,
+    slug,
+  ]);
+
+  //? Subscribe this component to exactly one of the 3 possible queries:
+  //? * if the data is loaded client-side
+  //? * once the cache is ready (will use cache data)
+  const globalQuery =
+    dataConnectorsApi.endpoints.getDataConnectorsGlobalBySlug.useQuery(
+      !projectNamespace && (loaderData.clientSideFetch || isCacheReady)
+        ? { slug }
+        : skipToken
+    );
+
+  const namespaceQuery = useGetNamespacesByNamespaceDataConnectorsAndSlugQuery(
+    projectNamespace &&
+      !dataConnectorNamespace &&
+      (loaderData.clientSideFetch || isCacheReady)
+      ? {
+          namespace: projectNamespace,
+          slug,
+        }
+      : skipToken
+  );
+
+  const projectQuery =
+    useGetNamespacesByNamespaceProjectsAndProjectDataConnectorsSlugQuery(
+      projectNamespace &&
+        dataConnectorNamespace &&
+        (loaderData.clientSideFetch || isCacheReady)
+        ? {
+            namespace: projectNamespace,
+            project: dataConnectorNamespace,
+            slug,
+          }
+        : skipToken
+    );
+
+  const {
+    currentData: dataConnector,
+    isLoading,
+    error,
+  } = projectNamespace && dataConnectorNamespace
+    ? projectQuery
+    : projectNamespace
+    ? namespaceQuery
+    : globalQuery;
+
+  useEffect(() => {
+    if (dataConnector == null) return;
+
+    const previousBasePath = generatePath(
+      ABSOLUTE_ROUTES.v2.dataConnectors.show.root,
+      {
+        projectNamespace: projectNamespace ?? null,
+        dataConnectorNamespace: dataConnectorNamespace ?? null,
+        slug,
+      }
+    );
+
+    let nextProjectNamespace: string | null = null;
+    let nextDataConnectorNamespace: string | null = null;
+
+    if (dataConnector.namespace) {
+      const parts = dataConnector.namespace.split("/");
+
+      if (parts.length >= 2) {
+        nextProjectNamespace = parts[0] ?? null;
+        nextDataConnectorNamespace = parts[1] ?? null;
+      } else {
+        nextProjectNamespace = dataConnector.namespace;
+      }
+    }
+
+    const nextBasePath = generatePath(
+      ABSOLUTE_ROUTES.v2.dataConnectors.show.root,
+      {
+        projectNamespace: nextProjectNamespace,
+        dataConnectorNamespace: nextDataConnectorNamespace,
+        slug: dataConnector.slug,
+      }
+    );
+
+    if (previousBasePath !== nextBasePath) {
+      const deltaUrl = pathname.slice(previousBasePath.length);
+      navigate(nextBasePath + deltaUrl, { replace: true });
+    }
+  }, [
+    dataConnector,
+    dataConnectorNamespace,
+    navigate,
+    pathname,
+    projectNamespace,
+    slug,
+  ]);
+
+  if (
+    isLoading ||
+    (!loaderData.clientSideFetch &&
+      loaderData.dataConnector != null &&
+      !isCacheReady)
+  ) {
+    return <Loader className="align-self-center" />;
+  }
+
+  if (error || dataConnector == null) {
+    return <h1>TODO: DC not found</h1>;
+    // ! Implement that "not found" page
+    // return <DataConnectorNotFound error={error ?? loaderData.error} />;
+  }
+
+  const routeParams = {
+    projectNamespace: projectNamespace ?? null,
+    dataConnectorNamespace: dataConnectorNamespace ?? null,
+    slug: dataConnector.slug,
+  };
+
+  return (
+    <DataConnectorPageLayout
+      dataConnector={dataConnector}
+      routeParams={routeParams}
+    >
+      <Outlet
+        context={
+          {
+            kind: "dataConnector",
+            namespace: dataConnector.namespace ?? "",
+            dataConnector,
+          } satisfies NamespaceContextType
+        }
+      />
+    </DataConnectorPageLayout>
+  );
+}

--- a/client/src/routes/dataConnectors/searchRedirect.tsx
+++ b/client/src/routes/dataConnectors/searchRedirect.tsx
@@ -1,0 +1,13 @@
+import { redirect } from "react-router";
+
+import { ABSOLUTE_ROUTES } from "~/routing/routes.constants";
+
+const DATA_CONNECTOR_SEARCH = `${ABSOLUTE_ROUTES.v2.search}?type=DataConnector`;
+
+export async function loader() {
+  throw redirect(DATA_CONNECTOR_SEARCH);
+}
+
+export async function clientLoader() {
+  throw redirect(DATA_CONNECTOR_SEARCH);
+}

--- a/client/src/routes/dataConnectors/settings.tsx
+++ b/client/src/routes/dataConnectors/settings.tsx
@@ -1,0 +1,5 @@
+import LazyDataConnectorSettings from "~/features/dataConnectorsV2/LazyDataConnectorSettings";
+
+export default function GroupOverviewPage() {
+  return <LazyDataConnectorSettings />;
+}

--- a/client/src/routing/routes.constants.ts
+++ b/client/src/routing/routes.constants.ts
@@ -30,9 +30,13 @@ export const ABSOLUTE_ROUTES = {
   v2: {
     index: "/",
     admin: "/admin",
-    integrations: {
-      root: "/integrations",
-      complete: "/integrations/complete",
+    dataConnectors: {
+      root: "/d/:slug",
+      show: {
+        root: "/d/:projectNamespace?/:dataConnectorNamespace?/:slug",
+        settings:
+          "/d/:projectNamespace?/:dataConnectorNamespace?/:slug/settings",
+      },
     },
     groups: {
       show: {
@@ -49,6 +53,10 @@ export const ABSOLUTE_ROUTES = {
       release: "/help/release",
       tos: "/help/tos",
       privacy: "/help/privacy",
+    },
+    integrations: {
+      root: "/integrations",
+      complete: "/integrations/complete",
     },
     projects: {
       show: {
@@ -87,9 +95,12 @@ export const RELATIVE_ROUTES = {
     index: "/",
     admin: "admin",
     betaRoot: "/v2/*",
-    integrations: {
-      root: "integrations",
-      complete: "complete",
+    dataConnectors: {
+      root: "d",
+      show: {
+        root: ":projectNamespace?/:dataConnectorNamespace?/:slug/*",
+        settings: "settings",
+      },
     },
     groups: {
       root: "g",
@@ -105,6 +116,10 @@ export const RELATIVE_ROUTES = {
       release: "release",
       tos: "tos",
       privacy: "privacy",
+    },
+    integrations: {
+      root: "integrations",
+      complete: "complete",
     },
     projects: {
       root: "p/*",

--- a/client/src/routing/routes.constants.ts
+++ b/client/src/routing/routes.constants.ts
@@ -54,7 +54,14 @@ export const ABSOLUTE_ROUTES = {
   v2: {
     root: "/",
     admin: "/admin",
-    integrations: "/integrations",
+    dataConnectors: {
+      root: "/d/:slug",
+      show: {
+        root: "/d/:projectNamespace?/:dataConnectorNamespace?/:slug",
+        settings:
+          "/d/:projectNamespace?/:dataConnectorNamespace?/:slug/settings",
+      },
+    },
     groups: {
       show: {
         root: "/g/:slug",
@@ -71,6 +78,7 @@ export const ABSOLUTE_ROUTES = {
       tos: "/help/tos",
       privacy: "/help/privacy",
     },
+    integrations: "/integrations",
     projects: {
       show: {
         root: "/p/:namespace/:slug",
@@ -120,7 +128,13 @@ export const RELATIVE_ROUTES = {
     root: "/*",
     admin: "admin",
     betaRoot: "/v2/*",
-    integrations: "integrations",
+    dataConnectors: {
+      root: "d",
+      show: {
+        root: ":projectNamespace?/:dataConnectorNamespace?/:slug/*",
+        settings: "settings",
+      },
+    },
     groups: {
       root: "g",
       show: {
@@ -136,6 +150,7 @@ export const RELATIVE_ROUTES = {
       tos: "tos",
       privacy: "privacy",
     },
+    integrations: "integrations",
     projects: {
       root: "p/*",
       show: {

--- a/client/src/store/store.utils.server.ts
+++ b/client/src/store/store.utils.server.ts
@@ -20,6 +20,7 @@ import { configureStore } from "@reduxjs/toolkit";
 import { parseCookie } from "cookie";
 import { createContext, type MiddlewareFunction } from "react-router";
 
+import { dataConnectorsApi } from "~/features/dataConnectorsV2/api/data-connectors.enhanced-api";
 import { platformApi } from "~/features/platform/api/platform.api";
 import { projectV2Api } from "~/features/projectsV2/api/projectV2.enhanced-api";
 import { usersApi } from "~/features/usersV2/api/users.api";
@@ -38,12 +39,14 @@ function makeStore() {
       [cookieSlice.reducerPath]: cookieSlice.reducer,
       // APIs
       [platformApi.reducerPath]: platformApi.reducer,
+      [dataConnectorsApi.reducerPath]: dataConnectorsApi.reducer,
       [projectV2Api.reducerPath]: projectV2Api.reducer,
       [usersApi.reducerPath]: usersApi.reducer,
     },
     middleware: (gDM) =>
       gDM()
         .concat(platformApi.middleware)
+        .concat(dataConnectorsApi.middleware)
         .concat(projectV2Api.middleware)
         .concat(usersApi.middleware),
   });

--- a/client/src/store/store.utils.server.ts
+++ b/client/src/store/store.utils.server.ts
@@ -20,6 +20,7 @@ import { configureStore } from "@reduxjs/toolkit";
 import { parseCookie } from "cookie";
 import { createContext, type MiddlewareFunction } from "react-router";
 
+import { dataConnectorsApi } from "~/features/dataConnectorsV2/api/data-connectors.enhanced-api";
 import { projectV2Api } from "~/features/projectsV2/api/projectV2.enhanced-api";
 import { usersApi } from "~/features/usersV2/api/users.api";
 import cookieSlice from "./cookie.slice.server";
@@ -36,11 +37,15 @@ function makeStore() {
       // Slices
       [cookieSlice.reducerPath]: cookieSlice.reducer,
       // APIs
+      [dataConnectorsApi.reducerPath]: dataConnectorsApi.reducer,
       [projectV2Api.reducerPath]: projectV2Api.reducer,
       [usersApi.reducerPath]: usersApi.reducer,
     },
     middleware: (gDM) =>
-      gDM().concat(projectV2Api.middleware).concat(usersApi.middleware),
+      gDM()
+        .concat(dataConnectorsApi.middleware)
+        .concat(projectV2Api.middleware)
+        .concat(usersApi.middleware),
   });
 }
 


### PR DESCRIPTION
This PR adds a standalone Data Connector page that can be opened from the data connectors side panels.

**Added elements**

- New full page for Data Connectors with SSR for linking DC to social media. For now, the page can be accessed on the Offcanvas by clicking on the icon to enlarge the visualization, next to the `X` close button .
- Settings page opening modals to apply the changes.

**Missing elements**

- There are a few places where the new DC page can be linked. Since the PR is big already, those changes to (a bunch of) other pages will be added later separately.
- There is an overlap between the new Cards in the DC overview and the elements used in the offcanvas. Updating the offcanvas will be in a separate PR. Mind that the new element can easily fit in there and the old ones will be removed.
- I'll add Cypress tests specific to this new page in a separate PR

<img width="1185" height="841" alt="image" src="https://github.com/user-attachments/assets/f080949c-c257-4330-ba22-20a0a3530ea9" />

<img width="1721" height="1330" alt="image" src="https://github.com/user-attachments/assets/56309bfc-b4a5-4f2f-99e7-032ad9981cb6" />

/deploy renku=release-2.17.0
