### PR TITLE
feat: enforce CPU integrality for resource classes on firecREST

### DIFF
--- a/client/eslint.config.mjs
+++ b/client/eslint.config.mjs
@@ -145,6 +145,7 @@ const jsRules = {
         "memoization",
         "mergerequests",
         "metadata_oauth",
+        "millicores",
         "mongodb",
         "monospace",
         "morgan",

--- a/client/eslint.config.mjs
+++ b/client/eslint.config.mjs
@@ -145,7 +145,6 @@ const jsRules = {
         "memoization",
         "mergerequests",
         "metadata_oauth",
-        "millicores",
         "mongodb",
         "monospace",
         "morgan",

--- a/client/src/features/admin/AddResourceClassButton.tsx
+++ b/client/src/features/admin/AddResourceClassButton.tsx
@@ -81,6 +81,7 @@ function AddResourceClassModal({
 }: AddResourceClassModalProps) {
   const { id, quota } = resourcePool;
   const requiresIntegerCpu = poolRequiresIntegerCpu(resourcePool.remote);
+  const cpuStep = requiresIntegerCpu ? 1 : 0.1;
 
   const [addResourceClass, result] =
     usePostResourcePoolsByResourcePoolIdClassesMutation();
@@ -91,7 +92,7 @@ function AddResourceClassModal({
     handleSubmit,
   } = useForm<ResourceClassForm>({
     defaultValues: {
-      cpu: requiresIntegerCpu ? 1 : 0.1,
+      cpu: cpuStep,
       default: false,
       default_storage: 1,
       gpu: 0,
@@ -193,14 +194,14 @@ function AddResourceClassModal({
                   className={cx(errors.cpu && "is-invalid")}
                   id={`addResourceClassCpu-${id}`}
                   type="number"
-                  min={requiresIntegerCpu ? 1 : 0.1}
-                  step={requiresIntegerCpu ? 1 : 0.1}
+                  min={cpuStep}
+                  step={cpuStep}
                   max={quota?.cpu}
                   {...field}
                 />
               )}
               rules={{
-                min: requiresIntegerCpu ? 1 : 0.1,
+                min: cpuStep,
                 max: quota?.cpu,
                 validate: requiresIntegerCpu
                   ? (value) =>

--- a/client/src/features/admin/AddResourceClassButton.tsx
+++ b/client/src/features/admin/AddResourceClassButton.tsx
@@ -39,6 +39,7 @@ import {
   type ResourcePoolWithId,
 } from "../sessionsV2/api/computeResources.api";
 import type { ResourceClassForm } from "./adminComputeResources.types";
+import { poolRequiresIntegerCpu } from "./adminComputeResources.utils";
 
 interface AddResourceClassButtonProps {
   resourcePool: ResourcePoolWithId;
@@ -79,6 +80,7 @@ function AddResourceClassModal({
   toggle,
 }: AddResourceClassModalProps) {
   const { id, quota } = resourcePool;
+  const requiresIntegerCpu = poolRequiresIntegerCpu(resourcePool.remote);
 
   const [addResourceClass, result] =
     usePostResourcePoolsByResourcePoolIdClassesMutation();
@@ -89,7 +91,7 @@ function AddResourceClassModal({
     handleSubmit,
   } = useForm<ResourceClassForm>({
     defaultValues: {
-      cpu: 0.1,
+      cpu: requiresIntegerCpu ? 1 : 0.1,
       default: false,
       default_storage: 1,
       gpu: 0,
@@ -191,13 +193,21 @@ function AddResourceClassModal({
                   className={cx(errors.cpu && "is-invalid")}
                   id={`addResourceClassCpu-${id}`}
                   type="number"
-                  min={0.1}
-                  step={0.1}
+                  min={requiresIntegerCpu ? 1 : 0.1}
+                  step={requiresIntegerCpu ? 1 : 0.1}
                   max={quota?.cpu}
                   {...field}
                 />
               )}
-              rules={{ min: 0.1, max: quota?.cpu }}
+              rules={{
+                min: requiresIntegerCpu ? 1 : 0.1,
+                max: quota?.cpu,
+                validate: requiresIntegerCpu
+                  ? (value) =>
+                      Number.isInteger(Number(value)) ||
+                      "CPUs must be a whole number for firecrest pools"
+                  : undefined,
+              }}
             />
             <div className="invalid-feedback">Invalid value for CPUs</div>
           </div>

--- a/client/src/features/admin/AddResourcePoolButton.tsx
+++ b/client/src/features/admin/AddResourcePoolButton.tsx
@@ -42,6 +42,7 @@ import {
   type RemoteConfiguration,
 } from "../sessionsV2/api/computeResources.api";
 import type { ResourcePoolForm } from "./adminComputeResources.types";
+import { poolRequiresIntegerCpu } from "./adminComputeResources.utils";
 import ResourcePoolClusterIdInput from "./forms/ResourcePoolClusterIdInput";
 import ResourcePoolRemoteSection from "./forms/ResourcePoolRemoteSection";
 
@@ -130,10 +131,15 @@ function AddResourcePoolModal({ isOpen, toggle }: AddResourcePoolModalProps) {
   const [addResourcePool, result] = usePostResourcePoolsMutation();
   const onSubmit = useCallback(
     (data: ResourcePoolForm) => {
+      const requiresIntegerCpu = poolRequiresIntegerCpu({
+        kind: data.remote.enabled ? data.remote.kind : null,
+      });
       const populatedClass = defaultSessionClass
         ? {
             name: defaultSessionClass.name,
-            cpu: defaultSessionClass.cpu,
+            cpu: requiresIntegerCpu
+              ? Math.ceil(defaultSessionClass.cpu)
+              : defaultSessionClass.cpu,
             memory: defaultSessionClass.memory,
             gpu: defaultSessionClass.gpu,
             max_storage: defaultSessionClass.max_storage,

--- a/client/src/features/admin/UpdateResourceClassButton.tsx
+++ b/client/src/features/admin/UpdateResourceClassButton.tsx
@@ -89,6 +89,7 @@ function UpdateResourceClassModal({
   const { id } = resourceClass;
   const { quota } = resourcePool;
   const requiresIntegerCpu = poolRequiresIntegerCpu(resourcePool.remote);
+  const cpuStep = requiresIntegerCpu ? 1 : 0.1;
 
   const [updateResourceClass, result] =
     usePatchResourcePoolsByResourcePoolIdClassesAndClassIdMutation();
@@ -225,13 +226,13 @@ function UpdateResourceClassModal({
                   className={cx(errors.cpu && "is-invalid")}
                   id={`updateResourceClassCpu-${id}`}
                   type="number"
-                  min={requiresIntegerCpu ? 1 : 0.1}
-                  step={requiresIntegerCpu ? 1 : 0.1}
+                  min={cpuStep}
+                  step={cpuStep}
                   {...field}
                 />
               )}
               rules={{
-                min: requiresIntegerCpu ? 1 : 0.1,
+                min: cpuStep,
                 max: quota?.cpu,
                 validate: requiresIntegerCpu
                   ? (value) =>

--- a/client/src/features/admin/UpdateResourceClassButton.tsx
+++ b/client/src/features/admin/UpdateResourceClassButton.tsx
@@ -40,6 +40,7 @@ import {
   type ResourcePoolWithId,
 } from "../sessionsV2/api/computeResources.api";
 import { ResourceClassForm } from "./adminComputeResources.types";
+import { poolRequiresIntegerCpu } from "./adminComputeResources.utils";
 
 import styles from "./UpdateResourceClassButton.module.scss";
 
@@ -87,6 +88,7 @@ function UpdateResourceClassModal({
 }: UpdateResourceClassModalProps) {
   const { id } = resourceClass;
   const { quota } = resourcePool;
+  const requiresIntegerCpu = poolRequiresIntegerCpu(resourcePool.remote);
 
   const [updateResourceClass, result] =
     usePatchResourcePoolsByResourcePoolIdClassesAndClassIdMutation();
@@ -223,12 +225,20 @@ function UpdateResourceClassModal({
                   className={cx(errors.cpu && "is-invalid")}
                   id={`updateResourceClassCpu-${id}`}
                   type="number"
-                  min={0.1}
-                  step={0.1}
+                  min={requiresIntegerCpu ? 1 : 0.1}
+                  step={requiresIntegerCpu ? 1 : 0.1}
                   {...field}
                 />
               )}
-              rules={{ min: 0.1, max: quota?.cpu }}
+              rules={{
+                min: requiresIntegerCpu ? 1 : 0.1,
+                max: quota?.cpu,
+                validate: requiresIntegerCpu
+                  ? (value) =>
+                      Number.isInteger(Number(value)) ||
+                      "CPUs must be a whole number for firecrest pools"
+                  : undefined,
+              }}
             />
             <div className="invalid-feedback">Invalid value for CPUs</div>
           </div>

--- a/client/src/features/admin/adminComputeResources.utils.test.ts
+++ b/client/src/features/admin/adminComputeResources.utils.test.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2025 - Swiss Data Science Center (SDSC)
+ * Copyright 2026 - Swiss Data Science Center (SDSC)
  * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
  * Eidgenössische Technische Hochschule Zürich (ETHZ).
  *

--- a/client/src/features/admin/adminComputeResources.utils.test.ts
+++ b/client/src/features/admin/adminComputeResources.utils.test.ts
@@ -33,10 +33,6 @@ describe("poolRequiresIntegerCpu", () => {
     expect(poolRequiresIntegerCpu({ kind: null })).toBe(false);
   });
 
-  it("returns false when remote is null", () => {
-    expect(poolRequiresIntegerCpu(null)).toBe(false);
-  });
-
   it("returns false when remote is undefined", () => {
     expect(poolRequiresIntegerCpu(undefined)).toBe(false);
   });

--- a/client/src/features/admin/adminComputeResources.utils.test.ts
+++ b/client/src/features/admin/adminComputeResources.utils.test.ts
@@ -1,0 +1,43 @@
+/*!
+ * Copyright 2025 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { poolRequiresIntegerCpu } from "./adminComputeResources.utils";
+
+describe("poolRequiresIntegerCpu", () => {
+  it("returns true for a firecrest remote configuration", () => {
+    expect(poolRequiresIntegerCpu({ kind: "firecrest" })).toBe(true);
+  });
+
+  it("returns false for a runai remote configuration", () => {
+    expect(poolRequiresIntegerCpu({ kind: "runai" })).toBe(false);
+  });
+
+  it("returns false when no remote kind is selected", () => {
+    expect(poolRequiresIntegerCpu({ kind: null })).toBe(false);
+  });
+
+  it("returns false when remote is null", () => {
+    expect(poolRequiresIntegerCpu(null)).toBe(false);
+  });
+
+  it("returns false when remote is undefined", () => {
+    expect(poolRequiresIntegerCpu(undefined)).toBe(false);
+  });
+});

--- a/client/src/features/admin/adminComputeResources.utils.ts
+++ b/client/src/features/admin/adminComputeResources.utils.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2025 - Swiss Data Science Center (SDSC)
+ * Copyright 2026 - Swiss Data Science Center (SDSC)
  * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
  * Eidgenössische Technische Hochschule Zürich (ETHZ).
  *

--- a/client/src/features/admin/adminComputeResources.utils.ts
+++ b/client/src/features/admin/adminComputeResources.utils.ts
@@ -1,0 +1,35 @@
+/*!
+ * Copyright 2025 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+interface RemoteKindLike {
+  kind: string | null;
+}
+
+/**
+ * Firecrest resource pools submit jobs to an HPC scheduler (e.g. SLURM) that
+ * only accepts whole CPU cores. The data-services backend therefore rejects
+ * resource classes (and the auto-created default class) carrying fractional
+ * `cpu` values on firecrest pools. K8s pools express cpu in millicores, so
+ * fractional values (e.g. 0.1) are valid there. Run:AI is left untouched for
+ * now pending backend confirmation.
+ */
+export function poolRequiresIntegerCpu(
+  remote: RemoteKindLike | null | undefined,
+): boolean {
+  return remote?.kind === "firecrest";
+}

--- a/client/src/features/admin/adminComputeResources.utils.ts
+++ b/client/src/features/admin/adminComputeResources.utils.ts
@@ -20,14 +20,7 @@ interface RemoteKindLike {
   kind: string | null;
 }
 
-/**
- * Firecrest resource pools submit jobs to an HPC scheduler (e.g. SLURM) that
- * only accepts whole CPU cores. The data-services backend therefore rejects
- * resource classes (and the auto-created default class) carrying fractional
- * `cpu` values on firecrest pools. K8s pools express cpu in millicores, so
- * fractional values (e.g. 0.1) are valid there. Run:AI is left untouched for
- * now pending backend confirmation.
- */
+// Firecrest pools need whole CPU cores (SLURM); K8s allows fractional.
 export function poolRequiresIntegerCpu(
   remote: RemoteKindLike | null | undefined,
 ): boolean {

--- a/client/src/features/sessionsV2/api/computeResources.generated-api.ts
+++ b/client/src/features/sessionsV2/api/computeResources.generated-api.ts
@@ -631,6 +631,15 @@ export type NodeAffinity = {
 export type NodeAffinityList = NodeAffinity[];
 export type IntegerId = number;
 export type QuotaEnforced = boolean;
+export type RemoteConfigurationFirecrestSystemName = string;
+export type RemoteConfigurationFirecrestPartition = string;
+export type RemoteClassConfigurationFirecrest = {
+  system_name?: RemoteConfigurationFirecrestSystemName;
+  partition?: RemoteConfigurationFirecrestPartition;
+  /** When true, Amalthea forwards the resource class CPU, memory, and GPU values to FirecREST. When false (the default), the HPC grid selects the resources; the class values are still used for display and quota matching.
+   */
+  forward_resource_values?: boolean;
+};
 export type ResourceClassWithId = {
   name: Name;
   default: DefaultFlag;
@@ -643,6 +652,7 @@ export type ResourceClassWithId = {
   node_affinities?: NodeAffinityList;
   id: IntegerId;
   quota_enforced?: QuotaEnforced;
+  remote?: RemoteClassConfigurationFirecrest;
 };
 export type ErrorResponse = {
   error: {
@@ -726,8 +736,6 @@ export type ResourceClassWithIdFiltered = ResourceClassWithId & {
 export type PublicFlag = boolean;
 export type RemoteConfigurationFirecrestProviderId = string;
 export type RemoteConfigurationFirecrestApiUrl = string;
-export type RemoteConfigurationFirecrestSystemName = string;
-export type RemoteConfigurationFirecrestPartition = string;
 export type RemoteConfigurationFirecrest = {
   /** Kind of remote resource pool */
   kind: "firecrest";
@@ -806,6 +814,7 @@ export type ResourceClass = {
   tolerations?: K8SLabelList;
   node_affinities?: NodeAffinityList;
   quota_enforced?: QuotaEnforced;
+  remote?: RemoteClassConfigurationFirecrest;
 };
 export type ResourceClasses = ResourceClass[];
 export type ResourcePool = {
@@ -854,6 +863,7 @@ export type ResourceClassProperties = {
   tolerations?: K8SLabelList;
   node_affinities?: NodeAffinityList;
   quota_enforced?: QuotaEnforced;
+  remote?: RemoteClassConfigurationFirecrest;
 };
 export type ResourceClassPatchWithId = ResourceClassProperties & {
   id: IntegerId;

--- a/client/src/features/sessionsV2/api/computeResources.openapi.json
+++ b/client/src/features/sessionsV2/api/computeResources.openapi.json
@@ -2019,6 +2019,9 @@
           },
           "quota_enforced": {
             "$ref": "#/components/schemas/QuotaEnforced"
+          },
+          "remote": {
+            "$ref": "#/components/schemas/RemoteClassConfigurationFirecrest"
           }
         }
       },
@@ -2060,6 +2063,9 @@
               }
             ],
             "default": false
+          },
+          "remote": {
+            "$ref": "#/components/schemas/RemoteClassConfigurationFirecrest"
           }
         },
         "required": [
@@ -2154,6 +2160,9 @@
               }
             ],
             "default": false
+          },
+          "remote": {
+            "$ref": "#/components/schemas/RemoteClassConfigurationFirecrest"
           }
         },
         "required": [
@@ -3163,6 +3172,23 @@
           }
         },
         "required": ["kind", "api_url", "system_name"]
+      },
+      "RemoteClassConfigurationFirecrest": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "system_name": {
+            "$ref": "#/components/schemas/RemoteConfigurationFirecrestSystemName"
+          },
+          "partition": {
+            "$ref": "#/components/schemas/RemoteConfigurationFirecrestPartition"
+          },
+          "forward_resource_values": {
+            "type": "boolean",
+            "default": false,
+            "description": "When true, Amalthea forwards the resource class CPU, memory, and GPU values to FirecREST. When false (the default), the HPC grid selects the resources; the class values are still used for display and quota matching.\n"
+          }
+        }
       },
       "RemoteConfigurationFirecrestProviderId": {
         "type": "string",


### PR DESCRIPTION
## Summary

Firecrest pools submit to SLURM, which only accepts whole CPU cores; K8s pools accept fractional CPU (millicores). The backend rejects fractional `cpu` on firecrest resource classes, so the admin UI now enforces integers there: class forms step by 1 with integer validation, and the default class auto-created with a new pool is rounded up.

## Motivation and context

The add/update class forms and the auto-created default class always used `0.1` as min/step/default, so admins could submit fractional CPU that the backend rejects for firecrest pools resulting in a failed create/update instead of a prevented one. Run:AI is untouched in the backend for now and stays fractional in the UI.

## Behavior

- **Add / Update resource class** (`AddResourceClassButton`, `UpdateResourceClassButton`): firecrest pools get `step=1`, `min=1`, default `1`, and a validation rule rejecting non-integers ("CPUs must be a whole number for firecrest pools"). Other remotes keep `0.1`.
- **Add resource pool** (`AddResourcePoolButton`): the default class `cpu` is `Math.ceil`-rounded for firecrest pools so the auto-created class isn't rejected.
- Shared helper `poolRequiresIntegerCpu(remote)` (`remote?.kind === "firecrest"`) centralizes the check; unit tests cover firecrest / runai / null / undefined.

## Changes

- **`adminComputeResources.utils.ts`** (new) + **`.utils.test.ts`** (new): the helper and its Vitest cases.
- **`AddResourceClassButton.tsx`**, **`UpdateResourceClassButton.tsx`**: derive `cpuStep` from the pool remote; drive input `min`/`step`/default and validation from it.
- **`AddResourcePoolButton.tsx`**: ceil-round the default class `cpu` for firecrest on submit.
- **API sync** (`computeResources.openapi.json`, `computeResources.generated-api.ts`): regenerated via `npm run update-api`; adds `RemoteClassConfigurationFirecrest` (`system_name`, `partition`, `forward_resource_values`) and a `remote` field on resource-class schemas.

## Notes

- E2E uses mocked APIs.
- The changes are deployed, with the top of this PR stack (#4334), to http://staging.dev.renku.ch

/deploy
