### PR TITLE
fix: no show frontend variant for jobs

### DIFF
--- a/client/src/features/sessionsV2/SessionView/EnvironmentItem.tsx
+++ b/client/src/features/sessionsV2/SessionView/EnvironmentItem.tsx
@@ -572,10 +572,12 @@ function CustomBuildEnvironmentValues({
         label="Environment type"
         value={builder_variant || ""}
       />
-      <EnvironmentRowWithLabel
-        label="User interface"
-        value={frontend_variant || ""}
-      />
+      {launcherCategory === "session" && (
+        <EnvironmentRowWithLabel
+          label="User interface"
+          value={frontend_variant || ""}
+        />
+      )}
       {launcherCategory === "job" &&
         environment.container_image === BUILDER_IMAGE_NOT_READY_VALUE && (
           <>


### PR DESCRIPTION
Removes the frontend variant field from the job details side panel.

/deploy extra-values=dataService.imageBuilders.enabled=true,dataService.imageBuilders.strategyName=renku-buildpacks-v3,dataService.imageBuilders.outputImagePrefix=harbor.dev.renku.ch/renku-build/,dataService.imageBuilders.nodeSelector.renku.io/node-purpose=user,dataService.imageBuilders.tolerations[0].effect=NoSchedule,dataService.imageBuilders.tolerations[0].key=renku.io/dedicated,dataService.imageBuilders.tolerations[0].operator=Equal,dataService.imageBuilders.tolerations[0].value=user