### PR TITLE
fix: wait for github intergation checks before showing a succesfull message

### DIFF
--- a/client/src/features/connectedServices/OAuthCompletePage.tsx
+++ b/client/src/features/connectedServices/OAuthCompletePage.tsx
@@ -22,8 +22,9 @@ import { Plugin, XLg } from "react-bootstrap-icons";
 import { Link, useSearchParams } from "react-router";
 import { Button } from "reactstrap";
 
-import { ErrorAlert, SuccessAlert } from "../../components/Alert";
+import { ErrorAlert, InfoAlert, SuccessAlert } from "../../components/Alert";
 import ContainerWrap from "../../components/container/ContainerWrap";
+import { Loader } from "../../components/Loader";
 import { ABSOLUTE_ROUTES } from "../../routing/routes.constants";
 import { GitHubOAuthCompleteFollowUp } from "./ConnectedServicesPage";
 import {
@@ -73,6 +74,11 @@ export default function OAuthCompletePage() {
     hasError,
     githubFollowUpData,
   );
+  const isCompletingGithubSetup =
+    !hasError &&
+    (githubFollowUpData.isLoadingProviders ||
+      githubFollowUpData.isLoadingConnections ||
+      githubFollowUpData.isGithubAppFollowUp);
 
   const onCloseTab = useCallback(() => {
     window.close();
@@ -116,6 +122,26 @@ export default function OAuthCompletePage() {
                 Close Tab
               </Button>
             </div>
+          </>
+        ) : isCompletingGithubSetup ? (
+          <>
+            <InfoAlert
+              dismissible={false}
+              timeout={0}
+              data-cy="oauth2-complete-pending"
+            >
+              <h3>Checking GitHub installation</h3>
+              <p>
+                Your authorization has been received. We are checking for
+                possible additional setup required on GitHub side. Please
+                wait... <Loader inline size={16} />
+              </p>
+            </InfoAlert>
+            <GitHubOAuthCompleteFollowUp
+              skipData={githubFollowUpData.skipData}
+              connection={githubFollowUpData.connection}
+              provider={githubFollowUpData.provider}
+            />
           </>
         ) : (
           <>

--- a/client/src/features/connectedServices/useGithubOAuthCompleteFollowUpData.hook.ts
+++ b/client/src/features/connectedServices/useGithubOAuthCompleteFollowUpData.hook.ts
@@ -92,17 +92,10 @@ export function shouldAutoCloseAfterOAuth(
   hasError: boolean,
   data: GithubOAuthCompleteFollowUpData,
 ): boolean {
-  const {
-    checkId,
-    skipData,
-    isGithubAppFollowUp,
-    isLoadingProviders,
-    isLoadingConnections,
-  } = data;
+  const { isLoadingProviders, isLoadingConnections, isGithubAppFollowUp } =
+    data;
 
   if (hasError) return false;
-  if (!checkId) return true;
   if (isLoadingProviders || isLoadingConnections) return false;
-  if (!isGithubAppFollowUp) return true;
-  return skipData;
+  return !isGithubAppFollowUp;
 }


### PR DESCRIPTION
We now wait to check the integration status on GitHub before automatically closing the redirected page.

<img width="853" height="268" alt="image" src="https://github.com/user-attachments/assets/23625c7e-3aeb-43a9-b826-f3be27b7d5ba" />

If the user has just activated the GitHub integration for the first time, there is a different message while invoking the APIs on GitHub and the (optional) modal with additional setup steps shows up again.

<img width="1685" height="1081" alt="Peek 2026-07-09 15-34" src="https://github.com/user-attachments/assets/a6f390bd-8847-4900-b2bd-9206743ee0eb" />

/deploy renku=feat/add-jobs
fix https://github.com/SwissDataScienceCenter/renku-ui/issues/4217
