### PR TITLE
fix?: setup rtk listeners to allow using refetchOnFocus and the like

### DIFF
--- a/client/src/store/store.ts
+++ b/client/src/store/store.ts
@@ -17,6 +17,7 @@
  */
 
 import { configureStore } from "@reduxjs/toolkit";
+import { setupListeners } from "@reduxjs/toolkit/query";
 
 import toastSlice from "~/components/toast/toast.slice";
 import adminKeycloakApi from "~/features/admin/adminKeycloak.api";
@@ -98,6 +99,8 @@ export const store = configureStore({
       .concat(usersApi.middleware)
       .concat(versionsApi.middleware),
 });
+
+setupListeners(store.dispatch);
 
 export type StoreType = typeof store;
 


### PR DESCRIPTION
We use RTK features like `refetchOnFocus` that don't work properly because we don't invoke `setupListeners`.

This PR is an attempt at fixing it.

/deploy renku=release-2.18.0
