### PR TITLE
fix: avoid resource pool overflow

### DIFF
--- a/client/src/features/sessionsV2/components/SessionsList.tsx
+++ b/client/src/features/sessionsV2/components/SessionsList.tsx
@@ -64,7 +64,7 @@ export function SessionRowResourceRequests({
     <div data-cy="session-view-resource-class-description">
       {resourceClassName && (
         <span key="name">
-          <span className="text-nowrap">{resourceClassName}</span>
+          <span>{resourceClassName}</span>
           {" | "}
         </span>
       )}


### PR DESCRIPTION
Avoid resource pool name overflow in the launcher side panel.

<img width="1392" height="294" alt="image" src="https://github.com/user-attachments/assets/f670c16e-b2e5-480d-806d-4a8e6666ff51" />

/deploy
