### PR TITLE
fix: align icons properly in session launcher dropdown

### DIFF
--- a/client/src/features/sessionsV2/components/SessionForm/LauncherEnvironmentIcon.tsx
+++ b/client/src/features/sessionsV2/components/SessionForm/LauncherEnvironmentIcon.tsx
@@ -30,15 +30,15 @@ export function LauncherEnvironmentIcon({
 }) {
   const currentEnvironment = launcher.environment;
   return currentEnvironment?.environment_kind === "GLOBAL" ? (
-    <EnvironmentIcon type="global" size={16} className={className ?? "me-2"} />
+    <EnvironmentIcon type="global" size={16} className={className ?? "me-1"} />
   ) : currentEnvironment?.environment_image_source === "build" ? (
     <EnvironmentIcon
       type="codeBased"
       size={16}
-      className={className ?? "me-2"}
+      className={className ?? "me-1"}
     />
   ) : currentEnvironment?.environment_kind === "CUSTOM" ? (
-    <EnvironmentIcon type="custom" size={16} className={className ?? "me-2"} />
+    <EnvironmentIcon type="custom" size={16} className={className ?? "me-1"} />
   ) : null;
 }
 


### PR DESCRIPTION
Minor visual glitch: the EnvironmentIcon icon has a larger-than-usual right margin

-----

**BEFORE**
    <img width="374" height="202" alt="Screenshot_20260813_105434" src="https://github.com/user-attachments/assets/c7cbc4c3-6c1a-4a13-bf85-4805980a4381" />

-----

**NOW**
    <img width="308" height="242" alt="image" src="https://github.com/user-attachments/assets/c4e3af3f-51f0-4690-ab7f-2ad591c2e7c3" />

