### PR TITLE
fix: prevent silently disabled secret location input

### DIFF
--- a/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/SecretsMountDirectoryComponent.tsx
+++ b/client/src/features/ProjectPageV2/ProjectPageContent/SessionSecrets/SecretsMountDirectoryComponent.tsx
@@ -58,14 +58,14 @@ export default function SecretsMountDirectoryComponent() {
   return (
     <>
       <InputGroup>
-        <Input type="text" value={mountDir} readOnly />
+        <Input disabled type="text" value={mountDir} readOnly />
         <PermissionsGuard
           disabled={null}
           enabled={
             <>
               <Button color="outline-primary" innerRef={ref} onClick={toggle}>
-                <Pencil className="bi" />
-                <span className="visually-hidden">Edit</span>
+                <Pencil className="me-1" />
+                <span>Edit</span>
               </Button>
               <UncontrolledTooltip target={ref}>
                 Edit the secrets mount location


### PR DESCRIPTION
The secrets location input isn't editable and it's confusing for users, since they would try to edit it

<img width="1497" height="879" alt="secrets-slot" src="https://github.com/user-attachments/assets/d8d688a9-33e2-45c5-a5d9-eee8d2e6c16f" />

This PR renders it as disabled and makes the edit button more prominent

<img width="1267" height="314" alt="image" src="https://github.com/user-attachments/assets/59abe483-5c7f-4b17-8471-f1d79fb44aab" />

/deploy

