### PR TITLE
minor: update old documentation links

### DIFF
--- a/client/src/features/ProjectPageV2/ProjectPageContent/Documentation/Documentation.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/Documentation/Documentation.tsx
@@ -32,6 +32,7 @@ import {
 } from "reactstrap";
 
 import LazyMarkdown from "~/components/markdown/LazyMarkdown";
+import { NEW_DOCS_MARKDOWN_SYNTAX } from "~/utils/constants/NewDocs";
 import RtkOrDataServicesError from "../../../../components/errors/RtkOrDataServicesError";
 import { ExternalLink } from "../../../../components/LegacyExternalLinks";
 import { Loader } from "../../../../components/Loader";
@@ -324,11 +325,8 @@ function DocumentationWordCount({
 function MarkdownHelp() {
   return (
     <div>
-      <ExternalLink
-        role="text"
-        url="https://www.notion.so/renku/Writing-Documentation-in-Renku-Renku-s-Markdown-1a70df2efafc80329211c493917ff6e4"
-      >
-        <Markdown className="bi me-1" /> Markdown supported
+      <ExternalLink role="text" url={NEW_DOCS_MARKDOWN_SYNTAX}>
+        <Markdown className="me-1" /> Markdown supported
       </ExternalLink>
     </div>
   );

--- a/client/src/features/ProjectPageV2/ProjectPageContent/Documentation/Documentation.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/Documentation/Documentation.tsx
@@ -326,7 +326,8 @@ function MarkdownHelp() {
   return (
     <div>
       <ExternalLink role="text" url={NEW_DOCS_MARKDOWN_SYNTAX}>
-        <Markdown className="me-1" /> Markdown supported
+        <Markdown className="me-1" />
+        Markdown supported
       </ExternalLink>
     </div>
   );

--- a/client/src/features/landing/components/RenkuUsers/RenkuUsers.tsx
+++ b/client/src/features/landing/components/RenkuUsers/RenkuUsers.tsx
@@ -21,10 +21,10 @@ import { ReactNode } from "react";
 import { Card, Col, Row } from "reactstrap";
 
 import {
+  NEW_DOCS_RENKU_EVENTS,
   NEW_DOCS_RESEARCH,
   NEW_DOCS_TEACHING,
 } from "~/utils/constants/NewDocs";
-import { Links } from "../../../../utils/constants/Docs.js";
 import educatorIcon from "../../assets/educatorIcon.svg";
 import organizerIcon from "../../assets/organizerIcon.svg";
 import researcherIcon from "../../assets/researcherIcon.svg";
@@ -112,7 +112,7 @@ export function RenkuUsers() {
       title: "Seamless Events",
       description:
         "Focus on innovation, not setup and infrastructure. Provide a consistent environment for all teams, and get participants coding and collaborating right away.",
-      link: Links.RENKU_2_EVENTS,
+      link: NEW_DOCS_RENKU_EVENTS,
       icon: (
         <img
           src={organizerIcon}

--- a/client/src/utils/constants/Docs.js
+++ b/client/src/utils/constants/Docs.js
@@ -29,8 +29,6 @@ const Links = {
   RENKU_2_ADMIN_HOW_TO_GUIDE_INCIDENTS:
     "https://docs.renkulab.io/en/0.70.0/how-to-guides/admin/incidents-maintenance.html",
   RENKU_2_LEARN_MORE: "https://blog.renkulab.io/early-access",
-  RENKU_2_EVENTS:
-    "https://renku.notion.site/Renku-for-Events-18c0df2efafc800bb26ae93333b4318d",
   RENKU_2_SUNSET: "https://blog.renkulab.io/sunsetting-legacy/",
   RENKU_2_REGISTER_REDIRECT:
     "https://www.notion.so/renku/2540df2efafc80c5ac36c6ecf6a375a0?v=2540df2efafc80b1ae2b000cee3e5a3c#2540df2efafc80c5ac36c6ecf6a375a0",

--- a/client/src/utils/constants/NewDocs.ts
+++ b/client/src/utils/constants/NewDocs.ts
@@ -107,3 +107,11 @@ export const NEW_DOCS_USER_INTEGRATIONS = newDocsLinkPage(
 export const NEW_DOCS_DATA_CONNECTORS = newDocsLinkPage("docs/users/data/data")(
   DEFAULT_NEW_DOC_LINK_ARGS,
 );
+
+export const NEW_DOCS_RENKU_EVENTS = newDocsLinkPage(
+  "docs/users/use-cases/events",
+)(DEFAULT_NEW_DOC_LINK_ARGS);
+
+export const NEW_DOCS_MARKDOWN_SYNTAX = newDocsLinkPage(
+  "docs/users/knowledge-base/writing-documentation-in-renku",
+)(DEFAULT_NEW_DOC_LINK_ARGS);


### PR DESCRIPTION
Update the older documentation links still pointing to Notion.

Best paired with this https://github.com/SwissDataScienceCenter/renku/pull/4463

/deploy