### PR TITLE
feat: always show the dismiss button for jobs

### DIFF
--- a/client/src/features/sessionsV2/SessionList/JobCard.tsx
+++ b/client/src/features/sessionsV2/SessionList/JobCard.tsx
@@ -98,7 +98,7 @@ export default function JobCard({ project, session, onOpen }: JobCardProps) {
           </Col>
           <Col
             xs={12}
-            lg={6}
+            xl={6}
             className={cx(
               "d-flex",
               "flex-column",

--- a/client/src/features/sessionsV2/components/SessionButton/ActiveSessionButton.actions.tsx
+++ b/client/src/features/sessionsV2/components/SessionButton/ActiveSessionButton.actions.tsx
@@ -30,7 +30,6 @@ import { Link } from "react-router";
 import { Button } from "reactstrap";
 
 import { Loader } from "~/components/Loader";
-import { JOB_STOPPING_BUTTON_LABEL } from "~/features/sessionsV2/session.utils.ts";
 import { SessionStatusState } from "../../sessionsV2.types";
 
 export interface ActiveSessionActionContext {
@@ -49,7 +48,7 @@ export interface ActiveSessionActionContext {
   toggleModifySession: () => void;
 }
 
-function StoppingStatusButton({ label }: { label: string }) {
+export function StoppingStatusButton({ label }: { label: string }) {
   return (
     <Button color="primary" data-cy="stopping-btn" disabled>
       <Loader className="me-1" inline size={16} />
@@ -57,28 +56,6 @@ function StoppingStatusButton({ label }: { label: string }) {
     </Button>
   );
 }
-
-// TODO: Reuse this button when a confirmation action is present to avoid dismiss jobs by mistake
-// function DismissJobButton({
-//   buttonClassName,
-//   color = "outline-primary",
-//   onStopSession,
-// }: {
-//   buttonClassName?: string;
-//   color?: "outline-primary" | "primary";
-//   onStopSession: () => void;
-// }) {
-//   return (
-//     <Button
-//       color={color}
-//       className={color === "outline-primary" ? buttonClassName : undefined}
-//       data-cy={"dismiss-job-button"}
-//       onClick={onStopSession}
-//     >
-//       <Trash className={cx("bi", "me-1")} /> Dismiss
-//     </Button>
-//   );
-// }
 
 function PausingStatusButton() {
   return (
@@ -114,6 +91,25 @@ function ResumeStatusButton({
           Resume
         </>
       )}
+    </Button>
+  );
+}
+
+export function DismissJobButton({
+  isRunning,
+  onDismiss,
+}: {
+  isRunning: boolean;
+  onDismiss: () => void;
+}) {
+  return (
+    <Button
+      color="outline-primary"
+      data-cy="delete-job-button"
+      onClick={onDismiss}
+    >
+      <Trash className={cx("bi", "me-1")} />
+      {isRunning ? "Cancel" : "Dismiss"}
     </Button>
   );
 }
@@ -265,16 +261,12 @@ export function getJobDefaultAction(
 ): ReactNode {
   const {
     status,
-    isStopping,
     isHibernating,
     isResuming,
     onResumeSession,
     toggleLogsModal,
   } = ctx;
 
-  if (status === "stopping" || isStopping) {
-    return <StoppingStatusButton label={JOB_STOPPING_BUTTON_LABEL} />;
-  }
   if (isHibernating) {
     return <PausingStatusButton />;
   }

--- a/client/src/features/sessionsV2/components/SessionButton/ActiveSessionButton.tsx
+++ b/client/src/features/sessionsV2/components/SessionButton/ActiveSessionButton.tsx
@@ -32,6 +32,7 @@ import { useNavigate } from "react-router";
 import { SingleValue } from "react-select";
 import {
   Button,
+  ButtonGroup,
   Col,
   DropdownItem,
   Modal,
@@ -58,6 +59,7 @@ import {
 } from "../../api/sessionsV2.api";
 import {
   getLauncherCategoryDefinition,
+  JOB_STOPPING_BUTTON_LABEL,
   sessionLauncherKindToCategory,
 } from "../../session.utils";
 import {
@@ -76,8 +78,10 @@ import {
 import ShutdownSessionContent from "../SessionModals/ShoutdownSessionContent";
 import { SessionRowResourceRequests } from "../SessionsList";
 import {
+  DismissJobButton,
   getInteractiveSessionDefaultAction,
   getJobDefaultAction,
+  StoppingStatusButton,
 } from "./ActiveSessionButton.actions";
 
 interface ActiveSessionButtonProps {
@@ -322,15 +326,16 @@ export default function ActiveSessionButton({
     </DropdownItem>
   );
 
-  const dismissAction = launcherCategory === "job" && (
-    <DropdownItem
-      data-cy="delete-session-button"
-      onClick={isRunning ? toggleStopSession : onStopSession}
-    >
-      <Trash className={cx("bi", "me-1")} />
-      {isRunning ? "Cancel" : "Dismiss"}
-    </DropdownItem>
-  );
+  const dismissAction =
+    launcherCategory === "job" &&
+    (status === "stopping" || isStopping ? (
+      <StoppingStatusButton label={JOB_STOPPING_BUTTON_LABEL} />
+    ) : (
+      <DismissJobButton
+        isRunning={isRunning}
+        onDismiss={isRunning ? toggleStopSession : onStopSession}
+      />
+    ));
 
   const modifyAction = (status === "hibernated" || status === "failed") &&
     !isStopping &&
@@ -362,28 +367,30 @@ export default function ActiveSessionButton({
 
   return (
     <div className={cx("d-flex", "flex-row", "gap-2")}>
-      <ButtonWithMenuV2
-        className={cx(className)}
-        color={launcherCategory === "job" ? "outline-primary" : "primary"}
-        default={defaultAction}
-        preventPropagation
-        size="sm"
-      >
-        {launcherCategory === "job" ? (
-          dismissAction
-        ) : (
-          <>
-            {hibernateAction}
-            {deleteAction}
-            {modifyAction}
-            {(hibernateAction || deleteAction || modifyAction) &&
-              (openInNewTabAction || logsAction) && <DropdownItem divider />}
+      {launcherCategory === "job" && (
+        <ButtonGroup size="sm">
+          {dismissAction}
+          {defaultAction}
+        </ButtonGroup>
+      )}
+      {launcherCategory === "session" && (
+        <ButtonWithMenuV2
+          className={cx(className)}
+          color="primary"
+          default={defaultAction}
+          preventPropagation
+          size="sm"
+        >
+          {hibernateAction}
+          {deleteAction}
+          {modifyAction}
+          {(hibernateAction || deleteAction || modifyAction) &&
+            (openInNewTabAction || logsAction) && <DropdownItem divider />}
 
-            {openInNewTabAction}
-            {logsAction}
-          </>
-        )}
-      </ButtonWithMenuV2>
+          {openInNewTabAction}
+          {logsAction}
+        </ButtonWithMenuV2>
+      )}
       <ConfirmDeleteModal
         isOpen={showModalStopSession}
         isStopping={isStopping}


### PR DESCRIPTION
Make Dismiss/Cancel job always visible

<img width="1461" height="602" alt="Screenshot 2026-08-05 at 12 09 16" src="https://github.com/user-attachments/assets/615a2645-78bc-4f41-aa4d-a8fb395e7bd7" />

<img width="1433" height="532" alt="Screenshot 2026-08-05 at 12 09 41" src="https://github.com/user-attachments/assets/c883f319-c3d5-4464-b01b-e8c83f118b1d" />

Closes #4301 

/deploy

