### PR TITLE
fix: reset data connector useForm values on edit

### DIFF
--- a/client/src/features/dataConnectorsV2/components/DataConnectorModal/DataConnectorModalBody.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorModal/DataConnectorModalBody.tsx
@@ -17,7 +17,7 @@
  */
 
 import cx from "classnames";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Eye, Globe, Lock, Pencil, PlusLg } from "react-bootstrap-icons";
 import { Controller, useForm } from "react-hook-form";
 import {
@@ -68,6 +68,7 @@ import DataConnectorSaveCredentialsInfo from "./DataConnectorSaveCredentialsInfo
 
 interface AddOrEditDataConnectorProps {
   dataConnector?: DataConnectorRead | null;
+  isOpen?: boolean;
   project?: Project;
   storageSecrets: DataConnectorSecret[];
   switchMode?: () => void;
@@ -237,6 +238,7 @@ function DataConnectorMount({ dataConnector }: AddOrEditDataConnectorProps) {
     formState: { dirtyFields, errors, touchedFields },
     setValue,
     getValues,
+    reset,
     watch,
   } = useForm<DataConnectorMountForm>({
     mode: "onChange",
@@ -254,8 +256,50 @@ function DataConnectorMount({ dataConnector }: AddOrEditDataConnectorProps) {
       visibility: flatDataConnector.visibility || "private",
     },
   });
+  const lastResetId = useRef<string | null>(null);
+
   const currentKeywords = watch("keywords");
   const oldKeywords = dataConnector?.keywords ?? [];
+
+  useEffect(() => {
+    const dataConnectorId = dataConnector?.id ?? null;
+
+    if (dataConnectorId == null) {
+      lastResetId.current = null;
+      return;
+    }
+    if (flatDataConnector.dataConnectorId !== dataConnectorId) return;
+    if (lastResetId.current === dataConnectorId) return;
+
+    reset({
+      keyword: "",
+      keywords: flatDataConnector.keywords || [],
+      mountPoint:
+        flatDataConnector.mountPoint ||
+        `${flatDataConnector.schema?.toLowerCase()}`,
+      name: flatDataConnector.name || "",
+      namespace: flatDataConnector.namespace || "",
+      readOnly: flatDataConnector.readOnly ?? false,
+      saveCredentials: cloudStorageState.saveCredentials,
+      slug: flatDataConnector.slug || "",
+      visibility: flatDataConnector.visibility || "private",
+    });
+
+    lastResetId.current = dataConnectorId;
+  }, [
+    cloudStorageState.saveCredentials,
+    dataConnector?.id,
+    flatDataConnector.dataConnectorId,
+    flatDataConnector.keywords,
+    flatDataConnector.mountPoint,
+    flatDataConnector.name,
+    flatDataConnector.namespace,
+    flatDataConnector.readOnly,
+    flatDataConnector.schema,
+    flatDataConnector.slug,
+    flatDataConnector.visibility,
+    reset,
+  ]);
 
   const onFieldValueChange = useCallback(
     (field: DataConnectorMountFormFields, value: string | boolean) => {

--- a/client/src/features/dataConnectorsV2/components/DataConnectorModal/DataConnectorModalBody.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorModal/DataConnectorModalBody.tsx
@@ -19,7 +19,7 @@
 import cx from "classnames";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Eye, Globe, Lock, Pencil, PlusLg } from "react-bootstrap-icons";
-import { Controller, useForm } from "react-hook-form";
+import { Controller, useForm, useWatch } from "react-hook-form";
 import {
   Button,
   ButtonGroup,
@@ -239,7 +239,6 @@ function DataConnectorMount({ dataConnector }: AddOrEditDataConnectorProps) {
     setValue,
     getValues,
     reset,
-    watch,
   } = useForm<DataConnectorMountForm>({
     mode: "onChange",
     defaultValues: {
@@ -258,7 +257,7 @@ function DataConnectorMount({ dataConnector }: AddOrEditDataConnectorProps) {
   });
   const lastResetId = useRef<string | null>(null);
 
-  const currentKeywords = watch("keywords");
+  const currentKeywords = useWatch({ control, name: "keywords" }) ?? [];
   const oldKeywords = dataConnector?.keywords ?? [];
 
   useEffect(() => {
@@ -366,8 +365,8 @@ function DataConnectorMount({ dataConnector }: AddOrEditDataConnectorProps) {
     (o) => flatDataConnector.options && flatDataConnector.options[o.name],
   );
 
-  const currentName = watch("name");
-  const currentSlug = watch("slug");
+  const currentName = useWatch({ control, name: "name" }) ?? "";
+  const currentSlug = useWatch({ control, name: "slug" }) ?? "";
   useEffect(() => {
     dispatch(
       dataConnectorFormSlice.actions.setFlatDataConnector({

--- a/client/src/features/dataConnectorsV2/components/DataConnectorModal/DataConnectorModalBody.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorModal/DataConnectorModalBody.tsx
@@ -68,7 +68,6 @@ import DataConnectorSaveCredentialsInfo from "./DataConnectorSaveCredentialsInfo
 
 interface AddOrEditDataConnectorProps {
   dataConnector?: DataConnectorRead | null;
-  isOpen?: boolean;
   project?: Project;
   storageSecrets: DataConnectorSecret[];
   switchMode?: () => void;


### PR DESCRIPTION
Properly reset when closing the Modal

/deploy renku=release-2.18.0

fix https://github.com/SwissDataScienceCenter/renku-ui/issues/4208