### PR TITLE
fix: show submit button in launcher list only if there is an available image

### DIFF
--- a/client/src/features/sessionsV2/components/launcherActions/job/JobLauncherActions.tsx
+++ b/client/src/features/sessionsV2/components/launcherActions/job/JobLauncherActions.tsx
@@ -118,8 +118,8 @@ export default function JobLauncherActions({
     if (applyDefaultBuildActions) {
       return (
         <ButtonGroup onClick={(e) => e.stopPropagation()}>
-          <BuildLauncherButtons launcher={launcher} isMainButton={false} />
-          {submitAction}
+          <BuildLauncherButtons launcher={launcher} isMainButton={true} />
+          {hasValidImage && submitAction}
         </ButtonGroup>
       );
     }


### PR DESCRIPTION
PR to sync the submit and launch buttons when building an image.

close #4300 

/deploy extra-values=dataService.imageBuilders.enabled=true,dataService.imageBuilders.strategyName=renku-buildpacks-v3,dataService.imageBuilders.outputImagePrefix=harbor.dev.renku.ch/renku-build/,dataService.imageBuilders.nodeSelector.renku.io/node-purpose=user,dataService.imageBuilders.tolerations[0].effect=NoSchedule,dataService.imageBuilders.tolerations[0].key=renku.io/dedicated,dataService.imageBuilders.tolerations[0].operator=Equal,dataService.imageBuilders.tolerations[0].value=user 