### PR TITLE
feat: add submit a job

### DIFF
--- a/client/src/features/ProjectPageV2/utils/useProjectPermissions.hook.ts
+++ b/client/src/features/ProjectPageV2/utils/useProjectPermissions.hook.ts
@@ -30,7 +30,7 @@ interface UseProjectPermissionsArgs {
 export default function useProjectPermissions({
   projectId,
 }: UseProjectPermissionsArgs): PermissionsWithLoadingState {
-  const { currentData, isLoading, isError, isUninitialized } =
+  const { currentData, isLoading, isError, isUninitialized, error } =
     projectV2Api.endpoints.getProjectsByProjectIdPermissions.useQueryState(
       projectId ? { projectId } : skipToken,
     );
@@ -44,17 +44,25 @@ export default function useProjectPermissions({
   }, [fetchPermissions, isUninitialized, projectId]);
 
   const isLoadingPermissions = isLoading || !!(projectId && isUninitialized);
+  const arePermissionsResolved =
+    !isLoadingPermissions && !isError && currentData != null;
 
   if (isLoading || isError || !currentData) {
     return {
       ...DEFAULT_PERMISSIONS,
+      arePermissionsResolved: false,
       isLoadingPermissions,
+      isPermissionsError: isError,
+      permissionsError: isError ? error : undefined,
     };
   }
 
   return {
     ...DEFAULT_PERMISSIONS,
     ...currentData,
+    arePermissionsResolved,
     isLoadingPermissions: false,
+    isPermissionsError: false,
+    permissionsError: undefined,
   };
 }

--- a/client/src/features/permissionsV2/permissions.types.ts
+++ b/client/src/features/permissionsV2/permissions.types.ts
@@ -23,5 +23,10 @@ export type Permissions = {
 };
 
 export type PermissionsWithLoadingState = Permissions & {
+  arePermissionsResolved: boolean;
   isLoadingPermissions: boolean;
+  isPermissionsError: boolean;
+  permissionsError?: unknown;
 };
+
+export type ProjectPermissions = PermissionsWithLoadingState;

--- a/client/src/features/sessionsV2/DataConnectorSecretsModal.tsx
+++ b/client/src/features/sessionsV2/DataConnectorSecretsModal.tsx
@@ -59,6 +59,13 @@ const CONTEXT_STRINGS = {
     testError:
       "The data connector could not be mounted. Please retry with different credentials, or skip the data connector. If you skip, the data connector will not be mounted in the session.",
   },
+  job: {
+    continueButton: "Continue",
+    dataCy: "job-data-connector-credentials-modal",
+    header: "Job Storage Credentials",
+    testError:
+      "The data connector could not be mounted. Please retry with different credentials, or skip the data connector. If you skip, the data connector will not be mounted in the job.",
+  },
   storage: {
     continueButton: "Test and Save",
     dataCy: "data-connector-credentials-modal",
@@ -158,7 +165,7 @@ function DataConnectorSecrets({
 }
 
 interface DataConnectorSecretsModalProps {
-  context?: "session" | "storage";
+  context?: "session" | "job" | "storage";
   isOpen: boolean;
   onCancel: () => void;
   onStart: (dataConnectorConfigs: DataConnectorConfiguration[]) => void;
@@ -352,7 +359,9 @@ function CredentialsButtons({
         <XLg className={cx("bi", "me-1")} />
         Cancel
       </Button>
-      {context === "session" && <SkipConnectionTestButton onSkip={onSkip} />}
+      {(context === "session" || context === "job") && (
+        <SkipConnectionTestButton context={context} onSkip={onSkip} />
+      )}
       {context === "storage" && (
         <ClearCredentialsButton
           onSkip={onSkip}
@@ -612,9 +621,11 @@ function SensitiveFieldInput({
 }
 
 function SkipConnectionTestButton({
+  context,
   onSkip,
-}: Pick<CredentialsButtonsProps, "onSkip">) {
+}: Pick<CredentialsButtonsProps, "context" | "onSkip">) {
   const skipButtonRef = useRef<HTMLAnchorElement>(null);
+  const targetLabel = context === "job" ? "job" : "session";
   return (
     <>
       <span ref={skipButtonRef}>
@@ -624,7 +635,7 @@ function SkipConnectionTestButton({
         </Button>
       </span>
       <UncontrolledTooltip target={skipButtonRef}>
-        Skip the data connector. It will not be mounted in the session.
+        {`Skip the data connector. It will not be mounted in the ${targetLabel}.`}
       </UncontrolledTooltip>
     </>
   );

--- a/client/src/features/sessionsV2/SaveCloudStorageCredentials.tsx
+++ b/client/src/features/sessionsV2/SaveCloudStorageCredentials.tsx
@@ -1,0 +1,184 @@
+/*!
+ * Copyright 2026 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import cx from "classnames";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import RtkOrDataServicesError from "~/components/errors/RtkOrDataServicesError";
+import ProgressStepsIndicator, {
+  ProgressStyle,
+  ProgressType,
+  StatusStepProgressBar,
+  StepsProgressBar,
+} from "~/components/progress/ProgressSteps";
+import { storageDefinitionAfterSavingCredentialsFromConfig } from "../cloudStorage/projectCloudStorage.utils";
+import { usePatchDataConnectorsByDataConnectorIdSecretsMutation } from "../dataConnectorsV2/api/data-connectors.enhanced-api";
+import { shouldCloudStorageSaveCredentials } from "./sessionLaunchValidation.utils";
+import type { SessionStartDataConnectorConfiguration } from "./startSessionOptionsV2.types";
+
+import progressBoxStyles from "~/components/progress/ProgressBox.module.scss";
+
+interface SaveCloudStorageCredentialsProps {
+  dataConnectors: SessionStartDataConnectorConfiguration[];
+  onComplete: (configs: SessionStartDataConnectorConfiguration[]) => void;
+  title?: string;
+}
+
+export default function SaveCloudStorageCredentials({
+  dataConnectors,
+  onComplete,
+  title = "Saving credentials",
+}: SaveCloudStorageCredentialsProps) {
+  const [steps, setSteps] = useState<StepsProgressBar[]>([]);
+  const [saveCredentials, saveCredentialsResult] =
+    usePatchDataConnectorsByDataConnectorIdSecretsMutation();
+
+  const credentialsToSave = useMemo(() => {
+    return dataConnectors
+      .filter(shouldCloudStorageSaveCredentials)
+      .map((cs) => ({
+        storageName: cs.dataConnector.name,
+        storageId: cs.dataConnector.id,
+        secrets: cs.sensitiveFieldValues,
+      }));
+  }, [dataConnectors]);
+
+  const [results, setResults] = useState<StatusStepProgressBar[]>(
+    credentialsToSave.map(() => StatusStepProgressBar.WAITING),
+  );
+
+  const [index, setIndex] = useState(0);
+  const [hasFailed, setHasFailed] = useState(false);
+  const [failedError, setFailedError] =
+    useState<typeof saveCredentialsResult.error>(undefined);
+  const hasCompletedRef = useRef(false);
+
+  useEffect(() => {
+    const theSteps = credentialsToSave.map((cs, i) => ({
+      id: i,
+      status: results[i],
+      step: `Saving credentials for ${cs.storageName}`,
+    }));
+    // TODO: fix react-hooks/set-state-in-effect
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setSteps(theSteps);
+  }, [credentialsToSave, results]);
+
+  useEffect(() => {
+    if (
+      hasFailed ||
+      credentialsToSave.length < 1 ||
+      index >= credentialsToSave.length
+    )
+      return;
+    // TODO: fix react-hooks/set-state-in-effect
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setResults((prev) => {
+      const newResults = [...prev];
+      newResults[index] = StatusStepProgressBar.EXECUTING;
+      return newResults;
+    });
+    const storage = credentialsToSave[index];
+    saveCredentials({
+      dataConnectorId: storage.storageId,
+      dataConnectorSecretPatchList: Object.entries(storage.secrets).map(
+        ([key, value]) => ({
+          name: key,
+          value,
+        }),
+      ),
+    });
+  }, [credentialsToSave, hasFailed, index, saveCredentials]);
+
+  useEffect(() => {
+    if (
+      saveCredentialsResult.isUninitialized ||
+      saveCredentialsResult.isLoading
+    )
+      return;
+    if (saveCredentialsResult.data != null) {
+      // TODO: fix react-hooks/set-state-in-effect
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setResults((prev) => {
+        const newResults = [...prev];
+        newResults[index] = StatusStepProgressBar.READY;
+        return newResults;
+      });
+      saveCredentialsResult.reset();
+      setIndex((prev) => prev + 1);
+      return;
+    }
+    if (saveCredentialsResult.error != null) {
+      setResults((prev) => {
+        const newResults = [...prev];
+        newResults[index] = StatusStepProgressBar.FAILED;
+        return newResults;
+      });
+      setFailedError(saveCredentialsResult.error);
+      setHasFailed(true);
+      saveCredentialsResult.reset();
+    }
+  }, [index, saveCredentialsResult]);
+
+  useEffect(() => {
+    if (
+      hasFailed ||
+      saveCredentialsResult.isLoading ||
+      hasCompletedRef.current
+    ) {
+      return;
+    }
+    if (index >= credentialsToSave.length) {
+      hasCompletedRef.current = true;
+      const cloudStorageConfigs = dataConnectors.map((cs) =>
+        storageDefinitionAfterSavingCredentialsFromConfig(cs),
+      );
+      onComplete(cloudStorageConfigs);
+    }
+  }, [
+    credentialsToSave.length,
+    dataConnectors,
+    hasFailed,
+    index,
+    onComplete,
+    saveCredentialsResult.isLoading,
+  ]);
+
+  return (
+    <div
+      className={cx(
+        progressBoxStyles.progressBoxSmall,
+        progressBoxStyles.progressBoxSmallSteps,
+      )}
+    >
+      {hasFailed && failedError != null && (
+        <RtkOrDataServicesError
+          dismissible={false}
+          error={failedError as never}
+        />
+      )}
+      <ProgressStepsIndicator
+        description="Saving credentials..."
+        type={ProgressType.Determinate}
+        style={ProgressStyle.Light}
+        title={title}
+        status={steps}
+      />
+    </div>
+  );
+}

--- a/client/src/features/sessionsV2/SessionList/SessionCard.tsx
+++ b/client/src/features/sessionsV2/SessionList/SessionCard.tsx
@@ -19,6 +19,10 @@
 import cx from "classnames";
 import { Col, Row } from "reactstrap";
 
+import {
+  getLauncherCategoryDefinition,
+  sessionLauncherKindToCategory,
+} from "~/features/sessionsV2/session.utils";
 import { Project } from "../../projectsV2/api/projectV2.api";
 import ActiveSessionButton from "../components/SessionButton/ActiveSessionButton";
 import {
@@ -38,7 +42,9 @@ interface SessionCardProps {
 export default function SessionCard({ project, session }: SessionCardProps) {
   if (!session) return null;
 
+  const launcherCategory = sessionLauncherKindToCategory(session.session_type);
   const stylesPerSession = getSessionStatusStyles(session);
+  const launcherDefinition = getLauncherCategoryDefinition(launcherCategory);
 
   return (
     <div
@@ -50,13 +56,21 @@ export default function SessionCard({ project, session }: SessionCardProps) {
         "pb-3",
       )}
     >
-      <img
-        src={stylesPerSession.sessionLine}
-        className={cx("position-absolute", styles.SessionLine)}
-        alt="Session line indicator"
-        loading="lazy"
-      />
-      <div className={cx("ms-5", "px-3", "pt-3")}>
+      {launcherCategory === "session" && (
+        <img
+          src={stylesPerSession.sessionLine}
+          className={cx("position-absolute", styles.SessionLine)}
+          alt="Session line indicator"
+          loading="lazy"
+        />
+      )}
+      <div
+        className={cx(
+          launcherCategory === "session" ? "ms-5" : "ms-2",
+          "px-3",
+          "pt-3",
+        )}
+      >
         <Row className="g-2">
           <Col xs={12} xl="auto">
             <Row className="g-2">
@@ -71,7 +85,8 @@ export default function SessionCard({ project, session }: SessionCardProps) {
                 )}
               >
                 <span className={cx("small", "text-muted", "me-3")}>
-                  Session
+                  {launcherDefinition.text.display}
+                  {session.submission_id ? `: ${session.submission_id}` : ""}
                 </span>
               </Col>
               <Col

--- a/client/src/features/sessionsV2/SessionList/SessionLauncherCard.tsx
+++ b/client/src/features/sessionsV2/SessionList/SessionLauncherCard.tsx
@@ -36,15 +36,14 @@ import {
   BuildStatusDescription,
 } from "../components/BuildStatusComponents";
 import { LauncherActions } from "../components/launcherActions/LauncherActions";
-import {
-  EnvironmentIcon,
-  LauncherEnvironmentIcon,
-} from "../components/SessionForm/LauncherEnvironmentIcon";
+import { LauncherEnvironmentIcon } from "../components/SessionForm/LauncherEnvironmentIcon";
 import SessionImageBadge from "../components/SessionStatus/SessionImageBadge";
 import { SessionBadge } from "../components/SessionStatus/SessionStatus";
+import { getEnvironmentKindLabel } from "../launcherEnvironment.utils";
 import {
   getLauncherCategory,
-  getLauncherCategoryDefinitionByLauncher,
+  getLauncherCategoryDefinition,
+  sessionLauncherKindToCategory,
 } from "../session.utils";
 import { SessionV2 } from "../sessionsV2.types";
 import useLauncherEnvironmentReadiness from "../useLauncherEnvironmentReadiness.hook";
@@ -78,8 +77,6 @@ export default function SessionLauncherCard({
     builds,
     isBuildInProgress,
     isCodeEnvironment,
-    isCustomImageEnvironment,
-    isGlobalEnvironment,
     isLoadingBuilds,
     isLoadingContainerImage,
     lastBuild,
@@ -90,8 +87,11 @@ export default function SessionLauncherCard({
 
   const environment = launcher?.environment;
   const hasSession = !!sessions?.length;
-  const launcherDefinition =
-    launcher && getLauncherCategoryDefinitionByLauncher(launcher);
+  const sessionType = sessions?.at(0)?.session_type ?? "interactive";
+  const launcherCategory = sessionLauncherKindToCategory(
+    launcher?.launcher_type || sessionType,
+  );
+  const launcherDefinition = getLauncherCategoryDefinition(launcherCategory);
   const LauncherTypeIcon = launcherDefinition?.icon || PlayCircle;
   const launcherTypeLabel = launcherDefinition?.text.display || null;
 
@@ -193,22 +193,13 @@ export default function SessionLauncherCard({
                     </span>
                   </Col>
                   <Col xs={12} xl="auto">
-                    {isGlobalEnvironment ? (
-                      <span className={cx(ENVIRONMENT_KIND_CLASSES)}>
-                        <EnvironmentIcon type="global" />
-                        Global environment
-                      </span>
-                    ) : isCodeEnvironment ? (
-                      <span className={cx(ENVIRONMENT_KIND_CLASSES)}>
-                        <EnvironmentIcon type="codeBased" size={16} />
-                        Code based environment
-                      </span>
-                    ) : isCustomImageEnvironment ? (
-                      <span className={cx(ENVIRONMENT_KIND_CLASSES)}>
-                        <EnvironmentIcon type="custom" size={16} />
-                        External image environment
-                      </span>
-                    ) : null}
+                    {launcher?.environment &&
+                      getEnvironmentKindLabel(launcher.environment) != null && (
+                        <span className={cx(ENVIRONMENT_KIND_CLASSES)}>
+                          <LauncherEnvironmentIcon launcher={launcher} />
+                          {getEnvironmentKindLabel(launcher.environment)}
+                        </span>
+                      )}
                   </Col>
                 </Row>
               )}
@@ -224,7 +215,9 @@ export default function SessionLauncherCard({
                     {name ? (
                       name
                     ) : (
-                      <span className="fst-italic">Orphan session</span>
+                      <span className="fst-italic">
+                        Orphan {launcherDefinition.text.display}
+                      </span>
                     )}
                   </span>
                 </Col>
@@ -315,9 +308,8 @@ export default function SessionLauncherCard({
                     hasSession={hasSession}
                     lastBuild={lastBuild}
                     launcher={launcher}
-                    namespace={project.namespace}
                     otherActions={otherLauncherActions}
-                    slug={project.slug}
+                    project={project}
                   />
                   {useOldImage && lastSuccessfulBuild && (
                     <BuildStatusDescription

--- a/client/src/features/sessionsV2/SessionList/SessionLauncherDisplay.tsx
+++ b/client/src/features/sessionsV2/SessionList/SessionLauncherDisplay.tsx
@@ -25,6 +25,7 @@ import { useGetSessionsQuery as useGetSessionsQueryV2 } from "../api/sessionsV2.
 import UpdateSessionLauncherMetadataModal from "../components/SessionModals/UpdateSessionLauncherMetadataModal";
 import UpdateSessionLauncherEnvironmentModal from "../components/SessionModals/UpdateSessionLauncherModal";
 import DeleteSessionV2Modal from "../DeleteSessionLauncherModal";
+import { SESSION_LAUNCHER_KIND } from "../sessionsV2.types";
 import SessionLaunchLinkModal from "../SessionView/SessionLaunchLinkModal";
 import { SessionView } from "../SessionView/SessionView";
 import SessionLauncherCard from "./SessionLauncherCard";
@@ -69,7 +70,9 @@ export function SessionLauncherDisplay({
     });
   }, [launcherHash, setHash]);
 
-  const { data: sessions } = useGetSessionsQueryV2({});
+  const { data: sessions } = useGetSessionsQueryV2({
+    sessionType: launcher.launcher_type,
+  });
 
   const filteredSessions = useMemo(
     () =>
@@ -95,7 +98,9 @@ export function SessionLauncherDisplay({
         toggleUpdateEnvironment={toggleUpdateEnvironment}
         toggleDelete={toggleDelete}
         toggleShareLink={
-          launcher.launcher_type === "interactive" ? toggleShareLink : undefined
+          launcher.launcher_type === SESSION_LAUNCHER_KIND.INTERACTIVE
+            ? toggleShareLink
+            : undefined
         }
         toggleSessionView={toggleSessionView}
       />

--- a/client/src/features/sessionsV2/SessionRepositoriesModal.tsx
+++ b/client/src/features/sessionsV2/SessionRepositoriesModal.tsx
@@ -53,19 +53,30 @@ import startSessionOptionsV2Slice from "./startSessionOptionsV2.slice";
 interface SessionRepositoriesModalProps {
   isOpen: boolean;
   project: Project;
+  onSkip?: () => void;
+  onCancel?: () => void;
+  continueLabel?: string;
+  title?: string;
+  warningIntro?: string;
 }
 export default function SessionRepositoriesModal({
   isOpen,
   project,
+  onSkip: onSkipProp,
+  onCancel: onCancelProp,
+  continueLabel = "Launch anyway",
+  title = "Session repositories not accessible",
+  warningIntro = "your attention before launching the session",
 }: SessionRepositoriesModalProps) {
   const navigate = useNavigate();
-  const onCancel = useCallback(() => {
+  const defaultOnCancel = useCallback(() => {
     const url = generatePath(ABSOLUTE_ROUTES.v2.projects.show.root, {
       namespace: project.namespace,
       slug: project.slug,
     });
     navigate(url);
   }, [navigate, project.namespace, project.slug]);
+  const onCancel = onCancelProp ?? defaultOnCancel;
 
   const projectPermissions = useProjectPermissions({ projectId: project.id });
   const { data, error, isLoading } = useGetRepositoriesQuery(
@@ -85,9 +96,10 @@ export default function SessionRepositoriesModal({
   }, [data, isLoading, projectPermissions?.write]);
 
   const dispatch = useAppDispatch();
-  const onSkip = useCallback(() => {
+  const defaultOnSkip = useCallback(() => {
     dispatch(startSessionOptionsV2Slice.actions.setRepositoriesReady(true));
   }, [dispatch]);
+  const onSkip = onSkipProp ?? defaultOnSkip;
 
   const content =
     isLoading || !data ? (
@@ -107,7 +119,7 @@ export default function SessionRepositoriesModal({
           {repoWithInterruptions.length === 1
             ? `is ${repoWithInterruptions.length} repository that requires`
             : `are ${repoWithInterruptions.length} repositories that require`}{" "}
-          your attention before launching the session:
+          your attention {warningIntro}:
         </p>
         <ListGroup>
           {repoWithInterruptions.map((repository) => (
@@ -129,7 +141,7 @@ export default function SessionRepositoriesModal({
       isOpen={isOpen}
       size="lg"
     >
-      <ModalHeader tag="h2">Session repositories not accessible</ModalHeader>
+      <ModalHeader tag="h2">{title}</ModalHeader>
       <ModalBody>{content}</ModalBody>
       <ModalFooter>
         <Button
@@ -146,7 +158,7 @@ export default function SessionRepositoriesModal({
           onClick={onSkip}
         >
           <SkipForward className={cx("bi", "me-1")} />
-          Launch anyway
+          {continueLabel}
         </Button>
       </ModalFooter>
     </ScrollableModal>

--- a/client/src/features/sessionsV2/SessionSecretsModal.tsx
+++ b/client/src/features/sessionsV2/SessionSecretsModal.tsx
@@ -65,29 +65,37 @@ interface SessionSecretsModalProps {
   isOpen: boolean;
   project: Project;
   sessionSecretSlotsWithSecrets: SessionSecretSlotWithSecret[];
+  onSkip?: () => void;
+  onCancel?: () => void;
+  title?: string;
 }
 
 export default function SessionSecretsModal({
   isOpen,
   project,
   sessionSecretSlotsWithSecrets,
+  onSkip: onSkipProp,
+  onCancel: onCancelProp,
+  title = "Session secrets",
 }: SessionSecretsModalProps) {
   const { data: user } = useGetUserQueryState();
 
   const navigate = useNavigate();
-  const onCancel = useCallback(() => {
+  const defaultOnCancel = useCallback(() => {
     const url = generatePath(ABSOLUTE_ROUTES.v2.projects.show.root, {
       namespace: project.namespace,
       slug: project.slug,
     });
     navigate(url);
   }, [navigate, project.namespace, project.slug]);
+  const onCancel = onCancelProp ?? defaultOnCancel;
 
   const dispatch = useAppDispatch();
 
-  const onSkip = useCallback(() => {
+  const defaultOnSkip = useCallback(() => {
     dispatch(startSessionOptionsV2Slice.actions.setUserSecretsReady(true));
   }, [dispatch]);
+  const onSkip = onSkipProp ?? defaultOnSkip;
 
   const loginUrl = useLoginUrl();
   const content = user?.isLoggedIn ? (
@@ -135,7 +143,7 @@ export default function SessionSecretsModal({
       isOpen={isOpen}
       size="lg"
     >
-      <ModalHeader tag="h2">Session secrets</ModalHeader>
+      <ModalHeader tag="h2">{title}</ModalHeader>
       <ModalBody>{content}</ModalBody>
       <ModalFooter>
         <Button

--- a/client/src/features/sessionsV2/SessionStartPage.tsx
+++ b/client/src/features/sessionsV2/SessionStartPage.tsx
@@ -37,17 +37,12 @@ import ProgressStepsIndicator, {
 import { ABSOLUTE_ROUTES } from "../../routing/routes.constants";
 import useAppDispatch from "../../utils/customHooks/useAppDispatch.hook";
 import useAppSelector from "../../utils/customHooks/useAppSelector.hook";
-import {
-  dataConnectorsOverrideFromConfig,
-  storageDefinitionAfterSavingCredentialsFromConfig,
-} from "../cloudStorage/projectCloudStorage.utils";
-import { usePatchDataConnectorsByDataConnectorIdSecretsMutation } from "../dataConnectorsV2/api/data-connectors.enhanced-api";
+import { dataConnectorsOverrideFromConfig } from "../cloudStorage/projectCloudStorage.utils";
 import type { DataConnectorConfiguration } from "../dataConnectorsV2/components/useDataConnectorConfiguration.hook";
 import { resetFavicon, setFavicon } from "../display/displaySlice";
 import type { SessionSecretSlotWithSecret } from "../ProjectPageV2/ProjectPageContent/SessionSecrets/sessionSecrets.types";
 import type { Project } from "../projectsV2/api/projectV2.api";
 import { useGetNamespacesByNamespaceProjectsAndSlugQuery } from "../projectsV2/api/projectV2.enhanced-api";
-import { storageSecretNameToFieldName } from "../secretsV2/secrets.utils";
 import type { SessionLauncher } from "./api/sessionLaunchersV2.api";
 import { useGetProjectsByProjectIdSessionLaunchersQuery as useGetProjectSessionLaunchersQuery } from "./api/sessionLaunchersV2.api";
 import {
@@ -56,9 +51,15 @@ import {
 } from "./api/sessionsV2.api";
 import { SelectResourceClassModal } from "./components/SessionModals/SelectResourceClass";
 import DataConnectorSecretsModal from "./DataConnectorSecretsModal";
+import SaveCloudStorageCredentials from "./SaveCloudStorageCredentials";
 import { CUSTOM_LAUNCH_SEARCH_PARAM } from "./session.constants";
 import { validateEnvVariableName } from "./session.utils";
 import SessionImageModal from "./SessionImageModal";
+import {
+  dataConnectorsNeedCredentials,
+  dataConnectorsShouldSaveCredentials,
+  doesCloudStorageNeedCredentials,
+} from "./sessionLaunchValidation.utils";
 import SessionRepositoriesModal from "./SessionRepositoriesModal";
 import SessionSecretsModal from "./SessionSecretsModal";
 import startSessionOptionsV2Slice from "./startSessionOptionsV2.slice";
@@ -82,131 +83,28 @@ function SaveCloudStorage({
   startSessionOptionsV2,
 }: SaveCloudStorageProps) {
   const dispatch = useAppDispatch();
-  const [steps, setSteps] = useState<StepsProgressBar[]>([]);
-  const [saveCredentials, saveCredentialsResult] =
-    usePatchDataConnectorsByDataConnectorIdSecretsMutation();
 
-  const credentialsToSave = useMemo(() => {
-    return startSessionOptionsV2.dataConnectors
-      ? startSessionOptionsV2.dataConnectors
-          .filter(shouldCloudStorageSaveCredentials)
-          .map((cs) => ({
-            storageName: cs.dataConnector.name,
-            storageId: cs.dataConnector.id,
-            secrets: cs.sensitiveFieldValues,
-          }))
-      : [];
-  }, [startSessionOptionsV2.dataConnectors]);
-
-  const [results, setResults] = useState<StatusStepProgressBar[]>(
-    credentialsToSave.map(() => StatusStepProgressBar.WAITING),
+  const onComplete = useCallback(
+    (cloudStorageConfigs: SessionStartDataConnectorConfiguration[]) => {
+      dispatch(
+        startSessionOptionsV2Slice.actions.setDataConnectorsOverrides(
+          cloudStorageConfigs,
+        ),
+      );
+    },
+    [dispatch],
   );
 
-  const [index, setIndex] = useState(0);
-
-  useEffect(() => {
-    const theSteps = credentialsToSave.map((cs, i) => ({
-      id: i,
-      status: results[i],
-      step: `Saving credentials for ${cs.storageName}`,
-    }));
-    // TODO: fix react-hooks/set-state-in-effect
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setSteps(theSteps);
-  }, [credentialsToSave, results]);
-
-  // Save all the credentials that need to be saved
-  useEffect(() => {
-    if (credentialsToSave.length < 1 || index >= credentialsToSave.length)
-      return;
-    // TODO: fix react-hooks/set-state-in-effect
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setResults((prev) => {
-      const newResults = [...prev];
-      newResults[index] = StatusStepProgressBar.EXECUTING;
-      return newResults;
-    });
-    const storage = credentialsToSave[index];
-    saveCredentials({
-      dataConnectorId: storage.storageId,
-      dataConnectorSecretPatchList: Object.entries(storage.secrets).map(
-        ([key, value]) => ({
-          name: key,
-          value,
-        }),
-      ),
-    });
-  }, [credentialsToSave, index, saveCredentials]);
-
-  useEffect(() => {
-    if (
-      saveCredentialsResult.isUninitialized ||
-      saveCredentialsResult.isLoading
-    )
-      return;
-    if (saveCredentialsResult.data != null) {
-      // TODO: fix react-hooks/set-state-in-effect
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setResults((prev) => {
-        const newResults = [...prev];
-        newResults[index] = StatusStepProgressBar.READY;
-        return newResults;
-      });
-    }
-    if (saveCredentialsResult.error != null) {
-      // TODO: fix react-hooks/set-state-in-effect
-
-      setResults((prev) => {
-        const newResults = [...prev];
-        newResults[index] = StatusStepProgressBar.FAILED;
-        return newResults;
-      });
-    }
-    saveCredentialsResult.reset();
-    setIndex((prev) => prev + 1);
-  }, [index, saveCredentialsResult]);
-
-  useEffect(() => {
-    if (
-      saveCredentialsResult.isLoading ||
-      !startSessionOptionsV2.dataConnectors
-    ) {
-      return;
-    }
-    if (index >= credentialsToSave.length) {
-      const cloudStorageConfigs = startSessionOptionsV2.dataConnectors?.map(
-        (cs) => storageDefinitionAfterSavingCredentialsFromConfig(cs),
-      );
-      if (cloudStorageConfigs)
-        dispatch(
-          startSessionOptionsV2Slice.actions.setDataConnectorsOverrides(
-            cloudStorageConfigs,
-          ),
-        );
-    }
-  }, [
-    dispatch,
-    credentialsToSave,
-    index,
-    saveCredentialsResult,
-    startSessionOptionsV2.dataConnectors,
-  ]);
+  if (!startSessionOptionsV2.dataConnectors) {
+    return null;
+  }
 
   return (
-    <div
-      className={cx(
-        progressBoxStyles.progressBoxSmall,
-        progressBoxStyles.progressBoxSmallSteps,
-      )}
-    >
-      <ProgressStepsIndicator
-        description="Saving credentials..."
-        type={ProgressType.Determinate}
-        style={ProgressStyle.Light}
-        title={`Launching session ${launcher.name}`}
-        status={steps}
-      />
-    </div>
+    <SaveCloudStorageCredentials
+      dataConnectors={startSessionOptionsV2.dataConnectors}
+      onComplete={onComplete}
+      title={`Launching session ${launcher.name}`}
+    />
   );
 }
 
@@ -324,36 +222,6 @@ function SessionStarting({ launcher, project }: StartSessionFromLauncherProps) {
       </div>
     </div>
   );
-}
-
-function doesCloudStorageNeedCredentials(
-  config: SessionStartDataConnectorConfiguration,
-) {
-  if (!config.active || config.skip) {
-    return false;
-  }
-
-  const sensitiveFields = Object.keys(config.sensitiveFieldValues);
-  const credentialFieldDict = config.savedCredentialFields
-    ? Object.fromEntries(
-        config.savedCredentialFields?.map((field) => [
-          storageSecretNameToFieldName({ name: field }),
-          true,
-        ]),
-      )
-    : {};
-  if (sensitiveFields.every((key) => credentialFieldDict[key] != null)) {
-    return false;
-  }
-  return Object.values(config.sensitiveFieldValues).some(
-    (value) => value === "",
-  );
-}
-
-function shouldCloudStorageSaveCredentials(
-  config: SessionStartDataConnectorConfiguration,
-) {
-  return config.saveCredentials;
 }
 
 interface StartSessionWithCloudStorageModalProps extends StartSessionFromLauncherProps {
@@ -498,12 +366,12 @@ function StartSessionFromLauncher({
     isCustomLaunch: hasCustomQuery,
   });
 
-  const needsCredentials = startSessionOptionsV2.dataConnectors?.some(
-    doesCloudStorageNeedCredentials,
+  const needsCredentials = dataConnectorsNeedCredentials(
+    startSessionOptionsV2.dataConnectors,
   );
 
-  const shouldSaveCredentials = startSessionOptionsV2.dataConnectors?.some(
-    shouldCloudStorageSaveCredentials,
+  const shouldSaveCredentials = dataConnectorsShouldSaveCredentials(
+    startSessionOptionsV2.dataConnectors,
   );
 
   const allDataFetched =

--- a/client/src/features/sessionsV2/SessionView/EnvironmentItem.tsx
+++ b/client/src/features/sessionsV2/SessionView/EnvironmentItem.tsx
@@ -48,6 +48,7 @@ import {
 } from "../components/BuildStatusComponents";
 import { EnvironmentIcon } from "../components/SessionForm/LauncherEnvironmentIcon";
 import SessionImageBadge from "../components/SessionStatus/SessionImageBadge";
+import { getEnvironmentKindLabel } from "../launcherEnvironment.utils";
 import { BUILDER_IMAGE_NOT_READY_VALUE } from "../session.constants";
 import { getLauncherCategory, safeStringify } from "../session.utils";
 
@@ -68,6 +69,7 @@ export default function EnvironmentItem({
 
   const { environment_kind, name } = environment;
   const cardName = environment_kind === "GLOBAL" ? name || "" : launcher.name;
+  const environmentKindLabel = getEnvironmentKindLabel(environment);
 
   const buildActions = imageBuildersEnabled &&
     launcher.environment.environment_kind === "CUSTOM" &&
@@ -97,20 +99,21 @@ export default function EnvironmentItem({
             {buildActions}
           </Col>
           <EnvironmentRow>
-            {environment.environment_kind === "GLOBAL" ? (
+            {environmentKindLabel != null && (
               <>
-                <EnvironmentIcon type="global" />
-                Global environment
-              </>
-            ) : environment.environment_image_source === "build" ? (
-              <>
-                <EnvironmentIcon type="codeBased" size={16} />
-                Code based environment
-              </>
-            ) : (
-              <>
-                <EnvironmentIcon type="custom" size={16} />
-                External image environment
+                <EnvironmentIcon
+                  type={
+                    environment.environment_kind === "GLOBAL"
+                      ? "global"
+                      : environment.environment_image_source === "build"
+                        ? "codeBased"
+                        : "custom"
+                  }
+                  size={
+                    environment.environment_kind === "GLOBAL" ? undefined : 16
+                  }
+                />
+                {environmentKindLabel}
               </>
             )}
           </EnvironmentRow>

--- a/client/src/features/sessionsV2/SessionView/SessionView.tsx
+++ b/client/src/features/sessionsV2/SessionView/SessionView.tsx
@@ -78,6 +78,7 @@ import { DEFAULT_URL } from "../session.constants";
 import {
   getLauncherCategory,
   getLauncherCategoryDefinition,
+  sessionLauncherKindToCategory,
 } from "../session.utils";
 import { getShowSessionUrlByProject, SessionV2Actions } from "../SessionsV2";
 import { LauncherCategory, SessionV2 } from "../sessionsV2.types";
@@ -124,12 +125,11 @@ function SessionCardContent({
 function SessionCard({
   session,
   project,
-  launcherCategory,
 }: {
   session: SessionV2;
   project: Project;
-  launcherCategory: LauncherCategory;
 }) {
+  const launcherCategory = sessionLauncherKindToCategory(session.session_type);
   return (
     <SessionCardContent
       color={getSessionColor(session.status.state, launcherCategory)}
@@ -188,8 +188,7 @@ function SessionCardNotRunning({
             placement="launcher-side-panel"
             hasSession={hasSession}
             launcher={launcher}
-            namespace={project.namespace}
-            slug={project.slug}
+            project={project}
           />
         </div>
       }
@@ -197,22 +196,24 @@ function SessionCardNotRunning({
   );
 }
 
-function getSessionColor(state: string, launcherCategory: LauncherCategory) {
+function getSessionColor(state: string, launcherCategory?: LauncherCategory) {
   return state === "running" && launcherCategory === "session"
     ? "success"
     : state === "running" && launcherCategory === "job"
       ? "warning"
-      : state === "starting"
+      : state === "starting" && launcherCategory === "session"
         ? "warning"
-        : state === "succeeded"
-          ? "success"
+        : state === "starting" && launcherCategory === "job"
+          ? "info"
           : state === "stopping"
             ? "warning"
             : state === "hibernated"
               ? "dark"
               : state === "failed"
                 ? "danger"
-                : "dark";
+                : state === "succeeded"
+                  ? "success"
+                  : "dark";
 }
 
 interface SessionViewProps {
@@ -383,11 +384,7 @@ export function SessionView({
                       session={session}
                       launcher={launcher}
                     />
-                    <SessionCard
-                      session={session}
-                      project={project}
-                      launcherCategory={launcherCategory || orphanCategory}
-                    />
+                    <SessionCard session={session} project={project} />
                   </div>
                 ))
               ) : (

--- a/client/src/features/sessionsV2/SessionsV2.tsx
+++ b/client/src/features/sessionsV2/SessionsV2.tsx
@@ -110,7 +110,7 @@ export default function SessionsV2({ project }: SessionsV2Props) {
       <p className="text-body-secondary">
         {totalSessions > 0
           ? "Launchers are available to everyone who can see the project. Only you can see your running sessions and jobs."
-          : "Define interactive environments in which to do your work and share it  with others."}
+          : "Define interactive or not environments in which to do your work and share it  with others."}
       </p>
       {loading}
       {totalSessions > 0 && !isLoading && (

--- a/client/src/features/sessionsV2/components/SessionButton/ActiveSessionButton.actions.tsx
+++ b/client/src/features/sessionsV2/components/SessionButton/ActiveSessionButton.actions.tsx
@@ -1,0 +1,272 @@
+/*!
+ * Copyright 2026 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import cx from "classnames";
+import { ReactNode } from "react";
+import {
+  ArrowRightCircle,
+  FileEarmarkText,
+  PauseCircle,
+  PlayFill,
+  Tools,
+  Trash,
+} from "react-bootstrap-icons";
+import { Link } from "react-router";
+import { Button } from "reactstrap";
+
+import { Loader } from "~/components/Loader";
+import { SessionStatusState } from "../../sessionsV2.types";
+
+export interface ActiveSessionActionContext {
+  status: SessionStatusState;
+  isStopping: boolean;
+  isHibernating: boolean;
+  isResuming: boolean;
+  failedScheduling: boolean;
+  isUserLoggedIn: boolean;
+  showSessionUrl: string;
+  buttonClassName: string;
+  onHibernateSession: () => void;
+  onStopSession: () => void;
+  onResumeSession: () => void;
+  toggleLogsModal: () => void;
+  toggleModifySession: () => void;
+}
+
+function StoppingStatusButton({ label }: { label: string }) {
+  return (
+    <Button color="primary" data-cy="stopping-btn" disabled>
+      <Loader className="me-1" inline size={16} />
+      {label}
+    </Button>
+  );
+}
+
+function PausingStatusButton() {
+  return (
+    <Button color="primary" data-cy="stopping-btn" disabled>
+      <Loader className="me-1" inline size={16} />
+      Pausing
+    </Button>
+  );
+}
+
+function ResumeStatusButton({
+  isResuming,
+  onResumeSession,
+}: {
+  isResuming: boolean;
+  onResumeSession: () => void;
+}) {
+  return (
+    <Button
+      color="outline-primary"
+      data-cy="resume-session-button"
+      disabled={isResuming}
+      onClick={onResumeSession}
+    >
+      {isResuming ? (
+        <>
+          <Loader className="me-1" inline size={16} />
+          Resuming
+        </>
+      ) : (
+        <>
+          <PlayFill className={cx("bi", "me-1")} />
+          Resume
+        </>
+      )}
+    </Button>
+  );
+}
+
+function LogsStatusButton({
+  onClick,
+  label,
+}: {
+  onClick: () => void;
+  label: string;
+}) {
+  return (
+    <Button
+      color="outline-primary"
+      data-cy="show-logs-session-button"
+      onClick={onClick}
+    >
+      <FileEarmarkText className={cx("bi", "me-1")} />
+      {label}
+    </Button>
+  );
+}
+
+function OpenSessionButton({ showSessionUrl }: { showSessionUrl: string }) {
+  return (
+    <Link
+      className={cx("btn", "btn-primary")}
+      data-cy="open-session"
+      to={showSessionUrl}
+    >
+      <ArrowRightCircle className={cx("bi", "me-1")} />
+      Open
+    </Link>
+  );
+}
+
+function PauseOrDeleteButton({
+  buttonClassName,
+  color = "outline-primary",
+  isUserLoggedIn,
+  onHibernateSession,
+  onStopSession,
+}: {
+  buttonClassName?: string;
+  color?: "outline-primary" | "primary";
+  isUserLoggedIn: boolean;
+  onHibernateSession: () => void;
+  onStopSession: () => void;
+}) {
+  return (
+    <Button
+      color={color}
+      className={color === "outline-primary" ? buttonClassName : undefined}
+      data-cy={
+        isUserLoggedIn ? "pause-session-button" : "delete-session-button"
+      }
+      onClick={isUserLoggedIn ? onHibernateSession : onStopSession}
+    >
+      {isUserLoggedIn ? (
+        <span className="align-self-start">
+          <PauseCircle className={cx("bi", "me-1")} />
+        </span>
+      ) : (
+        <Trash className={cx("bi", "me-1")} />
+      )}
+      {isUserLoggedIn ? "Pause" : "Delete"}
+    </Button>
+  );
+}
+
+export function getInteractiveSessionDefaultAction(
+  ctx: ActiveSessionActionContext,
+): ReactNode {
+  const {
+    status,
+    isStopping,
+    isHibernating,
+    isResuming,
+    failedScheduling,
+    isUserLoggedIn,
+    showSessionUrl,
+    buttonClassName,
+    onHibernateSession,
+    onStopSession,
+    onResumeSession,
+    toggleLogsModal,
+    toggleModifySession,
+  } = ctx;
+
+  if (status === "stopping" || isStopping) {
+    return <StoppingStatusButton label="Shutting down" />;
+  }
+  if (isHibernating) {
+    return <PausingStatusButton />;
+  }
+  if (status === "starting") {
+    return <OpenSessionButton showSessionUrl={showSessionUrl} />;
+  }
+  if (status === "running") {
+    return (
+      <>
+        <PauseOrDeleteButton
+          buttonClassName={buttonClassName}
+          isUserLoggedIn={isUserLoggedIn}
+          onHibernateSession={onHibernateSession}
+          onStopSession={onStopSession}
+        />
+        <OpenSessionButton showSessionUrl={showSessionUrl} />
+      </>
+    );
+  }
+  if (status === "hibernated") {
+    return (
+      <ResumeStatusButton
+        isResuming={isResuming}
+        onResumeSession={onResumeSession}
+      />
+    );
+  }
+  if (failedScheduling) {
+    return (
+      <>
+        <LogsStatusButton onClick={toggleLogsModal} label="Get logs" />
+        <Button
+          color="primary"
+          className={buttonClassName}
+          data-cy="modify-session-button"
+          onClick={toggleModifySession}
+        >
+          <Tools className={cx("bi", "me-1")} />
+          Modify
+        </Button>
+      </>
+    );
+  }
+  return (
+    <>
+      <LogsStatusButton onClick={toggleLogsModal} label="Get logs" />
+      <PauseOrDeleteButton
+        color="primary"
+        isUserLoggedIn={isUserLoggedIn}
+        onHibernateSession={onHibernateSession}
+        onStopSession={onStopSession}
+      />
+    </>
+  );
+}
+
+export function getJobDefaultAction(
+  ctx: ActiveSessionActionContext,
+): ReactNode {
+  const {
+    status,
+    isStopping,
+    isHibernating,
+    isResuming,
+    onResumeSession,
+    toggleLogsModal,
+  } = ctx;
+
+  if (status === "stopping" || isStopping) {
+    return <StoppingStatusButton label="Dismissing job" />;
+  }
+  if (isHibernating) {
+    return <PausingStatusButton />;
+  }
+  if (status === "starting" || status === "running" || status === "succeeded") {
+    return <LogsStatusButton onClick={toggleLogsModal} label="Logs" />;
+  }
+  if (status === "hibernated") {
+    return (
+      <ResumeStatusButton
+        isResuming={isResuming}
+        onResumeSession={onResumeSession}
+      />
+    );
+  }
+  return <LogsStatusButton onClick={toggleLogsModal} label="Get logs" />;
+}

--- a/client/src/features/sessionsV2/components/SessionButton/ActiveSessionButton.tsx
+++ b/client/src/features/sessionsV2/components/SessionButton/ActiveSessionButton.tsx
@@ -19,7 +19,6 @@
 import cx from "classnames";
 import { useCallback, useEffect, useState } from "react";
 import {
-  ArrowRightCircle,
   BoxArrowUpRight,
   CheckLg,
   FileEarmarkText,
@@ -29,7 +28,7 @@ import {
   Trash,
   XLg,
 } from "react-bootstrap-icons";
-import { Link, useNavigate } from "react-router";
+import { useNavigate } from "react-router";
 import { SingleValue } from "react-select";
 import {
   Button,
@@ -44,7 +43,6 @@ import {
 
 import { WarnAlert } from "~/components/Alert";
 import { ButtonWithMenuV2 } from "~/components/buttons/Button";
-import { Loader } from "~/components/Loader";
 import useRenkuToast from "~/components/toast/useRenkuToast";
 import SessionLogsModal from "~/features/logsDisplay/SessionLogsModal";
 import { useGetUserQueryState } from "~/features/usersV2/api/users.api";
@@ -57,6 +55,7 @@ import {
   usePatchSessionsBySessionIdMutation as usePatchSessionMutation,
   useDeleteSessionsBySessionIdMutation as useStopSessionMutation,
 } from "../../api/sessionsV2.api";
+import { sessionLauncherKindToCategory } from "../../session.utils";
 import {
   SessionResources,
   SessionStatus,
@@ -71,6 +70,10 @@ import {
 } from "../SessionModals/ResourceClassWarning";
 import ShutdownSessionContent from "../SessionModals/ShoutdownSessionContent";
 import { SessionRowResourceRequests } from "../SessionsList";
+import {
+  getInteractiveSessionDefaultAction,
+  getJobDefaultAction,
+} from "./ActiveSessionButton.actions";
 
 interface ActiveSessionButtonProps {
   className?: string;
@@ -121,10 +124,7 @@ export default function ActiveSessionButton({
       // TODO: fix react-hooks/set-state-in-effect
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setIsResuming(false);
-      navigate(showSessionUrl);
-      // TODO: fix react-hooks/set-state-in-effect
-
-      setIsResuming(false);
+      if (session.session_type === "interactive") navigate(showSessionUrl);
     }
   }, [
     isResuming,
@@ -132,6 +132,7 @@ export default function ActiveSessionButton({
     isWaitingForResumedSession,
     navigate,
     showSessionUrl,
+    session.session_type,
   ]);
   useEffect(() => {
     if (errorResumeSession) {
@@ -266,121 +267,30 @@ export default function ActiveSessionButton({
     "btn-outline-primary",
   );
 
+  const launcherCategory = sessionLauncherKindToCategory(session.session_type);
+
+  const actionContext = {
+    status,
+    isStopping,
+    isHibernating,
+    isResuming,
+    failedScheduling,
+    isUserLoggedIn,
+    showSessionUrl,
+    buttonClassName,
+    onHibernateSession,
+    onStopSession,
+    onResumeSession,
+    toggleLogsModal,
+    toggleModifySession,
+  };
+
   const defaultAction =
-    status === "stopping" || isStopping ? (
-      <Button color="primary" data-cy="stopping-btn" disabled>
-        <Loader className="me-1" inline size={16} />
-        Shutting down
-      </Button>
-    ) : isHibernating ? (
-      <Button color="primary" data-cy="stopping-btn" disabled>
-        <Loader className="me-1" inline size={16} />
-        Pausing
-      </Button>
-    ) : status === "starting" ? (
-      <Link
-        className={cx("btn", "btn-primary")}
-        data-cy="open-session"
-        to={showSessionUrl}
-      >
-        <ArrowRightCircle className={cx("bi", "me-1")} />
-        Open
-      </Link>
-    ) : status === "running" ? (
-      <>
-        <Button
-          color="outline-primary"
-          className={buttonClassName}
-          data-cy={
-            isUserLoggedIn ? "pause-session-button" : "delete-session-button"
-          }
-          onClick={isUserLoggedIn ? onHibernateSession : onStopSession}
-        >
-          {isUserLoggedIn ? (
-            <span className="align-self-start">
-              <PauseCircle className={cx("bi", "me-1")} />
-            </span>
-          ) : (
-            <Trash className={cx("bi", "me-1")} />
-          )}
-          {isUserLoggedIn ? "Pause" : "Delete"}
-        </Button>
-        <Link
-          className={cx("btn", "btn-primary")}
-          data-cy="open-session"
-          to={showSessionUrl}
-        >
-          <ArrowRightCircle className={cx("bi", "me-1")} />
-          Open
-        </Link>
-      </>
-    ) : status === "hibernated" ? (
-      <Button
-        color="primary"
-        data-cy="resume-session-button"
-        disabled={isResuming}
-        onClick={onResumeSession}
-      >
-        {isResuming ? (
-          <>
-            <Loader className="me-1" inline size={16} />
-            Resuming
-          </>
-        ) : (
-          <>
-            <PlayFill className={cx("bi", "me-1")} />
-            Resume
-          </>
-        )}
-      </Button>
-    ) : failedScheduling ? (
-      <>
-        <Button
-          color="outline-primary"
-          data-cy="show-logs-session-button"
-          onClick={toggleLogsModal}
-        >
-          <FileEarmarkText className={cx("bi", "me-1")} />
-          Get logs
-        </Button>
-        <Button
-          color="primary"
-          className={buttonClassName}
-          data-cy="modify-session-button"
-          onClick={toggleModifySession}
-        >
-          <Tools className={cx("bi", "me-1")} />
-          Modify
-        </Button>
-      </>
-    ) : (
-      <>
-        <Button
-          color="outline-primary"
-          data-cy={"show-logs-session-button"}
-          onClick={toggleLogsModal}
-        >
-          <FileEarmarkText className={cx("bi", "me-1")} />
-          Get logs
-        </Button>
-        <Button
-          color="primary"
-          data-cy={
-            isUserLoggedIn ? "pause-session-button" : "delete-session-button"
-          }
-          onClick={isUserLoggedIn ? onHibernateSession : onStopSession}
-        >
-          {isUserLoggedIn ? (
-            <span className="align-self-start">
-              <PauseCircle className={cx("bi", "me-1")} />
-            </span>
-          ) : (
-            <Trash className={cx("bi", "me-1")} />
-          )}
-          {isUserLoggedIn ? "Pause" : "Delete"}
-        </Button>
-      </>
-    );
+    launcherCategory === "session"
+      ? getInteractiveSessionDefaultAction(actionContext)
+      : launcherCategory === "job"
+        ? getJobDefaultAction(actionContext)
+        : null;
 
   const hibernateAction = status !== "stopping" &&
     (status !== "failed" || failedScheduling) &&
@@ -404,6 +314,13 @@ export default function ActiveSessionButton({
     >
       <Trash className={cx("bi", "me-1")} />
       Shut down session
+    </DropdownItem>
+  );
+
+  const dismissAction = launcherCategory === "job" && (
+    <DropdownItem data-cy="delete-session-button" onClick={onStopSession}>
+      <XLg className={cx("bi", "me-1")} />
+      Dismiss job
     </DropdownItem>
   );
 
@@ -434,6 +351,27 @@ export default function ActiveSessionButton({
       Get logs
     </DropdownItem>
   );
+
+  if (launcherCategory === "job") {
+    return (
+      <div className={cx("d-flex", "flex-row", "gap-2")}>
+        <ButtonWithMenuV2
+          className={cx(className)}
+          color={"outline-primary"}
+          default={defaultAction}
+          preventPropagation
+          size="sm"
+        >
+          {dismissAction}
+        </ButtonWithMenuV2>
+        <SessionLogsModal
+          isOpen={showLogsModal}
+          sessionName={session.name}
+          toggle={toggleLogsModal}
+        />
+      </div>
+    );
+  }
 
   return (
     <div className={cx("d-flex", "flex-row", "gap-2")}>

--- a/client/src/features/sessionsV2/components/SessionForm/AdvancedSettingsFields.tsx
+++ b/client/src/features/sessionsV2/components/SessionForm/AdvancedSettingsFields.tsx
@@ -228,6 +228,7 @@ export interface JsonFieldProps<T extends FieldValues> {
   isOptional?: boolean;
   dataCy?: string;
   id?: string;
+  disabled?: boolean;
 }
 
 export function JsonField<T extends FieldValues>({
@@ -240,6 +241,7 @@ export function JsonField<T extends FieldValues>({
   isOptional = true,
   dataCy,
   id,
+  disabled = false,
 }: JsonFieldProps<T>) {
   const rules = isOptional
     ? {
@@ -273,6 +275,7 @@ export function JsonField<T extends FieldValues>({
               <textarea
                 className={cx("w-100", "form-control", error && "is-invalid")}
                 data-cy={dataCy ?? `session-launcher-field-${name}`}
+                disabled={disabled}
                 id={id ?? `addSessionLauncher${name}`}
                 rows={2}
                 {...field}

--- a/client/src/features/sessionsV2/components/SessionModals/JobSubmitModal.tsx
+++ b/client/src/features/sessionsV2/components/SessionModals/JobSubmitModal.tsx
@@ -1,0 +1,81 @@
+/*!
+ * Copyright 2026 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Project } from "~/features/projectsV2/api/projectV2.api";
+import type { SessionLauncher } from "../../api/sessionLaunchersV2.api";
+import SubmitJobFormModal from "./SubmitJobFormModal";
+import SubmitJobPrerequisiteModals from "./SubmitJobPrerequisiteModals";
+import useSubmitJobFlow from "./useSubmitJobFlow";
+
+export type { SubmitJobForm } from "./useSubmitJobForm";
+
+interface JobSubmitModalProps {
+  isOpen: boolean;
+  launcher: SessionLauncher;
+  project: Project;
+  toggle: () => void;
+}
+
+function JobSubmitModalOpen({
+  launcher,
+  project,
+  toggle,
+}: Omit<JobSubmitModalProps, "isOpen">) {
+  const submitJobFlow = useSubmitJobFlow({ launcher, project });
+
+  return (
+    <>
+      <SubmitJobFormModal
+        isOpen
+        launcher={launcher}
+        submitJobFlow={submitJobFlow}
+        toggle={toggle}
+      />
+      <SubmitJobPrerequisiteModals
+        configsNeedingCredentials={submitJobFlow.configsNeedingCredentials}
+        dataConnectorConfigs={submitJobFlow.dataConnectorConfigs}
+        launcher={launcher}
+        onCancel={submitJobFlow.cancelValidation}
+        onDataConnectorsComplete={submitJobFlow.onDataConnectorsComplete}
+        onRepositoriesSkip={submitJobFlow.onRepositoriesSkip}
+        onSaveCredentialsComplete={submitJobFlow.onSaveCredentialsComplete}
+        onSecretsSkip={submitJobFlow.onSecretsSkip}
+        project={project}
+        sessionSecretSlotsWithSecrets={
+          submitJobFlow.sessionSecretSlotsWithSecrets
+        }
+        validationStep={submitJobFlow.validationStep}
+      />
+    </>
+  );
+}
+
+export default function JobSubmitModal({
+  isOpen,
+  launcher,
+  project,
+  toggle,
+}: JobSubmitModalProps) {
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <JobSubmitModalOpen launcher={launcher} project={project} toggle={toggle} />
+  );
+}

--- a/client/src/features/sessionsV2/components/SessionModals/SubmitJobEnvironmentSummary.tsx
+++ b/client/src/features/sessionsV2/components/SessionModals/SubmitJobEnvironmentSummary.tsx
@@ -1,0 +1,123 @@
+/*!
+ * Copyright 2026 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import cx from "classnames";
+
+import { WarnAlert } from "~/components/Alert";
+import { TimeCaption } from "~/components/TimeCaption";
+import type { SessionLauncher } from "../../api/sessionLaunchersV2.api";
+import { getEnvironmentKindLabel } from "../../launcherEnvironment.utils";
+import useLauncherEnvironmentReadiness from "../../useLauncherEnvironmentReadiness.hook";
+import { BuildStatusDescription } from "../BuildStatusComponents";
+import { LauncherEnvironmentIcon } from "../SessionForm/LauncherEnvironmentIcon";
+
+interface SubmitJobEnvironmentSummaryProps {
+  launcher: SessionLauncher;
+}
+
+export default function SubmitJobEnvironmentSummary({
+  launcher,
+}: SubmitJobEnvironmentSummaryProps) {
+  const {
+    containerImage,
+    isCodeEnvironment,
+    isCustomImageEnvironment,
+    isLastBuildRunning,
+    isLoadingContainerImage,
+    lastBuild,
+    lastSuccessfulBuild,
+    useOldImage,
+  } = useLauncherEnvironmentReadiness({ launcher });
+
+  const environmentKindLabel = getEnvironmentKindLabel(launcher.environment);
+
+  return (
+    <>
+      <h2 className={cx("fw-bold", "mb-0")} data-cy="submit-job-launcher-name">
+        {launcher.name}
+      </h2>
+
+      <div
+        className={cx("d-flex", "flex-wrap", "align-items-center", "gap-4")}
+        data-cy="submit-job-environment"
+      >
+        {environmentKindLabel != null && (
+          <span className={cx("text-muted", "small")}>
+            <LauncherEnvironmentIcon launcher={launcher} />
+            {environmentKindLabel}
+          </span>
+        )}
+        {isCodeEnvironment && (
+          <BuildStatusDescription
+            status={lastBuild?.status ?? lastSuccessfulBuild?.status}
+            createdAt={lastBuild?.created_at ?? lastSuccessfulBuild?.created_at}
+            completedAt={
+              lastBuild?.status === "succeeded"
+                ? lastBuild?.result?.completed_at
+                : lastSuccessfulBuild?.status === "succeeded"
+                  ? lastSuccessfulBuild?.result?.completed_at
+                  : undefined
+            }
+          />
+        )}
+      </div>
+
+      {useOldImage && lastSuccessfulBuild && (
+        <WarnAlert
+          className="mb-0"
+          data-cy="submit-job-old-image-warning"
+          dismissible={false}
+        >
+          {isLastBuildRunning ? (
+            <p className="mb-1">
+              The environment for this launcher is currently rebuilding and not
+              yet complete. This job will use the last successfully built
+              environment from{" "}
+              <TimeCaption
+                datetime={lastSuccessfulBuild.created_at}
+                enableTooltip
+                noCaption
+              />
+            </p>
+          ) : (
+            <p className="mb-1">
+              The most recent build for this environment failed, so this job
+              will use the last successfully built environment from{" "}
+              <TimeCaption
+                datetime={lastSuccessfulBuild.created_at}
+                enableTooltip
+                noCaption
+              />
+            </p>
+          )}
+        </WarnAlert>
+      )}
+
+      {isCustomImageEnvironment &&
+        !isLoadingContainerImage &&
+        containerImage?.accessible === false && (
+          <WarnAlert className="mb-0" dismissible={false}>
+            <p className="mb-0">
+              Image accessibility could not be verified. You may still submit if
+              your integration provides access at runtime.
+            </p>
+          </WarnAlert>
+        )}
+    </>
+  );
+}

--- a/client/src/features/sessionsV2/components/SessionModals/SubmitJobFormModal.tsx
+++ b/client/src/features/sessionsV2/components/SessionModals/SubmitJobFormModal.tsx
@@ -1,0 +1,386 @@
+/*!
+ * Copyright 2026 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { skipToken } from "@reduxjs/toolkit/query";
+import cx from "classnames";
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { Send } from "react-bootstrap-icons";
+import { Controller, useForm } from "react-hook-form";
+import {
+  Button,
+  Form,
+  FormText,
+  Input,
+  Label,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+} from "reactstrap";
+
+import { SuccessAlert, WarnAlert } from "~/components/Alert";
+import RtkOrDataServicesError from "~/components/errors/RtkOrDataServicesError";
+import { Loader } from "~/components/Loader";
+import { useGetResourcePoolsQuery } from "../../api/computeResources.api";
+import type { SessionLauncher } from "../../api/sessionLaunchersV2.api";
+import { useGetSessionsQuery } from "../../api/sessionsV2.api";
+import {
+  ENVIRONMENT_VALUES_DESCRIPTION,
+  SUBMISSION_ID_VALIDATION_MESSAGE,
+} from "../../session.constants";
+import {
+  generateSubmissionId,
+  isSubmissionIdTaken,
+  validateSubmissionId,
+} from "../../session.utils";
+import useLauncherEnvironmentReadiness from "../../useLauncherEnvironmentReadiness.hook";
+import { JsonField } from "../SessionForm/AdvancedSettingsFields";
+import SubmitJobEnvironmentSummary from "./SubmitJobEnvironmentSummary";
+import SubmitJobResourceClassField from "./SubmitJobResourceClassField";
+import type { SubmitJobFlow } from "./useSubmitJobFlow";
+import {
+  getSubmitJobDefaultValues,
+  resolveDefaultResourceClass,
+  type SubmitJobForm,
+} from "./useSubmitJobForm";
+
+export interface SubmitJobFormModalProps {
+  isOpen: boolean;
+  launcher: SessionLauncher;
+  submitJobFlow: SubmitJobFlow;
+  toggle: () => void;
+}
+
+export default function SubmitJobFormModal({
+  isOpen,
+  launcher,
+  submitJobFlow,
+  toggle,
+}: SubmitJobFormModalProps) {
+  const {
+    buildRequestError,
+    handleSubmitAttempt,
+    isCheckingLaunchPrerequisites,
+    isPermissionsError,
+    isSubmitting,
+    permissionsError,
+    postSessionResult,
+  } = submitJobFlow;
+  const submissionIdInputRef = useRef<HTMLInputElement>(null);
+  const projectId = launcher.project_id;
+
+  const {
+    containerImage,
+    displayLaunchSession,
+    isCodeEnvironment,
+    isCustomImageEnvironment,
+    isLoadingBuilds,
+    isLoadingContainerImage,
+    lastBuild,
+  } = useLauncherEnvironmentReadiness({
+    launcher,
+  });
+
+  const {
+    data: resourcePools,
+    isLoading: isLoadingResourcePools,
+    isError: isErrorResourcePools,
+  } = useGetResourcePoolsQuery({});
+
+  const { data: sessions, isLoading: isLoadingSessions } = useGetSessionsQuery(
+    isOpen ? {} : skipToken,
+  );
+
+  const defaultValues = useMemo(
+    () => getSubmitJobDefaultValues(launcher),
+    [launcher],
+  );
+
+  const {
+    control,
+    formState: { errors },
+    handleSubmit,
+    reset,
+    setValue,
+    watch,
+  } = useForm<SubmitJobForm>({
+    defaultValues,
+  });
+
+  // eslint-disable-next-line react-hooks/incompatible-library
+  const watchResourceClass = watch("resourceClass");
+
+  useEffect(() => {
+    if (!isOpen) {
+      reset(defaultValues);
+      return;
+    }
+    reset({
+      ...defaultValues,
+      submissionId: generateSubmissionId(),
+    });
+    submissionIdInputRef.current?.focus();
+  }, [defaultValues, isOpen, reset]);
+
+  useEffect(() => {
+    if (!isOpen || watchResourceClass) {
+      return;
+    }
+    const defaultResourceClass = resolveDefaultResourceClass({
+      launcher,
+      resourcePools,
+    });
+    if (!defaultResourceClass) {
+      return;
+    }
+    setValue("resourceClass", defaultResourceClass);
+    setValue(
+      "diskStorage",
+      defaultResourceClass.default_storage ??
+        launcher.disk_storage ??
+        undefined,
+    );
+  }, [isOpen, watchResourceClass, launcher, resourcePools, setValue]);
+
+  const launcherSessions = useMemo(
+    () =>
+      sessions?.filter(
+        (session) =>
+          session.launcher_id === launcher.id &&
+          session.project_id === projectId,
+      ) ?? [],
+    [launcher.id, projectId, sessions],
+  );
+
+  const onSubmit = useCallback(
+    (data: SubmitJobForm) => {
+      if (!data.resourceClass) {
+        return;
+      }
+      handleSubmitAttempt(data);
+    },
+    [handleSubmitAttempt],
+  );
+
+  const isFormLoading =
+    isCheckingLaunchPrerequisites ||
+    (isLoadingResourcePools && resourcePools == null) ||
+    (isLoadingSessions && sessions == null) ||
+    (isCodeEnvironment && isLoadingBuilds && lastBuild == null) ||
+    (isCustomImageEnvironment &&
+      isLoadingContainerImage &&
+      containerImage == null);
+
+  const areFormInputsDisabled = isSubmitting;
+
+  const isSubmitDisabled =
+    isPermissionsError ||
+    !displayLaunchSession ||
+    !watchResourceClass ||
+    isFormLoading ||
+    isSubmitting;
+
+  const buildRequestErrorAlert =
+    buildRequestError != null ? (
+      <WarnAlert className="mb-0" dismissible={false}>
+        <p className="mb-0">{buildRequestError}</p>
+      </WarnAlert>
+    ) : null;
+
+  return (
+    <Modal
+      backdrop="static"
+      centered
+      data-cy="submit-job-modal"
+      isOpen={isOpen}
+      size="lg"
+      toggle={toggle}
+    >
+      <ModalHeader tag="h2" toggle={toggle}>
+        <Send className={cx("bi", "me-1")} /> Review and submit Job
+      </ModalHeader>
+      <ModalBody>
+        {postSessionResult.isSuccess ? (
+          <SuccessAlert dismissible={false} timeout={0}>
+            <p className="mb-1">
+              Job{" "}
+              {postSessionResult.data?.submission_id ??
+                watch("submissionId")?.trim()}{" "}
+              submitted successfully
+            </p>
+          </SuccessAlert>
+        ) : isPermissionsError ? (
+          permissionsError != null ? (
+            <RtkOrDataServicesError
+              dismissible={false}
+              error={permissionsError as never}
+            />
+          ) : (
+            <WarnAlert dismissible={false}>
+              <p className="mb-0">
+                Unable to load project permissions. Please try again later.
+              </p>
+            </WarnAlert>
+          )
+        ) : isSubmitting && buildRequestError == null ? (
+          <p className={cx("mb-0", "text-muted")}>
+            <Loader inline size={16} className="me-1" />
+            Submitting job...
+          </p>
+        ) : (
+          <Form noValidate onSubmit={handleSubmit(onSubmit)}>
+            {buildRequestErrorAlert}
+            {Boolean(postSessionResult.error) && (
+              <RtkOrDataServicesError
+                dismissible={false}
+                error={postSessionResult.error as never}
+              />
+            )}
+            <div className={cx("d-flex", "flex-column", "gap-3")}>
+              <SubmitJobEnvironmentSummary launcher={launcher} />
+
+              {isFormLoading ? (
+                <Loader inline size={16} />
+              ) : (
+                <>
+                  <div className="mt-3">
+                    <Label className="form-label" for="submitJobSubmissionId">
+                      Submission ID
+                    </Label>
+                    <Controller
+                      control={control}
+                      name="submissionId"
+                      rules={{
+                        required: SUBMISSION_ID_VALIDATION_MESSAGE.required,
+                        validate: {
+                          format: (value) => validateSubmissionId(value),
+                          unique: (value) => {
+                            const formatResult = validateSubmissionId(value);
+                            if (formatResult !== true) {
+                              return formatResult;
+                            }
+                            if (
+                              isSubmissionIdTaken({
+                                sessions: launcherSessions,
+                                launcherId: launcher.id,
+                                projectId,
+                                submissionId: value,
+                              })
+                            ) {
+                              return SUBMISSION_ID_VALIDATION_MESSAGE.taken;
+                            }
+                            return true;
+                          },
+                        },
+                      }}
+                      render={({ field, fieldState: { error } }) => (
+                        <>
+                          <Input
+                            {...field}
+                            autoFocus
+                            className={cx(error && "is-invalid")}
+                            data-cy="submit-job-submission-id-input"
+                            id="submitJobSubmissionId"
+                            innerRef={submissionIdInputRef}
+                            type="text"
+                            disabled={areFormInputsDisabled}
+                          />
+                          <div className="invalid-feedback">
+                            {error?.message}
+                          </div>
+                        </>
+                      )}
+                    />
+                    <FormText>
+                      {SUBMISSION_ID_VALIDATION_MESSAGE.helpText}
+                    </FormText>
+                  </div>
+                  <div>
+                    <JsonField<SubmitJobForm>
+                      control={control}
+                      name="command"
+                      label={
+                        isCustomImageEnvironment ? "Command CMD" : "Job command"
+                      }
+                      helpText={
+                        isCodeEnvironment
+                          ? 'Enter the command that will run as a job (JSON array format) e.g. ["python","my_repo/main.py"]'
+                          : 'Enter a valid JSON array format e.g. ["python","my_repo/main.py"]'
+                      }
+                      info={ENVIRONMENT_VALUES_DESCRIPTION.command}
+                      errors={errors}
+                      isOptional={!isCodeEnvironment}
+                      dataCy="submit-job-command-input"
+                      disabled={areFormInputsDisabled}
+                    />
+                  </div>
+                  <div>
+                    <JsonField<SubmitJobForm>
+                      control={control}
+                      name="args"
+                      label={
+                        isCustomImageEnvironment
+                          ? "Command Arguments CMD"
+                          : "Job args"
+                      }
+                      helpText='Please enter a valid JSON array format e.g. ["--arg1", "--arg2"]'
+                      info={ENVIRONMENT_VALUES_DESCRIPTION.args}
+                      errors={errors}
+                      isOptional={isCustomImageEnvironment || isCodeEnvironment}
+                      dataCy="submit-job-args-input"
+                      disabled={areFormInputsDisabled}
+                    />
+                  </div>
+                  <SubmitJobResourceClassField
+                    control={control}
+                    isErrorResourcePools={isErrorResourcePools}
+                    isLoadingResourcePools={isLoadingResourcePools}
+                    areFormInputsDisabled={areFormInputsDisabled}
+                    resourcePools={resourcePools}
+                    setValue={setValue}
+                  />
+                </>
+              )}
+            </div>
+          </Form>
+        )}
+      </ModalBody>
+      <ModalFooter>
+        <Button color="outline-primary" onClick={toggle}>
+          {postSessionResult.isSuccess ? "Close" : "Cancel"}
+        </Button>
+        {!postSessionResult.isSuccess && (
+          <Button
+            color="primary"
+            data-cy="submit-job-confirm-button"
+            disabled={isSubmitDisabled}
+            onClick={handleSubmit(onSubmit)}
+            type="button"
+          >
+            {isSubmitting ? (
+              <Loader className="me-1" inline size={16} />
+            ) : (
+              <Send className={cx("bi", "me-1")} />
+            )}
+            Submit job
+          </Button>
+        )}
+      </ModalFooter>
+    </Modal>
+  );
+}

--- a/client/src/features/sessionsV2/components/SessionModals/SubmitJobPrerequisiteModals.tsx
+++ b/client/src/features/sessionsV2/components/SessionModals/SubmitJobPrerequisiteModals.tsx
@@ -1,0 +1,116 @@
+/*!
+ * Copyright 2026 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Modal, ModalBody, ModalHeader } from "reactstrap";
+
+import type { DataConnectorConfiguration } from "../../../dataConnectorsV2/components/useDataConnectorConfiguration.hook";
+import type { SessionSecretSlotWithSecret } from "../../../ProjectPageV2/ProjectPageContent/SessionSecrets/sessionSecrets.types";
+import type { Project } from "../../../projectsV2/api/projectV2.api";
+import type { SessionLauncher } from "../../api/sessionLaunchersV2.api";
+import DataConnectorSecretsModal from "../../DataConnectorSecretsModal";
+import SaveCloudStorageCredentials from "../../SaveCloudStorageCredentials";
+import SessionRepositoriesModal from "../../SessionRepositoriesModal";
+import SessionSecretsModal from "../../SessionSecretsModal";
+import type { SessionStartDataConnectorConfiguration } from "../../startSessionOptionsV2.types";
+import type { SubmitJobValidationStep } from "./submitJobValidation.utils";
+
+interface SubmitJobPrerequisiteModalsProps {
+  validationStep: SubmitJobValidationStep | null;
+  project: Project;
+  launcher: SessionLauncher;
+  sessionSecretSlotsWithSecrets: SessionSecretSlotWithSecret[] | null;
+  configsNeedingCredentials: DataConnectorConfiguration[];
+  dataConnectorConfigs: SessionStartDataConnectorConfiguration[] | undefined;
+  onCancel: () => void;
+  onRepositoriesSkip: () => void;
+  onSecretsSkip: () => void;
+  onDataConnectorsComplete: (configs: DataConnectorConfiguration[]) => void;
+  onSaveCredentialsComplete: (
+    configs: SessionStartDataConnectorConfiguration[],
+  ) => void;
+}
+
+export default function SubmitJobPrerequisiteModals({
+  validationStep,
+  project,
+  launcher,
+  sessionSecretSlotsWithSecrets,
+  configsNeedingCredentials,
+  dataConnectorConfigs,
+  onCancel,
+  onRepositoriesSkip,
+  onSecretsSkip,
+  onDataConnectorsComplete,
+  onSaveCredentialsComplete,
+}: SubmitJobPrerequisiteModalsProps) {
+  return (
+    <>
+      {validationStep === "repositories" && (
+        <SessionRepositoriesModal
+          continueLabel="Submit anyway"
+          isOpen
+          onCancel={onCancel}
+          onSkip={onRepositoriesSkip}
+          project={project}
+          title="Project repositories not accessible"
+          warningIntro="your attention before submitting the job"
+        />
+      )}
+
+      {validationStep === "sessionSecrets" && sessionSecretSlotsWithSecrets && (
+        <SessionSecretsModal
+          isOpen
+          onCancel={onCancel}
+          onSkip={onSecretsSkip}
+          project={project}
+          sessionSecretSlotsWithSecrets={sessionSecretSlotsWithSecrets}
+          title="Job secrets"
+        />
+      )}
+
+      {validationStep === "dataConnectors" && (
+        <DataConnectorSecretsModal
+          context="job"
+          dataConnectorConfigs={configsNeedingCredentials}
+          isOpen
+          onCancel={onCancel}
+          onStart={onDataConnectorsComplete}
+        />
+      )}
+
+      {validationStep === "saveCredentials" && dataConnectorConfigs && (
+        <Modal
+          backdrop="static"
+          centered
+          data-cy="submit-job-save-credentials-modal"
+          isOpen
+          toggle={onCancel}
+        >
+          <ModalHeader tag="h2">Saving credentials</ModalHeader>
+          <ModalBody>
+            <SaveCloudStorageCredentials
+              dataConnectors={dataConnectorConfigs}
+              onComplete={onSaveCredentialsComplete}
+              title={`Submitting job ${launcher.name}`}
+            />
+          </ModalBody>
+        </Modal>
+      )}
+    </>
+  );
+}

--- a/client/src/features/sessionsV2/components/SessionModals/SubmitJobResourceClassField.tsx
+++ b/client/src/features/sessionsV2/components/SessionModals/SubmitJobResourceClassField.tsx
@@ -1,0 +1,89 @@
+/*!
+ * Copyright 2026 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import cx from "classnames";
+import { Control, Controller, UseFormSetValue } from "react-hook-form";
+import { Label } from "reactstrap";
+
+import type { ResourcePoolWithIdFiltered } from "../../api/computeResources.api";
+import SessionClassSelector from "../SessionClassSelector";
+import {
+  ErrorOrNotAvailableResourcePools,
+  FetchingResourcePools,
+} from "./ResourceClassWarning";
+import type { SubmitJobForm } from "./useSubmitJobForm";
+
+interface SubmitJobResourceClassFieldProps {
+  control: Control<SubmitJobForm>;
+  isErrorResourcePools: boolean;
+  isLoadingResourcePools: boolean;
+  areFormInputsDisabled: boolean;
+  resourcePools: ResourcePoolWithIdFiltered[] | undefined;
+  setValue: UseFormSetValue<SubmitJobForm>;
+}
+
+export default function SubmitJobResourceClassField({
+  control,
+  isErrorResourcePools,
+  isLoadingResourcePools,
+  areFormInputsDisabled,
+  resourcePools,
+  setValue,
+}: SubmitJobResourceClassFieldProps) {
+  const resourceClassSelector = isLoadingResourcePools ? (
+    <FetchingResourcePools />
+  ) : !resourcePools || resourcePools.length === 0 || isErrorResourcePools ? (
+    <ErrorOrNotAvailableResourcePools />
+  ) : (
+    <Controller
+      control={control}
+      name="resourceClass"
+      render={({ field: { onChange, value }, fieldState: { error } }) => (
+        <>
+          <SessionClassSelector
+            id="submitJobResourceClass"
+            currentSessionClass={value}
+            resourcePools={resourcePools}
+            disabled={areFormInputsDisabled}
+            onChange={(resourceClass) => {
+              onChange(resourceClass);
+              if (resourceClass) {
+                setValue("diskStorage", resourceClass.default_storage);
+              }
+            }}
+          />
+          {error && (
+            <div className={cx("small", "text-danger")}>
+              {error.message || "Please provide a valid resource class."}
+            </div>
+          )}
+        </>
+      )}
+      rules={{ required: "Please provide a valid resource class." }}
+    />
+  );
+
+  return (
+    <>
+      <Label className="form-label" for="submitJobResourceClass">
+        Compute resources
+      </Label>
+      <div className="field-group">{resourceClassSelector}</div>
+    </>
+  );
+}

--- a/client/src/features/sessionsV2/components/SessionModals/submitJobValidation.utils.ts
+++ b/client/src/features/sessionsV2/components/SessionModals/submitJobValidation.utils.ts
@@ -1,0 +1,101 @@
+/*!
+ * Copyright 2026 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { SessionSecretSlotWithSecret } from "../../../ProjectPageV2/ProjectPageContent/SessionSecrets/sessionSecrets.types";
+import { allSessionSecretsReady } from "../../sessionLaunchValidation.utils";
+
+export interface SubmitJobGates {
+  repositoriesReady: boolean;
+  userSecretsReady: boolean;
+  dataConnectorsResolved: boolean;
+  credentialsSaved: boolean;
+}
+
+export const INITIAL_SUBMIT_JOB_GATES: SubmitJobGates = {
+  repositoriesReady: false,
+  userSecretsReady: false,
+  dataConnectorsResolved: false,
+  credentialsSaved: false,
+};
+
+export type SubmitJobValidationStep =
+  | "repositories"
+  | "sessionSecrets"
+  | "dataConnectors"
+  | "saveCredentials"
+  | "complete";
+
+export interface GetSubmitJobValidationStepArgs {
+  isValidating: boolean;
+  isLoadingPrerequisites: boolean;
+  gates: SubmitJobGates;
+  repositoriesNeedAttention: boolean;
+  secretsNeedAttention: boolean;
+  sessionSecretSlotsWithSecrets: SessionSecretSlotWithSecret[] | null;
+  needsCredentials: boolean;
+  shouldSaveCredentials: boolean;
+}
+
+function isUserSecretsReadyForSubmit(
+  gates: SubmitJobGates,
+  isValidating: boolean,
+  sessionSecretSlotsWithSecrets: SessionSecretSlotWithSecret[] | null,
+): boolean {
+  return (
+    gates.userSecretsReady ||
+    (isValidating &&
+      !!sessionSecretSlotsWithSecrets &&
+      allSessionSecretsReady(sessionSecretSlotsWithSecrets))
+  );
+}
+
+export function getSubmitJobValidationStep({
+  isValidating,
+  isLoadingPrerequisites,
+  gates,
+  repositoriesNeedAttention,
+  secretsNeedAttention,
+  sessionSecretSlotsWithSecrets,
+  needsCredentials,
+  shouldSaveCredentials,
+}: GetSubmitJobValidationStepArgs): SubmitJobValidationStep | null {
+  if (!isValidating || isLoadingPrerequisites) {
+    return null;
+  }
+  if (!gates.repositoriesReady && repositoriesNeedAttention) {
+    return "repositories";
+  }
+  if (
+    !isUserSecretsReadyForSubmit(
+      gates,
+      isValidating,
+      sessionSecretSlotsWithSecrets,
+    ) &&
+    secretsNeedAttention &&
+    sessionSecretSlotsWithSecrets
+  ) {
+    return "sessionSecrets";
+  }
+  if (!gates.dataConnectorsResolved && needsCredentials) {
+    return "dataConnectors";
+  }
+  if (shouldSaveCredentials && !gates.credentialsSaved) {
+    return "saveCredentials";
+  }
+  return "complete";
+}

--- a/client/src/features/sessionsV2/components/SessionModals/useSubmitJobFlow.ts
+++ b/client/src/features/sessionsV2/components/SessionModals/useSubmitJobFlow.ts
@@ -1,0 +1,293 @@
+/*!
+ * Copyright 2026 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import type { Project } from "~/features/projectsV2/api/projectV2.api";
+import type { DataConnectorConfiguration } from "../../../dataConnectorsV2/components/useDataConnectorConfiguration.hook";
+import type { SessionLauncher } from "../../api/sessionLaunchersV2.api";
+import { usePostSessionsMutation } from "../../api/sessionsV2.api";
+import { buildJobSessionPostRequest } from "../../session.utils";
+import {
+  dataConnectorsShouldSaveCredentials,
+  doesCloudStorageNeedCredentials,
+} from "../../sessionLaunchValidation.utils";
+import type { SessionStartDataConnectorConfiguration } from "../../startSessionOptionsV2.types";
+import useSessionLaunchPrerequisites from "../../useSessionLaunchPrerequisites.hook";
+import {
+  getSubmitJobValidationStep,
+  INITIAL_SUBMIT_JOB_GATES,
+  type SubmitJobGates,
+  type SubmitJobValidationStep,
+} from "./submitJobValidation.utils";
+import type { SubmitJobForm } from "./useSubmitJobForm";
+
+interface UseSubmitJobFlowArgs {
+  launcher: SessionLauncher;
+  project: Project;
+}
+
+export default function useSubmitJobFlow({
+  launcher,
+  project,
+}: UseSubmitJobFlowArgs) {
+  const prerequisites = useSessionLaunchPrerequisites({
+    project,
+  });
+
+  const [postSession, postSessionResult] = usePostSessionsMutation();
+  const { reset: resetPostSession } = postSessionResult;
+  const hasSubmittedRef = useRef(false);
+  const [gates, setGates] = useState<SubmitJobGates>(INITIAL_SUBMIT_JOB_GATES);
+  const [dataConnectorConfigs, setDataConnectorConfigs] = useState<
+    SessionStartDataConnectorConfiguration[] | undefined
+  >();
+  const [pendingSubmit, setPendingSubmit] = useState<SubmitJobForm | null>(
+    null,
+  );
+  const [isValidating, setIsValidating] = useState(false);
+  const [hasPrerequisitesLoaded, setHasPrerequisitesLoaded] = useState(false);
+  const [buildRequestError, setBuildRequestError] = useState<string | null>(
+    null,
+  );
+
+  if (!prerequisites.isInitialLoading && !hasPrerequisitesLoaded) {
+    setHasPrerequisitesLoaded(true);
+  }
+
+  useEffect(() => {
+    resetPostSession();
+    // Clear stale mutation state when the submit modal opens.
+    // resetPostSession is intentionally omitted from deps: RTK Query recreates
+    // reset when requestId/promise change, which would wipe success right after submit.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const isLoadingPrerequisitesForValidation =
+    prerequisites.isInitialLoading && !hasPrerequisitesLoaded;
+
+  const configsWithCredentials = useMemo(
+    () =>
+      (prerequisites.dataConnectorConfigs ?? []).filter(
+        (config) => !doesCloudStorageNeedCredentials(config),
+      ),
+    [prerequisites.dataConnectorConfigs],
+  );
+
+  const shouldSaveCredentials =
+    dataConnectorConfigs != null &&
+    dataConnectorsShouldSaveCredentials(dataConnectorConfigs);
+
+  const validationStep = useMemo(
+    (): SubmitJobValidationStep | null =>
+      getSubmitJobValidationStep({
+        isValidating,
+        isLoadingPrerequisites: isLoadingPrerequisitesForValidation,
+        gates,
+        repositoriesNeedAttention: prerequisites.repositoriesNeedAttention,
+        secretsNeedAttention: prerequisites.secretsNeedAttention,
+        sessionSecretSlotsWithSecrets:
+          prerequisites.sessionSecretSlotsWithSecrets,
+        needsCredentials: prerequisites.needsCredentials,
+        shouldSaveCredentials,
+      }),
+    [
+      gates,
+      isValidating,
+      isLoadingPrerequisitesForValidation,
+      prerequisites.needsCredentials,
+      prerequisites.repositoriesNeedAttention,
+      prerequisites.secretsNeedAttention,
+      prerequisites.sessionSecretSlotsWithSecrets,
+      shouldSaveCredentials,
+    ],
+  );
+
+  const sessionPostRequestResult = useMemo(() => {
+    if (
+      validationStep !== "complete" ||
+      !pendingSubmit?.resourceClass ||
+      postSessionResult.isLoading ||
+      postSessionResult.isSuccess ||
+      postSessionResult.isError
+    ) {
+      return { request: null, error: null };
+    }
+
+    try {
+      return {
+        request: buildJobSessionPostRequest({
+          launcher,
+          submissionId: pendingSubmit.submissionId,
+          resourceClass: pendingSubmit.resourceClass,
+          diskStorage: pendingSubmit.diskStorage,
+          command: pendingSubmit.command,
+          args: pendingSubmit.args,
+          dataConnectors: dataConnectorConfigs,
+        }),
+        error: null,
+      };
+    } catch (error) {
+      return {
+        request: null,
+        error: error instanceof Error ? error.message : "Unable to submit job",
+      };
+    }
+  }, [
+    dataConnectorConfigs,
+    launcher,
+    pendingSubmit,
+    postSessionResult.isError,
+    postSessionResult.isLoading,
+    postSessionResult.isSuccess,
+    validationStep,
+  ]);
+
+  if (postSessionResult.isSuccess && isValidating) {
+    setIsValidating(false);
+  }
+
+  if (sessionPostRequestResult.error && isValidating) {
+    setBuildRequestError(sessionPostRequestResult.error);
+    setIsValidating(false);
+  }
+
+  if (sessionPostRequestResult.request && buildRequestError != null) {
+    setBuildRequestError(null);
+  }
+
+  useEffect(() => {
+    if (validationStep !== "complete") {
+      hasSubmittedRef.current = false;
+      return;
+    }
+    const { request } = sessionPostRequestResult;
+    if (!request || hasSubmittedRef.current) {
+      return;
+    }
+    hasSubmittedRef.current = true;
+    postSession({ sessionPostRequest: request });
+  }, [postSession, sessionPostRequestResult, validationStep]);
+
+  const cancelValidation = useCallback(() => {
+    setIsValidating(false);
+  }, []);
+
+  const handleSubmitAttempt = useCallback(
+    (data: SubmitJobForm) => {
+      if (
+        isLoadingPrerequisitesForValidation ||
+        prerequisites.isPermissionsError
+      ) {
+        return;
+      }
+      hasSubmittedRef.current = false;
+      if (postSessionResult.isError) {
+        postSessionResult.reset();
+      }
+      setBuildRequestError(null);
+      setPendingSubmit(data);
+      setIsValidating(true);
+      setGates({
+        repositoriesReady: !prerequisites.repositoriesNeedAttention,
+        userSecretsReady: !prerequisites.secretsNeedAttention,
+        dataConnectorsResolved: !prerequisites.needsCredentials,
+        credentialsSaved: false,
+      });
+      if (
+        !prerequisites.needsCredentials &&
+        prerequisites.dataConnectorConfigs
+      ) {
+        setDataConnectorConfigs(prerequisites.dataConnectorConfigs);
+      } else {
+        setDataConnectorConfigs(undefined);
+      }
+    },
+    [
+      postSessionResult,
+      isLoadingPrerequisitesForValidation,
+      prerequisites.dataConnectorConfigs,
+      prerequisites.isPermissionsError,
+      prerequisites.needsCredentials,
+      prerequisites.repositoriesNeedAttention,
+      prerequisites.secretsNeedAttention,
+    ],
+  );
+
+  const onDataConnectorsComplete = useCallback(
+    (configs: DataConnectorConfiguration[]) => {
+      const cloudStorageConfigs = [
+        ...configsWithCredentials,
+        ...configs,
+      ] as SessionStartDataConnectorConfiguration[];
+      setDataConnectorConfigs(cloudStorageConfigs);
+      setGates((prev) => ({
+        ...prev,
+        dataConnectorsResolved: true,
+        credentialsSaved:
+          !dataConnectorsShouldSaveCredentials(cloudStorageConfigs),
+      }));
+    },
+    [configsWithCredentials],
+  );
+
+  const onSaveCredentialsComplete = useCallback(
+    (configs: SessionStartDataConnectorConfiguration[]) => {
+      setDataConnectorConfigs(configs);
+      setGates((prev) => ({ ...prev, credentialsSaved: true }));
+    },
+    [],
+  );
+
+  const onRepositoriesSkip = useCallback(() => {
+    setGates((prev) => ({ ...prev, repositoriesReady: true }));
+  }, []);
+
+  const onSecretsSkip = useCallback(() => {
+    setGates((prev) => ({ ...prev, userSecretsReady: true }));
+  }, []);
+
+  const isSubmitting =
+    buildRequestError == null &&
+    (postSessionResult.isLoading ||
+      (validationStep === "complete" &&
+        pendingSubmit != null &&
+        !postSessionResult.isSuccess &&
+        !postSessionResult.isError));
+
+  return {
+    buildRequestError,
+    cancelValidation,
+    configsNeedingCredentials: prerequisites.configsNeedingCredentials,
+    dataConnectorConfigs,
+    handleSubmitAttempt,
+    isCheckingLaunchPrerequisites: isLoadingPrerequisitesForValidation,
+    isPermissionsError: prerequisites.isPermissionsError,
+    isSubmitting,
+    onDataConnectorsComplete,
+    onRepositoriesSkip,
+    onSaveCredentialsComplete,
+    onSecretsSkip,
+    permissionsError: prerequisites.permissionsError,
+    postSessionResult,
+    sessionSecretSlotsWithSecrets: prerequisites.sessionSecretSlotsWithSecrets,
+    validationStep,
+  };
+}
+
+export type SubmitJobFlow = ReturnType<typeof useSubmitJobFlow>;

--- a/client/src/features/sessionsV2/components/SessionModals/useSubmitJobForm.ts
+++ b/client/src/features/sessionsV2/components/SessionModals/useSubmitJobForm.ts
@@ -1,0 +1,59 @@
+/*!
+ * Copyright 2026 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  ResourceClassWithId,
+  ResourcePoolWithIdFiltered,
+} from "../../api/computeResources.api";
+import type { SessionLauncher } from "../../api/sessionLaunchersV2.api";
+import { getJSONStringArray } from "../../session.utils";
+
+export interface SubmitJobForm {
+  submissionId: string;
+  command: string;
+  args: string;
+  resourceClass: ResourceClassWithId | undefined;
+  diskStorage: number | undefined;
+}
+
+export function getSubmitJobDefaultValues(
+  launcher: SessionLauncher,
+): SubmitJobForm {
+  return {
+    submissionId: "",
+    command: getJSONStringArray(launcher.environment?.command) ?? "",
+    args: getJSONStringArray(launcher.environment?.args) ?? "",
+    resourceClass: undefined,
+    diskStorage: launcher.disk_storage ?? undefined,
+  };
+}
+
+export function resolveDefaultResourceClass({
+  launcher,
+  resourcePools,
+}: {
+  launcher: SessionLauncher;
+  resourcePools: ResourcePoolWithIdFiltered[] | undefined;
+}): ResourceClassWithId | undefined {
+  if (resourcePools == null || launcher.resource_class_id == null) {
+    return undefined;
+  }
+  return resourcePools
+    .flatMap((pool) => pool.classes)
+    .find((c) => c.id === launcher.resource_class_id && c.matching);
+}

--- a/client/src/features/sessionsV2/components/launcherActions/LauncherActions.tsx
+++ b/client/src/features/sessionsV2/components/launcherActions/LauncherActions.tsx
@@ -27,9 +27,8 @@ export function LauncherActions({
   hasSession,
   lastBuild,
   launcher,
-  namespace,
   otherActions,
-  slug,
+  project,
 }: LauncherActionsProps) {
   const category = getLauncherCategory(launcher);
   return category === "session" ? (
@@ -38,9 +37,8 @@ export function LauncherActions({
       hasSession={hasSession}
       lastBuild={lastBuild}
       launcher={launcher}
-      namespace={namespace}
       otherActions={placement === "launcher-card" && otherActions}
-      slug={slug}
+      project={project}
       displayBuildActions={placement === "launcher-card"}
       alwaysShowLaunchAction={placement === "launcher-side-panel"}
     />
@@ -50,9 +48,8 @@ export function LauncherActions({
       hasSession={hasSession}
       lastBuild={lastBuild}
       launcher={launcher}
-      namespace={namespace}
       otherActions={placement === "launcher-card" && otherActions}
-      slug={slug}
+      project={project}
       displayBuildActions={placement === "launcher-card"}
     />
   );

--- a/client/src/features/sessionsV2/components/launcherActions/job/JobLauncherActions.tsx
+++ b/client/src/features/sessionsV2/components/launcherActions/job/JobLauncherActions.tsx
@@ -51,6 +51,7 @@ export default function JobLauncherActions({
   lastBuild,
   launcher,
   otherActions,
+  project,
   displayBuildActions: displayBuildActionsProp,
 }: LauncherCardActionsProps) {
   const { isLoadingPermissions, write } = useProjectPermissions({
@@ -99,24 +100,20 @@ export default function JobLauncherActions({
       return <CheckingLauncherButton />;
     }
 
-    if (!write) {
-      return (
-        <JobSubmitButton
-          disabled={!hasValidImage}
-          canWriteProject={write}
-          imageStatus={imageStatus}
-        />
-      );
-    }
-
     const submitAction = (
       <JobSubmitButton
+        canWriteProject={write}
         className={submitButtonClassName}
         disabled={!hasValidImage}
-        canWriteProject={write}
         imageStatus={imageStatus}
+        launcher={launcher}
+        project={project}
       />
     );
+
+    if (!write) {
+      return submitAction;
+    }
 
     if (applyDefaultBuildActions) {
       return (
@@ -134,6 +131,7 @@ export default function JobLauncherActions({
     imageStatus,
     isLoadingContainerImage,
     launcher,
+    project,
     submitButtonClassName,
     write,
   ]);

--- a/client/src/features/sessionsV2/components/launcherActions/job/JobSubmitButton.tsx
+++ b/client/src/features/sessionsV2/components/launcherActions/job/JobSubmitButton.tsx
@@ -17,18 +17,23 @@
  */
 
 import cx from "classnames";
-import { useCallback, useRef } from "react";
+import { useCallback, useRef, useState } from "react";
 import { Send } from "react-bootstrap-icons";
 import { Button, UncontrolledTooltip } from "reactstrap";
 
+import type { Project } from "~/features/projectsV2/api/projectV2.api";
 import { getLaunchActionTooltip } from "~/features/sessionsV2/session.utils";
 import { ImageStatus } from "~/features/sessionsV2/sessionsV2.types";
+import type { SessionLauncher } from "../../../api/sessionLaunchersV2.api";
+import JobSubmitModal from "../../SessionModals/JobSubmitModal";
 
 interface JobSubmitButtonProps {
   className?: string;
   disabled?: boolean;
   canWriteProject: boolean;
   imageStatus: ImageStatus;
+  launcher: SessionLauncher;
+  project: Project;
 }
 
 export default function JobSubmitButton({
@@ -36,22 +41,31 @@ export default function JobSubmitButton({
   disabled = false,
   imageStatus,
   canWriteProject,
+  launcher,
+  project,
 }: JobSubmitButtonProps) {
   const buttonRef = useRef<HTMLButtonElement>(null);
+  const [isSubmitOpen, setIsSubmitOpen] = useState(false);
   const tooltipMessage = getLaunchActionTooltip(
     canWriteProject,
     imageStatus,
     "job",
   );
 
+  const toggleSubmit = useCallback(() => {
+    setIsSubmitOpen((open) => !open);
+  }, []);
+
   const handleClick = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
       event.stopPropagation();
       if (disabled) {
         event.preventDefault();
+        return;
       }
+      toggleSubmit();
     },
-    [disabled],
+    [disabled, toggleSubmit],
   );
 
   return (
@@ -74,6 +88,12 @@ export default function JobSubmitButton({
           {tooltipMessage}
         </UncontrolledTooltip>
       ) : null}
+      <JobSubmitModal
+        isOpen={isSubmitOpen}
+        launcher={launcher}
+        project={project}
+        toggle={toggleSubmit}
+      />
     </>
   );
 }

--- a/client/src/features/sessionsV2/components/launcherActions/session/SessionLauncherActions.tsx
+++ b/client/src/features/sessionsV2/components/launcherActions/session/SessionLauncherActions.tsx
@@ -44,12 +44,12 @@ export default function SessionLauncherActions({
   hasSession,
   lastBuild,
   launcher,
-  namespace,
+  project,
   otherActions,
-  slug,
   alwaysShowLaunchAction = false,
   displayBuildActions: displayBuildActionsProp,
 }: SessionLauncherCardActionsProps) {
+  const { namespace, slug } = project;
   const { isLoadingPermissions, write } = useProjectPermissions({
     projectId: launcher.project_id,
   });

--- a/client/src/features/sessionsV2/components/launcherActions/types.ts
+++ b/client/src/features/sessionsV2/components/launcherActions/types.ts
@@ -18,6 +18,7 @@
 
 import type { ReactNode } from "react";
 
+import type { Project } from "~/features/projectsV2/api/projectV2.api";
 import type { Build, SessionLauncher } from "../../api/sessionLaunchersV2.api";
 
 export type LauncherActionPlacement = "launcher-card" | "launcher-side-panel";
@@ -27,16 +28,16 @@ export interface LauncherCardActionsProps {
   hasSession?: boolean;
   lastBuild?: Build;
   launcher: SessionLauncher;
-  namespace: string;
   otherActions?: ReactNode;
-  slug: string;
+  project: Project;
   displayBuildActions?: boolean;
 }
 
-export type LauncherPanelActionsProps = Pick<
-  LauncherCardActionsProps,
-  "hasSession" | "launcher" | "namespace" | "slug"
->;
+export interface LauncherPanelActionsProps {
+  hasSession?: boolean;
+  launcher: SessionLauncher;
+  project: Project;
+}
 
 export interface LauncherActionsProps
   extends LauncherCardActionsProps, LauncherPanelActionsProps {

--- a/client/src/features/sessionsV2/launcherEnvironment.utils.ts
+++ b/client/src/features/sessionsV2/launcherEnvironment.utils.ts
@@ -16,8 +16,29 @@
  * limitations under the License.
  */
 
-import type { SessionLauncher } from "./api/sessionLaunchersV2.api";
+import type {
+  SessionLauncher,
+  SessionLauncherEnvironmentParams,
+} from "./api/sessionLaunchersV2.api";
 import type { EnvironmentSelectOption } from "./sessionsV2.types";
+
+export function getEnvironmentKindLabel(
+  environment: SessionLauncherEnvironmentParams | undefined,
+): string | null {
+  if (!environment) {
+    return null;
+  }
+  if (environment.environment_kind === "GLOBAL") {
+    return "Global environment";
+  }
+  if (environment.environment_image_source === "build") {
+    return "Code based environment";
+  }
+  if (environment.environment_kind === "CUSTOM") {
+    return "External image environment";
+  }
+  return null;
+}
 
 export function getLauncherEnvironmentSelect(
   launcher: SessionLauncher,

--- a/client/src/features/sessionsV2/session.constants.tsx
+++ b/client/src/features/sessionsV2/session.constants.tsx
@@ -39,10 +39,11 @@ import faviconWaitingICO from "../../styles/assets/favicon/FaviconWaiting.ico";
 import faviconWaitingSVG from "../../styles/assets/favicon/FaviconWaiting.svg";
 import faviconWaiting16px from "../../styles/assets/favicon/FaviconWaiting16px.png";
 import faviconWaiting32px from "../../styles/assets/favicon/FaviconWaiting32px.png";
-import type {
-  BuilderSelectorOption,
-  LauncherCategory,
-  LauncherCategoryDefinition,
+import {
+  SESSION_LAUNCHER_KIND,
+  type BuilderSelectorOption,
+  type LauncherCategory,
+  type LauncherCategoryDefinition,
 } from "./sessionsV2.types";
 
 export const DEFAULT_URL = "/";
@@ -210,6 +211,17 @@ export const MIN_SESSION_STORAGE_GB = 1;
 
 export const STEP_SESSION_STORAGE_GB = 1;
 
+export const SUBMISSION_ID_PATTERN = /^[a-z][-0-9a-z]{3,19}$/;
+
+export const SUBMISSION_ID_VALIDATION_MESSAGE = {
+  required: "Please provide a submission id.",
+  pattern:
+    "Submission ID must start with a lowercase letter, then use letters, numbers, or hyphens (min 4 characters, no spaces).",
+  taken: "This submission ID is already used for a job on this launcher.",
+  helpText:
+    "Must start with a lowercase letter, then use letters, numbers, or hyphens (min 4 characters, no spaces).",
+};
+
 export const LAUNCHER_OPTIONS: LauncherCategory[] = ["session", "job"];
 
 export const LAUNCHER_BY_CATEGORY: Record<
@@ -217,7 +229,7 @@ export const LAUNCHER_BY_CATEGORY: Record<
   LauncherCategoryDefinition
 > = {
   session: {
-    apiType: "interactive",
+    apiType: SESSION_LAUNCHER_KIND.INTERACTIVE,
     text: {
       display: "Session",
       inline: "session",
@@ -229,7 +241,7 @@ export const LAUNCHER_BY_CATEGORY: Record<
     allowedEnvironmentSelects: ["global", "custom + build", "custom + image"],
   },
   job: {
-    apiType: "non-interactive",
+    apiType: SESSION_LAUNCHER_KIND.NON_INTERACTIVE,
     text: {
       display: "Job",
       inline: "job",

--- a/client/src/features/sessionsV2/session.utils.ts
+++ b/client/src/features/sessionsV2/session.utils.ts
@@ -16,16 +16,23 @@
  * limitations under the License
  */
 
+import { dataConnectorsOverrideFromConfig } from "../cloudStorage/projectCloudStorage.utils";
 import { FaviconStatus } from "../display/display.types";
-import type { ResourcePoolWithId } from "./api/computeResources.api";
 import type {
-  LauncherType,
+  ResourceClassWithId,
+  ResourcePoolWithId,
+} from "./api/computeResources.api";
+import type {
   EnvironmentList as SessionEnvironmentList,
   SessionLauncher,
   SessionLauncherEnvironmentParams,
   SessionLauncherEnvironmentPatchParams,
 } from "./api/sessionLaunchersV2.api";
-import type { ImageCheckResponse } from "./api/sessionsV2.api";
+import type {
+  ImageCheckResponse,
+  SessionPostRequest,
+  SessionResponse,
+} from "./api/sessionsV2.api";
 import {
   BUILDER_FRONTEND_COMBINATIONS,
   BUILDER_PLATFORMS,
@@ -34,15 +41,20 @@ import {
   ENV_VARIABLES_RESERVED_PREFIX,
   getCompatibleFrontends,
   LAUNCHER_BY_CATEGORY,
+  SUBMISSION_ID_PATTERN,
+  SUBMISSION_ID_VALIDATION_MESSAGE,
 } from "./session.constants";
 import {
-  EnvironmentSelectOption,
   ImageStatus,
-  LauncherCategory,
-  LauncherCategoryDefinition,
-  SessionLauncherForm,
-  SessionStatusState,
+  SESSION_LAUNCHER_KIND,
+  type EnvironmentSelectOption,
+  type LauncherCategory,
+  type LauncherCategoryDefinition,
+  type SessionLauncherForm,
+  type SessionLauncherKind,
+  type SessionStatusState,
 } from "./sessionsV2.types";
+import type { SessionStartDataConnectorConfiguration } from "./startSessionOptionsV2.types";
 
 export function getLauncherCategoryDefinitionByLauncher(
   launcher: SessionLauncher,
@@ -52,10 +64,16 @@ export function getLauncherCategoryDefinitionByLauncher(
     : LAUNCHER_BY_CATEGORY["session"];
 }
 
+export function sessionLauncherKindToCategory(
+  kind: SessionLauncherKind,
+): LauncherCategory {
+  return kind === SESSION_LAUNCHER_KIND.NON_INTERACTIVE ? "job" : "session";
+}
+
 export function getLauncherCategory(
   launcher: SessionLauncher,
 ): LauncherCategory {
-  return isJobLauncher(launcher) ? "job" : "session";
+  return sessionLauncherKindToCategory(launcher.launcher_type);
 }
 
 export function getLauncherCategoryDefinition(
@@ -64,12 +82,14 @@ export function getLauncherCategoryDefinition(
   return LAUNCHER_BY_CATEGORY[category];
 }
 
-export function getLauncherApiType(category: LauncherCategory): LauncherType {
+export function getLauncherApiType(
+  category: LauncherCategory,
+): SessionLauncherKind {
   return getLauncherCategoryDefinition(category).apiType;
 }
 
 export function isJobLauncher(launcher: SessionLauncher): boolean {
-  return launcher.launcher_type === "non-interactive";
+  return launcher.launcher_type === SESSION_LAUNCHER_KIND.NON_INTERACTIVE;
 }
 
 export function isGlobalEnvironmentIncluded(allowedEnvironments: string[]) {
@@ -556,6 +576,95 @@ export function validateEnvVariableName(name: string): true | string {
   return true;
 }
 
+export function validateSubmissionId(value: string): true | string {
+  const trimmed = value?.trim() ?? "";
+  if (!trimmed) {
+    return SUBMISSION_ID_VALIDATION_MESSAGE.required;
+  }
+  if (/\s/.test(trimmed)) {
+    return SUBMISSION_ID_VALIDATION_MESSAGE.pattern;
+  }
+  if (!SUBMISSION_ID_PATTERN.test(trimmed)) {
+    return SUBMISSION_ID_VALIDATION_MESSAGE.pattern;
+  }
+  return true;
+}
+
+export function isSubmissionIdTaken({
+  sessions,
+  launcherId,
+  projectId,
+  submissionId,
+}: {
+  sessions: SessionResponse[] | undefined;
+  launcherId: string;
+  projectId: string;
+  submissionId: string;
+}): boolean {
+  const trimmed = submissionId.trim();
+  if (!trimmed || sessions == null) {
+    return false;
+  }
+  return sessions.some(
+    (session) =>
+      session.launcher_id === launcherId &&
+      session.project_id === projectId &&
+      session.submission_id === trimmed,
+  );
+}
+
+export interface BuildJobSessionPostRequestArgs {
+  launcher: SessionLauncher;
+  submissionId: string;
+  resourceClass: ResourceClassWithId;
+  diskStorage?: number;
+  command?: string;
+  args?: string;
+  dataConnectors?: SessionStartDataConnectorConfiguration[];
+}
+
+export function buildJobSessionPostRequest({
+  launcher,
+  submissionId,
+  resourceClass,
+  diskStorage,
+  command,
+  args,
+  dataConnectors,
+}: BuildJobSessionPostRequestArgs): SessionPostRequest {
+  const commandParsed = safeParseJSONStringArray(command ?? "");
+  const argsParsed = safeParseJSONStringArray(args ?? "");
+
+  if (command?.trim() && !commandParsed.parsed) {
+    throw new Error("Invalid job command format");
+  }
+  if (args?.trim() && !argsParsed.parsed) {
+    throw new Error("Invalid job args format");
+  }
+
+  const request: SessionPostRequest = {
+    launcher_id: launcher.id,
+    submission_id: submissionId.trim(),
+    resource_class_id: resourceClass.id,
+    job_command_override: command?.trim() ? commandParsed.data : undefined,
+    job_args_override: args?.trim() ? argsParsed.data : undefined,
+  };
+
+  if (diskStorage != null && diskStorage !== resourceClass.default_storage) {
+    request.disk_storage = diskStorage;
+  }
+
+  if (dataConnectors?.length) {
+    request.data_connectors_overrides = dataConnectors.flatMap(
+      dataConnectorsOverrideFromConfig,
+    );
+  }
+
+  return request;
+}
+
+export { getLauncherEnvironmentSelect } from "./launcherEnvironment.utils";
+
 export function isImageCompatibleWith(
   image: ImageCheckResponse,
   platform: ResourcePoolWithId["platform"],
@@ -588,4 +697,9 @@ export function getLaunchActionTooltip(
     case "available":
       return undefined;
   }
+}
+
+export function generateSubmissionId(): string {
+  const randomPart = Math.random().toString(36).slice(2, 8);
+  return `run-${randomPart}`;
 }

--- a/client/src/features/sessionsV2/sessionLaunchValidation.utils.ts
+++ b/client/src/features/sessionsV2/sessionLaunchValidation.utils.ts
@@ -1,0 +1,97 @@
+/*!
+ * Copyright 2026 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { shouldInterrupt } from "../ProjectPageV2/ProjectPageContent/CodeRepositories/repositories.utils";
+import type { SessionSecretSlotWithSecret } from "../ProjectPageV2/ProjectPageContent/SessionSecrets/sessionSecrets.types";
+import type { GetRepositoriesApiResponse } from "../repositories/api/repositories.api";
+import { storageSecretNameToFieldName } from "../secretsV2/secrets.utils";
+import type { SessionStartDataConnectorConfiguration } from "./startSessionOptionsV2.types";
+
+export function doesCloudStorageNeedCredentials(
+  config: SessionStartDataConnectorConfiguration,
+): boolean {
+  if (!config.active || config.skip) {
+    return false;
+  }
+
+  const sensitiveFields = Object.keys(config.sensitiveFieldValues);
+  const credentialFieldDict = config.savedCredentialFields
+    ? Object.fromEntries(
+        config.savedCredentialFields?.map((field) => [
+          storageSecretNameToFieldName({ name: field }),
+          true,
+        ]),
+      )
+    : {};
+  if (sensitiveFields.every((key) => credentialFieldDict[key] != null)) {
+    return false;
+  }
+  return Object.values(config.sensitiveFieldValues).some(
+    (value) => value === "",
+  );
+}
+
+export function shouldCloudStorageSaveCredentials(
+  config: SessionStartDataConnectorConfiguration,
+): boolean {
+  return config.saveCredentials;
+}
+
+export function repositoriesNeedAttention(
+  repositories: GetRepositoriesApiResponse[] | undefined,
+  hasWritePermission: boolean,
+): boolean {
+  if (!repositories) {
+    return false;
+  }
+  return repositories.some(
+    (repo) =>
+      repo.error ||
+      (repo.data && shouldInterrupt(repo.data, hasWritePermission)),
+  );
+}
+
+export function allSessionSecretsReady(
+  sessionSecretSlotsWithSecrets: SessionSecretSlotWithSecret[] | null,
+): boolean {
+  if (!sessionSecretSlotsWithSecrets?.length) {
+    return true;
+  }
+  return sessionSecretSlotsWithSecrets.every(({ secretId }) => secretId);
+}
+
+export function secretsNeedAttention(
+  sessionSecretSlotsWithSecrets: SessionSecretSlotWithSecret[] | null,
+): boolean {
+  if (!sessionSecretSlotsWithSecrets?.length) {
+    return false;
+  }
+  return !allSessionSecretsReady(sessionSecretSlotsWithSecrets);
+}
+
+export function dataConnectorsNeedCredentials(
+  configs: SessionStartDataConnectorConfiguration[] | undefined,
+): boolean {
+  return configs?.some(doesCloudStorageNeedCredentials) ?? false;
+}
+
+export function dataConnectorsShouldSaveCredentials(
+  configs: SessionStartDataConnectorConfiguration[] | undefined,
+): boolean {
+  return configs?.some(shouldCloudStorageSaveCredentials) ?? false;
+}

--- a/client/src/features/sessionsV2/sessionsV2.types.ts
+++ b/client/src/features/sessionsV2/sessionsV2.types.ts
@@ -43,7 +43,15 @@ export interface SvgIconProps {
 
 export type LauncherCategory = "session" | "job";
 
-export type LauncherApiType = LauncherType;
+/** Shared API discriminator for `launcher_type` and `session_type`. */
+export type SessionLauncherKind = LauncherType & SessionType;
+
+export const SESSION_LAUNCHER_KIND = {
+  INTERACTIVE: "interactive",
+  NON_INTERACTIVE: "non-interactive",
+} as const satisfies Record<string, SessionLauncherKind>;
+
+export type LauncherApiType = SessionLauncherKind;
 
 export type EnvironmentSelectOption =
   | "global"
@@ -137,7 +145,7 @@ export interface SessionV2 {
   project_id: string;
   launcher_id: string;
   resource_class_id: number;
-  session_type: SessionType;
+  session_type: SessionLauncherKind;
   submission_id?: SubmissionId;
   command_args?: string[] | null;
   job_completed_at?: string | null;

--- a/client/src/features/sessionsV2/useLauncherEnvironmentReadiness.hook.ts
+++ b/client/src/features/sessionsV2/useLauncherEnvironmentReadiness.hook.ts
@@ -92,8 +92,6 @@ export default function useLauncherEnvironmentReadiness({
   );
   const builds = buildsProp ?? fetchedBuilds;
   const lastBuild = lastBuildProp ?? builds?.at(0);
-  const isBuildInProgress =
-    isCodeEnvironment && lastBuild?.status === "in_progress";
   const lastSuccessfulBuild = builds?.find(
     (build) => build.status === "succeeded" && build.id !== lastBuild?.id,
   );
@@ -114,6 +112,16 @@ export default function useLauncherEnvironmentReadiness({
     );
 
   const hasCustomImageAccessible = containerImage?.accessible === true;
+  const displayLaunchSession =
+    !isCodeEnvironment ||
+    lastBuild?.status === "succeeded" ||
+    (isCodeEnvironment && containerImage?.accessible === true) ||
+    useOldImage;
+
+  const isBuildInProgress =
+    isCodeEnvironment && lastBuild?.status === "in_progress";
+
+  const isLastBuildRunning = lastBuild?.status === "in_progress";
   const hasValidImage =
     isGlobalEnvironment || hasSuccessfulBuild || hasCustomImageAccessible;
 
@@ -135,9 +143,11 @@ export default function useLauncherEnvironmentReadiness({
     forceLaunch,
     hasSuccessfulBuild,
     hasValidImage,
+    isLastBuildRunning,
     isBuildInProgress,
     isCodeEnvironment,
     isCustomImageEnvironment,
+    displayLaunchSession,
     isGlobalEnvironment,
     isLoadingBuilds: shouldFetchBuilds && isLoadingBuilds,
     isLoadingContainerImage:

--- a/client/src/features/sessionsV2/useSessionLaunchPrerequisites.hook.ts
+++ b/client/src/features/sessionsV2/useSessionLaunchPrerequisites.hook.ts
@@ -1,0 +1,150 @@
+/*!
+ * Copyright 2026 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { skipToken } from "@reduxjs/toolkit/query";
+import { useMemo } from "react";
+
+import {
+  useGetDataConnectorsListByDataConnectorIdsQuery,
+  useGetProjectsByProjectIdDataConnectorLinksQuery,
+} from "../dataConnectorsV2/api/data-connectors.enhanced-api";
+import useDataConnectorConfiguration from "../dataConnectorsV2/components/useDataConnectorConfiguration.hook";
+import useProjectPermissions from "../ProjectPageV2/utils/useProjectPermissions.hook";
+import type { Project } from "../projectsV2/api/projectV2.api";
+import { useGetRepositoriesQuery } from "../repositories/api/repositories.api";
+import {
+  dataConnectorsNeedCredentials,
+  doesCloudStorageNeedCredentials,
+  repositoriesNeedAttention,
+  secretsNeedAttention,
+} from "./sessionLaunchValidation.utils";
+import type { SessionStartDataConnectorConfiguration } from "./startSessionOptionsV2.types";
+import useSessionSecrets from "./useSessionSecrets.hook";
+
+interface UseSessionLaunchPrerequisitesArgs {
+  project: Project;
+  autoMarkSecretsReady?: boolean;
+}
+
+export default function useSessionLaunchPrerequisites({
+  project,
+  autoMarkSecretsReady = false,
+}: UseSessionLaunchPrerequisitesArgs) {
+  const projectId = project.id;
+  const repositoryUrls = project.repositories ?? [];
+
+  const {
+    data: dataConnectorLinks,
+    isFetching: isFetchingDataConnectorLinks,
+    isLoading: isLoadingDataConnectorLinks,
+  } = useGetProjectsByProjectIdDataConnectorLinksQuery(
+    projectId ? { projectId } : skipToken,
+  );
+  const dataConnectorIds = useMemo(
+    () => dataConnectorLinks?.map((link) => link.data_connector_id),
+    [dataConnectorLinks],
+  );
+  const {
+    data: dataConnectorsMap,
+    isFetching: isFetchingDataConnectors,
+    isLoading: isLoadingDataConnectors,
+  } = useGetDataConnectorsListByDataConnectorIdsQuery(
+    dataConnectorIds ? { dataConnectorIds } : skipToken,
+  );
+
+  const dataConnectors = useMemo(
+    () => Object.values(dataConnectorsMap ?? {}),
+    [dataConnectorsMap],
+  );
+  const { dataConnectorConfigs, isReadyDataConnectorConfigs } =
+    useDataConnectorConfiguration({
+      dataConnectors: dataConnectors ? dataConnectors : undefined,
+    });
+
+  const { data: repositories, isFetching: isFetchingRepositories } =
+    useGetRepositoriesQuery(repositoryUrls ? repositoryUrls : skipToken);
+
+  const projectPermissions = useProjectPermissions({ projectId });
+
+  const {
+    isFetching: isFetchingSessionSecrets,
+    sessionSecretSlotsWithSecrets,
+  } = useSessionSecrets({
+    projectId,
+    autoMarkReady: autoMarkSecretsReady,
+  });
+
+  const isFetchingOrLoadingDataConnectors =
+    isFetchingDataConnectorLinks ||
+    isLoadingDataConnectorLinks ||
+    isLoadingDataConnectors ||
+    isFetchingDataConnectors ||
+    !isReadyDataConnectorConfigs;
+
+  const isInitialLoading =
+    projectPermissions.isLoadingPermissions ||
+    dataConnectorLinks == null ||
+    (dataConnectorLinks != null &&
+      dataConnectorIds != null &&
+      dataConnectorsMap == null) ||
+    (repositoryUrls.length > 0 && repositories == null) ||
+    sessionSecretSlotsWithSecrets == null;
+
+  const hasWritePermission =
+    projectPermissions.arePermissionsResolved &&
+    projectPermissions.write === true;
+
+  const repositoriesNeedAttentionFlag = repositoriesNeedAttention(
+    repositories,
+    hasWritePermission,
+  );
+
+  const secretsNeedAttentionFlag = secretsNeedAttention(
+    sessionSecretSlotsWithSecrets,
+  );
+
+  const configsNeedingCredentials = useMemo(
+    () =>
+      dataConnectorConfigs?.filter((config) =>
+        doesCloudStorageNeedCredentials(config),
+      ) ?? [],
+    [dataConnectorConfigs],
+  );
+
+  const needsCredentials = dataConnectorsNeedCredentials(dataConnectorConfigs);
+
+  return {
+    dataConnectorConfigs: dataConnectorConfigs as
+      | SessionStartDataConnectorConfiguration[]
+      | undefined,
+    configsNeedingCredentials,
+    hasWritePermission,
+    isFetchingOrLoadingDataConnectors,
+    isFetchingRepositories,
+    isFetchingSessionSecrets,
+    isInitialLoading,
+    isPermissionsError: projectPermissions.isPermissionsError,
+    isReadyDataConnectorConfigs,
+    needsCredentials,
+    permissionsError: projectPermissions.permissionsError,
+    repositories,
+    repositoriesNeedAttention: repositoriesNeedAttentionFlag,
+    secretsNeedAttention: secretsNeedAttentionFlag,
+    sessionSecretSlotsWithSecrets,
+  };
+}

--- a/client/src/features/sessionsV2/useSessionLaunchState.hook.ts
+++ b/client/src/features/sessionsV2/useSessionLaunchState.hook.ts
@@ -21,22 +21,15 @@ import { useEffect, useMemo } from "react";
 
 import useAppDispatch from "~/utils/customHooks/useAppDispatch.hook";
 import useAppSelector from "~/utils/customHooks/useAppSelector.hook";
-import {
-  useGetDataConnectorsListByDataConnectorIdsQuery,
-  useGetProjectsByProjectIdDataConnectorLinksQuery,
-} from "../dataConnectorsV2/api/data-connectors.enhanced-api";
-import useDataConnectorConfiguration from "../dataConnectorsV2/components/useDataConnectorConfiguration.hook";
-import { shouldInterrupt } from "../ProjectPageV2/ProjectPageContent/CodeRepositories/repositories.utils";
-import useProjectPermissions from "../ProjectPageV2/utils/useProjectPermissions.hook";
 import type { Project } from "../projectsV2/api/projectV2.api";
-import { useGetRepositoriesQuery } from "../repositories/api/repositories.api";
 import { useGetResourcePoolsQuery } from "./api/computeResources.api";
 import type { SessionLauncher } from "./api/sessionLaunchersV2.api";
 import { useGetSessionsImagesQuery } from "./api/sessionsV2.api";
 import { DEFAULT_URL } from "./session.constants";
+import { repositoriesNeedAttention } from "./sessionLaunchValidation.utils";
 import startSessionOptionsV2Slice from "./startSessionOptionsV2.slice";
+import useSessionLaunchPrerequisites from "./useSessionLaunchPrerequisites.hook";
 import useSessionResourceClass from "./useSessionResourceClass.hook";
-import useSessionSecrets from "./useSessionSecrets.hook";
 
 interface StartSessionFromLauncherProps {
   launcher: SessionLauncher;
@@ -52,33 +45,25 @@ export default function useSessionLauncherState({
   const default_url = launcher.environment?.default_url ?? "";
 
   const {
-    data: dataConnectorLinks,
-    isFetching: isFetchingDataConnectorLinks,
-    isLoading: isLoadingDataConnectorLinks,
-  } = useGetProjectsByProjectIdDataConnectorLinksQuery({
-    projectId: project.id,
+    dataConnectorConfigs: initialDataConnectorConfigs,
+    hasWritePermission,
+    isFetchingOrLoadingDataConnectors: isFetchingOrLoadingStorages,
+    isFetchingRepositories,
+    isFetchingSessionSecrets,
+    isReadyDataConnectorConfigs,
+    repositories,
+    sessionSecretSlotsWithSecrets,
+  } = useSessionLaunchPrerequisites({
+    project,
+    autoMarkSecretsReady: true,
   });
-  const dataConnectorIds = useMemo(
-    () => dataConnectorLinks?.map((link) => link.data_connector_id),
-    [dataConnectorLinks],
-  );
-  const {
-    data: dataConnectorsMap,
-    isFetching: isFetchingDataConnectors,
-    isLoading: isLoadingDataConnectors,
-  } = useGetDataConnectorsListByDataConnectorIdsQuery(
-    dataConnectorIds ? { dataConnectorIds } : skipToken,
-  );
+
   const { data: resourcePools } = useGetResourcePoolsQuery({});
   const { isPendingResourceClass, setResourceClass } = useSessionResourceClass({
     launcher,
     isCustomLaunch,
     resourcePools,
   });
-  const {
-    isFetching: isFetchingSessionSecrets,
-    sessionSecretSlotsWithSecrets,
-  } = useSessionSecrets({ projectId: project.id });
 
   const containerImage = launcher.environment?.container_image ?? "";
   const isExternalImageEnvironment =
@@ -131,30 +116,13 @@ export default function useSessionLauncherState({
   }, [default_url, dispatch, startSessionOptionsV2.defaultUrl]);
 
   useEffect(() => {
-    const repositories = (project.repositories ?? []).map((url) => ({ url }));
-    dispatch(startSessionOptionsV2Slice.actions.setRepositories(repositories));
+    const projectRepositories = (project.repositories ?? []).map((url) => ({
+      url,
+    }));
+    dispatch(
+      startSessionOptionsV2Slice.actions.setRepositories(projectRepositories),
+    );
   }, [dispatch, project.repositories]);
-
-  const dataConnectors = useMemo(
-    () => Object.values(dataConnectorsMap ?? {}),
-    [dataConnectorsMap],
-  );
-  const {
-    dataConnectorConfigs: initialDataConnectorConfigs,
-    isReadyDataConnectorConfigs,
-  } = useDataConnectorConfiguration({ dataConnectors });
-
-  const { data: repositories, isFetching: isFetchingRepositories } =
-    useGetRepositoriesQuery(project.repositories ?? []);
-
-  const projectPermissions = useProjectPermissions({ projectId: project.id });
-
-  const isFetchingOrLoadingStorages =
-    isFetchingDataConnectorLinks ||
-    isLoadingDataConnectorLinks ||
-    isLoadingDataConnectors ||
-    isFetchingDataConnectors ||
-    !isReadyDataConnectorConfigs;
 
   useEffect(() => {
     if (
@@ -187,20 +155,14 @@ export default function useSessionLauncherState({
 
   // Check for code repos availability -- it should only block if any repo requires it
   useEffect(() => {
-    const interrupt = !!repositories?.find(
-      (repo) =>
-        repo.error ||
-        (repo.data && shouldInterrupt(repo.data, !!projectPermissions?.write)),
+    const interrupt = repositoriesNeedAttention(
+      repositories,
+      hasWritePermission,
     );
     if (!isFetchingRepositories && !interrupt) {
       dispatch(startSessionOptionsV2Slice.actions.setRepositoriesReady(true));
     }
-  }, [
-    dispatch,
-    isFetchingRepositories,
-    projectPermissions?.write,
-    repositories,
-  ]);
+  }, [dispatch, hasWritePermission, isFetchingRepositories, repositories]);
 
   return {
     containerImage,

--- a/client/src/features/sessionsV2/useSessionSecrets.hook.ts
+++ b/client/src/features/sessionsV2/useSessionSecrets.hook.ts
@@ -30,10 +30,12 @@ import startSessionOptionsV2Slice from "./startSessionOptionsV2.slice";
 
 interface UseSessionSecretsArgs {
   projectId: string;
+  autoMarkReady?: boolean;
 }
 
 export default function useSessionSecrets({
   projectId,
+  autoMarkReady = true,
 }: UseSessionSecretsArgs) {
   const { data: user } = useGetUserQueryState();
   const isUserLoggedIn = !!user?.isLoggedIn;
@@ -42,7 +44,9 @@ export default function useSessionSecrets({
     currentData: sessionSecretSlots,
     isFetching: isFetchingSessionSecretSlots,
     error: sessionSecretSlotsError,
-  } = useGetProjectsByProjectIdSessionSecretSlotsQuery({ projectId });
+  } = useGetProjectsByProjectIdSessionSecretSlotsQuery(
+    projectId ? { projectId } : skipToken,
+  );
   const {
     currentData: sessionSecrets,
     isFetching: isFetchingSessionSecrets,
@@ -67,10 +71,13 @@ export default function useSessionSecrets({
   const dispatch = useAppDispatch();
 
   useEffect(() => {
-    if (sessionSecretSlotsWithSecrets?.every(({ secretId }) => secretId)) {
+    if (
+      autoMarkReady &&
+      sessionSecretSlotsWithSecrets?.every(({ secretId }) => secretId)
+    ) {
       dispatch(startSessionOptionsV2Slice.actions.setUserSecretsReady(true));
     }
-  }, [dispatch, sessionSecretSlotsWithSecrets, isUserLoggedIn]);
+  }, [autoMarkReady, dispatch, sessionSecretSlotsWithSecrets, isUserLoggedIn]);
 
   return {
     sessionSecretSlotsWithSecrets,

--- a/tests/cypress/e2e/projectV2LauncherActions.spec.ts
+++ b/tests/cypress/e2e/projectV2LauncherActions.spec.ts
@@ -282,9 +282,14 @@ describe("launcher card actions", () => {
       cy.wait("@getProjectV2Permissions");
     });
 
-    it("shows submit button on card (stub — no modal)", () => {
+    it("opens submit job modal from card", () => {
       withinFirstSessionLauncher(clickSubmitJobButton);
-      cy.getDataCy("submit-job-modal").should("not.exist");
+      cy.getDataCy("submit-job-modal").should("be.visible");
+      cy.getDataCy("submit-job-submission-id-input").should("be.visible");
+      cy.getDataCy("submit-job-confirm-button").should(
+        "contain.text",
+        "Submit job",
+      );
     });
 
     it("allows submit when a job is already running", () => {
@@ -309,7 +314,7 @@ describe("read-only user on job launcher", () => {
     cy.getDataCy("session-launcher-item")
       .first()
       .within(() => {
-        cy.getDataCy("submit-job-button").should("be.visible");
+        assertSubmitJobButtonEnabled();
         cy.getDataCy("button-with-menu-dropdown").should("not.exist");
       });
   });
@@ -413,7 +418,7 @@ describe("launcher panel actions", () => {
     cy.wait("@getProjectV2Permissions");
 
     openFirstLauncherPanel();
-    cy.getDataCy("submit-job-button").should("be.visible");
+    assertSubmitJobButtonEnabled();
     cy.getDataCy("button-with-menu-dropdown").should("not.exist");
   });
 

--- a/tests/cypress/fixtures/projectV2/sessions-with-submission-id.json
+++ b/tests/cypress/fixtures/projectV2/sessions-with-submission-id.json
@@ -1,0 +1,25 @@
+[
+  {
+    "image": "renku/renkulab-py:latest",
+    "name": "job-session-01",
+    "resources": {
+      "requests": {
+        "cpu": 0.5,
+        "memory": "1G",
+        "storage": "1G"
+      }
+    },
+    "started": "2024-05-23T10:00:00Z",
+    "status": {
+      "state": "running",
+      "ready_containers": 1,
+      "total_containers": 1
+    },
+    "url": "https://example.com",
+    "project_id": "01HYJE5FR1JV4CWFMBFJQFQ4RM",
+    "launcher_id": "01HYJE99XEKWNKPYN8WRB6QA8Z",
+    "resource_class_id": 2,
+    "session_type": "non_interactive",
+    "submission_id": "run01"
+  }
+]


### PR DESCRIPTION
PR to add submit a job from a job launcher.

User opens a modal, sets a Submission ID, edits command/args, picks a resource class, and submits. The app checks the ID, command/args format, resource class, environment readiness, and access to repos/secrets/connectors before sending.

**Note**: Job status in the UI may not be accurate yet. Status design and actions per status will come in a follow-up PR.

AI disclosure: Used Cursor as a coding assistant for parts of this PR (autocomplete/refactor suggestions).

/deploy renku=feat/add-jobs amalthea-sessions=main renku-data-services=main extra-values=dataService.imageBuilders.enabled=true,dataService.imageBuilders.strategyName=renku-buildpacks-v3,dataService.imageBuilders.outputImagePrefix=harbor.dev.renku.ch/renku-build/,dataService.imageBuilders.nodeSelector.renku.io/node-purpose=user,dataService.imageBuilders.tolerations[0].effect=NoSchedule,dataService.imageBuilders.tolerations[0].key=renku.io/dedicated,dataService.imageBuilders.tolerations[0].operator=Equal,dataService.imageBuilders.tolerations[0].value=user #no-tests