### PR TITLE
feat: add `infer` and `none` frontends to custom environments

### DIFF
--- a/client/src/features/sessionsV2/session.constants.tsx
+++ b/client/src/features/sessionsV2/session.constants.tsx
@@ -154,6 +154,22 @@ export const BUILDER_FRONTENDS = [
     /* eslint-enable spellcheck/spell-checker */
   },
   {
+    /* eslint-disable spellcheck/spell-checker */
+    value: "infer",
+    label: "Infer Frontend",
+    description:
+      "Infer frontend from dependencies, Currently only Marimo is supported.",
+    /* eslint-enable spellcheck/spell-checker */
+  },
+  {
+    /* eslint-disable spellcheck/spell-checker */
+    value: "none",
+    label: "None",
+    description:
+      "Do not inject a frontend. Please define the entrypoint in a Procfile if needed.",
+    /* eslint-enable spellcheck/spell-checker */
+  },
+  {
     value: "rstudio",
     label: "RStudio",
     description: "Web-based integrated development environment for R.",
@@ -162,8 +178,8 @@ export const BUILDER_FRONTENDS = [
 
 /* eslint-disable spellcheck/spell-checker */
 export const BUILDER_FRONTEND_COMBINATIONS: Record<string, string[]> = {
-  python: ["vscodium", "jupyterlab", "ttyd"],
-  r: ["rstudio"],
+  python: ["vscodium", "jupyterlab", "ttyd", "infer", "none"],
+  r: ["rstudio", "none"],
 };
 
 export const getCompatibleFrontends = (builderVariant: string) => {

--- a/client/src/features/sessionsV2/session.constants.tsx
+++ b/client/src/features/sessionsV2/session.constants.tsx
@@ -161,17 +161,17 @@ export const BUILDER_FRONTENDS = [
   {
     /* eslint-disable spellcheck/spell-checker */
     value: "infer",
-    label: "Infer Frontend",
+    label: "Auto-Detect",
     description:
-      "Infer frontend from dependencies, Currently only Marimo is supported.",
+      "Auto-detect the frontend from dependencies. Currently only Marimo is supported.",
     /* eslint-enable spellcheck/spell-checker */
   },
   {
     /* eslint-disable spellcheck/spell-checker */
     value: "none",
-    label: "None",
+    label: "Custom / No Frontend",
     description:
-      "Do not inject a frontend. Please define the entrypoint in a Procfile if needed.",
+      "Renku does not add a frontend. For a custom frontend, define an entrypoint in a Procfile.",
     /* eslint-enable spellcheck/spell-checker */
   },
 ] as readonly BuilderSelectorOption[];

--- a/client/src/features/sessionsV2/session.constants.tsx
+++ b/client/src/features/sessionsV2/session.constants.tsx
@@ -154,6 +154,11 @@ export const BUILDER_FRONTENDS = [
     /* eslint-enable spellcheck/spell-checker */
   },
   {
+    value: "rstudio",
+    label: "RStudio",
+    description: "Web-based integrated development environment for R.",
+  },
+  {
     /* eslint-disable spellcheck/spell-checker */
     value: "infer",
     label: "Infer Frontend",
@@ -168,11 +173,6 @@ export const BUILDER_FRONTENDS = [
     description:
       "Do not inject a frontend. Please define the entrypoint in a Procfile if needed.",
     /* eslint-enable spellcheck/spell-checker */
-  },
-  {
-    value: "rstudio",
-    label: "RStudio",
-    description: "Web-based integrated development environment for R.",
   },
 ] as readonly BuilderSelectorOption[];
 


### PR DESCRIPTION
/deploy #notest extra-values=dataService.imageBuilders.enabled=true,dataService.imageBuilders.outputImagePrefix=harbor.dev.renku.ch/renku-build/,dataService.imageBuilders.nodeSelector.renku.io/node-purpose=user renku-data-services=salimkayal/feat/add-support-for-inferred-frontend-and-no-implicit-frontend renku=salimkayal/chore/update-buildpacks-version