### PR TITLE
feat: allow deleting data connectors from the project's listing and offcanvas

### DIFF
--- a/client/src/features/dataConnectorsV2/api/data-connectors.enhanced-api.ts
+++ b/client/src/features/dataConnectorsV2/api/data-connectors.enhanced-api.ts
@@ -161,7 +161,8 @@ const enhancedApi = injectedApi.enhanceEndpoints({
   ],
   endpoints: {
     deleteDataConnectorsByDataConnectorId: {
-      invalidatesTags: (_result, error) => (error ? [] : ["DataConnectors"]),
+      invalidatesTags: (_result, error) =>
+        error ? [] : ["DataConnectors", "DataConnectorsProjectLinks"],
       onQueryStarted: async (_arg, { dispatch, queryFulfilled }) => {
         queryFulfilled.then(() => {
           if (_arg.dataConnectorId) {

--- a/client/src/features/dataConnectorsV2/components/DataConnectorActions.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorActions.tsx
@@ -157,8 +157,9 @@ export function DataConnectorRemoveDeleteModal({
                 <Row>
                   <Col>
                     <p>
-                      Are you sure you want to delete this data connector? It is
-                      possible that it is used in some projects.
+                      Are you sure you want to permanently delete this data
+                      connector? It is possible that it is used in some
+                      projects.
                     </p>
                     <p>
                       Please type <strong>{dataConnector?.slug}</strong>, the
@@ -175,7 +176,8 @@ export function DataConnectorRemoveDeleteModal({
                 <Row>
                   <Col>
                     <p>
-                      Are you sure you want to delete this data connector?{" "}
+                      Are you sure you want to permanently delete this data
+                      connector?{" "}
                       {dataConnectorLinks.length < 1 ? (
                         <>
                           It is not used in any projects that are visible to
@@ -462,13 +464,6 @@ function DataConnectorActionsInner({
   );
   const namespace = pathMatch?.params?.namespace;
   const slug = pathMatch?.params?.slug;
-  const removeMode =
-    pathMatch == null ||
-    namespace == null ||
-    slug == null ||
-    dataConnectorLink == null
-      ? "delete"
-      : "unlink";
   const requiresCredentials =
     dataConnector.storage.sensitive_fields?.length > 0;
   const lastDeposit = useMemo(() => {
@@ -552,21 +547,7 @@ function DataConnectorActionsInner({
           },
         ]
       : []),
-    ...(permissions.delete && removeMode === "delete" && scope !== "global"
-      ? [
-          {
-            key: "data-connector-delete",
-            onClick: toggleDelete,
-            content: (
-              <>
-                <Trash className={cx("bi", "me-1")} />
-                Remove
-              </>
-            ),
-          },
-        ]
-      : []),
-    ...(projectPermissions.write && removeMode === "unlink"
+    ...(projectPermissions.write
       ? [
           {
             key: "data-connector-unlink",
@@ -575,6 +556,20 @@ function DataConnectorActionsInner({
               <>
                 <NodeMinus className={cx("bi", "me-1")} />
                 Unlink
+              </>
+            ),
+          },
+        ]
+      : []),
+    ...(permissions.delete && scope !== "global"
+      ? [
+          {
+            key: "data-connector-delete",
+            onClick: toggleDelete,
+            content: (
+              <>
+                <Trash className={cx("bi", "me-1")} />
+                Delete
               </>
             ),
           },

--- a/client/src/features/dataConnectorsV2/components/DataConnectorActions.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorActions.tsx
@@ -130,7 +130,7 @@ export function DataConnectorRemoveDeleteModal({
 
   return (
     <Modal
-      data-cy="data-connector-edit-modal"
+      data-cy="data-connector-delete-modal"
       size="lg"
       isOpen={isOpen}
       toggle={toggleModal}

--- a/client/src/features/dataConnectorsV2/components/DataConnectorActions.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorActions.tsx
@@ -95,7 +95,7 @@ export function DataConnectorRemoveDeleteModal({
   } = useGetDataConnectorsByDataConnectorIdProjectLinksQuery({
     dataConnectorId: dataConnector?.id ?? "",
   });
-  const [deleteDataConnector, { error, isLoading, isSuccess }] =
+  const [deleteDataConnector, { error, isLoading }] =
     useDeleteDataConnectorsByDataConnectorIdMutation();
 
   const [typedName, setTypedName] = useState("");
@@ -108,11 +108,6 @@ export function DataConnectorRemoveDeleteModal({
 
   const navigate = useNavigate();
 
-  useEffect(() => {
-    if (isSuccess && executeOnSuccess) {
-      executeOnSuccess();
-    }
-  }, [isSuccess, executeOnSuccess]);
   const onDeleteDataConnector = useCallback(async () => {
     if (!dataConnector?.id) return;
 
@@ -120,11 +115,18 @@ export function DataConnectorRemoveDeleteModal({
       await deleteDataConnector({
         dataConnectorId: dataConnector.id,
       }).unwrap();
+      executeOnSuccess?.();
       if (redirectOnSuccess) navigate(redirectOnSuccess);
     } catch {
       // keep existing `error` rendering from the mutation result
     }
-  }, [dataConnector, deleteDataConnector, redirectOnSuccess, navigate]);
+  }, [
+    dataConnector,
+    deleteDataConnector,
+    executeOnSuccess,
+    redirectOnSuccess,
+    navigate,
+  ]);
 
   return (
     <Modal

--- a/client/src/features/dataConnectorsV2/components/DataConnectorsBoxListDisplay.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorsBoxListDisplay.tsx
@@ -299,6 +299,7 @@ export default function DataConnectorBoxListDisplay({
             dataConnector={dataConnector}
             dataConnectorLink={dataConnectorLink}
             toggleEdit={toggleEdit}
+            toggleView={showOffCanvas ? toggleOffCanvas : undefined}
           />
         </div>
       </ListGroupItem>

--- a/tests/cypress/e2e/dataConnector.spec.ts
+++ b/tests/cypress/e2e/dataConnector.spec.ts
@@ -447,7 +447,7 @@ describe("Data connector page", () => {
 
     // Delete the data connector
     cy.getDataCy("data-connector-delete-settings-button").click();
-    cy.getDataCy("data-connector-edit-modal").should("be.visible");
+    cy.getDataCy("data-connector-delete-modal").should("be.visible");
     cy.getDataCy("delete-data-connector-modal-button").should("not.be.enabled");
 
     cy.getDataCy("delete-confirmation-input").type(dataConnectorSlug);

--- a/tests/cypress/e2e/groupV2.spec.ts
+++ b/tests/cypress/e2e/groupV2.spec.ts
@@ -407,11 +407,10 @@ describe("Work with group data connectors", () => {
       .click();
     cy.getDataCy("data-connector-view")
       .find('[data-cy="data-connector-delete"]')
+      .scrollIntoView()
       .should("be.visible")
       .click();
-    cy.contains("Are you sure you want to delete this data connector").should(
-      "be.visible",
-    );
+    cy.getDataCy("data-connector-delete-modal").should("be.visible");
     cy.getDataCy("delete-confirmation-input").clear().type("public-storage");
     cy.getDataCy("delete-data-connector-modal-button")
       .should("be.visible")


### PR DESCRIPTION
Allow deleting data connectors from the offcanvas panel and the DC listing in the project page

<img width="1037" height="1046" alt="Screenshot_20260714_115514" src="https://github.com/user-attachments/assets/c273ec02-7c13-4dc1-a6d5-afaaf9975290" />

closes #4262
/deploy
