### PR TITLE
fix: bring back custom env fields for jobs

### DIFF
--- a/client/src/features/sessionsV2/components/SessionButton/ActiveSessionButton.actions.tsx
+++ b/client/src/features/sessionsV2/components/SessionButton/ActiveSessionButton.actions.tsx
@@ -58,26 +58,27 @@ function StoppingStatusButton({ label }: { label: string }) {
   );
 }
 
-function DismissJobButton({
-  buttonClassName,
-  color = "outline-primary",
-  onStopSession,
-}: {
-  buttonClassName?: string;
-  color?: "outline-primary" | "primary";
-  onStopSession: () => void;
-}) {
-  return (
-    <Button
-      color={color}
-      className={color === "outline-primary" ? buttonClassName : undefined}
-      data-cy={"dismiss-job-button"}
-      onClick={onStopSession}
-    >
-      <Trash className={cx("bi", "me-1")} /> Dismiss
-    </Button>
-  );
-}
+// TODO: Reuse this button when a confirmation action is present to avoid dismiss jobs by mistake
+// function DismissJobButton({
+//   buttonClassName,
+//   color = "outline-primary",
+//   onStopSession,
+// }: {
+//   buttonClassName?: string;
+//   color?: "outline-primary" | "primary";
+//   onStopSession: () => void;
+// }) {
+//   return (
+//     <Button
+//       color={color}
+//       className={color === "outline-primary" ? buttonClassName : undefined}
+//       data-cy={"dismiss-job-button"}
+//       onClick={onStopSession}
+//     >
+//       <Trash className={cx("bi", "me-1")} /> Dismiss
+//     </Button>
+//   );
+// }
 
 function PausingStatusButton() {
   return (
@@ -269,7 +270,6 @@ export function getJobDefaultAction(
     isResuming,
     onResumeSession,
     toggleLogsModal,
-    onStopSession,
   } = ctx;
 
   if (status === "stopping" || isStopping) {
@@ -278,12 +278,10 @@ export function getJobDefaultAction(
   if (isHibernating) {
     return <PausingStatusButton />;
   }
-  if (status === "starting" || status === "running") {
+  if (status === "starting" || status === "running" || status === "succeeded") {
     return <LogsStatusButton onClick={toggleLogsModal} label="View logs" />;
   }
-  if (status === "succeeded") {
-    return <DismissJobButton onStopSession={onStopSession} />;
-  }
+
   if (status === "hibernated") {
     return (
       <ResumeStatusButton

--- a/client/src/features/sessionsV2/components/SessionButton/ActiveSessionButton.tsx
+++ b/client/src/features/sessionsV2/components/SessionButton/ActiveSessionButton.tsx
@@ -372,11 +372,7 @@ export default function ActiveSessionButton({
         size="sm"
       >
         {launcherCategory === "job" ? (
-          status === "succeeded" ? (
-            logsAction
-          ) : (
-            dismissAction
-          )
+          dismissAction
         ) : (
           <>
             {deleteAction}

--- a/client/src/features/sessionsV2/components/SessionForm/AdvancedSettingsFields.tsx
+++ b/client/src/features/sessionsV2/components/SessionForm/AdvancedSettingsFields.tsx
@@ -352,47 +352,56 @@ export function AdvancedSettingsFields<
       )}
 
       <div className={cx("row", "gy-3")}>
-        {launcherCategory === "session" && (
-          <>
-            <div className={cx("col-12")}>
-              <FormField<T>
-                control={control}
-                name={"working_directory" as Path<T>}
-                label="Working Directory"
-                isOptional={true}
-                errors={errors}
-                info={ENVIRONMENT_VALUES_DESCRIPTION.workingDirectory}
-                type="text"
-              />
-            </div>
-            <div className={cx("col-12", "col-md-6")}>
-              <FormField<T>
-                control={control}
-                name={"uid" as Path<T>}
-                label="UID"
-                isOptional={true}
-                placeholder="e.g. 1000"
-                type="number"
-                errors={errors}
-                info={ENVIRONMENT_VALUES_DESCRIPTION.uid}
-                rules={{ min: 1, max: 65535 }}
-              />
-            </div>
-            <div className={cx("col-12", "col-md-6")}>
-              <FormField<T>
-                control={control}
-                name={"gid" as Path<T>}
-                label="GID"
-                isOptional={true}
-                placeholder="e.g. 1000"
-                type="number"
-                errors={errors}
-                info={ENVIRONMENT_VALUES_DESCRIPTION.gid}
-                rules={{ min: 1, max: 65535 }}
-              />
-            </div>
-          </>
+        {launcherCategory === "job" && (
+          <div className={cx("col-12")}>
+            <FormField<T>
+              control={control}
+              name={"mount_directory" as Path<T>}
+              label="Mount Directory"
+              isOptional={true}
+              errors={errors}
+              info={ENVIRONMENT_VALUES_DESCRIPTION.mountDirectory}
+              type="text"
+            />
+          </div>
         )}
+        <div className={cx("col-12")}>
+          <FormField<T>
+            control={control}
+            name={"working_directory" as Path<T>}
+            label="Working Directory"
+            isOptional={true}
+            errors={errors}
+            info={ENVIRONMENT_VALUES_DESCRIPTION.workingDirectory}
+            type="text"
+          />
+        </div>
+        <div className={cx("col-12", "col-md-6")}>
+          <FormField<T>
+            control={control}
+            name={"uid" as Path<T>}
+            label="UID"
+            isOptional={true}
+            placeholder="e.g. 1000"
+            type="number"
+            errors={errors}
+            info={ENVIRONMENT_VALUES_DESCRIPTION.uid}
+            rules={{ min: 1, max: 65535 }}
+          />
+        </div>
+        <div className={cx("col-12", "col-md-6")}>
+          <FormField<T>
+            control={control}
+            name={"gid" as Path<T>}
+            label="GID"
+            isOptional={true}
+            placeholder="e.g. 1000"
+            type="number"
+            errors={errors}
+            info={ENVIRONMENT_VALUES_DESCRIPTION.gid}
+            rules={{ min: 1, max: 65535 }}
+          />
+        </div>
         <div className={cx("col-12")}>
           <JsonField<T>
             control={control}

--- a/client/src/features/sessionsV2/session.utils.ts
+++ b/client/src/features/sessionsV2/session.utils.ts
@@ -122,6 +122,8 @@ export function getNewLauncherFormDefaultValues(
   | "frontend_variant"
   | "command"
   | "args"
+  | "gid"
+  | "uid"
 > {
   return {
     name: "",
@@ -137,6 +139,8 @@ export function getNewLauncherFormDefaultValues(
     frontend_variant: "jupyterlab", // eslint-disable-line spellcheck/spell-checker
     command: "",
     args: "",
+    gid: 1000,
+    uid: 1000,
   };
 }
 
@@ -189,6 +193,7 @@ export function prioritizeSelectedEnvironment(
  *
  * @param {SessionLauncherForm} data - The form data used to configure the environment for a session launcher.
  *
+ * @param launcherCategory
  * @returns {{ success: boolean; data?: SessionLauncherEnvironmentParams; error?: string }} -
  *  Returns an object with the following structure:
  *   - `success`: A boolean indicating whether the function executed successfully.


### PR DESCRIPTION
PR to fix form and ux problems in job
1. bring back custom env fields mount directory, working directory, UID and GID
2. show default value for GID and UID in forms for sessions and jobs
3. remove dismiss job by default when job is completed, it causes UX problems like dismissing jobs by mistake.

/deploy amalthea-sessions=main renku-data-services=main extra-values=dataService.imageBuilders.enabled=true,dataService.imageBuilders.strategyName=renku-buildpacks-v3,dataService.imageBuilders.outputImagePrefix=harbor.dev.renku.ch/renku-build/,dataService.imageBuilders.nodeSelector.renku.io/node-purpose=user,dataService.imageBuilders.tolerations[0].effect=NoSchedule,dataService.imageBuilders.tolerations[0].key=renku.io/dedicated,dataService.imageBuilders.tolerations[0].operator=Equal,dataService.imageBuilders.tolerations[0].value=user

