### PR TITLE
feat: add remote fields for resource classes on FirecREST

### DIFF
--- a/client/src/features/admin/AddResourceClassButton.tsx
+++ b/client/src/features/admin/AddResourceClassButton.tsx
@@ -39,7 +39,11 @@ import {
   type ResourcePoolWithId,
 } from "../sessionsV2/api/computeResources.api";
 import type { ResourceClassForm } from "./adminComputeResources.types";
-import { poolRequiresIntegerCpu } from "./adminComputeResources.utils";
+import {
+  buildResourceClassRemote,
+  poolRequiresIntegerCpu,
+} from "./adminComputeResources.utils";
+import ResourceClassFirecrestFields from "./forms/ResourceClassFirecrestFields";
 
 interface AddResourceClassButtonProps {
   resourcePool: ResourcePoolWithId;
@@ -99,6 +103,7 @@ function AddResourceClassModal({
       max_storage: 1,
       memory: 1,
       name: "",
+      remote: { systemName: "", partition: "", forwardResourceValues: false },
     },
   });
   const {
@@ -116,16 +121,26 @@ function AddResourceClassModal({
   } = useFieldArray({ control, name: "node_affinities" });
   const onSubmit = useCallback(
     (data: ResourceClassForm) => {
-      const tolerations = data.tolerations.map(({ label }) => label);
+      const { remote: remoteForm, ...rest } = data;
+      const tolerations = rest.tolerations.map(({ label }) => label);
+      const remote = buildResourceClassRemote(
+        remoteForm ?? {
+          systemName: "",
+          partition: "",
+          forwardResourceValues: false,
+        },
+        requiresIntegerCpu,
+      );
       addResourceClass({
         resourcePoolId: resourcePool.id,
         resourceClass: {
-          ...data,
+          ...rest,
           tolerations,
+          remote,
         },
       });
     },
-    [addResourceClass, resourcePool.id],
+    [addResourceClass, requiresIntegerCpu, resourcePool.id],
   );
 
   const onAddTolerationLabel = useCallback(() => {
@@ -303,6 +318,17 @@ function AddResourceClassModal({
               )}
             />
           </div>
+
+          {requiresIntegerCpu && (
+            <div className="mb-3">
+              <div className="form-label">Firecrest options</div>
+              <ResourceClassFirecrestFields
+                control={control}
+                formPrefix="addResourceClass"
+                name="remote"
+              />
+            </div>
+          )}
 
           <div className="mb-3">
             <div className="form-label">Tolerations</div>

--- a/client/src/features/admin/AddResourceClassButton.tsx
+++ b/client/src/features/admin/AddResourceClassButton.tsx
@@ -121,13 +121,12 @@ function AddResourceClassModal({
   } = useFieldArray({ control, name: "node_affinities" });
   const onSubmit = useCallback(
     (data: ResourceClassForm) => {
-      const { remote: remoteForm, ...rest } = data;
-      const tolerations = rest.tolerations.map(({ label }) => label);
-      const remote = buildResourceClassRemote(remoteForm, requiresIntegerCpu);
+      const tolerations = data.tolerations.map(({ label }) => label);
+      const remote = buildResourceClassRemote(data.remote, requiresIntegerCpu);
       addResourceClass({
         resourcePoolId: resourcePool.id,
         resourceClass: {
-          ...rest,
+          ...data,
           tolerations,
           remote,
         },

--- a/client/src/features/admin/AddResourceClassButton.tsx
+++ b/client/src/features/admin/AddResourceClassButton.tsx
@@ -123,14 +123,7 @@ function AddResourceClassModal({
     (data: ResourceClassForm) => {
       const { remote: remoteForm, ...rest } = data;
       const tolerations = rest.tolerations.map(({ label }) => label);
-      const remote = buildResourceClassRemote(
-        remoteForm ?? {
-          systemName: "",
-          partition: "",
-          forwardResourceValues: false,
-        },
-        requiresIntegerCpu,
-      );
+      const remote = buildResourceClassRemote(remoteForm, requiresIntegerCpu);
       addResourceClass({
         resourcePoolId: resourcePool.id,
         resourceClass: {

--- a/client/src/features/admin/AdminPage.tsx
+++ b/client/src/features/admin/AdminPage.tsx
@@ -474,20 +474,18 @@ function ResourceClassItem({
           node affinities: {node_affinities?.length ?? 0}
         </div>
         {requiresIntegerCpu && (
-          <div className={cx(columnClasses)}>
-            system: {resourceClass.remote?.system_name ?? "—"}
-          </div>
-        )}
-        {requiresIntegerCpu && (
-          <div className={cx(columnClasses)}>
-            partition: {resourceClass.remote?.partition ?? "—"}
-          </div>
-        )}
-        {requiresIntegerCpu && (
-          <div className={cx(columnClasses)}>
-            forward resources:{" "}
-            {resourceClass.remote?.forward_resource_values ? "yes" : "no"}
-          </div>
+          <>
+            <div className={cx(columnClasses)}>
+              system: {resourceClass.remote?.system_name ?? "—"}
+            </div>
+            <div className={cx(columnClasses)}>
+              partition: {resourceClass.remote?.partition ?? "—"}
+            </div>
+            <div className={cx(columnClasses)}>
+              forward resources:{" "}
+              {resourceClass.remote?.forward_resource_values ? "yes" : "no"}
+            </div>
+          </>
         )}
         <div
           className={cx(

--- a/client/src/features/admin/AdminPage.tsx
+++ b/client/src/features/admin/AdminPage.tsx
@@ -56,6 +56,7 @@ import AddManyUsersToResourcePoolButton from "./AddManyUsersToResourcePoolButton
 import AddResourceClassButton from "./AddResourceClassButton";
 import AddResourcePoolButton from "./AddResourcePoolButton";
 import AddUserToResourcePoolButton from "./AddUserToResourcePoolButton";
+import { poolRequiresIntegerCpu } from "./adminComputeResources.utils";
 import { useGetKeycloakUserQuery } from "./adminKeycloak.api";
 import { KeycloakUser } from "./adminKeycloak.types";
 import ConnectedServicesSection from "./ConnectedServicesSection";
@@ -450,6 +451,7 @@ function ResourceClassItem({
   } = resourceClass;
 
   const columnClasses = ["col-12", "col-sm-4", "col-md-3", "col-xl-2"];
+  const requiresIntegerCpu = poolRequiresIntegerCpu(resourcePool.remote);
 
   return (
     <li>
@@ -471,6 +473,22 @@ function ResourceClassItem({
         <div className={cx(columnClasses)}>
           node affinities: {node_affinities?.length ?? 0}
         </div>
+        {requiresIntegerCpu && (
+          <div className={cx(columnClasses)}>
+            system: {resourceClass.remote?.system_name ?? "—"}
+          </div>
+        )}
+        {requiresIntegerCpu && (
+          <div className={cx(columnClasses)}>
+            partition: {resourceClass.remote?.partition ?? "—"}
+          </div>
+        )}
+        {requiresIntegerCpu && (
+          <div className={cx(columnClasses)}>
+            forward resources:{" "}
+            {resourceClass.remote?.forward_resource_values ? "yes" : "no"}
+          </div>
+        )}
         <div
           className={cx(
             columnClasses,

--- a/client/src/features/admin/UpdateResourceClassButton.tsx
+++ b/client/src/features/admin/UpdateResourceClassButton.tsx
@@ -141,14 +141,7 @@ function UpdateResourceClassModal({
     (data: ResourceClassForm) => {
       const { remote: remoteForm, ...rest } = data;
       const tolerations = rest.tolerations.map(({ label }) => label);
-      const remote = buildResourceClassRemote(
-        remoteForm ?? {
-          systemName: "",
-          partition: "",
-          forwardResourceValues: false,
-        },
-        requiresIntegerCpu,
-      );
+      const remote = buildResourceClassRemote(remoteForm, requiresIntegerCpu);
       updateResourceClass({
         resourcePoolId: resourcePool.id,
         classId: `${resourceClass.id}`,

--- a/client/src/features/admin/UpdateResourceClassButton.tsx
+++ b/client/src/features/admin/UpdateResourceClassButton.tsx
@@ -40,7 +40,11 @@ import {
   type ResourcePoolWithId,
 } from "../sessionsV2/api/computeResources.api";
 import { ResourceClassForm } from "./adminComputeResources.types";
-import { poolRequiresIntegerCpu } from "./adminComputeResources.utils";
+import {
+  buildResourceClassRemote,
+  poolRequiresIntegerCpu,
+} from "./adminComputeResources.utils";
+import ResourceClassFirecrestFields from "./forms/ResourceClassFirecrestFields";
 
 import styles from "./UpdateResourceClassButton.module.scss";
 
@@ -108,6 +112,12 @@ function UpdateResourceClassModal({
       max_storage: resourceClass.max_storage,
       memory: resourceClass.memory,
       name: resourceClass.name,
+      remote: {
+        systemName: resourceClass.remote?.system_name ?? "",
+        partition: resourceClass.remote?.partition ?? "",
+        forwardResourceValues:
+          resourceClass.remote?.forward_resource_values ?? false,
+      },
       tolerations: (resourceClass.tolerations ?? []).map((label) => ({
         label,
       })),
@@ -129,17 +139,32 @@ function UpdateResourceClassModal({
   } = useFieldArray({ control, name: "node_affinities" });
   const onSubmit = useCallback(
     (data: ResourceClassForm) => {
-      const tolerations = data.tolerations.map(({ label }) => label);
+      const { remote: remoteForm, ...rest } = data;
+      const tolerations = rest.tolerations.map(({ label }) => label);
+      const remote = buildResourceClassRemote(
+        remoteForm ?? {
+          systemName: "",
+          partition: "",
+          forwardResourceValues: false,
+        },
+        requiresIntegerCpu,
+      );
       updateResourceClass({
         resourcePoolId: resourcePool.id,
         classId: `${resourceClass.id}`,
         resourceClassPatch: {
-          ...data,
+          ...rest,
           tolerations,
+          remote,
         },
       });
     },
-    [resourceClass.id, resourcePool.id, updateResourceClass],
+    [
+      resourceClass.id,
+      resourcePool.id,
+      requiresIntegerCpu,
+      updateResourceClass,
+    ],
   );
 
   const onAddTolerationLabel = useCallback(() => {
@@ -166,6 +191,12 @@ function UpdateResourceClassModal({
       max_storage: resourceClass.max_storage,
       memory: resourceClass.memory,
       name: resourceClass.name,
+      remote: {
+        systemName: resourceClass.remote?.system_name ?? "",
+        partition: resourceClass.remote?.partition ?? "",
+        forwardResourceValues:
+          resourceClass.remote?.forward_resource_values ?? false,
+      },
       tolerations: (resourceClass.tolerations ?? []).map((label) => ({
         label,
       })),
@@ -334,6 +365,17 @@ function UpdateResourceClassModal({
               )}
             />
           </div>
+
+          {requiresIntegerCpu && (
+            <div className="mb-3">
+              <div className="form-label">Firecrest options</div>
+              <ResourceClassFirecrestFields
+                control={control}
+                formPrefix="updateResourceClass"
+                name="remote"
+              />
+            </div>
+          )}
 
           <div className="mb-3">
             <div className="form-label">Tolerations</div>

--- a/client/src/features/admin/UpdateResourceClassButton.tsx
+++ b/client/src/features/admin/UpdateResourceClassButton.tsx
@@ -139,14 +139,13 @@ function UpdateResourceClassModal({
   } = useFieldArray({ control, name: "node_affinities" });
   const onSubmit = useCallback(
     (data: ResourceClassForm) => {
-      const { remote: remoteForm, ...rest } = data;
-      const tolerations = rest.tolerations.map(({ label }) => label);
-      const remote = buildResourceClassRemote(remoteForm, requiresIntegerCpu);
+      const tolerations = data.tolerations.map(({ label }) => label);
+      const remote = buildResourceClassRemote(data.remote, requiresIntegerCpu);
       updateResourceClass({
         resourcePoolId: resourcePool.id,
         classId: `${resourceClass.id}`,
         resourceClassPatch: {
-          ...rest,
+          ...data,
           tolerations,
           remote,
         },

--- a/client/src/features/admin/adminComputeResources.types.ts
+++ b/client/src/features/admin/adminComputeResources.types.ts
@@ -17,6 +17,7 @@
  */
 
 import { type RemoteConfiguration as BackendRemoteConfiguration } from "../sessionsV2/api/computeResources.generated-api";
+import { type ResourceClassFormRemote } from "./adminComputeResources.utils";
 
 export interface ResourcePoolForm {
   name: string;
@@ -64,6 +65,7 @@ export interface ResourceClassForm {
   default: boolean;
   tolerations: ResourceClassFormToleration[];
   node_affinities: ResourceClassFormNodeAffinity[];
+  remote?: ResourceClassFormRemote;
 }
 
 export interface ResourceClassFormToleration {

--- a/client/src/features/admin/adminComputeResources.types.ts
+++ b/client/src/features/admin/adminComputeResources.types.ts
@@ -65,7 +65,7 @@ export interface ResourceClassForm {
   default: boolean;
   tolerations: ResourceClassFormToleration[];
   node_affinities: ResourceClassFormNodeAffinity[];
-  remote?: ResourceClassFormRemote;
+  remote: ResourceClassFormRemote;
 }
 
 export interface ResourceClassFormToleration {

--- a/client/src/features/admin/adminComputeResources.utils.test.ts
+++ b/client/src/features/admin/adminComputeResources.utils.test.ts
@@ -18,7 +18,10 @@
 
 import { describe, expect, it } from "vitest";
 
-import { poolRequiresIntegerCpu } from "./adminComputeResources.utils";
+import {
+  buildResourceClassRemote,
+  poolRequiresIntegerCpu,
+} from "./adminComputeResources.utils";
 
 describe("poolRequiresIntegerCpu", () => {
   it("returns true for a firecrest remote configuration", () => {
@@ -37,3 +40,62 @@ describe("poolRequiresIntegerCpu", () => {
     expect(poolRequiresIntegerCpu(undefined)).toBe(false);
   });
 });
+
+/* eslint-disable spellcheck/spell-checker */
+describe("buildResourceClassRemote", () => {
+  it("omits system_name and partition when both are empty strings", () => {
+    expect(
+      buildResourceClassRemote(
+        { systemName: "", partition: "", forwardResourceValues: false },
+        true,
+      ),
+    ).toEqual({ forward_resource_values: false });
+  });
+
+  it("returns the full snake_case payload when all fields are populated", () => {
+    expect(
+      buildResourceClassRemote(
+        {
+          systemName: "eiger",
+          partition: "normal",
+          forwardResourceValues: true,
+        },
+        true,
+      ),
+    ).toEqual({
+      system_name: "eiger",
+      partition: "normal",
+      forward_resource_values: true,
+    });
+  });
+
+  it("trims whitespace and omits an empty partition", () => {
+    expect(
+      buildResourceClassRemote(
+        {
+          systemName: "  eiger  ",
+          partition: "",
+          forwardResourceValues: false,
+        },
+        true,
+      ),
+    ).toEqual({
+      system_name: "eiger",
+      forward_resource_values: false,
+    });
+  });
+
+  it("returns undefined when the pool is not firecrest", () => {
+    expect(
+      buildResourceClassRemote(
+        {
+          systemName: "eiger",
+          partition: "normal",
+          forwardResourceValues: true,
+        },
+        false,
+      ),
+    ).toBeUndefined();
+  });
+});
+/* eslint-enable spellcheck/spell-checker */

--- a/client/src/features/admin/adminComputeResources.utils.ts
+++ b/client/src/features/admin/adminComputeResources.utils.ts
@@ -26,3 +26,29 @@ export function poolRequiresIntegerCpu(
 ): boolean {
   return remote?.kind === "firecrest";
 }
+
+export interface ResourceClassFormRemote {
+  systemName: string;
+  partition: string;
+  forwardResourceValues: boolean;
+}
+
+export function buildResourceClassRemote(
+  form: ResourceClassFormRemote,
+  isFirecrest: boolean,
+):
+  | {
+      system_name?: string;
+      partition?: string;
+      forward_resource_values: boolean;
+    }
+  | undefined {
+  if (!isFirecrest) return undefined;
+  const system_name = form.systemName.trim() || undefined;
+  const partition = form.partition.trim() || undefined;
+  return {
+    system_name,
+    partition,
+    forward_resource_values: form.forwardResourceValues,
+  };
+}

--- a/client/src/features/admin/forms/ResourceClassFirecrestFields.tsx
+++ b/client/src/features/admin/forms/ResourceClassFirecrestFields.tsx
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2025 - Swiss Data Science Center (SDSC)
+ * Copyright 2026 - Swiss Data Science Center (SDSC)
  * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
  * Eidgenössische Technische Hochschule Zürich (ETHZ).
  *

--- a/client/src/features/admin/forms/ResourceClassFirecrestFields.tsx
+++ b/client/src/features/admin/forms/ResourceClassFirecrestFields.tsx
@@ -95,10 +95,13 @@ export default function ResourceClassFirecrestFields<T extends FieldValues>({
           render={({ field }) => (
             <div className="form-check">
               <Input
+                className="form-check-input"
                 id={`${formPrefix}RemoteForwardResourceValues`}
                 type="checkbox"
                 checked={field.value}
-                {...field}
+                innerRef={field.ref}
+                onBlur={field.onBlur}
+                onChange={field.onChange}
               />
               <Label
                 className={cx("form-check-label", "ms-2")}

--- a/client/src/features/admin/forms/ResourceClassFirecrestFields.tsx
+++ b/client/src/features/admin/forms/ResourceClassFirecrestFields.tsx
@@ -1,0 +1,116 @@
+/*!
+ * Copyright 2025 - Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import cx from "classnames";
+import {
+  Controller,
+  type Control,
+  type FieldPathByValue,
+  type FieldValues,
+} from "react-hook-form";
+import { FormText, Input, Label } from "reactstrap";
+
+import type { ResourceClassFormRemote } from "../adminComputeResources.utils";
+
+const FORWARD_RESOURCE_VALUES_HELP =
+  "When true, Amalthea forwards the resource class CPU, memory, and GPU values to FirecREST. When false, the HPC grid selects the resources."; // eslint-disable-line spellcheck/spell-checker
+
+interface ResourceClassFirecrestFieldsProps<T extends FieldValues> {
+  control: Control<T>;
+  formPrefix: string;
+  name: FieldPathByValue<T, ResourceClassFormRemote | undefined>;
+}
+
+export default function ResourceClassFirecrestFields<T extends FieldValues>({
+  control,
+  formPrefix,
+  name,
+}: ResourceClassFirecrestFieldsProps<T>) {
+  const systemNameField = `${name}.systemName` as FieldPathByValue<T, string>;
+  const partitionField = `${name}.partition` as FieldPathByValue<T, string>;
+  const forwardResourceValuesField =
+    `${name}.forwardResourceValues` as FieldPathByValue<T, boolean>;
+
+  return (
+    <>
+      <div className="mb-3">
+        <Label className="form-label" for={`${formPrefix}RemoteSystemName`}>
+          System name
+          <span className={cx("small", "text-muted", "ms-2")}>(Optional)</span>
+        </Label>
+        <Controller
+          control={control}
+          name={systemNameField}
+          render={({ field }) => (
+            <Input
+              id={`${formPrefix}RemoteSystemName`}
+              placeholder='System name, e.g. "eiger"' // eslint-disable-line spellcheck/spell-checker
+              type="text"
+              {...field}
+              value={field.value ?? ""}
+            />
+          )}
+        />
+      </div>
+
+      <div className="mb-3">
+        <Label className="form-label" for={`${formPrefix}RemotePartition`}>
+          Partition
+          <span className={cx("small", "text-muted", "ms-2")}>(Optional)</span>
+        </Label>
+        <Controller
+          control={control}
+          name={partitionField}
+          render={({ field }) => (
+            <Input
+              id={`${formPrefix}RemotePartition`}
+              placeholder='SLURM partition, e.g. "normal"'
+              type="text"
+              {...field}
+              value={field.value ?? ""}
+            />
+          )}
+        />
+      </div>
+
+      <div className="mb-3">
+        <Controller
+          control={control}
+          name={forwardResourceValuesField}
+          render={({ field }) => (
+            <div className="form-check">
+              <Input
+                id={`${formPrefix}RemoteForwardResourceValues`}
+                type="checkbox"
+                checked={field.value}
+                {...field}
+              />
+              <Label
+                className={cx("form-check-label", "ms-2")}
+                for={`${formPrefix}RemoteForwardResourceValues`}
+              >
+                Forward resource values
+              </Label>
+            </div>
+          )}
+        />
+        <FormText>{FORWARD_RESOURCE_VALUES_HELP}</FormText>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

FirecREST resource pools now expose per-class remote configuration (system name, SLURM partition, and a forward-resource-values toggle) in the admin create/update class forms and the class list row. A `buildResourceClassRemote` helper converts the form's camelCase remote into the backend's snake_case payload, omitting empty system/partition and returning `undefined` for non-firecrest pools.

## Motivation and context

FirecREST-backed pools need per-class remote targeting (which HPC system, which SLURM partition) and a toggle for whether Amalthea forwards CPU/memory/GPU or lets the grid decide. The admin UI previously had no way to set or view these. Stacked on `salimkayal/feat/enforce-integrality-for-resource-classes-on-firecrest`, which established the firecrest-pool detection (`poolRequiresIntegerCpu`) reused here.

## Behavior

- On firecrest pools, the Add and Update Resource Class forms show a "Firecrest options" section: System name (optional), Partition (optional), and a Forward resource values checkbox.
- On non-firecrest pools, the section is hidden and no `remote` object is sent on submit.
- The admin resource class list row shows `system`, `partition`, and `forward resources` columns for firecrest pools.

## Changes

- **`adminComputeResources.utils.ts`**: add `ResourceClassFormRemote` type and `buildResourceClassRemote(form, isFirecrest)`: trims whitespace, omits empty `system_name`/`partition`, returns `undefined` for non-firecrest.
- **`adminComputeResources.utils.test.ts`**: cover the helper: empty, full, trim, and non-firecrest cases.
- **`adminComputeResources.types.ts`**: add `remote: ResourceClassFormRemote` to `ResourceClassForm`.
- **`forms/ResourceClassFirecrestFields.tsx`** (new): reusable RHF-controlled fields (system name, partition, forward-resource-values checkbox) with help text.
- **`AddResourceClassButton.tsx`**: seed `remote` default, render firecrest fields when `requiresIntegerCpu`, route submit through `buildResourceClassRemote`.
- **`UpdateResourceClassButton.tsx`**: hydrate `remote` from the existing class, render fields, route submit through the helper.
- **`AdminPage.tsx`**: `ResourceClassItem` shows system/partition/forward-resources columns for firecrest pools.

## Notes

- The changes are deployed, with the bottom of this PR stack (#4333), to http://staging.dev.renku.ch

/deploy
