### PR TITLE
fix:  data connector credentials ux

### DIFF
--- a/client/src/features/dataConnectorsV2/components/DataConnectorCredentialsModal.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorCredentialsModal.tsx
@@ -56,6 +56,10 @@ export default function DataConnectorCredentialsModal({
   const isSuccess =
     deleteCredentialsResult.isSuccess || saveCredentialsResult.isSuccess;
 
+  const closeModal = useCallback(() => {
+    setOpen(false);
+  }, [setOpen]);
+
   const onSave = useCallback(
     (configs: DataConnectorConfiguration[]) => {
       const activeConfigs = configs.filter((c) => c.active);
@@ -111,7 +115,7 @@ export default function DataConnectorCredentialsModal({
           This data connector does not require any credentials.
         </ModalBody>
         <ModalFooter>
-          <Button color="primary" onClick={() => setOpen(false)}>
+          <Button color="primary" onClick={closeModal}>
             <XLg className={cx("bi", "me-1")} />
             Close
           </Button>

--- a/client/src/features/dataConnectorsV2/components/DataConnectorCredentialsModal.tsx
+++ b/client/src/features/dataConnectorsV2/components/DataConnectorCredentialsModal.tsx
@@ -21,6 +21,7 @@ import { useCallback, useEffect } from "react";
 import { XLg } from "react-bootstrap-icons";
 import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from "reactstrap";
 
+import { SuccessAlert } from "../../../components/Alert";
 import RtkOrDataServicesError from "../../../components/errors/RtkOrDataServicesError";
 import { Loader } from "../../../components/Loader";
 import DataConnectorSecretsModal from "../../sessionsV2/DataConnectorSecretsModal";
@@ -52,6 +53,9 @@ export default function DataConnectorCredentialsModal({
   const [deleteCredentials, deleteCredentialsResult] =
     useDeleteDataConnectorsByDataConnectorIdSecretsMutation();
 
+  const isSuccess =
+    deleteCredentialsResult.isSuccess || saveCredentialsResult.isSuccess;
+
   const onSave = useCallback(
     (configs: DataConnectorConfiguration[]) => {
       const activeConfigs = configs.filter((c) => c.active);
@@ -82,10 +86,12 @@ export default function DataConnectorCredentialsModal({
   );
 
   useEffect(() => {
-    if (deleteCredentialsResult.isSuccess || saveCredentialsResult.isSuccess) {
-      setOpen(false);
+    if (!isOpen) {
+      saveCredentialsResult.reset();
+      deleteCredentialsResult.reset();
     }
-  }, [deleteCredentialsResult, saveCredentialsResult.isSuccess, setOpen]);
+  }, [deleteCredentialsResult, isOpen, saveCredentialsResult]);
+
   if (!isOpen) return null;
   if (
     dataConnector?.storage.sensitive_fields == null ||
@@ -103,6 +109,36 @@ export default function DataConnectorCredentialsModal({
         </ModalHeader>
         <ModalBody>
           This data connector does not require any credentials.
+        </ModalBody>
+        <ModalFooter>
+          <Button color="primary" onClick={() => setOpen(false)}>
+            <XLg className={cx("bi", "me-1")} />
+            Close
+          </Button>
+        </ModalFooter>
+      </Modal>
+    );
+  }
+
+  if (isSuccess) {
+    return (
+      <Modal
+        centered
+        data-cy="data-connector-credentials-success-modal"
+        isOpen={isOpen}
+        size="lg"
+      >
+        <ModalHeader className={cx("fw-bold")}>
+          Data Connector Credentials
+        </ModalHeader>
+        <ModalBody>
+          <SuccessAlert className="mb-0" dismissible={false} timeout={0}>
+            <p className="mb-0">
+              {deleteCredentialsResult.isSuccess
+                ? "The credentials have been successfully cleared."
+                : "The credentials have been successfully updated."}
+            </p>
+          </SuccessAlert>
         </ModalBody>
         <ModalFooter>
           <Button color="primary" onClick={() => setOpen(false)}>

--- a/client/src/features/sessionsV2/DataConnectorSecretsModal.tsx
+++ b/client/src/features/sessionsV2/DataConnectorSecretsModal.tsx
@@ -287,6 +287,12 @@ export default function DataConnectorSecretsModal({
   const hasSavedCredentials = dataConnectorConfigs.some(
     (csc) => csc.savedCredentialFields?.length > 0,
   );
+  const total = dataConnectorConfigs.length;
+  const showCredentialsCounter =
+    (context === "session" || context === "job") && total > 1;
+  const modalTitle = showCredentialsCounter
+    ? `${CONTEXT_STRINGS[context].header} ${index + 1} of ${total}`
+    : CONTEXT_STRINGS[context].header;
 
   return (
     <Modal
@@ -295,7 +301,7 @@ export default function DataConnectorSecretsModal({
       isOpen={isOpen}
       size="lg"
     >
-      <ModalHeader tag="h2">{CONTEXT_STRINGS[context].header}</ModalHeader>
+      <ModalHeader tag="h2">{modalTitle}</ModalHeader>
       <Form
         noValidate
         data-cy="data-connector-edit-options"

--- a/client/src/features/sessionsV2/DataConnectorSecretsModal.tsx
+++ b/client/src/features/sessionsV2/DataConnectorSecretsModal.tsx
@@ -151,8 +151,8 @@ function DataConnectorSecrets({
           );
         })}
       </div>
-      {context === "session" && user?.isLoggedIn && (
-        <SaveCredentialsInput control={control} />
+      {(context === "session" || context === "job") && user?.isLoggedIn && (
+        <SaveCredentialsInput context={context} control={control} />
       )}
       {context === "storage" && hasIncompleteSavedCredentials && (
         <div className={cx("text-danger", "mb-3")}>
@@ -470,8 +470,10 @@ function ProgressBreadcrumbs({
 }
 
 function SaveCredentialsInput({
+  context,
   control,
-}: Pick<SensitiveFieldWidgetProps, "control">) {
+}: Pick<SensitiveFieldWidgetProps, "context" | "control">) {
+  const targetLabel = context === "job" ? "jobs" : "sessions";
   return (
     <div className="mb-3">
       <Controller
@@ -494,7 +496,7 @@ function SaveCredentialsInput({
         className={cx("form-check-label", "ms-2")}
         htmlFor="saveCredentials"
       >
-        Save credentials for future sessions
+        Save credentials for future {targetLabel}
       </Label>
     </div>
   );

--- a/tests/cypress/e2e/dataConnector.spec.ts
+++ b/tests/cypress/e2e/dataConnector.spec.ts
@@ -947,6 +947,13 @@ describe("Set up data connectors with credentials in group pages", () => {
     cy.wait("@patchDataConnectorSecrets");
     cy.wait("@getDataConnectorSecrets");
 
+    cy.getDataCy("data-connector-credentials-success-modal")
+      .should("be.visible")
+      .and("contain.text", "The credentials have been successfully updated.");
+    cy.getDataCy("data-connector-credentials-success-modal")
+      .contains("Close")
+      .click();
+
     // Credentials should be stored
     cy.getDataCy("data-connector-title").should(
       "contain.text",
@@ -1021,6 +1028,13 @@ describe("Set up data connectors with credentials in group pages", () => {
     cy.getDataCy("data-connector-credentials-modal").contains("Clear").click();
     cy.wait("@deleteDataConnectorSecrets");
     cy.wait("@getDataConnectorSecrets2");
+
+    cy.getDataCy("data-connector-credentials-success-modal")
+      .should("be.visible")
+      .and("contain.text", "The credentials have been successfully cleared.");
+    cy.getDataCy("data-connector-credentials-success-modal")
+      .contains("Close")
+      .click();
 
     // Credentials should be changed
     cy.getDataCy("data-connector-title").should(


### PR DESCRIPTION
Issue 1: Add a confirmation message when clearing a data connector credential secret or editing an existing secret
<img width="912" height="358" alt="Screenshot 2026-08-07 at 22 09 57" src="https://github.com/user-attachments/assets/da797565-1ef7-4faf-9567-3ce2123aff58" />
<img width="911" height="340" alt="Screenshot 2026-08-07 at 22 09 43" src="https://github.com/user-attachments/assets/2898a274-aa69-4e6e-ae99-be8f4ccf945a" />


Issue 2: Show pending credential count when launching a session or submitting a job with multiple pending credential secrets
<img width="912" height="508" alt="Screenshot 2026-08-07 at 22 11 02" src="https://github.com/user-attachments/assets/8c327c65-4f2d-4236-b305-3fe53746457b" />



Issue 3: Allow saving credentials when submitting a job
<img width="888" height="753" alt="Screenshot 2026-08-07 at 22 11 38" src="https://github.com/user-attachments/assets/4525c0d4-db00-4cdd-9f4e-b7684f9ced8c" />



closes #4312



/deploy